### PR TITLE
Compile and use custom binary for system-tests (#1665)

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -42,7 +42,16 @@ steps:
       - echo "$${GITHUB_DEPLOY_SSH_PRIVATE_KEY}" >~/.ssh/id_rsa ; chmod 0600 ~/.ssh/id_rsa
       - ssh-keyscan github.com 1>~/.ssh/known_hosts 2>/dev/null ; chmod 0644 ~/.ssh/known_hosts
       - unset GITHUB_DEPLOY_SSH_PRIVATE_KEY
+      # Build normal executable
       - ./script/build.sh -t linux/amd64
+      # Build executable for sytstem-tests, with custom Governance parameters. 8760h is 24*365 hours.
+      - env
+          VEGA_GOVERNANCE_MIN_CLOSE=5s
+          VEGA_GOVERNANCE_MAX_CLOSE=8760h
+          VEGA_GOVERNANCE_MIN_ENACT=5s
+          VEGA_GOVERNANCE_MAX_ENACT=8760h
+          VEGA_GOVERNANCE_MIN_PARTICIPATION_STAKE=1
+          ./script/build.sh -t linux/amd64 -s "-systemtests"
     depends_on:
       - fetch
     when:
@@ -104,9 +113,9 @@ steps:
     commands:
       # https://github.com/vegaprotocol/system-tests/blob/master/systemtests.sh
       - codefile="$$(mktemp)" ; logfile="$$(mktemp)"
-      - ln -fs vega-linux-amd64 cmd/vega/vega
+      # Run system-tests, using previously built executable with custom Governance parameters.
       - (
-          /usr/local/bin/systemtests.sh -v all ;
+          /usr/local/bin/systemtests.sh -x "$$PWD/cmd/vega/vega-linux-amd64-systemtests" -v all ;
           echo "$$?" >"$$codefile"
         ) 2>&1 | tee "$$logfile"
       - test "$$(cat "$$codefile")" = 0 && exit 0

--- a/governance/README.md
+++ b/governance/README.md
@@ -85,9 +85,9 @@ Specify some/all of the following variables. The values for Close and Enact are 
 ```bash
 env \
 	VEGA_GOVERNANCE_MIN_CLOSE=3s \
-	VEGA_GOVERNANCE_MAX_CLOSE=10m \
+	VEGA_GOVERNANCE_MAX_CLOSE=24h \
 	VEGA_GOVERNANCE_MIN_ENACT=1h \
-	VEGA_GOVERNANCE_MAX_ENACT=99d \
+	VEGA_GOVERNANCE_MAX_ENACT=8760h \
 	VEGA_GOVERNANCE_MIN_PARTICIPATION_STAKE=55 \
 	make install
 ```
@@ -95,5 +95,5 @@ env \
 If the log level for the Execution engine (not the Governance engine) is Debug, then this message will appear:
 
 ```
-governance/engine.go:68 Governance parameters {"MinClose": "3s", "MaxClose": "10m0s", "MinEnact": "1h0m0s", "MaxEnact": "99d0h0m0s", "MinParticipationStake": 55}
+governance/engine.go:68 Governance parameters {"MinClose": "3s", "MaxClose": "24h0m0s", "MinEnact": "1h0m0s", "MaxEnact": "8760h0m0s", "MinParticipationStake": 55}
 ```

--- a/script/build.sh
+++ b/script/build.sh
@@ -182,9 +182,7 @@ run() {
 			continue
 		fi
 
-		if !can_build "$target" "$cc" "$cxx" ; then
-			continue
-		fi
+		can_build "$target" "$cc" "$cxx" || continue
 
 		export \
 			CC="$cc" \

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get a list of apps to build by looking at the directories in cmd.
 mapfile -t apps < <(find cmd -maxdepth 1 -and -not -name cmd | sed -e 's#^cmd/##')
@@ -13,10 +13,11 @@ alltargets=( \
 help() {
 	echo "Command line arguments:"
 	echo
-	echo "  -d       Build debug binaries"
-	echo "  -T       Build all available GOOS+GOARCH combinations (see below)"
-	echo "  -t list  Build specified GOOS+GOARCH combinations"
-	echo "  -h       Show this help"
+	echo "  -d         Build debug binaries"
+	echo "  -T         Build all available GOOS+GOARCH combinations (see below)"
+	echo "  -t list    Build specified GOOS+GOARCH combinations"
+	echo "  -s suffix  Add arbitrary suffix to compiled binary names"
+	echo "  -h         Show this help"
 	echo
 	echo "Apps to be built:"
 	for app in "${apps[@]}" ; do
@@ -59,15 +60,19 @@ set_ldflags() {
 parse_args() {
 	# set defaults
 	gcflags=""
+	dbgsuffix=""
 	suffix=""
 	targets=()
 
-	while getopts 'dTt:h' flag; do
+	while getopts 'ds:Tt:h' flag; do
 		case "$flag" in
 		d)
 			gcflags="all=-N -l"
-			suffix="-dbg"
+			dbgsuffix="-dbg"
 			version="debug-$version"
+			;;
+		s)
+			suffix="$OPTARG"
 			;;
 		t)
 			mapfile -t targets < <(echo "$OPTARG" | tr ' ,' '\n')
@@ -93,6 +98,23 @@ parse_args() {
 	fi
 }
 
+can_build() {
+	local canbuild target
+	canbuild=0
+	target="$1" ; shift
+	for compiler in "$@" ; do
+		if test -z "$compiler" ; then
+			continue
+		fi
+
+		if ! which command -v "$compiler" 1>/dev/null ; then
+			echo "$target: Cannot build. Need $compiler"
+			canbuild=1
+		fi
+	done
+	return "$canbuild"
+}
+
 run() {
 	set_version
 	parse_args "$@"
@@ -108,6 +130,7 @@ run() {
 		goarm=""
 		goarch="$(echo "$target" | cut -f2 -d/)"
 		goos="$(echo "$target" | cut -f1 -d/)"
+		typesuffix=""
 		skip=no
 		case "$target" in
 		darwin/*)
@@ -141,7 +164,7 @@ run() {
 			cxx=mips64el-linux-gnuabi64-g++-9
 			;;
 		windows/*)
-			o="$o.exe"
+			typesuffix=".exe"
 			cc=x86_64-w64-mingw32-gcc-posix
 			cxx=x86_64-w64-mingw32-g++-posix
 			# https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=vs-2019
@@ -156,6 +179,10 @@ run() {
 		esac
 
 		if test "$skip" == yes ; then
+			continue
+		fi
+
+		if !can_build "$target" "$cc" "$cxx" ; then
 			continue
 		fi
 
@@ -204,7 +231,7 @@ run() {
 		fi
 
 		for app in "${apps[@]}" ; do
-			o="cmd/$app/$app-$goos-$goarch$suffix"
+			o="cmd/$app/$app-$goos-$goarch$dbgsuffix$suffix$typesuffix"
 			log="$o.log"
 			echo "$target: go build $o ... "
 			rm -f "$o" "$log"


### PR DESCRIPTION
This PR:

* compiles a custom vega binary using custom Governance parameters
* runs system-tests using the custom binary

Closes #1665.
Closes #1685 (minor change to build script `!#` line)