### PR TITLE
proposal resolver, if a party does not exists build inplace

### DIFF
--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -861,7 +861,15 @@ func (r *myProposalResolver) Party(ctx context.Context, data *types.GovernanceDa
 	if data == nil || data.Proposal == nil {
 		return nil, ErrInvalidProposal
 	}
-	return getParty(ctx, r.log, r.tradingDataClient, data.Proposal.PartyID)
+	p, err := getParty(ctx, r.log, r.tradingDataClient, data.Proposal.PartyID)
+	if p == nil && err == nil {
+		// the api could return an nil party in some cases
+		// e.g: when a party does not exists in the stores
+		// this is not an error, but here we are not checking
+		// if a party exists or not, but what party did propose
+		p = &types.Party{Id: data.Proposal.PartyID}
+	}
+	return p, err
 }
 
 func (r *myProposalResolver) State(ctx context.Context, data *types.GovernanceData) (ProposalState, error) {


### PR DESCRIPTION
When a party does not exists (no deposit ever made for it before) the graphql api for proposal may fail ge the PartyByID, we then construct it in place in order to not get an error to the client.
We could also make the party optional from the Proposal type in the graphql schema, but it would make less senses as party was initially specified, it just did not exists.
 
closes #1885