### PR TITLE
Add subset of system-tests (close-out)

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -755,6 +755,7 @@ func (m *Market) resolveClosedOutTraders(ctx context.Context, distressedMarginEv
 			// Update positions - this is a special trade involving the network as party
 			// so rather than checking this every time we call Update, call special UpdateNetwork
 			m.position.UpdateNetwork(trade)
+			m.settlement.AddTrade(trade)
 		}
 		m.broker.SendBatch(tradeEvts)
 	}

--- a/integration/features/1847-closeout-long.feature
+++ b/integration/features/1847-closeout-long.feature
@@ -47,3 +47,14 @@ Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTest
 
     # then we make sure the insurance pool collected the funds
     And the insurance pool balance is "0" for the market "ETH/DEC19"
+
+    #Then dump orders
+
+    #check positions
+    Then position API produce the following:
+      | trader | volume | unrealisedPNL | realisedPNL |
+      | tt_4   | 4      | -200          | 0           |
+      | tt_5   | 0      | 0             | -100        |
+      | tt_6   | -4     | 200           | -32         |
+      | tt_10  | 30     | 0             | 0           |
+      | tt_11  | -30    | 200           | -70         |

--- a/integration/features/1847-closeout-long.feature
+++ b/integration/features/1847-closeout-long.feature
@@ -55,6 +55,6 @@ Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTest
       | trader | volume | unrealisedPNL | realisedPNL |
       | tt_4   | 4      | -200          | 0           |
       | tt_5   | 0      | 0             | -100        |
-      | tt_6   | -4     | 200           | -32         |
+      | tt_6   | -4     | 200           | -1130       |
       | tt_10  | 30     | 0             | 0           |
       | tt_11  | -30    | 200           | -70         |

--- a/integration/features/1847-closeout-long.feature
+++ b/integration/features/1847-closeout-long.feature
@@ -1,0 +1,49 @@
+Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTests.py & https://github.com/vegaprotocol/scenario-runner/tree/develop/scenarios/QA/issues/86)
+
+  Background:
+    Given the insurance pool initial balance for the markets is "0":
+    And the executon engine have these markets:
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             |
+
+  Scenario: https://drive.google.com/file/d/1bYWbNJvG7E-tcqsK26JMu2uGwaqXqm0L/view
+    # setup accounts
+    Given the following traders:
+      | name  | amount    |
+      | tt_4  | 500000    |
+      | tt_5  | 100       |
+      | tt_6  | 100000000 |
+      | tt_10 | 10000000  |
+      | tt_11 | 10000000  |
+    Then I Expect the traders to have new general account:
+      | name  | asset |
+      | tt_4  | BTC   |
+      | tt_5  | BTC   |
+      | tt_6  | BTC   |
+      | tt_10 | BTC   |
+      | tt_11 | BTC   |
+
+    # place orders and generate trades
+    Then traders place following orders with references:
+      | trader | id        | type | volume | price | resulting trades | type        | tif     | reference |
+      | tt_10  | ETH/DEC19 | buy  | 5      | 100   | 0                | TYPE_LIMIT  | TIF_GTT | tt_10-1   |
+      | tt_11  | ETH/DEC19 | sell | 5      | 100   | 1                | TYPE_LIMIT  | TIF_GTT | tt_11-1   |
+      | tt_4   | ETH/DEC19 | buy  | 2      | 150   | 0                | TYPE_LIMIT  | TIF_GTC | tt_4-1    |
+      | tt_4   | ETH/DEC19 | buy  | 2      | 150   | 0                | TYPE_LIMIT  | TIF_GTC | tt_4-2    |
+      | tt_5   | ETH/DEC19 | buy  | 2      | 150   | 0                | TYPE_LIMIT  | TIF_GTC | tt_5-1    |
+      | tt_6   | ETH/DEC19 | sell | 2      | 150   | 1                | TYPE_LIMIT  | TIF_GTC | tt_6-1    |
+      | tt_5   | ETH/DEC19 | buy  | 2      | 150   | 0                | TYPE_LIMIT  | TIF_GTC | tt_5-2    |
+      | tt_6   | ETH/DEC19 | sell | 2      | 150   | 1                | TYPE_LIMIT  | TIF_GTC | tt_6-2    |
+      | tt_10  | ETH/DEC19 | buy  | 25     | 100   | 0                | TYPE_LIMIT  | TIF_GTC | tt_10-2   |
+      | tt_11  | ETH/DEC19 | sell | 25     | 0     | 3                | TYPE_MARKET | TIF_FOK | tt_11-2   |
+
+
+    And the mark price for the market "ETH/DEC19" is "100"
+
+    # checking margins
+    Then I expect the trader to have a margin:
+      | trader | asset | id        | margin | general |
+      | tt_5   | BTC   | ETH/DEC19 | 0      | 0       |
+
+    # then we make sure the insurance pool collected the funds
+    And the insurance pool balance is "0" for the market "ETH/DEC19"

--- a/integration/features/1847-closeout-short.feature
+++ b/integration/features/1847-closeout-short.feature
@@ -46,11 +46,6 @@ Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTest
     # then we make sure the insurance pool collected the funds
     And the insurance pool balance is "100" for the market "ETH/DEC19"
 
-    #check positions
-    Then position API produce the following:
-      | trader | volume | unrealisedPNL | realisedPNL |
-      | tt_15  | 0      | 0             | -100        |
-
     #Then dump orders
 
     #check positions

--- a/integration/features/1847-closeout-short.feature
+++ b/integration/features/1847-closeout-short.feature
@@ -1,0 +1,64 @@
+Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTests.py)
+
+  Background:
+    Given the insurance pool initial balance for the markets is "0":
+    And the executon engine have these markets:
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             |
+
+  Scenario: https://drive.google.com/file/d/1bYWbNJvG7E-tcqsK26JMu2uGwaqXqm0L/view
+    # setup accounts
+    Given the following traders:
+      | name  | amount   |
+      | tt_12 | 10000000 |
+      | tt_13 | 10000000 |
+      | tt_14 | 10000000 |
+      | tt_15 | 100      |
+      | tt_16 | 10000000 |
+    Then I Expect the traders to have new general account:
+      | name  | asset |
+      | tt_12 | BTC   |
+      | tt_13 | BTC   |
+      | tt_14 | BTC   |
+      | tt_15 | BTC   |
+      | tt_16 | BTC   |
+
+    # place orders and generate trades
+    Then traders place following orders with references:
+      | trader | id        | type | volume | price | resulting trades | type       | tif     | reference |
+      | tt_12  | ETH/DEC19 | buy  | 5      | 20    | 0                | TYPE_LIMIT | TIF_GTT | tt_12-1   |
+      | tt_13  | ETH/DEC19 | sell | 5      | 20    | 1                | TYPE_LIMIT | TIF_GTT | tt_13-1   |
+      | tt_14  | ETH/DEC19 | sell | 2      | 50    | 0                | TYPE_LIMIT | TIF_GTC | tt_14-1   |
+      | tt_14  | ETH/DEC19 | sell | 2      | 50    | 0                | TYPE_LIMIT | TIF_GTC | tt_14-2   |
+      | tt_15  | ETH/DEC19 | sell | 2      | 20    | 0                | TYPE_LIMIT | TIF_GTC | tt_15-1   |
+      | tt_16  | ETH/DEC19 | buy  | 2      | 20    | 1                | TYPE_LIMIT | TIF_GTC | tt_16-1   |
+      | tt_15  | ETH/DEC19 | sell | 2      | 20    | 0                | TYPE_LIMIT | TIF_GTC | tt_15-2   |
+      | tt_16  | ETH/DEC19 | buy  | 2      | 20    | 1                | TYPE_LIMIT | TIF_GTC | tt_16-2   |
+
+
+    And the mark price for the market "ETH/DEC19" is "20"
+
+    # checking margins
+    Then I expect the trader to have a margin:
+      | trader | asset | id        | margin | general |
+      | tt_15  | BTC   | ETH/DEC19 | 0      | 0       |
+
+    # then we make sure the insurance pool collected the funds
+    And the insurance pool balance is "100" for the market "ETH/DEC19"
+
+    #check positions
+    Then position API produce the following:
+      | trader | volume | unrealisedPNL | realisedPNL |
+      | tt_15  | 0      | 0             | -100        |
+
+    #Then dump orders
+
+    #check positions
+    Then position API produce the following:
+      | trader | volume | unrealisedPNL | realisedPNL |
+      | tt_12  | 5      | 0             | 0           |
+      | tt_13  | -5     | 0             | 0           |
+      | tt_14  | -4     | 120           | 0           |
+      | tt_15  | 0      | 0             | -100        |
+      | tt_16  | 4      | 0             | 0           |
+

--- a/integration/features/1847-closeout-short.feature
+++ b/integration/features/1847-closeout-short.feature
@@ -1,4 +1,4 @@
-Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTests.py)
+Feature: Long close-out test (see ln 449 of system-tests/grpc/trading/tradesTests.py & https://github.com/vegaprotocol/scenario-runner/tree/develop/scenarios/QA/issues/86)
 
   Background:
     Given the insurance pool initial balance for the markets is "0":

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -178,8 +178,6 @@ func (e *Engine) UpdateNetwork(trade *types.Trade) []events.MarketPosition {
 	// there's only 1 position
 	var pos *MarketPosition
 	size := int64(trade.Size)
-	// there will only be 1 event
-	ret := make([]events.MarketPosition, 0, 1)
 	if trade.Buyer != "network" {
 		if b, ok := e.positions[trade.Buyer]; !ok {
 			pos = &MarketPosition{
@@ -208,9 +206,7 @@ func (e *Engine) UpdateNetwork(trade *types.Trade) []events.MarketPosition {
 		size = -size
 	}
 	pos.size += size
-	// updated pos should be appended to event slice
-	ret = append(ret, *pos)
-	return ret
+	return []events.MarketPosition{*pos}
 }
 
 // Update pushes the previous positions on the channel + the updated open volumes of buyer/seller


### PR DESCRIPTION
Added integration tests based on ln 293 and ln 449 of system-tests/grpc/trading/tradesTests.py.

There seems to be a problem with position API, see: https://github.com/vegaprotocol/vega/issues/1917

Closes #1847 , #1917 .