### PR TITLE
Allow overriding of Governance parameters with `ldflags` (#1665)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ deps: ## Get the dependencies
 	@modvendor -copy="**/*.proto"
 
 .PHONY: build
-build: SHELL:=/bin/bash
 build: ## install the binaries in cmd/{progname}/
 	@d="" ; test -n "$$DEBUGVEGA" && d="-d" ; \
 	./script/build.sh $d -t linux/amd64
@@ -81,10 +80,10 @@ gofmtsimplify:
 .PHONY: install
 install: SHELL:=/bin/bash
 install: ## install the binaries in GOPATH/bin
-	@source ./script/build.sh && set_version && \
+	@source ./script/build.sh && set_version && set_ldflags && \
 	echo "Version: $$version ($$version_hash)" && \
 	for app in "$${apps[@]}" ; do \
-		env CGO_ENABLED=1 go install -v -ldflags "-X main.Version=$$version -X main.VersionHash=$$version_hash" "./cmd/$$app" || exit 1 ; \
+		env CGO_ENABLED=1 go install -v -ldflags "$$ldflags" "./cmd/$$app" || exit 1 ; \
 	done
 
 .PHONY: gqlgen
@@ -151,28 +150,34 @@ print_check: ## Check for fmt.Print functions in Go code
 	if test "$$count" -gt 0 ; then exit 1 ; fi
 
 .PHONY: docker
+docker: SHELL:=/bin/bash
 docker: ## Make docker container image from scratch
-	@test -f "$(HOME)/.ssh/id_rsa" || exit 1
-	@docker build \
+	@source ./script/build.sh && \
+	if ! test -f "$(HOME)/.ssh/id_rsa" ; then \
+		exit 1 ; \
+	fi ; \
+	docker build \
 		--build-arg SSH_KEY="$$(cat ~/.ssh/id_rsa)" \
-		-t "docker.pkg.github.com/vegaprotocol/vega/vega:$(VERSION)" \
+		-t "docker.pkg.github.com/vegaprotocol/vega/vega:$$version" \
 		.
 
 .PHONY: docker_quick
+docker_quick: SHELL:=/bin/bash
 docker_quick: build ## Make docker container image using pre-existing binaries
-	@for app in $(APPS) ; do \
+	@source ./script/build.sh && \
+	for app in "$${apps[@]}" ; do \
 		f="cmd/$$app/$$app" ; \
 		if ! test -f "$$f" ; then \
 			echo "Failed to find: $$f" ; \
 			exit 1 ; \
 		fi ; \
 		cp -a "$$f" . || exit 1 ; \
-	done
-	@docker build \
-		-t "docker.pkg.github.com/vegaprotocol/vega/vega:$(VERSION)" \
+	done && \
+	docker build \
+		-t "docker.pkg.github.com/vegaprotocol/vega/vega:$$version" \
 		-f Dockerfile.quick \
-		.
-	@for app in $(APPS) ; do \
+		. && \
+	for app in "$${apps[@]}" ; do \
 		rm -rf "./$$app" ; \
 	done
 
@@ -207,9 +212,11 @@ staticcheck: ## Run statick analysis checks
 	count="$$(wc -l <"$$f")" && rm -f "$$f" && if test "$$count" -gt 0 ; then exit 1 ; fi
 
 .PHONY: clean
+clean: SHELL:=/bin/bash
 clean: ## Remove previous build
-	@rm -f cmd/*/*.log
-	for app in $(APPS) ; do \
+	@source ./script/build.sh && \
+	rm -f cmd/*/*.log && \
+	for app in "$${apps[@]}" ; do \
 		rm -f "$$app" "cmd/$$app/$$app" "cmd/$$app/$$app"-* ; \
 	done
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -91,3 +91,9 @@ env \
 	VEGA_GOVERNANCE_MIN_PARTICIPATION_STAKE=55 \
 	make install
 ```
+
+If the log level for the Execution engine (not the Governance engine) is Debug, then this message will appear:
+
+```
+governance/engine.go:68 Governance parameters {"MinClose": "3s", "MaxClose": "10m0s", "MinEnact": "1h0m0s", "MaxEnact": "99d0h0m0s", "MinParticipationStake": 55}
+```

--- a/governance/README.md
+++ b/governance/README.md
@@ -74,4 +74,20 @@ type proposalVote struct {
 }
 ```
 
-This is the governance domain object representing a proposal. In the world of gRPC, a proposal and a vote are distinct messages. As far as governance is concerned, a proposal has a one-to-many relation with votes. We store both the yes and no votes in a map[string]*types.Vote. The reasoning behind using a map as opposed to a slice is so we can delete previous votes cast by a party, and only count the last vote. This prevents abuse where a single party can spam-vote _"yes"_ on a proposal and have their tokens counted multiple times.
+This is the governance domain object representing a proposal. In the world of gRPC, a proposal and a vote are distinct messages. As far as governance is concerned, a proposal has a one-to-many relation with votes. We store both the yes and no votes in a `map[string]*types.Vote`. The reasoning behind using a map as opposed to a slice is so we can delete previous votes cast by a party, and only count the last vote. This prevents abuse where a single party can spam-vote _"yes"_ on a proposal and have their tokens counted multiple times.
+
+## Modifying governance parameters for testing
+
+In order to allow testing of Governance, the following environment variables can be specified in order to compile a binary with custom parameters.
+
+Specify some/all of the following variables. The values for Close and Enact are standard Golang [time.Duration](https://golang.org/pkg/time/#ParseDuration).
+
+```bash
+env \
+	VEGA_GOVERNANCE_MIN_CLOSE=3s \
+	VEGA_GOVERNANCE_MAX_CLOSE=10m \
+	VEGA_GOVERNANCE_MIN_ENACT=1h \
+	VEGA_GOVERNANCE_MAX_ENACT=99d \
+	VEGA_GOVERNANCE_MIN_PARTICIPATION_STAKE=55 \
+	make install
+```

--- a/governance/engine.go
+++ b/governance/engine.go
@@ -64,6 +64,13 @@ type proposalVote struct {
 }
 
 func NewEngine(log *logging.Logger, cfg Config, params *NetworkParameters, accs Accounts, buf Buffer, vbuf VoteBuf, now time.Time) *Engine {
+	log.Debug("Governance parameters",
+		logging.String("MinClose", params.minClose.String()),
+		logging.String("MaxClose", params.maxClose.String()),
+		logging.String("MinEnact", params.minEnact.String()),
+		logging.String("MaxEnact", params.maxEnact.String()),
+		logging.Uint64("MinParticipationStake", params.minParticipationStake),
+	)
 	return &Engine{
 		Config:        cfg,
 		accs:          accs,

--- a/governance/networkparams.go
+++ b/governance/networkparams.go
@@ -1,24 +1,37 @@
 package governance
 
-import "time"
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
 
 const (
 	day  = 24 * time.Hour // day here is 24 hours
 	year = 365 * day      // year here is 365 days (ignoring leap years)
 )
 
+// These Governance parameters are fixed, unless overridden by ldflags for test purposes.
+var (
+	MinClose              = ""
+	MaxClose              = ""
+	MinEnact              = ""
+	MaxEnact              = ""
+	MinParticipationStake = ""
+)
+
 const (
-	// DefaultMinClose is harcoded minimum voting close offset duration
-	//(relative to the time proposal is received from the chain)
-	DefaultMinClose = 2 * day
-	// DefaultMaxClose is harcoded maximum voting close offset duration
-	DefaultMaxClose = 1 * year
-	// DefaultMinEnact is harcoded minimum enactment offset duration
-	DefaultMinEnact = 2 * day // must be >= minClose
-	// DefaultMaxEnact is harcoded maximum enactment offset duration
-	DefaultMaxEnact = 1 * year
-	// DefaultMinParticipationStake is hardcoded minimum participation stake percent
-	DefaultMinParticipationStake = 1
+	// defaultMinClose is the hardcoded minimum voting close offset duration
+	// (relative to the time proposal is received from the chain)
+	defaultMinClose = 2 * day
+	// defaultMaxClose is the hardcoded maximum voting close offset duration
+	defaultMaxClose = 1 * year
+	// defaultMinEnact is the hardcoded minimum enactment offset duration
+	defaultMinEnact = 2 * day // must be >= minClose
+	// defaultMaxEnact is the hardcoded maximum enactment offset duration
+	defaultMaxEnact = 1 * year
+	// defaultMinParticipationStake is hardcoded minimum participation stake percent
+	defaultMinParticipationStake = 1
 )
 
 // NetworkParameters stores governance network parameters
@@ -32,13 +45,48 @@ type NetworkParameters struct {
 
 // DefaultNetworkParameters returns default, hardcoded, network parameters
 func DefaultNetworkParameters() *NetworkParameters {
+	var err error
 	result := &NetworkParameters{
-		minClose:              DefaultMinClose,
-		maxClose:              DefaultMaxClose,
-		minEnact:              DefaultMinEnact,
-		maxEnact:              DefaultMaxEnact,
-		minParticipationStake: DefaultMinParticipationStake,
+		minClose:              defaultMinClose,
+		maxClose:              defaultMaxClose,
+		minEnact:              defaultMinEnact,
+		maxEnact:              defaultMaxEnact,
+		minParticipationStake: defaultMinParticipationStake,
 	}
+	if len(MinClose) > 0 {
+		result.minClose, err = time.ParseDuration(MinClose)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to parse time duration: %s", MinClose))
+		}
+	}
+	if len(MaxClose) > 0 {
+		result.maxClose, err = time.ParseDuration(MaxClose)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to parse time duration: %s", MaxClose))
+		}
+	}
+	if len(MinEnact) > 0 {
+		result.minEnact, err = time.ParseDuration(MinEnact)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to parse time duration: %s", MinEnact))
+		}
+	}
+	if len(MaxEnact) > 0 {
+		result.maxEnact, err = time.ParseDuration(MaxEnact)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to parse time duration: %s", MaxEnact))
+		}
+	}
+	if len(MinParticipationStake) > 0 {
+		result.minParticipationStake, err = strconv.ParseUint(MinParticipationStake, 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to parse time integer: %s", MinParticipationStake))
+		}
+		if result.minParticipationStake > 100 {
+			panic(fmt.Sprintf("Invalid MinParticipationStake (over 100): %d", result.minParticipationStake))
+		}
+	}
+
 	result.maxClose = max(result.maxClose, result.minClose) // maxClose must be >= minClose
 	result.minEnact = max(result.minEnact, result.minClose) // minEnact must be >= minClose
 	result.maxEnact = max(result.maxEnact, result.minEnact) // maxEnact must be >= minEnact


### PR DESCRIPTION
This PR enables overriding of Governance parameters by using environment variables injected with `-ldflags "-X importpath.Variable=value"`.

As in the Governance readme:

> In order to allow testing of Governance, the following environment variables can be specified in order to compile a binary with custom parameters.
>
> Specify some/all of the following variables. The values for Close and Enact are standard Golang [time.Duration](https://golang.org/pkg/time/#ParseDuration).
>
> ```bash
> env \
> 	VEGA_GOVERNANCE_MIN_CLOSE=3s \
> 	VEGA_GOVERNANCE_MAX_CLOSE=10m \
> 	VEGA_GOVERNANCE_MIN_ENACT=1h \
> 	VEGA_GOVERNANCE_MAX_ENACT=99d \
> 	VEGA_GOVERNANCE_MIN_PARTICIPATION_STAKE=55 \
> 	make install
> ```
>
> If the log level for the Execution engine (not the Governance engine) is Debug, then this message will appear:
>
> ```
> governance/engine.go:68 Governance parameters {"MinClose": "3s", "MaxClose": "10m0s", "MinEnact": "1h0m0s", "MaxEnact": "99d0h0m0s", "MinParticipationStake": 55}
> ```
