### PR TITLE
Remove single mutex lock for sending all events, speeds up broker

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -80,8 +80,9 @@ func (b *Broker) Send(event events.Event) {
 				if sub.required {
 					sub.Push(event)
 				} else {
+					ch := sub.C()
 					select {
-					case sub.C() <- event:
+					case ch <- event:
 						continue
 					default:
 						// skip this event


### PR DESCRIPTION
Performance of the event bus is rather stifled because the broker acquires a lock for each event being sent, and holds on to that lock until all subscribers have received the events. This is sub-optimal to say the least. Made some small changes to get a copy of current subscribers, and send off events in a single routine that no longer needs the lock. A lock can be acquired in case of a subscriber being marked as halted, so it'll be removed from the broker.