### PR TITLE
A order being amended to GTT does not return GTT when cancelled

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1202,6 +1202,8 @@ func (m *Market) AmendOrder(orderAmendment *types.OrderAmendment) (*types.OrderC
 	// if expiration has changed and is not 0, and is before currentTime
 	// then we expire the order
 	if amendedOrder.ExpiresAt != 0 && amendedOrder.ExpiresAt < amendedOrder.UpdatedAt {
+		// Update the exiting message in place before we cancel it
+		m.orderAmendInPlace(existingOrder, amendedOrder)
 		cancellation, err := m.matching.CancelOrder(amendedOrder)
 		if cancellation == nil || err != nil {
 			if m.log.GetLevel() == logging.DebugLevel {

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -277,3 +277,55 @@ func TestMarkPriceUpdateAfterPartialFill(t *testing.T) {
 	// Validate that the mark price has been updated
 	assert.EqualValues(t, tm.market.GetMarketData().MarkPrice, 10)
 }
+
+func TestExpireCancelGTCOrder(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(10000000000, 0)
+	tm := getTestMarket(t, now, closingAt)
+
+	addAccount(tm, party1)
+	tm.orderStore.EXPECT().Add(gomock.Any()).AnyTimes()
+	tm.accountBuf.EXPECT().Add(gomock.Any()).AnyTimes()
+	tm.tradeStore.EXPECT().Add(gomock.Any()).AnyTimes()
+	tm.candleStore.EXPECT().AddTrade(gomock.Any()).AnyTimes()
+	tm.candleStore.EXPECT().Flush(gomock.Any(), gomock.Any()).AnyTimes()
+
+	orderBuy := &types.Order{
+		TimeInForce: types.Order_GTC,
+		Id:          "someid",
+		Side:        types.Side_Buy,
+		PartyID:     party1,
+		MarketID:    tm.market.GetID(),
+		Size:        100,
+		Price:       10,
+		Remaining:   100,
+		Reference:   "party1-buy-order",
+		Type:        types.Order_LIMIT,
+	}
+	// Submit the original order
+	buyConfirmation, err := tm.market.SubmitOrder(orderBuy)
+	assert.NotNil(t, buyConfirmation)
+	assert.NoError(t, err)
+
+	// Move the current time forward
+	tm.market.OnChainTimeUpdate(time.Unix(10, 100))
+
+	amend := &types.OrderAmendment{
+		OrderID:     buyConfirmation.GetOrder().GetId(),
+		PartyID:     party1,
+		MarketID:    tm.market.GetID(),
+		ExpiresAt:   &types.Timestamp{Value: 10000000010},
+		TimeInForce: types.Order_GTT,
+	}
+	amended, err := tm.market.AmendOrder(amend)
+	assert.NotNil(t, amended)
+	assert.NoError(t, err)
+
+	// Validate that the mark price has been updated
+	assert.EqualValues(t, amended.Order.TimeInForce, types.Order_GTT)
+	assert.EqualValues(t, amended.Order.Status, types.Order_Expired)
+	assert.EqualValues(t, amended.Order.CreatedAt, 10000000000)
+	assert.EqualValues(t, amended.Order.ExpiresAt, 10000000010)
+	assert.EqualValues(t, amended.Order.UpdatedAt, 10000000100)
+}


### PR DESCRIPTION
If a GTC order is amended to GTT with an expiry value which will result in the order being cancelled, the TIF flag is not updated before the order is cancelled. This can be confusing for the user as how could the expiry be set if the order was GTC.

The code is being updated to amend the order in this case before the cancel is handled.