### PR TITLE
Remove deprecated directives from input types

### DIFF
--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -3938,16 +3938,16 @@ type InstrumentConfiguration {
 
 "A mode where Vega try to execute order as soon as they are received"
 input ContinuousTradingInput {
-  "Size of an increment in price in terms of the quote currency"
-  tickSize: String @deprecated(reason: "tickSize should not be used and will be ignored")
+  "Size of an increment in price in terms of the quote currency. Note this field should not be used and will be ignored"
+  tickSize: String
 }
 
 "Frequent batch auctions trading mode"
 input DiscreteTradingInput {
   "Duration of the discrete trading batch in nanoseconds. Maximum 1 month."
   duration: Int!
-  "Size of an increment in price in terms of the quote currency"
-  tickSize: String @deprecated(reason: "tickSize should not be used and will be ignored")
+  "Size of an increment in price in terms of the quote currency. Note this field should not be used and will be ignored"
+  tickSize: String
 }
 
 """

--- a/gateway/graphql/models.go
+++ b/gateway/graphql/models.go
@@ -89,7 +89,7 @@ func (ContinuousTrading) IsTradingMode() {}
 
 // A mode where Vega try to execute order as soon as they are received
 type ContinuousTradingInput struct {
-	// Size of an increment in price in terms of the quote currency
+	// Size of an increment in price in terms of the quote currency. Note this field should not be used and will be ignored
 	TickSize *string `json:"tickSize"`
 }
 
@@ -107,7 +107,7 @@ func (DiscreteTrading) IsTradingMode() {}
 type DiscreteTradingInput struct {
 	// Duration of the discrete trading batch in nanoseconds. Maximum 1 month.
 	Duration int `json:"duration"`
-	// Size of an increment in price in terms of the quote currency
+	// Size of an increment in price in terms of the quote currency. Note this field should not be used and will be ignored
 	TickSize *string `json:"tickSize"`
 }
 

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -1274,16 +1274,16 @@ type InstrumentConfiguration {
 
 "A mode where Vega try to execute order as soon as they are received"
 input ContinuousTradingInput {
-  "Size of an increment in price in terms of the quote currency"
-  tickSize: String @deprecated(reason: "tickSize should not be used and will be ignored")
+  "Size of an increment in price in terms of the quote currency. Note this field should not be used and will be ignored"
+  tickSize: String
 }
 
 "Frequent batch auctions trading mode"
 input DiscreteTradingInput {
   "Duration of the discrete trading batch in nanoseconds. Maximum 1 month."
   duration: Int!
-  "Size of an increment in price in terms of the quote currency"
-  tickSize: String @deprecated(reason: "tickSize should not be used and will be ignored")
+  "Size of an increment in price in terms of the quote currency. Note this field should not be used and will be ignored"
+  tickSize: String
 }
 
 """


### PR DESCRIPTION
I've replaced the deprecated directives with a comment instead as they are not permitted on input types.