### PR TITLE
Hotfix/candles

### DIFF
--- a/broker/mocks/subscriber_mock.go
+++ b/broker/mocks/subscriber_mock.go
@@ -90,15 +90,19 @@ func (mr *MockSubscriberMockRecorder) ID() *gomock.Call {
 }
 
 // Push mocks base method
-func (m *MockSubscriber) Push(arg0 events.Event) {
+func (m *MockSubscriber) Push(arg0 ...events.Event) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Push", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Push", varargs...)
 }
 
 // Push indicates an expected call of Push
-func (mr *MockSubscriberMockRecorder) Push(arg0 interface{}) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) Push(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockSubscriber)(nil).Push), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockSubscriber)(nil).Push), arg0...)
 }
 
 // SetID mocks base method

--- a/broker/readme.md
+++ b/broker/readme.md
@@ -31,7 +31,7 @@ Subscribers implement a fairly simple interface:
 ```go
 type Subscriber interface {
     Ack() bool
-	Push(val events.Event)
+	Push(val ...events.Event)
 	Skip() <-chan struct{}
 	Closed() <-chan struct{}
 	C() chan<- events.Event
@@ -43,7 +43,7 @@ type Subscriber interface {
 
 * `Ack()`: Indicates whether or not this subscriber "Ack's" the events it receives. In this case: the event has to be passed to the `Push` function.
 * `Types`: The broker uses this call to determine what events this subscriber wants to receive.
-* `Push`: A required subscriber will receive all its events from the broker through a normal function call. This ensures the event is indeed received
+* `Push`: A required subscriber will receive all its events from the broker through a normal function call. This ensures the event is indeed received. This function accepts one or more events. If `SendBatch()` was called on the broker, ack'ing subscribers will receive the entire batch of events in a single call.
 * `C`: This is used for non-required subscribers. This returns a write channel where the prober attempts to push an event onto. If this fails (because the buffer is full), the event is dropped for that subscriber
 * `Closed`: A subscriber can be halted (if it's no longer needed). This function will return a closed channel indicating that this subscriber is redundant, and should be removed
 * `Skip`: If a subscriber only periodically needs to get data, we kan keep it registered, but put it in a _"pauzed"_ state. A paused subscriber will return a closed channel for as long as we're not interested in receiving data.

--- a/events/bus.go
+++ b/events/bus.go
@@ -52,12 +52,14 @@ const (
 	SettleDistressedEvent
 	MarketCreatedEvent
 	AssetEvent
+	MarketTickEvent
 )
 
 var (
 	marketEvents = []Type{
 		PositionResolution,
 		MarketCreatedEvent,
+		MarketTickEvent,
 	}
 
 	eventStrings = map[Type]string{
@@ -80,6 +82,7 @@ var (
 		SettleDistressedEvent:  "SettleDistressedEvent",
 		MarketCreatedEvent:     "MarketCreatedEvent",
 		AssetEvent:             "AssetEvent",
+		MarketTickEvent:        "MarketTickEvent",
 	}
 )
 

--- a/events/market_tick.go
+++ b/events/market_tick.go
@@ -1,0 +1,33 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type MarketTick struct {
+	*Base
+	id string
+	t  time.Time
+}
+
+func NewMarketTick(ctx context.Context, id string, t time.Time) *MarketTick {
+	return &MarketTick{
+		Base: newBase(ctx, MarketTickEvent),
+		id:   id,
+		t:    t,
+	}
+}
+
+func (m MarketTick) MarketID() string {
+	return m.id
+}
+
+func (m MarketTick) Time() time.Time {
+	return m.t
+}
+
+func (m MarketTick) MarketEvent() string {
+	return fmt.Sprintf("Market %s on time %s", m.id, m.t.String())
+}

--- a/governance/service.go
+++ b/governance/service.go
@@ -163,10 +163,8 @@ func (s *Svc) ObserveGovernance(ctx context.Context, retries int) <-chan []types
 		}()
 		ret := retries
 		for {
+			// wait for actual changes
 			data := sub.GetGovernanceData()
-			if len(data) == 0 {
-				continue
-			}
 			select {
 			case <-ctx.Done():
 				return
@@ -198,9 +196,6 @@ func (s *Svc) ObservePartyProposals(ctx context.Context, retries int, partyID st
 		ret := retries
 		for {
 			data := sub.GetGovernanceData()
-			if len(data) == 0 {
-				continue
-			}
 			select {
 			case <-ctx.Done():
 				return

--- a/integration/stubs_test.go
+++ b/integration/stubs_test.go
@@ -45,19 +45,19 @@ func (b *brokerStub) SendBatch(evts []events.Event) {
 	t := evts[0].Type()
 	b.mu.Lock()
 	if subs, ok := b.subT[t]; ok {
-		for _, e := range evts {
-			for _, sub := range subs {
-				if sub.Ack() {
-					sub.Push(e)
-				} else {
-					select {
-					case <-sub.Closed():
-						continue
-					case <-sub.Skip():
-						continue
-					case sub.C() <- e:
-						continue
-					}
+		for _, sub := range subs {
+			if sub.Ack() {
+				sub.Push(evts...)
+				continue
+			}
+			for _, e := range evts {
+				select {
+				case <-sub.Closed():
+					continue
+				case <-sub.Skip():
+					continue
+				case sub.C() <- e:
+					continue
 				}
 			}
 		}

--- a/plugins/assets.go
+++ b/plugins/assets.go
@@ -36,12 +36,12 @@ func NewAsset(ctx context.Context) (a *Asset) {
 	}
 }
 
-func (a *Asset) Push(e events.Event) {
-	ae, ok := e.(AssetEvent)
-	if !ok {
-		return
+func (a *Asset) Push(evts ...events.Event) {
+	for _, e := range evts {
+		if ae, ok := e.(AssetEvent); ok {
+			a.ch <- ae.Asset()
+		}
 	}
-	a.ch <- ae.Asset()
 }
 
 func (a *Asset) consume() {

--- a/plugins/notary.go
+++ b/plugins/notary.go
@@ -39,12 +39,12 @@ func NewNotary(ctx context.Context) *Notary {
 	return n
 }
 
-func (n *Notary) Push(e events.Event) {
-	nse, ok := e.(NodeSignatureEvent)
-	if !ok {
-		return
+func (n *Notary) Push(evts ...events.Event) {
+	for _, e := range evts {
+		if nse, ok := e.(NodeSignatureEvent); ok {
+			n.ch <- nse.NodeSignature()
+		}
 	}
-	n.ch <- nse.NodeSignature()
 }
 
 func (n *Notary) consume() {

--- a/plugins/position_spec_test.go
+++ b/plugins/position_spec_test.go
@@ -1,5 +1,3 @@
-// +build !race ignore
-
 package plugins_test
 
 import (

--- a/plugins/positions.go
+++ b/plugins/positions.go
@@ -62,6 +62,11 @@ func NewPositions(ctx context.Context) *Positions {
 }
 
 func (p *Positions) Push(evts ...events.Event) {
+	if len(evts) == 0 {
+		return
+	}
+	// lock here, because some of these events are sent in batch (if not all of them)
+	p.mu.Lock()
 	for _, e := range evts {
 		switch te := e.(type) {
 		case SPE:
@@ -72,10 +77,10 @@ func (p *Positions) Push(evts ...events.Event) {
 			p.applyLossSocialization(te)
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *Positions) applyLossSocialization(e LSE) {
-	p.mu.Lock()
 	marketID, partyID, amountLoss := e.MarketID(), e.PartyID(), e.AmountLost()
 	pos, ok := p.data[marketID][partyID]
 	if !ok {
@@ -89,11 +94,9 @@ func (p *Positions) applyLossSocialization(e LSE) {
 	pos.RealisedPNLFP += float64(amountLoss)
 	pos.RealisedPNL += amountLoss
 	p.data[marketID][partyID] = pos
-	p.mu.Unlock()
 }
 
 func (p *Positions) updatePosition(e SPE) {
-	p.mu.Lock()
 	mID, tID := e.MarketID(), e.PartyID()
 	if _, ok := p.data[mID]; !ok {
 		p.data[mID] = map[string]Position{}
@@ -104,11 +107,9 @@ func (p *Positions) updatePosition(e SPE) {
 	}
 	updateSettlePosition(&calc, e)
 	p.data[mID][tID] = calc
-	p.mu.Unlock()
 }
 
 func (p *Positions) updateSettleDestressed(e SDE) {
-	p.mu.Lock()
 	mID, tID := e.MarketID(), e.PartyID()
 	if _, ok := p.data[mID]; !ok {
 		p.data[mID] = map[string]Position{}
@@ -131,37 +132,35 @@ func (p *Positions) updateSettleDestressed(e SDE) {
 	calc.UnrealisedPNLFP = 0
 	calc.AverageEntryPriceFP = 0
 	p.data[mID][tID] = calc
-	p.mu.Unlock()
 }
 
 // GetPositionsByMarketAndParty get the position of a single trader in a given market
 func (p *Positions) GetPositionsByMarketAndParty(market, party string) (*types.Position, error) {
 	p.mu.RLock()
 	mp, ok := p.data[market]
+	p.mu.RUnlock()
 	if !ok {
-		p.mu.RUnlock()
 		return nil, nil
 	}
 	pos, ok := mp[party]
 	if !ok {
-		p.mu.RUnlock()
 		return nil, nil
 	}
-	p.mu.RUnlock()
 	return &pos.Position, nil
 }
 
 // GetPositionsByParty get all positions for a given trader
 func (p *Positions) GetPositionsByParty(party string) ([]*types.Position, error) {
 	p.mu.RLock()
+	data := p.data
+	p.mu.RUnlock()
 	// at most, trader is active in all markets
-	positions := make([]*types.Position, 0, len(p.data))
-	for _, traders := range p.data {
+	positions := make([]*types.Position, 0, len(data))
+	for _, traders := range data {
 		if pos, ok := traders[party]; ok {
 			positions = append(positions, &pos.Position)
 		}
 	}
-	p.mu.RUnlock()
 	if len(positions) == 0 {
 		return nil, nil
 		// return nil, ErrPartyNotFound
@@ -173,15 +172,14 @@ func (p *Positions) GetPositionsByParty(party string) ([]*types.Position, error)
 func (p *Positions) GetPositionsByMarket(market string) ([]*types.Position, error) {
 	p.mu.RLock()
 	mp, ok := p.data[market]
+	p.mu.RUnlock()
 	if !ok {
-		p.mu.RUnlock()
 		return nil, ErrMarketNotFound
 	}
 	s := make([]*types.Position, 0, len(mp))
 	for _, tp := range mp {
 		s = append(s, &tp.Position)
 	}
-	p.mu.RUnlock()
 	return s, nil
 }
 

--- a/plugins/positions.go
+++ b/plugins/positions.go
@@ -61,14 +61,16 @@ func NewPositions(ctx context.Context) *Positions {
 	}
 }
 
-func (p *Positions) Push(e events.Event) {
-	switch te := e.(type) {
-	case SPE:
-		p.updatePosition(te)
-	case SDE:
-		p.updateSettleDestressed(te)
-	case LSE:
-		p.applyLossSocialization(te)
+func (p *Positions) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch te := e.(type) {
+		case SPE:
+			p.updatePosition(te)
+		case SDE:
+			p.updateSettleDestressed(te)
+		case LSE:
+			p.applyLossSocialization(te)
+		}
 	}
 }
 

--- a/plugins/positions_test.go
+++ b/plugins/positions_test.go
@@ -1,5 +1,3 @@
-// +build !race ignore
-
 package plugins_test
 
 // No race condition checks on these tests, the channels are buffered to avoid actual issues

--- a/subscribers/candle_subscriber.go
+++ b/subscribers/candle_subscriber.go
@@ -25,7 +25,7 @@ type MarketTickEvt interface {
 
 type tradeBlock struct {
 	trades []types.Trade
-	last   types.Trade
+	last   *types.Trade
 	time   time.Time
 	mID    string
 }
@@ -34,9 +34,8 @@ type CandleSub struct {
 	*Base
 	store   CandleStore
 	mu      sync.Mutex
-	b2      map[string][]types.Trade
-	last    map[string]types.Trade
-	buf     []types.Trade
+	buf     map[string][]types.Trade
+	last    map[string]*types.Trade
 	tCh     chan tradeBlock
 	candles map[string]map[string]types.Candle
 }
@@ -55,9 +54,8 @@ func NewCandleSub(ctx context.Context, store CandleStore, ack bool) *CandleSub {
 	sub := &CandleSub{
 		Base:    NewBase(ctx, 1, ack),
 		store:   store,
-		b2:      map[string][]types.Trade{},
-		last:    map[string]types.Trade{},
-		buf:     []types.Trade{},
+		buf:     map[string][]types.Trade{},
+		last:    map[string]*types.Trade{},
 		tCh:     make(chan tradeBlock, 10), // ensure we're one block behind
 		candles: map[string]map[string]types.Candle{},
 	}
@@ -72,53 +70,56 @@ func (c *CandleSub) internalLoop() {
 			return
 		case block := <-c.tCh:
 			// if no new trades, just check if we need to add the market ID to candles map
-			if len(block.trades) == 0 {
+			if block.last == nil {
 				if _, ok := c.candles[block.mID]; !ok {
 					c.candles[block.mID] = map[string]types.Candle{}
 				}
-			} else if len(block.trades) > 0 {
+			} else {
 				c.updateCandles(block)
 			}
 		}
 	}
 }
 
-func (c *CandleSub) Push(e events.Event) {
-	switch te := e.(type) {
-	case TE:
-		trade := te.Trade()
-		mID := trade.MarketID
-		c.mu.Lock()
-		if _, ok := c.b2[mID]; !ok {
-			c.b2[mID] = []types.Trade{}
-		}
-		c.b2[mID] = append(c.b2[mID], trade)
-		c.last[mID] = trade
-		c.mu.Unlock()
-	case NME:
-		mID := te.Market().Id
-		c.mu.Lock()
-		if _, ok := c.b2[mID]; !ok {
-			c.b2[mID] = []types.Trade{}
-		}
-		c.mu.Unlock()
-		c.tCh <- tradeBlock{
-			mID: mID,
-		}
-	case MarketTickEvt:
-		mID := te.MarketID()
-		c.mu.Lock()
-		cpy := c.b2[mID]
-		last := c.last[mID]
-		c.b2[mID] = make([]types.Trade, 0, cap(cpy))
-		c.mu.Unlock()
-		c.tCh <- tradeBlock{
-			trades: cpy,
-			time:   te.Time(),
-			last:   last,
-			mID:    mID,
+func (c *CandleSub) Push(evts ...events.Event) {
+	if len(evts) == 0 {
+		return
+	}
+	// trade events are batched, we need to lock outside of the loop
+	c.mu.Lock()
+	for _, e := range evts {
+		switch te := e.(type) {
+		case TE:
+			trade := te.Trade()
+			mID := trade.MarketID
+			if _, ok := c.buf[mID]; !ok {
+				c.buf[mID] = []types.Trade{}
+			}
+			c.buf[mID] = append(c.buf[mID], trade)
+			c.last[mID] = &trade
+		case NME:
+			mID := te.Market().Id
+			if _, ok := c.buf[mID]; !ok {
+				c.buf[mID] = []types.Trade{}
+			}
+			c.tCh <- tradeBlock{
+				mID: mID,
+			}
+		case MarketTickEvt:
+			mID := te.MarketID()
+			cpy := c.buf[mID]
+			last := c.last[mID]
+			c.last[mID] = nil
+			c.buf[mID] = make([]types.Trade, 0, cap(cpy))
+			c.tCh <- tradeBlock{
+				trades: cpy,
+				time:   te.Time(),
+				last:   last,
+				mID:    mID,
+			}
 		}
 	}
+	c.mu.Unlock()
 }
 
 func (c *CandleSub) Types() []events.Type {
@@ -130,59 +131,50 @@ func (c *CandleSub) Types() []events.Type {
 }
 
 func (c *CandleSub) updateCandles(block tradeBlock) {
-	// Add trades and create candles
-	lastByMarket := map[string]types.Trade{}
 	for _, t := range block.trades {
-		mID := t.MarketID
 		for _, interval := range supportedIntervals {
 			roundedTradeTime := vegatime.RoundToNearest(vegatime.UnixNano(t.Timestamp), interval)
-
-			bufkey := bufferKey(roundedTradeTime, interval)
-
+			bufKey := bufferKey(roundedTradeTime, interval)
 			// check if bufferKey is present in buffer
-			mktBuf, ok := c.candles[mID]
+			mktBuf, ok := c.candles[block.mID]
 			if !ok {
 				mktBuf = map[string]types.Candle{}
-				c.candles[mID] = mktBuf
+				c.candles[block.mID] = mktBuf
 			}
-			if candl, ok := mktBuf[bufkey]; ok {
+			if candl, ok := mktBuf[bufKey]; ok {
 				// if exists update the value of the candle under bufferKey with trade data
 				updateCandle(&candl, &t)
-				mktBuf[bufkey] = candl
+				mktBuf[bufKey] = candl
 			} else {
 				// if doesn't exist create new candle under this buffer key
-				mktBuf[bufkey] = newCandle(roundedTradeTime, t.Price, t.Size, interval)
+				mktBuf[bufKey] = newCandle(roundedTradeTime, t.Price, t.Size, interval)
 			}
-			lastByMarket[mID] = t
 		}
 	}
-
 	// Start logic (actually set last candles)
 	roundedTimestamps := GetMapOfIntervalsToRoundedTimestamps(block.time)
-	for mID, t := range lastByMarket {
-		previous := c.candles[mID]
-		for _, interval := range supportedIntervals {
-			bufkey := bufferKey(roundedTimestamps[interval], interval)
-			var lastClose uint64
-			if candl, ok := previous[bufkey]; ok {
-				lastClose = candl.Close
-			}
-
-			if lastClose == 0 {
-				previousCandle, err := c.store.FetchLastCandle(mID, interval)
-				if err == nil {
-					lastClose = previousCandle.Close
-				}
-			}
-
-			if lastClose == 0 {
-				lastClose = t.Price
-			}
-
-			c.candles[mID][bufkey] = newCandle(roundedTimestamps[interval], lastClose, 0, interval)
+	previous := c.candles[block.mID]
+	for _, interval := range supportedIntervals {
+		bufkey := bufferKey(roundedTimestamps[interval], interval)
+		var lastClose uint64
+		if candl, ok := previous[bufkey]; ok {
+			lastClose = candl.Close
 		}
-		_ = c.store.GenerateCandlesFromBuffer(mID, previous)
+
+		if lastClose == 0 {
+			previousCandle, err := c.store.FetchLastCandle(block.mID, interval)
+			if err == nil {
+				lastClose = previousCandle.Close
+			}
+		}
+
+		if lastClose == 0 {
+			lastClose = block.last.Price
+		}
+
+		c.candles[block.mID][bufkey] = newCandle(roundedTimestamps[interval], lastClose, 0, interval)
 	}
+	_ = c.store.GenerateCandlesFromBuffer(block.mID, previous)
 }
 
 // GetMapOfIntervalsToRoundedTimestamps rounds timestamp to nearest minute, 5minute,

--- a/subscribers/governance_data.go
+++ b/subscribers/governance_data.go
@@ -44,24 +44,26 @@ func (g *GovernanceDataSub) loop(ctx context.Context) {
 	}
 }
 
-func (g *GovernanceDataSub) Push(e events.Event) {
-	switch et := e.(type) {
-	case PropE:
-		prop := et.Proposal()
-		gd := g.getData(prop.ID)
-		g.proposals[prop.ID] = prop
-		gd.Proposal = &prop
-	case VoteE:
-		vote := et.Vote()
-		gd := g.getData(vote.ProposalID)
-		if vote.Value == types.Vote_VALUE_YES {
-			gd.Yes = append(gd.Yes, &vote)
-			delete(gd.NoParty, vote.PartyID)
-			gd.YesParty[vote.PartyID] = &vote
-		} else {
-			gd.No = append(gd.No, &vote)
-			delete(gd.YesParty, vote.PartyID)
-			gd.NoParty[vote.PartyID] = &vote
+func (g *GovernanceDataSub) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch et := e.(type) {
+		case PropE:
+			prop := et.Proposal()
+			gd := g.getData(prop.ID)
+			g.proposals[prop.ID] = prop
+			gd.Proposal = &prop
+		case VoteE:
+			vote := et.Vote()
+			gd := g.getData(vote.ProposalID)
+			if vote.Value == types.Vote_VALUE_YES {
+				gd.Yes = append(gd.Yes, &vote)
+				delete(gd.NoParty, vote.PartyID)
+				gd.YesParty[vote.PartyID] = &vote
+			} else {
+				gd.No = append(gd.No, &vote)
+				delete(gd.YesParty, vote.PartyID)
+				gd.NoParty[vote.PartyID] = &vote
+			}
 		}
 	}
 }

--- a/subscribers/margin_levels.go
+++ b/subscribers/margin_levels.go
@@ -49,18 +49,20 @@ func (m *MarginLevelSub) loop(ctx context.Context) {
 	}
 }
 
-func (m *MarginLevelSub) Push(e events.Event) {
-	switch te := e.(type) {
-	case MLE:
-		ml := te.MarginLevels()
-		m.mu.Lock()
-		if _, ok := m.buf[ml.PartyID]; !ok {
-			m.buf[ml.PartyID] = map[string]types.MarginLevels{}
+func (m *MarginLevelSub) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch te := e.(type) {
+		case MLE:
+			ml := te.MarginLevels()
+			m.mu.Lock()
+			if _, ok := m.buf[ml.PartyID]; !ok {
+				m.buf[ml.PartyID] = map[string]types.MarginLevels{}
+			}
+			m.buf[ml.PartyID][ml.MarketID] = ml
+			m.mu.Unlock()
+		case TimeEvent:
+			m.flush()
 		}
-		m.buf[ml.PartyID][ml.MarketID] = ml
-		m.mu.Unlock()
-	case TimeEvent:
-		m.flush()
 	}
 }
 

--- a/subscribers/market_created.go
+++ b/subscribers/market_created.go
@@ -46,9 +46,15 @@ func (m *Market) loop(ctx context.Context) {
 	}
 }
 
-func (m *Market) Push(e events.Event) {
-	if te, ok := e.(NME); ok {
-		m.store.SaveBatch([]types.Market{te.Market()})
+func (m *Market) Push(evts ...events.Event) {
+	batch := make([]types.Market, 0, len(evts))
+	for _, e := range evts {
+		if te, ok := e.(NME); ok {
+			batch = append(batch, te.Market())
+		}
+	}
+	if len(batch) > 0 {
+		_ = m.store.SaveBatch(batch)
 	}
 }
 

--- a/subscribers/market_data.go
+++ b/subscribers/market_data.go
@@ -50,15 +50,17 @@ func (m *MarketDataSub) loop(ctx context.Context) {
 	}
 }
 
-func (m *MarketDataSub) Push(e events.Event) {
-	switch te := e.(type) {
-	case MDE:
-		md := te.MarketData()
-		m.mu.Lock()
-		m.buf = append(m.buf, md)
-		m.mu.Unlock()
-	case TimeEvent:
-		m.flush()
+func (m *MarketDataSub) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch te := e.(type) {
+		case MDE:
+			md := te.MarketData()
+			m.mu.Lock()
+			m.buf = append(m.buf, md)
+			m.mu.Unlock()
+		case TimeEvent:
+			m.flush()
+		}
 	}
 }
 

--- a/subscribers/market_events.go
+++ b/subscribers/market_events.go
@@ -44,12 +44,14 @@ func (m *MarketEvent) loop() {
 	}
 }
 
-func (m *MarketEvent) Push(e events.Event) {
-	me, ok := e.(ME)
-	if !ok {
-		return
+func (m *MarketEvent) Push(evts ...events.Event) {
+	for _, e := range evts {
+		me, ok := e.(ME)
+		if !ok {
+			return
+		}
+		m.write(me)
 	}
-	m.write(me)
 }
 
 // this function will be replaced - this is where the events will be normalised for a market event plugin to use

--- a/subscribers/order_events.go
+++ b/subscribers/order_events.go
@@ -53,12 +53,14 @@ func (o *OrderEvent) loop(ctx context.Context) {
 	}
 }
 
-func (o *OrderEvent) Push(e events.Event) {
-	switch te := e.(type) {
-	case OE:
-		o.write(te)
-	case TimeEvent:
-		o.flush()
+func (o *OrderEvent) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch te := e.(type) {
+		case OE:
+			o.write(te)
+		case TimeEvent:
+			o.flush()
+		}
 	}
 }
 

--- a/subscribers/party_events.go
+++ b/subscribers/party_events.go
@@ -50,15 +50,17 @@ func (a *PartySub) loop(ctx context.Context) {
 	}
 }
 
-func (p *PartySub) Push(e events.Event) {
-	switch et := e.(type) {
-	case PE:
-		party := et.Party()
-		p.mu.Lock()
-		p.buf = append(p.buf, party)
-		p.mu.Unlock()
-	case TimeEvent:
-		p.flush()
+func (p *PartySub) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch et := e.(type) {
+		case PE:
+			party := et.Party()
+			p.mu.Lock()
+			p.buf = append(p.buf, party)
+			p.mu.Unlock()
+		case TimeEvent:
+			p.flush()
+		}
 	}
 }
 

--- a/subscribers/proposals.go
+++ b/subscribers/proposals.go
@@ -121,20 +121,22 @@ func (p *ProposalFilteredSub) loop(ctx context.Context) {
 	}
 }
 
-func (p *ProposalFilteredSub) Push(e events.Event) {
-	switch et := e.(type) {
-	case TimeEvent:
-		p.Flush()
-	case PropE:
-		prop := et.Proposal()
-		for _, f := range p.filters {
-			if !f(prop) {
-				return
+func (p *ProposalFilteredSub) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch et := e.(type) {
+		case TimeEvent:
+			p.Flush()
+		case PropE:
+			prop := et.Proposal()
+			for _, f := range p.filters {
+				if !f(prop) {
+					return
+				}
 			}
+			p.mu.Lock()
+			p.matched = append(p.matched, prop)
+			p.mu.Unlock()
 		}
-		p.mu.Lock()
-		p.matched = append(p.matched, prop)
-		p.mu.Unlock()
 	}
 }
 

--- a/subscribers/transfer_response.go
+++ b/subscribers/transfer_response.go
@@ -77,13 +77,17 @@ func (t *TransferResponse) flush() error {
 }
 
 // Push - takes the event pushed by the broker
-func (t *TransferResponse) Push(e events.Event) {
-	switch te := e.(type) {
-	case TimeEvent:
-		_ = t.flush()
-	case TransferResponseEvent:
-		t.mu.Lock()
-		t.trs = append(t.trs, te.TransferResponses()...)
-		t.mu.Unlock()
+// in this case, transfer responses are already packaged into a single event
+// but this may change over time. In that case, the use of the mutex needs to be updated
+func (t *TransferResponse) Push(evts ...events.Event) {
+	for _, e := range evts {
+		switch te := e.(type) {
+		case TimeEvent:
+			_ = t.flush()
+		case TransferResponseEvent:
+			t.mu.Lock()
+			t.trs = append(t.trs, te.TransferResponses()...)
+			t.mu.Unlock()
+		}
 	}
 }


### PR DESCRIPTION
This should fix #1929 (tentatively, because candles are tricky to say the least)

* In addition to that, this PR contains some further unit testing on the broker (specifically the `SendBatch` function)
* Batched events are handled differently (more efficiently), to further reduce the load on the CPU.
* Governance streams in the service were polling for changes in the event data in a busy loop. This obviously hits the CPU quite hard. This approach has been replaced with an internal channel, where the functions returning data changes only if the subscriber has picked up on relevant events. Whereas the service was calling the same function in a loop, checking if it returned anything previously, all calls to this function are now blocking and won't return anything until there is new data.

It's important to note that vega nodes, since the event bus was introduced, will always experience higher CPU usage compared to before (buffers), as we're now able to process data concurrently (especially in API nodes).