### PR TITLE
Add auction support to matching engine (in progress), upate unit tests

### DIFF
--- a/matching/auction.go
+++ b/matching/auction.go
@@ -1,0 +1,146 @@
+package matching
+
+import (
+	"code.vegaprotocol.io/vega/logging"
+	types "code.vegaprotocol.io/vega/proto"
+)
+
+type AuctionBook struct {
+	buy, sell *OrderBookSide
+	expiring  *ExpiringOrders
+	byID      map[string]*types.Order
+	levels    map[uint64]*auctionPriceLevel
+	highest   *auctionPriceLevel
+}
+
+type auctionPriceLevel struct {
+	trades        []*types.Trade
+	price, volume uint64
+	orders        map[string]*types.Order
+}
+
+func newAuctionBook(log *logging.Logger) *AuctionBook {
+	return &AuctionBook{
+		buy:      &OrderBookSide{log: log},
+		sell:     &OrderBookSide{log: log},
+		expiring: NewExpiringOrders(),
+		byID:     map[string]*types.Order{},
+		levels:   map[uint64]*auctionPriceLevel{},
+		highest:  &auctionPriceLevel{}, // empty -> volume 0
+	}
+}
+
+func (b *AuctionBook) applyOrder(order *types.Order) error {
+	side, add := b.buy, b.sell
+	if order.Side == types.Side_SIDE_BUY {
+		side, add = add, side
+	}
+	uncross := *order
+	cpy := &uncross
+	trades, impactedOrders, _, err := side.uncross(cpy)
+	// wash trade is rejected
+	if err != nil && err == ErrWashTrade {
+		return err
+	}
+	if cpy.Remaining == 0 {
+		cpy.Status = types.Order_STATUS_FILLED
+	} else if isPersistent(cpy) {
+		add.addOrder(cpy, cpy.Side)
+		if order.TimeInForce == types.Order_TIF_GTT {
+			b.expiring.Insert(*cpy)
+		}
+	}
+
+	for _, o := range impactedOrders {
+		if o.Remaining == 0 {
+			o.Status = types.Order_STATUS_FILLED
+			if o.TimeInForce == types.Order_TIF_GTT {
+				b.expiring.RemoveOrder(*o)
+			}
+			delete(b.byID, o.Id)
+		}
+	}
+
+	// pointer to the original, unaltered order
+	// so we can uncross at a later point (remove/amend)
+	if cpy.Status == types.Order_STATUS_ACTIVE {
+		b.byID[order.Id] = order
+	}
+	lvl := b.getLevel(cpy.Price)
+	// this order is new add now:
+	lvl.orders[cpy.Id] = cpy
+	lvl.appendTrades(trades)
+	lvl.appendOrders(impactedOrders)
+	if b.highest != lvl && b.highest.volume < lvl.volume {
+		b.highest = lvl
+	}
+	return nil
+}
+
+func (b *AuctionBook) amendOrder(original, amended *types.Order) {
+	side := b.buy
+	if original.Side == types.Side_SIDE_SELL {
+		side = b.sell
+	}
+	_ = side.amendOrder(amended)
+	if original.ExpiresAt != amended.ExpiresAt ||
+		original.TimeInForce != amended.TimeInForce {
+		b.expiring.RemoveOrder(*original)
+		if amended.TimeInForce == types.Order_TIF_GTT {
+			b.expiring.Insert(*amended)
+		}
+	}
+}
+
+// remove one or more orders (cancel orders + order expiry)
+func (b *AuctionBook) removeOrders(buy, sell *OrderBookSide, orders ...types.Order) {
+	// remove the original book
+	for _, o := range orders {
+		delete(b.byID, o.Id)
+		if o.TimeInForce == types.Order_TIF_GTT {
+			b.expiring.RemoveOrder(o)
+		}
+	}
+	b.levels = make(map[uint64]*auctionPriceLevel, len(b.levels)) // we'll have to re-uncross the whole thing
+	// copy over the un-uncrossed buy and sell sides (deep copies)
+	b.buy, b.sell = buy, sell
+	// now uncross all orders again
+	byID := b.byID
+	b.byID = make(map[string]*types.Order, len(byID)) // clear out the original map
+	for _, o := range byID {
+		_ = b.applyOrder(o)
+	}
+}
+
+func (b *AuctionBook) getLevel(price uint64) *auctionPriceLevel {
+	if l, ok := b.levels[price]; ok {
+		return l
+	}
+	l := &auctionPriceLevel{
+		price:  price,
+		trades: []*types.Trade{},
+		orders: map[string]*types.Order{},
+	}
+	b.levels[price] = l
+	return l
+}
+
+// this returns the level we want to uncross
+func (b *AuctionBook) getMarketLevel() *auctionPriceLevel {
+	return b.highest
+}
+
+func (l *auctionPriceLevel) appendTrades(trades []*types.Trade) {
+	l.trades = append(l.trades, trades...)
+	for _, t := range trades {
+		l.volume += t.Size
+	}
+}
+
+func (l *auctionPriceLevel) appendOrders(orders []*types.Order) {
+	for _, o := range orders {
+		if _, ok := l.orders[o.Id]; !ok {
+			l.orders[o.Id] = o
+		}
+	}
+}

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -62,6 +62,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "order0",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -73,6 +74,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIF_GTC,
 		},
 		{
+			Id:          "order1",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -84,6 +86,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIF_GTC,
 		},
 		{
+			Id:          "order2",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -95,6 +98,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIF_GTC,
 		},
 		{
+			Id:          "order3",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -127,6 +131,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "order0",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -138,6 +143,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIF_GTC,
 		},
 		{
+			Id:          "order1",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -149,6 +155,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIF_GTC,
 		},
 		{
+			Id:          "order2",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -160,6 +167,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIF_GTC,
 		},
 		{
+			Id:          "order3",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1347,6 +1355,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 	m[0] = []*types.Order{
 		// Side Sell
 		{
+			Id:          "order0",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1359,6 +1368,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "order1",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1372,6 +1382,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		},
 		// Side Buy
 		{
+			Id:          "order2",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1384,6 +1395,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "order3",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1401,6 +1413,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 	m[1] = []*types.Order{
 		// Side Sell
 		{
+			Id:          "order4",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1414,6 +1427,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		},
 		// Side Buy
 		{
+			Id:          "order5",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketID:    market,
@@ -1445,6 +1459,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		{
 			// same price level, remaining on the passive
 			aggressiveOrder: &types.Order{
+				Id:          "order6",
 				Status:      types.Order_STATUS_ACTIVE,
 				Type:        types.Order_TYPE_LIMIT,
 				MarketID:    market,
@@ -1469,6 +1484,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			},
 			expectedPassiveOrdersAffected: []types.Order{
 				{
+					Id:          "order7",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,
@@ -1485,6 +1501,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		{
 			// same price level, remaining on the passive
 			aggressiveOrder: &types.Order{
+				Id:          "order8",
 				Status:      types.Order_STATUS_ACTIVE,
 				Type:        types.Order_TYPE_LIMIT,
 				MarketID:    market,
@@ -1518,6 +1535,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			},
 			expectedPassiveOrdersAffected: []types.Order{
 				{
+					Id:          "order9",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,
@@ -1530,6 +1548,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 					CreatedAt:   0,
 				},
 				{
+					Id:          "order10",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,
@@ -1546,6 +1565,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		{
 			// same price level, NO PRORATA
 			aggressiveOrder: &types.Order{
+				Id:          "order11",
 				Status:      types.Order_STATUS_ACTIVE,
 				Type:        types.Order_TYPE_LIMIT,
 				MarketID:    market,
@@ -1588,6 +1608,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			},
 			expectedPassiveOrdersAffected: []types.Order{
 				{
+					Id:          "order12",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,
@@ -1600,6 +1621,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 					CreatedAt:   1,
 				},
 				{
+					Id:          "order13",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,
@@ -1612,6 +1634,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 					CreatedAt:   0,
 				},
 				{
+					Id:          "order14",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,
@@ -1628,6 +1651,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		{
 			// same price level, NO PRORATA
 			aggressiveOrder: &types.Order{
+				Id:          "order15",
 				Status:      types.Order_STATUS_ACTIVE,
 				Type:        types.Order_TYPE_LIMIT,
 				MarketID:    market,
@@ -1652,6 +1676,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			},
 			expectedPassiveOrdersAffected: []types.Order{
 				{
+					Id:          "order16",
 					Status:      types.Order_STATUS_ACTIVE,
 					Type:        types.Order_TYPE_LIMIT,
 					MarketID:    market,

--- a/matching/pricelevel_test.go
+++ b/matching/pricelevel_test.go
@@ -26,6 +26,7 @@ func TestAddAndRemoveOrdersToPriceLevel(t *testing.T) {
 	side := &OrderBookSide{}
 	l := side.getPriceLevel(100, types.Side_SIDE_SELL)
 	order := &types.Order{
+		Id:          "order1",
 		MarketID:    "testOrderBook",
 		PartyID:     "A",
 		Side:        types.Side_SIDE_SELL,
@@ -40,7 +41,9 @@ func TestAddAndRemoveOrdersToPriceLevel(t *testing.T) {
 	assert.Equal(t, 0, len(l.orders))
 	l.addOrder(order)
 	assert.Equal(t, 1, len(l.orders))
-	l.addOrder(order)
+	o2 := *order
+	o2.Id = "order2"
+	l.addOrder(&o2)
 	assert.Equal(t, 2, len(l.orders))
 
 	// remove orders

--- a/matching/simpleorders_test.go
+++ b/matching/simpleorders_test.go
@@ -540,6 +540,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "order",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketID:    market,
 		PartyID:     "B",
@@ -555,6 +556,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order1 := types.Order{
+		Id:          "order1",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketID:    market,
 		PartyID:     "A",
@@ -570,6 +572,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "order2",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketID:    market,
 		PartyID:     "A",


### PR DESCRIPTION
This adds a primitive auction mode to the matching engine. Rather crude (because it's just creating copies of the orderbook, and uncrossing them every time a new order is added/or removed). It gives us a basis to write tests against, work out how we handle/implement the volume maximised price stuff etc... while we can consider working on a better uncrossing system to avoid having to use copies of the book.