### PR TITLE
Check for unspecified Vote Value (#1786)

### DIFF
--- a/api/trading.go
+++ b/api/trading.go
@@ -205,6 +205,10 @@ func (s *tradingService) PrepareVote(ctx context.Context, req *protoapi.PrepareV
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
 	}
 
+	if req.Vote.Value == types.Vote_VALUE_UNSPECIFIED {
+		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest)
+	}
+
 	vote, err := s.governanceService.PrepareVote(req.Vote)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrPrepareVote, err)


### PR DESCRIPTION
This PR adds a check during `PrepareVote` that `Vote.Value` is not `UNSPECIFIED`.

Closes #1786.