### PR TITLE
Expiration settlement date for market changed to 30/10/2020-22:59:59

### DIFF
--- a/cmd/vega/init.go
+++ b/cmd/vega/init.go
@@ -210,7 +210,7 @@ func createDefaultMarkets(confpath string) ([]string, error) {
 			baseName:              "GBP",
 			quoteName:             "VUSD",
 			settlementAsset:       "VUSD",
-			maturity:              time.Date(2020, 6, 30, 22, 59, 59, 0, time.UTC),
+			maturity:              time.Date(2020, 10, 30, 22, 59, 59, 0, time.UTC),
 			initialMarkPrice:      130000,
 			settlementValue:       126000,
 			riskAversionParameter: 0.01,


### PR DESCRIPTION

Market is due to expire on 30/06, extending to October as settlement at expiry is not tested/ready yet.

```
baseName:              "GBP",
quoteName:             "VUSD",
settlementAsset:       "VUSD"
```
