### PR TITLE
Removed duplicate updates to createdAt time

### DIFF
--- a/execution/engine.go
+++ b/execution/engine.go
@@ -321,10 +321,6 @@ func (e *Engine) SubmitOrder(ctx context.Context, order *types.Order) (*types.Or
 
 	mkt, ok := e.markets[order.MarketID]
 	if !ok {
-		t, err := e.time.GetTimeNow()
-		if err != nil {
-			order.CreatedAt = t.UnixNano()
-		}
 		e.idgen.SetID(order)
 
 		// adding rejected order to the buf

--- a/execution/market.go
+++ b/execution/market.go
@@ -353,7 +353,6 @@ func (m *Market) SubmitOrder(ctx context.Context, order *types.Order) (*types.Or
 
 	// set those at the begining as even rejected order get through the buffers
 	m.idgen.SetID(order)
-	order.CreatedAt = m.currentTime.UnixNano()
 	order.Version = InitialOrderVersion
 
 	if m.closed {

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -276,6 +276,7 @@ func TestExpireCancelGTCOrder(t *testing.T) {
 	tm.candleStore.EXPECT().Flush(gomock.Any(), gomock.Any()).AnyTimes()
 
 	orderBuy := &types.Order{
+		CreatedAt:   10000000000,
 		Status:      types.Order_STATUS_ACTIVE,
 		TimeInForce: types.Order_TIF_GTC,
 		Id:          "someid",


### PR DESCRIPTION
We should only set the `createdAt` time for a new order when it first comes into the system from the block-chain. All other updates to that value are redundant and will not change the actual value and have been removed.

The only place the `createdAt` field is set is in processor/processor.go: submitOrder()

This has a small impact on unit tests as they will need to set the `createdAt` time themselves instead of relying on the matching-engine to set it.

Closes #1819 