### PR TITLE
Remove wildcard and very general codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,4 @@
 # VEGA code owners - aka 'people who should probably be included in reviews on...'
 
-# Wildcard starting point
-* @ashleyvega @jeremyletang @EVODelavega
-
 # GraphQL schema changes should be reviewd by Team Vega Console
-gateway/graphql/schema.graphql @edd @mattrussell36 @campbellssource
-
-# Docs changes should be reviewed by the wider team
-*.md @ashleyvega @jeremyletang @EVODelavega @pand-dev @peterbarrow
+gateway/graphql/schema.graphql @edd @mattrussell36 


### PR DESCRIPTION
I added the CODEOWNERS file with some people set as default owners for everything. This has been agreed to be a terrible approach. After a call where we touched on this, I reduced the CODEOWNERS required reviews from 2 to 1, but the wildcard owners are still pulled in to every review, which is the real issue. This commit removes the wildcard and very general docs rule, leaving only myself and matt as required on changes that change the GraphQL schema.

In a future retro we'll talk about CODEOWNERS and how to roll it out in a more reasonable way.

For the mean time, feel free to submit a PR with changes to this file if required.

- Remove wildcard codeowners
- Remove general docs codeowners