### PR TITLE
Set order state for wash trades to rejected

### DIFF
--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -330,7 +330,7 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 
 	// if we did hit a wash trade, set the status to stopped
 	if err != nil && err == ErrWashTrade {
-		order.Status = types.Order_STATUS_STOPPED
+		order.Status = types.Order_STATUS_REJECTED
 	}
 
 	if order.Status == types.Order_STATUS_ACTIVE {

--- a/matching/simpleorders_test.go
+++ b/matching/simpleorders_test.go
@@ -532,7 +532,7 @@ func TestOrderBookSimple_simpleWashTrade(t *testing.T) {
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(confirm.Trades))
-	assert.Equal(t, order2.Status, types.Order_STATUS_STOPPED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_REJECTED)
 }
 
 func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T) {
@@ -584,7 +584,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(len(confirm.Trades)))
-	assert.Equal(t, order2.Status, types.Order_STATUS_STOPPED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_REJECTED)
 	assert.Equal(t, int(order2.Remaining), 1)
 }
 
@@ -637,7 +637,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStoppedDifferentPrice
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(len(confirm.Trades)))
-	assert.Equal(t, order2.Status, types.Order_STATUS_STOPPED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_REJECTED)
 	assert.Equal(t, int(order2.Remaining), 1)
 }
 


### PR DESCRIPTION
A partially filled wash trade should be rejected but was wrongly being set to stopped. The code has been updated to set the order status to rejected after it has been identified as a wash trade.