### PR TITLE
Increased max badger file space from 16GB to 128GB

### DIFF
--- a/storage/badger.go
+++ b/storage/badger.go
@@ -85,7 +85,7 @@ func DefaultStoreOptions() ConfigOptions {
 		NumVersionsToKeep:       1,         // int
 		MaxTableSize:            64 << 20,  // int64, default 64<<20 (64MB)
 		LevelSizeMultiplier:     2,         // int, default 10
-		MaxLevels:               7,         // int
+		MaxLevels:               10,        // int
 		ValueThreshold:          16,        // int, default 32
 		NumMemtables:            1,         // int, default 5
 		NumLevelZeroTables:      1,         // int, default 5


### PR DESCRIPTION
To help prevent the nodes from running out of badger space I have increased the max file size from 16GB to 128GB.