### PR TITLE
Set order status for fully filled network orders to be FILLED

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -847,7 +847,7 @@ func (m *Market) zeroOutNetwork(ctx context.Context, traders []events.MarketPosi
 		order.Size = tSize
 		order.Remaining = 0
 		order.Side = nSide
-		order.Status = types.Order_STATUS_ACTIVE // ensure the status is always active
+		order.Status = types.Order_STATUS_FILLED // An order with no remaining must be filled
 		m.idgen.SetID(&order)
 
 		// this is the party order


### PR DESCRIPTION
We were incorrectly setting the order state of a fully filled network order to be ACTIVE.
This change sets the status to FILLED

closes #1801 