### PR TITLE
update graphql API to support asset proposals

### DIFF
--- a/gateway/graphql/models.go
+++ b/gateway/graphql/models.go
@@ -67,6 +67,18 @@ type BuiltinAsset struct {
 
 func (BuiltinAsset) IsAssetSource() {}
 
+// A vega builtin asset, mostly for testing purpose
+type BuiltinAssetInput struct {
+	// The full name of the asset (e.g: Great British Pound)
+	Name string `json:"name"`
+	// The symbol of the asset (e.g: GBP)
+	Symbol string `json:"symbol"`
+	// The total supply of the market
+	TotalSupply string `json:"totalSupply"`
+	// The precision of the asset
+	Decimals int `json:"decimals"`
+}
+
 // A mode where Vega try to execute order as soon as they are received
 type ContinuousTrading struct {
 	// Size of an increment in price in terms of the quote currency
@@ -106,6 +118,12 @@ type Erc20 struct {
 }
 
 func (Erc20) IsAssetSource() {}
+
+// An asset originated from an Ethereum ERC20 Token
+type ERC20Input struct {
+	// The address of the erc20 contract
+	ContractAddress string `json:"contractAddress"`
+}
 
 // An Ethereum oracle
 type EthereumEvent struct {
@@ -279,6 +297,22 @@ type Market struct {
 	Data *proto.MarketData `json:"data"`
 }
 
+// A new asset proposal change
+type NewAsset struct {
+	// the source of the new Asset
+	Source AssetSource `json:"source"`
+}
+
+func (NewAsset) IsProposalChange() {}
+
+// A new asset to be added into vega
+type NewAssetInput struct {
+	// A new builtin assed to be created
+	BuiltinAsset *BuiltinAssetInput `json:"builtinAsset"`
+	// A new ERC20 asset to be created
+	Erc20 *ERC20Input `json:"erc20"`
+}
+
 type NewMarket struct {
 	// New market instrument configuration
 	Instrument *InstrumentConfiguration `json:"instrument"`
@@ -370,6 +404,8 @@ type ProposalTermsInput struct {
 	// It can only be set if "newMarket" and "updateMarket" are not set (the proposal will be rejected otherwise).
 	// One of "newMarket", "updateMarket", "updateNetwork" must be set (the proposal will be rejected otherwise).
 	UpdateNetwork *UpdateNetworkInput `json:"updateNetwork"`
+	// a new Asset proposal, this will create a new asset to be used in the vega network
+	NewAsset *NewAssetInput `json:"newAsset"`
 }
 
 type ProposalVote struct {

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -1301,6 +1301,11 @@ input UpdateMarketInput {
   marketId: String!
 }
 
+"A new asset proposal change"
+type NewAsset {
+  "the source of the new Asset"
+  source: AssetSource!
+}
 
 "Allows submitting a proposal for changing governance network parameters"
 type UpdateNetwork {
@@ -1401,7 +1406,7 @@ input UpdateNetworkInput {
 }
 
 
-union ProposalChange = NewMarket | UpdateMarket | UpdateNetwork
+union ProposalChange = NewMarket | UpdateMarket | UpdateNetwork | NewAsset
 # there are no unions for input types as of today, see: https://github.com/graphql/graphql-spec/issues/488
 
 type ProposalTerms {
@@ -1454,6 +1459,40 @@ input ProposalTermsInput {
   One of "newMarket", "updateMarket", "updateNetwork" must be set (the proposal will be rejected otherwise).
   """
   updateNetwork: UpdateNetworkInput
+
+  "a new Asset proposal, this will create a new asset to be used in the vega network"
+  newAsset: NewAssetInput
+
+}
+
+"A new asset to be added into vega"
+input NewAssetInput {
+  "A new builtin assed to be created"
+  builtinAsset: BuiltinAssetInput
+
+  "A new ERC20 asset to be created"
+  erc20: ERC20Input
+}
+
+"An asset originated from an Ethereum ERC20 Token"
+input ERC20Input {
+  "The address of the erc20 contract"
+  contractAddress: String!
+}
+
+"A vega builtin asset, mostly for testing purpose"
+input BuiltinAssetInput {
+  "The full name of the asset (e.g: Great British Pound)"
+  name: String!
+
+  "The symbol of the asset (e.g: GBP)"
+  symbol: String!
+
+  "The total supply of the market"
+  totalSupply: String!
+
+  "The precision of the asset"
+  decimals: Int!
 }
 
 """


### PR DESCRIPTION
This adds the NewAsset fields in the proposal TermsInput and the proposal Terms.

closes #1632 