### PR TITLE
Fixed code that writes orders to order buffer

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1141,8 +1141,6 @@ func (m *Market) AmendOrder(orderAmendment *types.OrderAmendment) (*types.OrderC
 		}, nil
 	}
 
-	m.orderBuf.Add(*amendedOrder) // saving amended order
-
 	// if expiration has changed and is not 0, and is before currentTime
 	// then we expire the order
 	if amendedOrder.ExpiresAt != 0 && amendedOrder.ExpiresAt < amendedOrder.UpdatedAt {
@@ -1195,10 +1193,22 @@ func (m *Market) AmendOrder(orderAmendment *types.OrderAmendment) (*types.OrderC
 		timeInForceChange = true
 	}
 
+	// If nothing changed, amend in place to update updatedAt and version number
+	if !priceShift && !sizeIncrease && !sizeDecrease && !expiryChange && !timeInForceChange {
+		ret, err := m.orderAmendInPlace(amendedOrder)
+		if err == nil {
+			m.orderBuf.Add(*amendedOrder)
+		}
+		return ret, err
+	}
+
 	// if increase in size or change in price
 	// ---> DO atomic cancel and submit
 	if priceShift || sizeIncrease {
 		ret, err := m.orderCancelReplace(existingOrder, amendedOrder)
+		if err == nil {
+			m.orderBuf.Add(*amendedOrder)
+		}
 		return ret, err
 	}
 
@@ -1223,7 +1233,11 @@ func (m *Market) AmendOrder(orderAmendment *types.OrderAmendment) (*types.OrderC
 			}
 		}
 
-		return m.orderAmendInPlace(amendedOrder)
+		ret, err := m.orderAmendInPlace(amendedOrder)
+		if err == nil {
+			m.orderBuf.Add(*amendedOrder)
+		}
+		return ret, err
 	}
 
 	m.log.Error("Order amendment not allowed", logging.Order(*existingOrder))
@@ -1235,15 +1249,6 @@ func (m *Market) validateOrderAmendment(
 	order *types.Order,
 	amendment *types.OrderAmendment,
 ) error {
-	// check size changes
-	if amendment.SizeDelta != 0 {
-		// only new size not permitted to be <= 0
-		newSize := int64(order.Size) + amendment.SizeDelta
-		if newSize <= 0 {
-			return errors.New("amend order size can't be <= 0")
-		}
-	}
-
 	// check TIF and expiracy
 	if amendment.TimeInForce == types.Order_GTT {
 		if amendment.ExpiresAt == nil {
@@ -1310,7 +1315,12 @@ func (m *Market) applyOrderAmendment(
 	}
 
 	// apply tif
-	order.TimeInForce = amendment.TimeInForce
+	if amendment.TimeInForce != types.Order_TIF_UNSPECIFIED {
+		order.TimeInForce = amendment.TimeInForce
+		if amendment.TimeInForce != types.Order_GTT {
+			order.ExpiresAt = 0
+		}
+	}
 	if amendment.ExpiresAt != nil {
 		order.ExpiresAt = amendment.ExpiresAt.Value
 	}
@@ -1322,23 +1332,18 @@ func (m *Market) orderCancelReplace(existingOrder, newOrder *types.Order) (conf 
 
 	m.log.Debug("Cancel/replace order")
 
-	ordCancel := types.OrderCancellation{
-		OrderID:  existingOrder.Id,
-		PartyID:  existingOrder.PartyID,
-		MarketID: existingOrder.MarketID,
-	}
-
-	cancellation, err := m.CancelOrder(&ordCancel)
-	if err != nil || cancellation == nil {
-		if err == nil {
+	cancellation, err := m.matching.CancelOrder(existingOrder)
+	if cancellation == nil {
+		if err != nil {
+			m.log.Error("Failed to cancel order from matching engine during CancelReplace",
+				logging.OrderWithTag(*existingOrder, "existing-order"),
+				logging.OrderWithTag(*newOrder, "new-order"),
+				logging.Error(err))
+		} else {
 			err = fmt.Errorf("order cancellation failed (no error given)")
 		}
-		m.log.Error("Failed to cancel order from matching engine during CancelReplace",
-			logging.OrderWithTag(*existingOrder, "existing-order"),
-			logging.OrderWithTag(*newOrder, "new-order"),
-			logging.Error(err))
 	} else {
-		conf, err = m.SubmitOrder(newOrder)
+		conf, err = m.matching.SubmitOrder(newOrder)
 	}
 
 	timer.EngineTimeCounterAdd()
@@ -1361,7 +1366,6 @@ func (m *Market) orderAmendInPlace(amendOrder *types.Order) (*types.OrderConfirm
 			logging.Error(err))
 		return nil, err
 	}
-	m.orderBuf.Add(*amendOrder)
 	return &types.OrderConfirmation{
 		Order: amendOrder,
 	}, nil

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -497,14 +497,6 @@ func TestMarketGetMarginOnAmendOrderCancelReplace(t *testing.T) {
 			assert.EqualValues(t, orderBuy.Version+1, order.Version, "storing amended version")
 		}
 	})
-	tm.orderStore.EXPECT().Add(gomock.Any()).Times(1).Do(func(order types.Order) {
-		if order.Id == amendedOrder.OrderID {
-			assert.EqualValues(t, orderBuy.Version, order.Version)
-		}
-	})
-	tm.orderStore.EXPECT().Add(gomock.Any()).Times(1).Do(func(order types.Order) {
-		assert.NotEqual(t, order.Id, amendedOrder.OrderID)
-	})
 	_, err = tm.market.AmendOrder(amendedOrder)
 	assert.Nil(t, err)
 	if err != nil {
@@ -620,4 +612,106 @@ func TestMarketCancelOrder(t *testing.T) {
 	cancelled, err = tm.market.CancelOrderByID("an id that does not exist")
 	assert.Nil(t, cancelled, "cancelling non-exitant order should not work")
 	assert.Error(t, err, "it should be an error to cancel an order that does not exist")
+}
+
+func TestOrderBufferOutputCount(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(10000000000, 0)
+	tm := getTestMarket(t, now, closingAt)
+
+	addAccount(tm, party1)
+	tm.orderStore.EXPECT().Add(gomock.Any()).Times(11)
+
+	orderBuy := &types.Order{
+		TimeInForce: types.Order_GTC,
+		Status:      types.Order_Active,
+		Id:          "someid",
+		Side:        types.Side_Buy,
+		PartyID:     party1,
+		MarketID:    tm.market.GetID(),
+		Size:        100,
+		Price:       100,
+		Remaining:   100,
+		CreatedAt:   now.UnixNano(),
+		ExpiresAt:   0,
+		Reference:   "party1-buy-order",
+	}
+	orderAmend := *orderBuy
+
+	// Create an order (generates one order message)
+	confirmation, err := tm.market.SubmitOrder(orderBuy)
+	assert.NotNil(t, confirmation)
+	assert.NoError(t, err)
+
+	// Cancel it (generates one order message)
+	cancelled, err := tm.market.CancelOrderByID(confirmation.Order.Id)
+	assert.NotNil(t, cancelled, "cancelled freshly submitted order")
+	assert.NoError(t, err)
+	assert.EqualValues(t, confirmation.Order.Id, cancelled.Order.Id)
+
+	// Create a new order (generates one order message)
+	orderAmend.Id = "amendingorder"
+	orderAmend.Reference = "amendingorderreference"
+	confirmation, err = tm.market.SubmitOrder(&orderAmend)
+	assert.NotNil(t, confirmation)
+	assert.NoError(t, err)
+
+	amend := &types.OrderAmendment{
+		MarketID: tm.market.GetID(),
+		PartyID:  party1,
+		OrderID:  orderAmend.Id,
+	}
+
+	// Amend price down (generates one order message)
+	amend.Price = &types.Price{Value: orderBuy.Price - 1}
+	amendConf, err := tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	// Amend price up (generates one order message)
+	amend.Price = &types.Price{Value: orderBuy.Price + 1}
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	// Amend size down (generates one order message)
+	amend.Price = nil
+	amend.SizeDelta = -1
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	// Amend size up (generates one order message)
+	amend.SizeDelta = +1
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	// Amend TIF -> GTT (generates one order message)
+	amend.SizeDelta = 0
+	amend.TimeInForce = types.Order_GTT
+	amend.ExpiresAt = &types.Timestamp{Value: now.UnixNano() + 100000000000}
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	// Amend TIF -> GTC (generates one order message)
+	amend.TimeInForce = types.Order_GTC
+	amend.ExpiresAt = nil
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	// Amend ExpiresAt (generates two order messages)
+	amend.TimeInForce = types.Order_GTT
+	amend.ExpiresAt = &types.Timestamp{Value: now.UnixNano() + 100000000000}
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+
+	amend.ExpiresAt = &types.Timestamp{Value: now.UnixNano() + 200000000000}
+	amendConf, err = tm.market.AmendOrder(amend)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
The ordering that the code wrote orders to the orderbuffer was incorrect and resulting in multiple order updates for a single amend. This PR fixes that problem

closes #1513 