### PR TITLE
Set the updatedAt field when expiring an order

### DIFF
--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -379,6 +379,7 @@ func (b *OrderBook) RemoveExpiredOrders(expirationTimestamp int64) []types.Order
 			// when they get cancelled as this would required unnecessary computation that
 			// can be delayed for later.
 			order.Status = types.Order_STATUS_EXPIRED
+			order.UpdatedAt = expirationTimestamp
 			out = append(out, *order)
 		}
 	}


### PR DESCRIPTION
Every update to the order object should result in the `updatedAt` field being updated at the same time. When we handle an expired order we do not update that field and it can lead to a confusing situation where the order is expired but the `updateAt` field is a lower value than the `expireAt` field.

This ticket adds the code to update the `updatedAt` field when an order is expired.