### PR TITLE
Add bug reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 # Problem encountered
 A clear and concise description of what the bug is.
 
-# System Response
+# System response
 Describe what the system response was, include the output from the command, automation, or else.
 
 **System version:** Specify the system version (0.xx.xx)
@@ -42,6 +42,6 @@ A clear and concise description of what you expected to happen.
 # Logs
 If applicable, add logs and/or screenshots to help explain your problem.
 
-# Additional Content
+# Additional content
 Add any other context about the problem here.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+# Problem encountered
+A clear and concise description of what the bug is.
+
+# **SYSTEM RESPONSE**
+Describe what the system response was, include the output from the command, automation, or else.
+
+**System version:** Specify the system version (0.xx.xx)
+**Protocol:** Specify the protocol
+- [ ] gRPC
+- [ ] REST
+- [ ] GraphQL
+
+**Component:** Specify the components that might be related
+- [ ] [Vega](https://github.com/vegaprotocol/vega/)
+- [ ] [Tendermint](https://github.com/tendermint/tendermint)
+- [ ] [Console](https://github.com/vegaprotocol/console/)
+- [ ] [Ethereum Bridge](https://github.com/vegaprotocol/Event_Queue)
+- [ ] [Vega Wallet](https://github.com/vegaprotocol/go-wallet/)
+
+# Steps to reproduce
+
+## Manual
+Steps to reproduce the behaviour manually:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Automation
+Link to automation and explanation on how to run it to reproduce the problem/bug
+
+https://github.com/vegaprotocol/system-tests/tree/master/....
+
+`Add the necessary file(s) needed to reproduce the problem`
+
+## Not reproducible
+Explain why the problem/bug is not reproducible
+
+# EXPECTED BEHAVIOUR
+A clear and concise description of what you expected to happen.
+
+# LOGS
+If applicable, add logs and/or screenshots to help explain your problem.
+
+# ADDITIONAL CONTEXT
+Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 # Problem encountered
 A clear and concise description of what the bug is.
 
-# **SYSTEM RESPONSE**
+# System Response
 Describe what the system response was, include the output from the command, automation, or else.
 
 **System version:** Specify the system version (0.xx.xx)
@@ -36,12 +36,12 @@ https://github.com/vegaprotocol/system-tests/tree/master/....
 ## Not reproducible
 Explain why the problem/bug is not reproducible
 
-# EXPECTED BEHAVIOUR
+# Expected behaviour
 A clear and concise description of what you expected to happen.
 
-# LOGS
+# Logs
 If applicable, add logs and/or screenshots to help explain your problem.
 
-# ADDITIONAL CONTEXT
+# Additional Content
 Add any other context about the problem here.
 


### PR DESCRIPTION
Here's Dom's draft of the bug report template. You can select it when you file a new issue.

I nearly added a reminder to put labels and projects on bugs. But everyone will do that anyway, right?