### PR TITLE
Overwrite original order after amending (#1511)

### DIFF
--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -215,8 +215,6 @@ func (b *OrderBook) AmendOrder(order *types.Order) error {
 			return err
 		}
 	}
-	b.ordersByID[order.GetId()] = order
-
 	return nil
 }
 

--- a/matching/side.go
+++ b/matching/side.go
@@ -97,7 +97,7 @@ func (s *OrderBookSide) amendOrder(orderAmend *types.Order) error {
 	}
 
 	reduceBy := oldOrder.Remaining - orderAmend.Size
-	s.levels[priceLevelIndex].orders[orderIndex] = orderAmend
+	*s.levels[priceLevelIndex].orders[orderIndex] = *orderAmend
 	s.levels[priceLevelIndex].reduceVolume(reduceBy)
 	return nil
 }


### PR DESCRIPTION
Instead of updating the map of orders to point to the new amended order, we overwrite the original order so everything is already pointing to the correct place.