### PR TITLE
Moved expiry time validation to post chain

### DIFF
--- a/integration/core_test.go
+++ b/integration/core_test.go
@@ -263,7 +263,7 @@ func theFollowingOrders(orderT *gherkin.DataTable) error {
 			Price:       uint64(price),
 			Size:        uint64(vol),
 			Remaining:   uint64(vol),
-			ExpiresAt:   tomorrow.Unix(),
+			ExpiresAt:   tomorrow.UnixNano(),
 			Type:        proto.Order_TYPE_LIMIT,
 			TimeInForce: proto.Order_TIF_GTT,
 			CreatedAt:   time.Now().UnixNano(),

--- a/orders/service.go
+++ b/orders/service.go
@@ -9,7 +9,6 @@ import (
 
 	"code.vegaprotocol.io/vega/contextutil"
 	"code.vegaprotocol.io/vega/logging"
-	"code.vegaprotocol.io/vega/vegatime"
 
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -158,10 +157,9 @@ func (s *Svc) validateOrderSubmission(sub *types.OrderSubmission) error {
 	}
 
 	if sub.TimeInForce == types.Order_TIF_GTT {
-		_, err := s.validateOrderExpirationTS(sub.ExpiresAt)
-		if err != nil {
-			s.log.Error("unable to get expiration time", logging.Error(err))
-			return err
+		if sub.ExpiresAt <= 0 {
+			s.log.Error("invalid expiration time")
+			return ErrInvalidExpirationDT
 		}
 	}
 
@@ -229,21 +227,6 @@ func (s *Svc) PrepareAmendOrder(ctx context.Context, amendment *types.OrderAmend
 		}
 	}
 	return nil
-}
-
-func (s *Svc) validateOrderExpirationTS(expiresAt int64) (time.Time, error) {
-	exp := vegatime.UnixNano(expiresAt)
-
-	now, err := s.timeService.GetTimeNow()
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	if exp.Before(now) || exp.Equal(now) {
-		return time.Time{}, ErrInvalidExpirationDT
-	}
-
-	return exp, nil
 }
 
 // GetByOrderID find an order using its orderID

--- a/orders/service_test.go
+++ b/orders/service_test.go
@@ -102,7 +102,6 @@ func testPrepareOrderSuccess(t *testing.T) {
 	svc := getTestService(t)
 	defer svc.ctrl.Finish()
 
-	svc.timeSvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
 	// ensure the blockchain client is not called
 	err := svc.svc.PrepareSubmitOrder(context.Background(), &order)
 	assert.NoError(t, err)
@@ -119,7 +118,6 @@ func testPrepareOrderRefSuccess(t *testing.T) {
 	svc := getTestService(t)
 	defer svc.ctrl.Finish()
 
-	svc.timeSvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
 	// ensure the blockchain client is not called
 	err := svc.svc.PrepareSubmitOrder(context.Background(), &order)
 	assert.NoError(t, err)
@@ -136,7 +134,6 @@ func testOrderSuccess(t *testing.T) {
 	svc := getTestService(t)
 	defer svc.ctrl.Finish()
 
-	svc.timeSvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
 	err := svc.svc.PrepareSubmitOrder(context.Background(), &order)
 	assert.NoError(t, err)
 }
@@ -167,7 +164,6 @@ func testCreateOrderFailNetworkOrderType(t *testing.T) {
 	svc := getTestService(t)
 	defer svc.ctrl.Finish()
 
-	svc.timeSvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
 	err := svc.svc.PrepareSubmitOrder(context.Background(), &order)
 	assert.EqualError(t, err, orders.ErrUnAuthorizedOrderType.Error())
 }


### PR DESCRIPTION
We had the expiresAt validation code in the PrepareOrder function which is an optional function client side for preparing new orders. This was breaking because it can be called before the Vega node is ready. We have moved the validation code from pre-chain to post chain so the VegaTime value is correct.

Closes #1830 