### PR TITLE
require vega wallet at startup of processor

### DIFF
--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -352,7 +352,10 @@ func (l *NodeCommand) preRun(_ *cobra.Command, _ []string) (err error) {
 
 	// TODO(jeremy): for now we assume a node started without the stores support
 	// is a validator, this will need to be changed later on.
-	l.processor = processor.New(l.Log, l.conf.Processor, l.executionEngine, l.timeService, l.stats.Blockchain, commander, l.nodeWallet, l.assets, l.topology, !l.noStores)
+	l.processor, err = processor.New(l.Log, l.conf.Processor, l.executionEngine, l.timeService, l.stats.Blockchain, commander, l.nodeWallet, l.assets, l.topology, !l.noStores)
+	if err != nil {
+		return err
+	}
 
 	l.cfgwatchr.OnConfigUpdate(func(cfg config.Config) { l.executionEngine.ReloadConf(cfg.Execution) })
 


### PR DESCRIPTION
closes #1704 

This load thevega wallet from the nodewallet when the Processor is constructed so we would return an error straight  away instead of loading the wallet everytime we need it, and produce an error then.