### PR TITLE
Add CI step to send changelog to Slack (#1735)

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -316,6 +316,18 @@ steps:
     depends_on:
       - build-multiarch
 
+  - name: changelog_slack
+    image: docker.pkg.github.com/vegaprotocol/devops-infra/cipipeline:1.11.13
+    environment:
+      SLACK_HOOK_URL:
+        from_secret: SLACK_HOOK_URL
+    commands:
+      - /usr/local/bin/changelog-slack.sh "$$DRONE_TAG" "$$SLACK_HOOK_URL"
+    when:
+      event: tag
+    depends_on:
+      - publish_artefacts
+
 volumes:
   - name: dockersock
     host:


### PR DESCRIPTION
This PR adds a Drone CI step that is run on tags, and sends the changelog entry for that tag to Slack.

e.g. With a tag of `v1.2.3`, and the following changelog:

```markdown
# Changelog

## 1.2.3

*yyyy-mm-dd*

This release adds feature X.

### Features

- Add feature X

### Improvements

-  Fix a bug in [example](https://www.example.com/)

## 1.2.2

*yyyy-mm-dd*

... and so on
```

the following is posted to Slack

> A release was tagged: **v1.2.3**
>
> *yyyy-mm-dd*
>
> This release adds feature X.
>
> **Features**
>
> - Add feature X
>
> **Improvements**
>
> - Fix a bug in [example](https://www.example.com/)

Closes #1735.
Closes vegaprotocol/devops-infra#113.
