### PR TITLE
Bugfix/1779 reject network order

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -366,10 +366,10 @@ func (m *Market) SubmitOrder(ctx context.Context, order *types.Order) (*types.Or
 		return nil, ErrMarketClosed
 	}
 
-	if order.Type == types.Order_NETWORK {
+	if order.Type == types.Order_TYPE_NETWORK {
 		// adding order to the buffer first
 		order.Status = types.Order_STATUS_REJECTED
-		order.Reason = types.OrderError_INVALID_TYPE
+		order.Reason = types.OrderError_ORDER_ERROR_INVALID_TYPE
 		m.broker.Send(events.NewOrderEvent(ctx, order))
 		return nil, ErrInvalidOrderType
 	}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -70,7 +70,7 @@ func theFollowingTraders(arg1 *gherkin.DataTable) error {
 			Amount:   u64val(row, 1),
 		}
 
-		err := execsetup.engine.NotifyTraderAccount(context.TODO(), &notif)
+		err := execsetup.engine.NotifyTraderAccount(context.Background, &notif)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func theMakesADepositOfIntoTheAccount(trader, amountstr, asset string) error {
 		Amount:   amount,
 	}
 
-	err := execsetup.engine.NotifyTraderAccount(context.TODO(), &notif)
+	err := execsetup.engine.NotifyTraderAccount(context.Background, &notif)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func theWithdrawFromTheAccount(trader, amountstr, asset string) error {
 		Asset:   asset,
 	}
 
-	err := execsetup.engine.Withdraw(context.TODO(), &notif)
+	err := execsetup.engine.Withdraw(context.Background, &notif)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func tradersPlaceFollowingOrders(orders *gherkin.DataTable) error {
 			TimeInForce: tif,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		result, err := execsetup.engine.SubmitOrder(context.TODO(), &order)
+		result, err := execsetup.engine.SubmitOrder(context.Background, &order)
 		if err != nil {
 			return fmt.Errorf("unable to place order, err=%v (trader=%v)", err, val(row, 0))
 		}
@@ -281,7 +281,7 @@ func missingTradersPlaceFollowingOrdersWithReferences(orders *gherkin.DataTable)
 			CreatedAt:   time.Now().UnixNano(),
 			Reference:   val(row, 8),
 		}
-		if _, err := execsetup.engine.SubmitOrder(context.TODO(), &order); err == nil {
+		if _, err := execsetup.engine.SubmitOrder(context.Background, &order); err == nil {
 			return fmt.Errorf("expected trader %s to not exist", order.PartyID)
 		}
 	}
@@ -318,7 +318,7 @@ func tradersPlaceFollowingOrdersWithReferences(orders *gherkin.DataTable) error 
 			CreatedAt:   time.Now().UnixNano(),
 			Reference:   val(row, 8),
 		}
-		result, err := execsetup.engine.SubmitOrder(context.TODO(), &order)
+		result, err := execsetup.engine.SubmitOrder(context.Background, &order)
 		if err != nil {
 			return err
 		}
@@ -346,7 +346,7 @@ func tradersCancelsTheFollowingFilledOrdersReference(refs *gherkin.DataTable) er
 			MarketID: o.MarketID,
 		}
 
-		if _, err = execsetup.engine.CancelOrder(context.TODO(), &cancel); err == nil {
+		if _, err = execsetup.engine.CancelOrder(context.Background, &cancel); err == nil {
 			return fmt.Errorf("successfully cancelled order for trader %s (reference %s)", o.PartyID, o.Reference)
 		}
 	}
@@ -371,7 +371,7 @@ func missingTradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) e
 			MarketID: o.MarketID,
 		}
 
-		if _, err = execsetup.engine.CancelOrder(context.TODO(), &cancel); err == nil {
+		if _, err = execsetup.engine.CancelOrder(context.Background, &cancel); err == nil {
 			return fmt.Errorf("successfully cancelled order for trader %s (reference %s)", o.PartyID, o.Reference)
 		}
 	}
@@ -396,7 +396,7 @@ func tradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			MarketID: o.MarketID,
 		}
 
-		_, err = execsetup.engine.CancelOrder(context.TODO(), &cancel)
+		_, err = execsetup.engine.CancelOrder(context.Background, &cancel)
 		if err != nil {
 			return fmt.Errorf("unable to cancel order for trader %s, reference %s", o.PartyID, o.Reference)
 		}
@@ -548,7 +548,7 @@ func tradersCannotPlaceTheFollowingOrdersAnymore(orders *gherkin.DataTable) erro
 			TimeInForce: proto.Order_TIF_GTT,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		_, err := execsetup.engine.SubmitOrder(context.TODO(), &order)
+		_, err := execsetup.engine.SubmitOrder(context.Background, &order)
 		if err == nil {
 			return fmt.Errorf("expected error (%v) but got (%v)", val(row, 6), err)
 		}
@@ -617,7 +617,7 @@ func tradersPlaceFollowingFailingOrders(orders *gherkin.DataTable) error {
 			TimeInForce: proto.Order_TIF_GTT,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		_, err = execsetup.engine.SubmitOrder(context.TODO(), &order)
+		_, err = execsetup.engine.SubmitOrder(context.Background, &order)
 		if err == nil {
 			return fmt.Errorf("expected error (%v) but got (%v)", val(row, 5), err)
 		}
@@ -799,7 +799,7 @@ func tradersAmendsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			TimeInForce: tif,
 		}
 
-		_, err = execsetup.engine.AmendOrder(context.TODO(), &amend)
+		_, err = execsetup.engine.AmendOrder(context.Background, &amend)
 		if err != nil && success {
 			return fmt.Errorf("expected to succeed amending but failed for trader %s (reference %s, err %v)", o.PartyID, o.Reference, err)
 		}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -70,7 +70,7 @@ func theFollowingTraders(arg1 *gherkin.DataTable) error {
 			Amount:   u64val(row, 1),
 		}
 
-		err := execsetup.engine.NotifyTraderAccount(context.Background, &notif)
+		err := execsetup.engine.NotifyTraderAccount(context.Background(), &notif)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func theMakesADepositOfIntoTheAccount(trader, amountstr, asset string) error {
 		Amount:   amount,
 	}
 
-	err := execsetup.engine.NotifyTraderAccount(context.Background, &notif)
+	err := execsetup.engine.NotifyTraderAccount(context.Background(), &notif)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func theWithdrawFromTheAccount(trader, amountstr, asset string) error {
 		Asset:   asset,
 	}
 
-	err := execsetup.engine.Withdraw(context.Background, &notif)
+	err := execsetup.engine.Withdraw(context.Background(), &notif)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func tradersPlaceFollowingOrders(orders *gherkin.DataTable) error {
 			TimeInForce: tif,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		result, err := execsetup.engine.SubmitOrder(context.Background, &order)
+		result, err := execsetup.engine.SubmitOrder(context.Background(), &order)
 		if err != nil {
 			return fmt.Errorf("unable to place order, err=%v (trader=%v)", err, val(row, 0))
 		}
@@ -281,7 +281,7 @@ func missingTradersPlaceFollowingOrdersWithReferences(orders *gherkin.DataTable)
 			CreatedAt:   time.Now().UnixNano(),
 			Reference:   val(row, 8),
 		}
-		if _, err := execsetup.engine.SubmitOrder(context.Background, &order); err == nil {
+		if _, err := execsetup.engine.SubmitOrder(context.Background(), &order); err == nil {
 			return fmt.Errorf("expected trader %s to not exist", order.PartyID)
 		}
 	}
@@ -318,7 +318,7 @@ func tradersPlaceFollowingOrdersWithReferences(orders *gherkin.DataTable) error 
 			CreatedAt:   time.Now().UnixNano(),
 			Reference:   val(row, 8),
 		}
-		result, err := execsetup.engine.SubmitOrder(context.Background, &order)
+		result, err := execsetup.engine.SubmitOrder(context.Background(), &order)
 		if err != nil {
 			return err
 		}
@@ -346,7 +346,7 @@ func tradersCancelsTheFollowingFilledOrdersReference(refs *gherkin.DataTable) er
 			MarketID: o.MarketID,
 		}
 
-		if _, err = execsetup.engine.CancelOrder(context.Background, &cancel); err == nil {
+		if _, err = execsetup.engine.CancelOrder(context.Background(), &cancel); err == nil {
 			return fmt.Errorf("successfully cancelled order for trader %s (reference %s)", o.PartyID, o.Reference)
 		}
 	}
@@ -371,7 +371,7 @@ func missingTradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) e
 			MarketID: o.MarketID,
 		}
 
-		if _, err = execsetup.engine.CancelOrder(context.Background, &cancel); err == nil {
+		if _, err = execsetup.engine.CancelOrder(context.Background(), &cancel); err == nil {
 			return fmt.Errorf("successfully cancelled order for trader %s (reference %s)", o.PartyID, o.Reference)
 		}
 	}
@@ -396,7 +396,7 @@ func tradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			MarketID: o.MarketID,
 		}
 
-		_, err = execsetup.engine.CancelOrder(context.Background, &cancel)
+		_, err = execsetup.engine.CancelOrder(context.Background(), &cancel)
 		if err != nil {
 			return fmt.Errorf("unable to cancel order for trader %s, reference %s", o.PartyID, o.Reference)
 		}
@@ -548,7 +548,7 @@ func tradersCannotPlaceTheFollowingOrdersAnymore(orders *gherkin.DataTable) erro
 			TimeInForce: proto.Order_TIF_GTT,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		_, err := execsetup.engine.SubmitOrder(context.Background, &order)
+		_, err := execsetup.engine.SubmitOrder(context.Background(), &order)
 		if err == nil {
 			return fmt.Errorf("expected error (%v) but got (%v)", val(row, 6), err)
 		}
@@ -617,7 +617,7 @@ func tradersPlaceFollowingFailingOrders(orders *gherkin.DataTable) error {
 			TimeInForce: proto.Order_TIF_GTT,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		_, err = execsetup.engine.SubmitOrder(context.Background, &order)
+		_, err = execsetup.engine.SubmitOrder(context.Background(), &order)
 		if err == nil {
 			return fmt.Errorf("expected error (%v) but got (%v)", val(row, 5), err)
 		}
@@ -799,7 +799,7 @@ func tradersAmendsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			TimeInForce: tif,
 		}
 
-		_, err = execsetup.engine.AmendOrder(context.Background, &amend)
+		_, err = execsetup.engine.AmendOrder(context.Background(), &amend)
 		if err != nil && success {
 			return fmt.Errorf("expected to succeed amending but failed for trader %s (reference %s, err %v)", o.PartyID, o.Reference, err)
 		}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -599,6 +599,11 @@ func tradersPlaceFollowingFailingOrders(orders *gherkin.DataTable) error {
 			continue
 		}
 
+		oty, err := ordertypeval(row, 6)
+		if err != nil {
+			return err
+		}
+
 		order := proto.Order{
 			Id:          uuid.NewV4().String(),
 			MarketID:    val(row, 1),
@@ -608,11 +613,11 @@ func tradersPlaceFollowingFailingOrders(orders *gherkin.DataTable) error {
 			Size:        u64val(row, 3),
 			Remaining:   u64val(row, 3),
 			ExpiresAt:   time.Now().Add(24 * time.Hour).UnixNano(),
-			Type:        proto.Order_TYPE_LIMIT,
+			Type:        oty,
 			TimeInForce: proto.Order_TIF_GTT,
 			CreatedAt:   time.Now().UnixNano(),
 		}
-		_, err := execsetup.engine.SubmitOrder(context.TODO(), &order)
+		_, err = execsetup.engine.SubmitOrder(context.TODO(), &order)
 		if err == nil {
 			return fmt.Errorf("expected error (%v) but got (%v)", val(row, 5), err)
 		}

--- a/integration/features/1779-cannot-place-network-order.feature
+++ b/integration/features/1779-cannot-place-network-order.feature
@@ -16,4 +16,4 @@ Feature: Cannot place an network order
     And "trader1" general accounts balance is "1"
     Then traders place following failing orders:
       | trader  | id        | type | volume | price | error              | type    |
-      | trader1 | ETH/DEC19 | sell |      1 |  1000 | invalid order type | NETWORK |
+      | trader1 | ETH/DEC19 | sell |      1 |  1000 | invalid order type | TYPE_NETWORK |

--- a/integration/features/1779-cannot-place-network-order.feature
+++ b/integration/features/1779-cannot-place-network-order.feature
@@ -1,0 +1,19 @@
+Feature: Cannot place an network order
+
+  Background:
+    Given the insurance pool initial balance for the markets is "0":
+    And the executon engine have these markets:
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 |
+
+  Scenario: an order is rejected if a trader try to place an order with type NETWORK
+    Given the following traders:
+      | name    | amount |
+      | trader1 |      1 |
+    Then I Expect the traders to have new general account:
+      | name    | asset |
+      | trader1 | ETH   |
+    And "trader1" general accounts balance is "1"
+    Then traders place following failing orders:
+      | trader  | id        | type | volume | price | error              | type    |
+      | trader1 | ETH/DEC19 | sell |      1 |  1000 | invalid order type | NETWORK |

--- a/integration/features/margins.feature
+++ b/integration/features/margins.feature
@@ -33,8 +33,8 @@ Feature: Test trader accounts
       | trader1 | ETH   |
     And "trader1" general accounts balance is "1"
     Then traders place following failing orders:
-      | trader  | id        | type | volume | price | error               |
-      | trader1 | ETH/DEC19 | sell |      1 |  1000 | margin check failed |
+      | trader  | id        | type | volume | price | error               | type  |
+      | trader1 | ETH/DEC19 | sell |      1 |  1000 | margin check failed | LIMIT |
     Then the following orders are rejected:
       | trader  | id        | reason                          |
       | trader1 | ETH/DEC19 | ORDER_ERROR_MARGIN_CHECK_FAILED |

--- a/integration/features/margins.feature
+++ b/integration/features/margins.feature
@@ -34,7 +34,7 @@ Feature: Test trader accounts
     And "trader1" general accounts balance is "1"
     Then traders place following failing orders:
       | trader  | id        | type | volume | price | error               | type  |
-      | trader1 | ETH/DEC19 | sell |      1 |  1000 | margin check failed | LIMIT |
+      | trader1 | ETH/DEC19 | sell |      1 |  1000 | margin check failed | TYPE_LIMIT |
     Then the following orders are rejected:
       | trader  | id        | reason                          |
       | trader1 | ETH/DEC19 | ORDER_ERROR_MARGIN_CHECK_FAILED |

--- a/orders/service.go
+++ b/orders/service.go
@@ -46,6 +46,8 @@ var (
 	ErrNoSide = errors.New("no value has been set for the side")
 	// ErrNoType no value has been set for the type
 	ErrNoType = errors.New("no value has been set for the type")
+	// ErrUnAuthorizedOrderType order type is not allowed (most likely NETWORK)
+	ErrUnAuthorizedOrderType = errors.New("unauthorized order type")
 )
 
 // TimeService ...
@@ -176,6 +178,9 @@ func (s *Svc) validateOrderSubmission(sub *types.OrderSubmission) error {
 	}
 	if sub.Type == types.Order_TYPE_LIMIT && sub.Price == 0 {
 		return ErrInvalidPriceForLimitOrder
+	}
+	if sub.Type == types.Order_NETWORK {
+		return ErrUnAuthorizedOrderType
 	}
 
 	return nil

--- a/orders/service.go
+++ b/orders/service.go
@@ -179,7 +179,7 @@ func (s *Svc) validateOrderSubmission(sub *types.OrderSubmission) error {
 	if sub.Type == types.Order_TYPE_LIMIT && sub.Price == 0 {
 		return ErrInvalidPriceForLimitOrder
 	}
-	if sub.Type == types.Order_NETWORK {
+	if sub.Type == types.Order_TYPE_NETWORK {
 		return ErrUnAuthorizedOrderType
 	}
 

--- a/orders/service_test.go
+++ b/orders/service_test.go
@@ -163,7 +163,7 @@ func testCreateOrderFailNetworkOrderType(t *testing.T) {
 	expires := now.Add(time.Hour * 2)
 	order := orderSubmission
 	order.ExpiresAt = expires.UnixNano()
-	order.Type = types.Order_NETWORK
+	order.Type = types.Order_TYPE_NETWORK
 	svc := getTestService(t)
 	defer svc.ctrl.Finish()
 


### PR DESCRIPTION
fixes #1779 

We Ensure the apis and core reject orders with a type of NETWORK which is allowed to be used only by the core when doing position resolution