### PR TITLE
Link to docs for Order.Status and Order.TimeInForce (#1848)

### DIFF
--- a/proto/api/trading.swagger.json
+++ b/proto/api/trading.swagger.json
@@ -923,7 +923,9 @@
         "STATUS_REJECTED",
         "STATUS_PARTIALLY_FILLED"
       ],
-      "default": "STATUS_INVALID"
+      "default": "STATUS_INVALID",
+      "description": "See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.\n\n - STATUS_INVALID: Default value, always invalid\n - STATUS_ACTIVE: used for active unfilled or partially filled orders\n - STATUS_EXPIRED: used for expired GTT orders\n - STATUS_CANCELLED: used for orders cancelled by the party that created the order\n - STATUS_STOPPED: used for unfilled FOK or IOC orders, and for orders that were stopped by the network\n - STATUS_FILLED: used for closed fully filled orders\n - STATUS_REJECTED: used for orders when not enough collateral was available to fill the margin requirements\n - STATUS_PARTIALLY_FILLED: used for closed partially filled IOC orders",
+      "title": "Order Status"
     },
     "OrderTimeInForce": {
       "type": "string",
@@ -935,7 +937,7 @@
         "TIF_FOK"
       ],
       "default": "TIF_UNSPECIFIED",
-      "description": "- TIF_UNSPECIFIED: Default value, can be valid for an amend\n - TIF_GTC: good til cancelled\n - TIF_GTT: good til time\n - TIF_IOC: immediate or cancel\n - TIF_FOK: fill or kill",
+      "description": "See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.\n\n - TIF_UNSPECIFIED: Default value, can be valid for an amend\n - TIF_GTC: good til cancelled\n - TIF_GTT: good til time\n - TIF_IOC: immediate or cancel\n - TIF_FOK: fill or kill",
       "title": "Order Time in Force"
     },
     "ProposalState": {
@@ -2019,11 +2021,12 @@
         },
         "createdAt": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "nanoseconds since the epoch. See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`."
         },
         "status": {
           "$ref": "#/definitions/OrderStatus",
-          "description": "If `status` is `Rejected`, check `reason`."
+          "description": "If `status` is `STATUS_REJECTED`, check `reason`."
         },
         "expiresAt": {
           "type": "string",

--- a/proto/doc/index.html
+++ b/proto/doc/index.html
@@ -6659,14 +6659,14 @@ Constrained by <tt>minEnactInSeconds</tt> and <tt>maxEnactInSeconds</tt> network
                   <td>createdAt</td>
                   <td><a href="#int64">int64</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>nanoseconds since the epoch. See <a href="#api.VegaTimeResponse"><tt>VegaTimeResponse</tt></a>.<tt>timestamp</tt>. </p></td>
                 </tr>
 
                 <tr>
                   <td>status</td>
                   <td><a href="#vega.Order.Status">Order.Status</a></td>
                   <td></td>
-                  <td><p>If <tt>status</tt> is <tt>Rejected</tt>, check <tt>reason</tt>. </p></td>
+                  <td><p>If <tt>status</tt> is <tt>STATUS_REJECTED</tt>, check <tt>reason</tt>. </p></td>
                 </tr>
 
                 <tr>
@@ -8219,7 +8219,7 @@ after each successful amend </p></td>
         </table>
 
         <h3 id="vega.Order.Status">Order.Status</h3>
-        <p></p>
+        <p>Order Status</p><p>See <a href="https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega">What order types are available to trade on Vega?</a> for details.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>
@@ -8229,56 +8229,56 @@ after each successful amend </p></td>
               <tr>
                 <td>STATUS_INVALID</td>
                 <td>0</td>
-                <td><p></p></td>
+                <td><p>Default value, always invalid</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_ACTIVE</td>
                 <td>1</td>
-                <td><p></p></td>
+                <td><p>used for active unfilled or partially filled orders</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_EXPIRED</td>
                 <td>2</td>
-                <td><p></p></td>
+                <td><p>used for expired GTT orders</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_CANCELLED</td>
                 <td>3</td>
-                <td><p></p></td>
+                <td><p>used for orders cancelled by the party that created the order</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_STOPPED</td>
                 <td>4</td>
-                <td><p></p></td>
+                <td><p>used for unfilled FOK or IOC orders, and for orders that were stopped by the network</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_FILLED</td>
                 <td>5</td>
-                <td><p></p></td>
+                <td><p>used for closed fully filled orders</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_REJECTED</td>
                 <td>6</td>
-                <td><p></p></td>
+                <td><p>used for orders when not enough collateral was available to fill the margin requirements</p></td>
               </tr>
 
               <tr>
                 <td>STATUS_PARTIALLY_FILLED</td>
                 <td>7</td>
-                <td><p></p></td>
+                <td><p>used for closed partially filled IOC orders</p></td>
               </tr>
 
           </tbody>
         </table>
 
         <h3 id="vega.Order.TimeInForce">Order.TimeInForce</h3>
-        <p>Order Time in Force</p>
+        <p>Order Time in Force</p><p>See <a href="https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega">What order types are available to trade on Vega?</a> for details.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>
@@ -8622,7 +8622,7 @@ after each successful amend </p></td>
     <h2 id="scalar-value-types">Scalar Value Types</h2>
     <table class="scalar-value-types-table">
       <thead>
-        <tr><td>.proto Type</td><td>Notes</td><td>C++ Type</td><td>Java Type</td><td>Python Type</td></tr>
+        <tr><td>.proto Type</td><td>Notes</td><td>C++</td><td>Java</td><td>Python</td><td>Go</td><td>C#</td><td>PHP</td><td>Ruby</td></tr>
       </thead>
       <tbody>
 
@@ -8632,6 +8632,10 @@ after each successful amend </p></td>
             <td>double</td>
             <td>double</td>
             <td>float</td>
+            <td>float64</td>
+            <td>double</td>
+            <td>float</td>
+            <td>Float</td>
           </tr>
 
           <tr id="float">
@@ -8640,6 +8644,10 @@ after each successful amend </p></td>
             <td>float</td>
             <td>float</td>
             <td>float</td>
+            <td>float32</td>
+            <td>float</td>
+            <td>float</td>
+            <td>Float</td>
           </tr>
 
           <tr id="int32">
@@ -8648,6 +8656,10 @@ after each successful amend </p></td>
             <td>int32</td>
             <td>int</td>
             <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
           </tr>
 
           <tr id="int64">
@@ -8656,6 +8668,10 @@ after each successful amend </p></td>
             <td>int64</td>
             <td>long</td>
             <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
           </tr>
 
           <tr id="uint32">
@@ -8664,6 +8680,10 @@ after each successful amend </p></td>
             <td>uint32</td>
             <td>int</td>
             <td>int/long</td>
+            <td>uint32</td>
+            <td>uint</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
           </tr>
 
           <tr id="uint64">
@@ -8672,6 +8692,10 @@ after each successful amend </p></td>
             <td>uint64</td>
             <td>long</td>
             <td>int/long</td>
+            <td>uint64</td>
+            <td>ulong</td>
+            <td>integer/string</td>
+            <td>Bignum or Fixnum (as required)</td>
           </tr>
 
           <tr id="sint32">
@@ -8680,6 +8704,10 @@ after each successful amend </p></td>
             <td>int32</td>
             <td>int</td>
             <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
           </tr>
 
           <tr id="sint64">
@@ -8688,6 +8716,10 @@ after each successful amend </p></td>
             <td>int64</td>
             <td>long</td>
             <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
           </tr>
 
           <tr id="fixed32">
@@ -8696,6 +8728,10 @@ after each successful amend </p></td>
             <td>uint32</td>
             <td>int</td>
             <td>int</td>
+            <td>uint32</td>
+            <td>uint</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
           </tr>
 
           <tr id="fixed64">
@@ -8704,6 +8740,10 @@ after each successful amend </p></td>
             <td>uint64</td>
             <td>long</td>
             <td>int/long</td>
+            <td>uint64</td>
+            <td>ulong</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
           </tr>
 
           <tr id="sfixed32">
@@ -8712,6 +8752,10 @@ after each successful amend </p></td>
             <td>int32</td>
             <td>int</td>
             <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
           </tr>
 
           <tr id="sfixed64">
@@ -8720,6 +8764,10 @@ after each successful amend </p></td>
             <td>int64</td>
             <td>long</td>
             <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
           </tr>
 
           <tr id="bool">
@@ -8728,6 +8776,10 @@ after each successful amend </p></td>
             <td>bool</td>
             <td>boolean</td>
             <td>boolean</td>
+            <td>bool</td>
+            <td>bool</td>
+            <td>boolean</td>
+            <td>TrueClass/FalseClass</td>
           </tr>
 
           <tr id="string">
@@ -8736,6 +8788,10 @@ after each successful amend </p></td>
             <td>string</td>
             <td>String</td>
             <td>str/unicode</td>
+            <td>string</td>
+            <td>string</td>
+            <td>string</td>
+            <td>String (UTF-8)</td>
           </tr>
 
           <tr id="bytes">
@@ -8744,6 +8800,10 @@ after each successful amend </p></td>
             <td>string</td>
             <td>ByteString</td>
             <td>str</td>
+            <td>[]byte</td>
+            <td>ByteString</td>
+            <td>string</td>
+            <td>String (ASCII-8BIT)</td>
           </tr>
 
       </tbody>

--- a/proto/doc/index.md
+++ b/proto/doc/index.md
@@ -92,11 +92,8 @@
     - [TradesSubscribeRequest](#api.TradesSubscribeRequest)
     - [VegaTimeResponse](#api.VegaTimeResponse)
 
-
-
     - [trading](#api.trading)
     - [trading_data](#api.trading_data)
-
 
 - [proto/assets.proto](#proto/assets.proto)
     - [Asset](#vega.Asset)
@@ -104,10 +101,6 @@
     - [BuiltinAsset](#vega.BuiltinAsset)
     - [DevAssets](#vega.DevAssets)
     - [ERC20](#vega.ERC20)
-
-
-
-
 
 - [proto/governance.proto](#proto/governance.proto)
     - [GovernanceData](#vega.GovernanceData)
@@ -122,9 +115,6 @@
 
     - [Proposal.State](#vega.Proposal.State)
     - [Vote.Value](#vega.Vote.Value)
-
-
-
 
 - [proto/markets.proto](#proto/markets.proto)
     - [ContinuousTrading](#vega.ContinuousTrading)
@@ -143,10 +133,6 @@
     - [SimpleModelParams](#vega.SimpleModelParams)
     - [SimpleRiskModel](#vega.SimpleRiskModel)
     - [TradableInstrument](#vega.TradableInstrument)
-
-
-
-
 
 - [proto/vega.proto](#proto/vega.proto)
     - [Account](#vega.Account)
@@ -195,9 +181,6 @@
     - [Side](#vega.Side)
     - [Trade.Type](#vega.Trade.Type)
     - [TransferType](#vega.TransferType)
-
-
-
 
 - [Scalar Value Types](#scalar-value-types)
 
@@ -2453,8 +2436,8 @@ Proposal can enter Failed state from any other state.
 | remaining | [uint64](#uint64) |  |  |
 | timeInForce | [Order.TimeInForce](#vega.Order.TimeInForce) |  |  |
 | type | [Order.Type](#vega.Order.Type) |  |  |
-| createdAt | [int64](#int64) |  |  |
-| status | [Order.Status](#vega.Order.Status) |  | If `status` is `Rejected`, check `reason`. |
+| createdAt | [int64](#int64) |  | nanoseconds since the epoch. See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`. |
+| status | [Order.Status](#vega.Order.Status) |  | If `status` is `STATUS_REJECTED`, check `reason`. |
 | expiresAt | [int64](#int64) |  |  |
 | reference | [string](#string) |  |  |
 | reason | [OrderError](#vega.OrderError) |  |  |
@@ -2950,18 +2933,20 @@ Proposal can enter Failed state from any other state.
 <a name="vega.Order.Status"></a>
 
 ### Order.Status
+Order Status
 
+See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| STATUS_INVALID | 0 |  |
-| STATUS_ACTIVE | 1 |  |
-| STATUS_EXPIRED | 2 |  |
-| STATUS_CANCELLED | 3 |  |
-| STATUS_STOPPED | 4 |  |
-| STATUS_FILLED | 5 |  |
-| STATUS_REJECTED | 6 |  |
-| STATUS_PARTIALLY_FILLED | 7 |  |
+| STATUS_INVALID | 0 | Default value, always invalid |
+| STATUS_ACTIVE | 1 | used for active unfilled or partially filled orders |
+| STATUS_EXPIRED | 2 | used for expired GTT orders |
+| STATUS_CANCELLED | 3 | used for orders cancelled by the party that created the order |
+| STATUS_STOPPED | 4 | used for unfilled FOK or IOC orders, and for orders that were stopped by the network |
+| STATUS_FILLED | 5 | used for closed fully filled orders |
+| STATUS_REJECTED | 6 | used for orders when not enough collateral was available to fill the margin requirements |
+| STATUS_PARTIALLY_FILLED | 7 | used for closed partially filled IOC orders |
 
 
 
@@ -2969,6 +2954,8 @@ Proposal can enter Failed state from any other state.
 
 ### Order.TimeInForce
 Order Time in Force
+
+See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -3079,21 +3066,21 @@ Order Type
 
 ## Scalar Value Types
 
-| .proto Type | Notes | C++ Type | Java Type | Python Type |
-| ----------- | ----- | -------- | --------- | ----------- |
-| <a name="double" /> double |  | double | double | float |
-| <a name="float" /> float |  | float | float | float |
-| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
-| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
-| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
-| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
-| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
-| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
-| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
-| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
-| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int |
-| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long |
-| <a name="bool" /> bool |  | bool | boolean | boolean |
-| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
-| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
 

--- a/proto/vega.pb.go
+++ b/proto/vega.pb.go
@@ -290,6 +290,8 @@ func (TransferType) EnumDescriptor() ([]byte, []int) {
 }
 
 // Order Time in Force
+//
+// See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.
 type Order_TimeInForce int32
 
 const (
@@ -365,16 +367,27 @@ func (Order_Type) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_bb6b8173ee11af27, []int{6, 1}
 }
 
+// Order Status
+//
+// See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.
 type Order_Status int32
 
 const (
-	Order_STATUS_INVALID          Order_Status = 0
-	Order_STATUS_ACTIVE           Order_Status = 1
-	Order_STATUS_EXPIRED          Order_Status = 2
-	Order_STATUS_CANCELLED        Order_Status = 3
-	Order_STATUS_STOPPED          Order_Status = 4
-	Order_STATUS_FILLED           Order_Status = 5
-	Order_STATUS_REJECTED         Order_Status = 6
+	// Default value, always invalid
+	Order_STATUS_INVALID Order_Status = 0
+	// used for active unfilled or partially filled orders
+	Order_STATUS_ACTIVE Order_Status = 1
+	// used for expired GTT orders
+	Order_STATUS_EXPIRED Order_Status = 2
+	// used for orders cancelled by the party that created the order
+	Order_STATUS_CANCELLED Order_Status = 3
+	// used for unfilled FOK or IOC orders, and for orders that were stopped by the network
+	Order_STATUS_STOPPED Order_Status = 4
+	// used for closed fully filled orders
+	Order_STATUS_FILLED Order_Status = 5
+	// used for orders when not enough collateral was available to fill the margin requirements
+	Order_STATUS_REJECTED Order_Status = 6
+	// used for closed partially filled IOC orders
 	Order_STATUS_PARTIALLY_FILLED Order_Status = 7
 )
 
@@ -728,8 +741,9 @@ type Order struct {
 	Remaining   uint64            `protobuf:"varint,7,opt,name=remaining,proto3" json:"remaining,omitempty"`
 	TimeInForce Order_TimeInForce `protobuf:"varint,8,opt,name=timeInForce,proto3,enum=vega.Order_TimeInForce" json:"timeInForce,omitempty"`
 	Type        Order_Type        `protobuf:"varint,9,opt,name=type,proto3,enum=vega.Order_Type" json:"type,omitempty"`
-	CreatedAt   int64             `protobuf:"varint,10,opt,name=createdAt,proto3" json:"createdAt,omitempty"`
-	// If `status` is `Rejected`, check `reason`.
+	// nanoseconds since the epoch. See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`.
+	CreatedAt int64 `protobuf:"varint,10,opt,name=createdAt,proto3" json:"createdAt,omitempty"`
+	// If `status` is `STATUS_REJECTED`, check `reason`.
 	Status    Order_Status `protobuf:"varint,11,opt,name=status,proto3,enum=vega.Order_Status" json:"status,omitempty"`
 	ExpiresAt int64        `protobuf:"varint,12,opt,name=expiresAt,proto3" json:"expiresAt,omitempty"`
 	Reference string       `protobuf:"bytes,13,opt,name=reference,proto3" json:"reference,omitempty"`

--- a/proto/vega.proto
+++ b/proto/vega.proto
@@ -84,6 +84,8 @@ message RiskResult {
 message Order {
 
   // Order Time in Force
+  //
+  // See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.
   enum TimeInForce {
     // Default value, can be valid for an amend
     TIF_UNSPECIFIED = 0;
@@ -124,14 +126,32 @@ message Order {
     //       - gateway/graphql/schema.graphql (enum OrderType)
   }
 
+  // Order Status
+  //
+  // See [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega) for details.
   enum Status {
+    // Default value, always invalid
     STATUS_INVALID = 0;
+
+    // used for active unfilled or partially filled orders
     STATUS_ACTIVE = 1;
+
+    // used for expired GTT orders
     STATUS_EXPIRED = 2;
+
+    // used for orders cancelled by the party that created the order
     STATUS_CANCELLED = 3;
+
+    // used for unfilled FOK or IOC orders, and for orders that were stopped by the network
     STATUS_STOPPED = 4;
+
+    // used for closed fully filled orders
     STATUS_FILLED = 5;
+
+    // used for orders when not enough collateral was available to fill the margin requirements
     STATUS_REJECTED = 6;
+
+    // used for closed partially filled IOC orders
     STATUS_PARTIALLY_FILLED = 7;
 
     // Note: If adding an enum value, add a matching entry in:
@@ -146,11 +166,13 @@ message Order {
   uint64 price = 5;
   uint64 size = 6;
   uint64 remaining = 7;
-  TimeInForce timeInForce  = 8;
+  TimeInForce timeInForce = 8;
   Type type = 9;
+
+  // nanoseconds since the epoch. See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`.
   int64 createdAt = 10;
 
-  // If `status` is `Rejected`, check `reason`.
+  // If `status` is `STATUS_REJECTED`, check `reason`.
   Status status = 11;
 
   int64 expiresAt = 12;

--- a/script/gettools.sh
+++ b/script/gettools.sh
@@ -27,7 +27,7 @@ github.com/gordonklaus/ineffassign@v0.0.0-20190601041439-ed7b1b5ee0f8
 github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.8.5
 github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.8.5
 github.com/mwitkow/go-proto-validators/protoc-gen-govalidators@v0.2.0
-github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.3.0
+github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.3.2
 golang.org/x/lint/golint
 golang.org/x/tools/cmd/goimports@v0.0.0-20190329200012-0ec5c269d481
 honnef.co/go/tools/cmd/staticcheck@2019.2.3"


### PR DESCRIPTION
This PR:
- bumps `github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc` to `v1.3.2` (ref vegaprotocol/devops-infra@d5bec4880ae4674e0479917d1135a2068c5643e8) because the old version (v1.3.0) was giving import errors
- adds documentation to `Order.Status` and `Order.TimeInForce`, describing the enum values and pointing to [What order types are available to trade on Vega?](https://docs.vega.xyz/docs/50-trading-questions/#what-order-types-are-available-to-trade-on-vega)
- makes use of a `splat` (vegaprotocol/docs.vega.xyz@887b681aededb8fd6eeb7588b7fb7fbb1928f632) added by @edd so that the links are all `docs.vega.xyz`, and these are _currently_ redirected to `docs.testnet.vega.xyz`.

Closes #1848