### PR TITLE
Adding validation for correct partyID when amending

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1158,6 +1158,16 @@ func (m *Market) AmendOrder(orderAmendment *types.OrderAmendment) (*types.OrderC
 		return nil, types.ErrInvalidOrderID
 	}
 
+	// We can only amend this order if we created it
+	if existingOrder.PartyID != orderAmendment.PartyID {
+		if m.log.GetLevel() == logging.DebugLevel {
+			m.log.Debug("Invalid party ID",
+				logging.String("original party id:", existingOrder.PartyID),
+				logging.String("amend party id:", orderAmendment.PartyID))
+		}
+		return nil, types.ErrInvalidPartyID
+	}
+
 	// Validate Market
 	if existingOrder.MarketID != m.mkt.Id {
 		if m.log.GetLevel() == logging.DebugLevel {


### PR DESCRIPTION
This PR adds a validation step for amends that the PartyID given in the amend matches the PartyID of the original order.
Added a unit test to confirm this is correct