### PR TITLE
Rename VOTE token (#1623)

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -19,7 +19,7 @@ const (
 	systemOwner = "*"
 	noMarket    = "!"
 
-	TokenAsset = "_t0k3n_"
+	TokenAsset = "VOTE"
 )
 
 var (


### PR DESCRIPTION
This is a one-line PR to give the VOTE token a better name.

I have changed the string value, but chose not to rename the variable `TokenAsset`.

Closes #1623.