### PR TITLE
Prevent a user from cancelling an order they did not create

### DIFF
--- a/execution/engine.go
+++ b/execution/engine.go
@@ -420,6 +420,9 @@ func (e *Engine) CancelOrder(order *types.OrderCancellation) (*types.OrderCancel
 	if !ok {
 		return nil, types.ErrInvalidMarketID
 	}
+
+	// Check cancel is from the same user as the original order
+
 	conf, err := mkt.CancelOrder(order)
 	if err != nil {
 		return nil, err

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -421,8 +421,6 @@ func (e *Engine) CancelOrder(order *types.OrderCancellation) (*types.OrderCancel
 		return nil, types.ErrInvalidMarketID
 	}
 
-	// Check cancel is from the same user as the original order
-
 	conf, err := mkt.CancelOrder(order)
 	if err != nil {
 		return nil, err

--- a/execution/market.go
+++ b/execution/market.go
@@ -1077,6 +1077,17 @@ func (m *Market) CancelOrder(oc *types.OrderCancellation) (*types.OrderCancellat
 		return nil, err
 	}
 
+	// Only allow the original order creator to cancel their order
+	if order.PartyID != oc.PartyID {
+		if m.log.GetLevel() == logging.DebugLevel {
+			m.log.Debug("Party ID mismatch",
+				logging.String("party-id", oc.PartyID),
+				logging.String("order-id", oc.OrderID),
+				logging.String("market", m.mkt.Id))
+		}
+		return nil, types.ErrInvalidPartyID
+	}
+
 	cancellation, err := m.matching.CancelOrder(order)
 	if cancellation == nil || err != nil {
 		if m.log.GetLevel() == logging.DebugLevel {


### PR DESCRIPTION
Looking to see why we can cancel an order from another user.
Closes #1611