### PR TITLE
Update Order map

### DIFF
--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -215,6 +215,7 @@ func (b *OrderBook) AmendOrder(order *types.Order) error {
 			return err
 		}
 	}
+	b.ordersByID[order.GetId()] = order
 
 	return nil
 }


### PR DESCRIPTION
Very small fix to make sure amends update the shared order map so lookups get the correct order after an amend