### PR TITLE
Remove expiry time validation from PrepareAmend call

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1188,6 +1188,17 @@ func (m *Market) AmendOrder(orderAmendment *types.OrderAmendment) (*types.OrderC
 		}, nil
 	}
 
+	// if expiration has changed and is before the original creation time, reject this amend
+	if amendedOrder.ExpiresAt != 0 && amendedOrder.ExpiresAt < existingOrder.CreatedAt {
+		if m.log.GetLevel() == logging.DebugLevel {
+			m.log.Debug("Amended expiry before original creation time",
+				logging.Int64("original order created at ts:", existingOrder.CreatedAt),
+				logging.Int64("amended expiry ts:", amendedOrder.ExpiresAt),
+				logging.Order(*existingOrder))
+		}
+		return nil, types.ErrInvalidExpirationDatetime
+	}
+
 	// if expiration has changed and is not 0, and is before currentTime
 	// then we expire the order
 	if amendedOrder.ExpiresAt != 0 && amendedOrder.ExpiresAt < amendedOrder.UpdatedAt {

--- a/orders/amend_order_test.go
+++ b/orders/amend_order_test.go
@@ -30,7 +30,7 @@ func TestPrepareAmendOrder(t *testing.T) {
 	t.Run("Prepare amend order increase - success", testPrepareAmendOrderJustIncreaseSuccess)
 	t.Run("Prepare amend order expiry - success", testPrepareAmendOrderJustExpirySuccess)
 	t.Run("Prepare amend order tif - success", testPrepareAmendOrderJustTIFSuccess)
-
+	t.Run("Prepare amend order expiry before creation time - success", testPrepareAmendOrderPastExpiry)
 	t.Run("Prepare amend order empty - fail", testPrepareAmendOrderEmptyFail)
 	t.Run("Prepare amend order nil - fail", testPrepareAmendOrderNilFail)
 	t.Run("Prepare amend order invalid expiry type - fail", testPrepareAmendOrderInvalidExpiryFail)
@@ -148,4 +148,22 @@ func testPrepareAmendOrderInvalidExpiryFail(t *testing.T) {
 	arg.TimeInForce = proto.Order_IOC
 	err = svc.svc.PrepareAmendOrder(context.Background(), &arg)
 	assert.Error(t, err)
+}
+
+/*
+ * Sending an old expiry date is OK and should not be rejected here.
+ * The validation should take place inside the core
+ */
+func testPrepareAmendOrderPastExpiry(t *testing.T) {
+	arg := proto.OrderAmendment{
+		OrderID:     "orderid",
+		PartyID:     "partyid",
+		TimeInForce: proto.Order_GTT,
+		ExpiresAt:   &proto.Timestamp{Value: 10},
+	}
+	svc := getTestService(t)
+	defer svc.ctrl.Finish()
+
+	err := svc.svc.PrepareAmendOrder(context.Background(), &arg)
+	assert.NoError(t, err)
 }

--- a/orders/service.go
+++ b/orders/service.go
@@ -210,12 +210,6 @@ func (s *Svc) PrepareAmendOrder(ctx context.Context, amendment *types.OrderAmend
 			s.log.Error("unable to set trade type to GTT when no expiry given")
 			return ErrGTTOrderWithNoExpiry
 		}
-
-		_, err := s.validateOrderExpirationTS(amendment.ExpiresAt.Value)
-		if err != nil {
-			s.log.Error("unable to get expiration time", logging.Error(err))
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
The validation of the amended expiry time is against the current time and the createAt time. This must be done post chain.

Closes #1661 