### PR TITLE
Preventing logging of retry count when disconnecting

### DIFF
--- a/monitoring/status.go
+++ b/monitoring/status.go
@@ -214,11 +214,11 @@ func (cs *ChainStatus) start(ctx context.Context) {
 			// if status changed to disconnect, we try to call the onChainDisconnect
 			// callback
 			if currentStatus == types.ChainStatus_CHAIN_STATUS_DISCONNECTED && cs.onChainDisconnect != nil && !cs.starting {
-				cs.log.Info("Chain is disconnected, we'll try to reconnect",
-					logging.Int("retries-left", cs.retriesCount),
-				)
 
-				if cs.retriesCount <= 0 {
+				if cs.retriesCount > 0 {
+					cs.log.Info("Chain is disconnected, we'll try to reconnect",
+						logging.Int("retries-left", cs.retriesCount))
+				} else {
 					cs.cfgMu.Lock()
 					cs.log.Info("Chain is still disconnected, shutting down now",
 						logging.Int("retries-count", int(cs.config.Retries)),


### PR DESCRIPTION
Currently the code to handle a chain disconnect waits for 5 seconds and then assumes the worst and tries to shut the Vega node down. However if this shutdown takes more than a second we will see the retry count being logged with a negative number. I have added logic to prevent the logging once the shutdown has been initialised.

Closes #1608 