### PR TITLE
add config + log levels to subscribers events

### DIFF
--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -205,8 +205,8 @@ func (l *NodeCommand) loadMarketsConfig() error {
 
 func (l *NodeCommand) setupSubscibers() {
 	l.transferSub = subscribers.NewTransferResponse(l.ctx, l.transferResponseStore, true)
-	l.marketEventSub = subscribers.NewMarketEvent(l.ctx, l.Log, false)
-	l.orderSub = subscribers.NewOrderEvent(l.ctx, l.Log, l.orderStore, true)
+	l.marketEventSub = subscribers.NewMarketEvent(l.ctx, l.conf.Subscribers, l.Log, false)
+	l.orderSub = subscribers.NewOrderEvent(l.ctx, l.conf.Subscribers, l.Log, l.orderStore, true)
 	l.accountSub = subscribers.NewAccountSub(l.ctx, l.accounts, true)
 	l.partySub = subscribers.NewPartySub(l.ctx, l.partyStore, true)
 	l.tradeSub = subscribers.NewTradeSub(l.ctx, l.tradeStore, true)

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ import (
 	"code.vegaprotocol.io/vega/risk"
 	"code.vegaprotocol.io/vega/settlement"
 	"code.vegaprotocol.io/vega/storage"
+	"code.vegaprotocol.io/vega/subscribers"
 	"code.vegaprotocol.io/vega/trades"
 	"code.vegaprotocol.io/vega/transfers"
 	"code.vegaprotocol.io/vega/vegatime"
@@ -38,33 +39,34 @@ import (
 
 // Config ties together all other application configuration types.
 type Config struct {
-	API        api.Config
-	Accounts   accounts.Config
-	Blockchain blockchain.Config
-	Candles    candles.Config
-	Collateral collateral.Config
-	Execution  execution.Config
-	Processor  processor.Config
-	Logging    logging.Config
-	Matching   matching.Config
-	Markets    markets.Config
-	Orders     orders.Config
-	Parties    parties.Config
-	Position   positions.Config
-	Risk       risk.Config
-	Settlement settlement.Config
-	Storage    storage.Config
-	Trades     trades.Config
-	Time       vegatime.Config
-	Monitoring monitoring.Config
-	Gateway    gateway.Config
-	Metrics    metrics.Config
-	Transfers  transfers.Config
-	Governance governance.Config
-	NodeWallet nodewallet.Config
-	Assets     assets.Config
-	Notary     notary.Config
-	EvtForward evtforward.Config
+	API         api.Config
+	Accounts    accounts.Config
+	Blockchain  blockchain.Config
+	Candles     candles.Config
+	Collateral  collateral.Config
+	Execution   execution.Config
+	Processor   processor.Config
+	Logging     logging.Config
+	Matching    matching.Config
+	Markets     markets.Config
+	Orders      orders.Config
+	Parties     parties.Config
+	Position    positions.Config
+	Risk        risk.Config
+	Settlement  settlement.Config
+	Storage     storage.Config
+	Trades      trades.Config
+	Time        vegatime.Config
+	Monitoring  monitoring.Config
+	Gateway     gateway.Config
+	Metrics     metrics.Config
+	Transfers   transfers.Config
+	Governance  governance.Config
+	NodeWallet  nodewallet.Config
+	Assets      assets.Config
+	Notary      notary.Config
+	EvtForward  evtforward.Config
+	Subscribers subscribers.Config
 
 	Pprof          pprof.Config
 	GatewayEnabled bool
@@ -104,6 +106,7 @@ func NewDefaultConfig(defaultStoreDirPath string) Config {
 		Assets:         assets.NewDefaultConfig(defaultStoreDirPath),
 		Notary:         notary.NewDefaultConfig(),
 		EvtForward:     evtforward.NewDefaultConfig(),
+		Subscribers:    subscribers.NewDefaultConfig(),
 		GatewayEnabled: true,
 		StoresEnabled:  true,
 		UlimitNOFile:   8192,

--- a/processor/config.go
+++ b/processor/config.go
@@ -13,7 +13,7 @@ const (
 	nodeApproval        = 1         // float for percentage
 )
 
-// Config represent the configuration of the blockchain package
+// Config represent the configuration of the processor package
 type Config struct {
 	Level               encoding.LogLevel
 	LogOrderSubmitDebug bool

--- a/subscribers/config.go
+++ b/subscribers/config.go
@@ -9,7 +9,7 @@ const (
 	namedLogger = "subscribers"
 )
 
-// Config represent the configuration of the blockchain package
+// Config represent the configuration of the subscribers package
 type Config struct {
 	OrderEventLogLevel  encoding.LogLevel
 	MarketEventLogLevel encoding.LogLevel

--- a/subscribers/config.go
+++ b/subscribers/config.go
@@ -1,0 +1,25 @@
+package subscribers
+
+import (
+	"code.vegaprotocol.io/vega/config/encoding"
+	"code.vegaprotocol.io/vega/logging"
+)
+
+const (
+	namedLogger = "subscribers"
+)
+
+// Config represent the configuration of the blockchain package
+type Config struct {
+	OrderEventLogLevel  encoding.LogLevel
+	MarketEventLogLevel encoding.LogLevel
+}
+
+// NewDefaultConfig creates an instance of the package specific configuration, given a
+// pointer to a logger instance to be used for logging within the package.
+func NewDefaultConfig() Config {
+	return Config{
+		MarketEventLogLevel: encoding.LogLevel{Level: logging.InfoLevel},
+		OrderEventLogLevel:  encoding.LogLevel{Level: logging.InfoLevel},
+	}
+}

--- a/subscribers/market_events.go
+++ b/subscribers/market_events.go
@@ -14,13 +14,17 @@ type ME interface {
 
 type MarketEvent struct {
 	*Base
+	cfg Config
 	log *logging.Logger
 }
 
-func NewMarketEvent(ctx context.Context, log *logging.Logger, ack bool) *MarketEvent {
+func NewMarketEvent(ctx context.Context, cfg Config, log *logging.Logger, ack bool) *MarketEvent {
+	log = log.Named(namedLogger)
+	log.SetLevel(cfg.MarketEventLogLevel.Level)
 	m := &MarketEvent{
 		Base: NewBase(ctx, 10, ack), // the size of the buffer can be tweaked, maybe use config?
 		log:  log,
+		cfg:  cfg,
 	}
 	if m.isRunning() {
 		go m.loop()

--- a/subscribers/market_events_test.go
+++ b/subscribers/market_events_test.go
@@ -29,7 +29,7 @@ func getTestME(t *testing.T, ack bool) *tstME {
 	ctrl := gomock.NewController(t)
 	ctx, cfunc := context.WithCancel(context.Background())
 	return &tstME{
-		MarketEvent: subscribers.NewMarketEvent(ctx, logging.NewTestLogger(), ack),
+		MarketEvent: subscribers.NewMarketEvent(ctx, subscribers.NewDefaultConfig(), logging.NewTestLogger(), ack),
 		ctx:         ctx,
 		cfunc:       cfunc,
 		ctrl:        ctrl,

--- a/subscribers/order_events.go
+++ b/subscribers/order_events.go
@@ -21,17 +21,22 @@ type OrderStore interface {
 type OrderEvent struct {
 	*Base
 	mu    sync.Mutex
+	cfg   Config
 	log   *logging.Logger
 	store OrderStore
 	buf   []types.Order
 }
 
-func NewOrderEvent(ctx context.Context, log *logging.Logger, store OrderStore, ack bool) *OrderEvent {
+func NewOrderEvent(ctx context.Context, cfg Config, log *logging.Logger, store OrderStore, ack bool) *OrderEvent {
+	log = log.Named(namedLogger)
+	log.SetLevel(cfg.OrderEventLogLevel.Level)
+
 	o := OrderEvent{
 		Base:  NewBase(ctx, 10, ack),
 		log:   log,
 		store: store,
 		buf:   []types.Order{},
+		cfg:   cfg,
 	}
 	if o.isRunning() {
 		go o.loop(o.ctx)


### PR DESCRIPTION
Some of the subscribers are logging information although the logger passed to them is setup to DEBUG, which makes them very noisy.

We added a new config to the subscribers package, and a LogLevel per subscribers (at least the being constructed with a logger) so we can customise this behaviour.