### PR TITLE
add a rollback function for the UpdateMarginOnOrder

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -459,7 +459,8 @@ func (m *Market) SubmitOrder(ctx context.Context, order *types.Order) (*types.Or
 	}
 
 	// Perform check and allocate margin
-	if err = m.checkMarginForOrder(ctx, pos, order); err != nil {
+	newOrderMarginRiskRollback, err := m.checkMarginForOrder(ctx, pos, order)
+	if err != nil {
 		_, err1 := m.position.UnregisterOrder(order)
 		if err1 != nil {
 			m.log.Error("Unable to unregister potential trader positions",
@@ -528,6 +529,30 @@ func (m *Market) SubmitOrder(ctx context.Context, order *types.Order) (*types.Or
 				logging.String("market-id", m.GetID()),
 				logging.Error(err))
 		}
+
+		// if the specific case we are in and FOK or IOC
+		// we moved some margin, which may never be released
+		// as we never create a position in the settlement engine.
+		// to be fair the monies would be released later on if the
+		// party place an order which stay in the book / trade.
+		// but in the case the party is actually neve used again
+		// the funds woulds be locked on the margin account until
+		// the market is being closed.
+		// we also check the margin risk update was not nil, as it's not
+		// guaranteed the trader had to pay any margin
+		if order.Remaining == order.Size && newOrderMarginRiskRollback != nil {
+			transfers, err := m.collateral.RollbackMarginUpdateOnOrder(
+				ctx, m.GetID(), asset, newOrderMarginRiskRollback)
+			if err != nil {
+				m.log.Error("Unable to rollback risk updates",
+					logging.String("market-id", m.GetID()),
+					logging.Error(err))
+			}
+			evt := events.NewTransferResponse(
+				ctx, []*types.TransferResponse{transfers})
+			m.broker.Send(evt)
+		}
+
 	}
 
 	// Insert aggressive remaining order
@@ -1042,18 +1067,23 @@ func (m *Market) zeroOutNetwork(ctx context.Context, traders []events.MarketPosi
 	return nil
 }
 
-func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketPosition, order *types.Order) error {
+func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketPosition, order *types.Order) (*types.Transfer, error) {
 	timer := metrics.NewTimeCounter(m.mkt.Id, "market", "checkMarginForOrder")
 	defer timer.EngineTimeCounterAdd()
 
+	// this is a rollback transfer to be used in case the order do not
+	// trade and do not stay in the book to prevent for margin being
+	// locked in the margin account forever
+	var riskRollback *types.Transfer
+
 	asset, err := m.mkt.GetAsset()
 	if err != nil {
-		return errors.Wrap(err, "unable to get risk updates")
+		return nil, errors.Wrap(err, "unable to get risk updates")
 	}
 
 	e, err := m.collateral.GetPartyMargin(pos, asset, m.GetID())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	riskUpdate, err := m.collateralAndRiskForOrder(e, m.markPrice)
@@ -1065,7 +1095,7 @@ func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketP
 				logging.Error(err),
 			)
 		}
-		return ErrMarginCheckInsufficient
+		return nil, ErrMarginCheckInsufficient
 	} else if riskUpdate == nil {
 		if m.log.GetLevel() == logging.DebugLevel {
 			m.log.Debug("No risk updates",
@@ -1076,7 +1106,7 @@ func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketP
 		// if it does fail, we need to return an error straight away
 		transfer, closePos, err := m.collateral.MarginUpdateOnOrder(ctx, m.GetID(), riskUpdate)
 		if err != nil {
-			return errors.Wrap(err, "unable to get risk updates")
+			return nil, errors.Wrap(err, "unable to get risk updates")
 		}
 		evt := events.NewTransferResponse(ctx, []*types.TransferResponse{transfer})
 		m.broker.Send(evt)
@@ -1091,7 +1121,7 @@ func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketP
 					logging.String("market-id", m.GetID()))
 			}
 
-			return ErrMarginCheckInsufficient
+			return nil, ErrMarginCheckInsufficient
 		}
 
 		if m.log.GetLevel() == logging.DebugLevel {
@@ -1104,8 +1134,21 @@ func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketP
 				)
 			}
 		}
+
+		if len(transfer.Transfers) > 0 {
+			// we create the rollback transfer here, so it can be used in case of.
+			riskRollback = &types.Transfer{
+				Owner: riskUpdate.Party(),
+				Amount: &types.FinancialAmount{
+					Amount: int64(transfer.Transfers[0].Amount),
+					Asset:  riskUpdate.Asset(),
+				},
+				Type:      types.TransferType_TRANSFER_TYPE_MARGIN_HIGH,
+				MinAmount: int64(transfer.Transfers[0].Amount),
+			}
+		}
 	}
-	return nil
+	return riskRollback, nil
 }
 
 // this function handles moving money after settle MTM + risk margin updates
@@ -1425,7 +1468,11 @@ func (m *Market) AmendOrder(ctx context.Context, orderAmendment *types.OrderAmen
 	}
 
 	// Perform check and allocate margin
-	if err = m.checkMarginForOrder(ctx, pos, amendedOrder); err != nil {
+	// ignore rollback return here, as if we amend it means the order
+	// is already on the book, not rollback will be needed, the margin
+	// will be updated later on for sure.
+
+	if _, err = m.checkMarginForOrder(ctx, pos, amendedOrder); err != nil {
 		// Undo the position registering
 		_, err1 := m.position.AmendOrder(amendedOrder, existingOrder)
 		if err1 != nil {

--- a/integration/features/1920-trader-with-no-pos-and-stopped-fok-should-have-0-margin.feature
+++ b/integration/features/1920-trader-with-no-pos-and-stopped-fok-should-have-0-margin.feature
@@ -1,0 +1,25 @@
+Feature: test for issue 1920
+
+  Background:
+    Given the insurance pool initial balance for the markets is "0":
+    And the executon engine have these markets:
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 |
+
+  Scenario: a trader place a new order in the system, margin are calculated, then the order is stopped, the margin is released
+    Given the following traders:
+      | name    | amount |
+      | trader1 | 10000  |
+    Then I Expect the traders to have new general account:
+      | name    | asset |
+      | trader1 | ETH   |
+    And "trader1" general accounts balance is "10000"
+    Then traders place following orders:
+      | trader  | id        | type | volume | price | resulting trades | type  | tif |
+      | trader1 | ETH/DEC19 | sell |      1 |  1000 |                0 | TYPE_LIMIT | TIF_FOK |
+    Then the margins levels for the traders are:
+      | trader  | id        | maintenance | search | initial | release |
+      | trader1 | ETH/DEC19 |         100 |    110 |     120 |     140 |
+    Then I expect the trader to have a margin:
+      | trader  | asset | id        | margin | general |
+      | trader1 | ETH   | ETH/DEC19 |      0 |   10000 |


### PR DESCRIPTION
In the case we create an FOK/IOC order, with a postion of 0 (only in the case the trader NEVER traded or had an order in the book before) and that the order is stopped, the margin may never be released if the trader never trade again after that, until the market is closed.

This add a check to release margin directly, only in these specifc cases.

@3jtechtest please check the integration test.

Closes #1920 