### PR TITLE
Add margin checks for orders during auction

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -192,10 +192,14 @@ func NewMarket(
 		partyEngine:        partyEngine,
 		broker:             broker,
 		fee:                feeEngine,
-		auctionEnd:         now.Add(time.Duration(mkt.OpeningAuction.Duration) * time.Second),
+		// keep this commented until the market framework is updated in other repos
+		// auctionEnd:         now.Add(time.Duration(mkt.OpeningAuction.Duration) * time.Second),
 	}
-	if market.auctionEnd.After(now) {
-		market.auction = true
+	if mkt.OpeningAuction != nil {
+		market.auctionEnd = now.Add(time.Duration(mkt.OpeningAuction.Duration) * time.Second)
+		if market.auctionEnd.After(now) {
+			market.auction = true
+		}
 	}
 	return market, nil
 }

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -951,6 +951,7 @@ func baseMarket(row *gherkin.TableRow) proto.Market {
 				},
 			},
 		},
+		OpeningAuction: &proto.AuctionDuration{},
 		TradingMode: &proto.Market_Continuous{
 			Continuous: &proto.ContinuousTrading{},
 		},

--- a/risk/engine.go
+++ b/risk/engine.go
@@ -160,7 +160,7 @@ func (e *Engine) UpdateMarginOnAuctionOrder(ctx context.Context, evt events.Marg
 		oldMargins = e.calculateAuctionMargin(evt, factors, old)
 	}
 	margins := e.calculateAuctionMargin(evt, factors, o)
-	maintenance := float64(margins.MaintenanceMargin) - float64(oldMargins.Maintenance)
+	maintenance := float64(margins.MaintenanceMargin) - float64(oldMargins.MaintenanceMargin)
 	initial := float64(margins.InitialMargin) - float64(oldMargins.InitialMargin)
 	// we have too much margin (size/price of order was reduced) -> release some money from margin account
 	if maintenance < 0 {

--- a/risk/margins_calculation.go
+++ b/risk/margins_calculation.go
@@ -18,6 +18,15 @@ func newMarginLevels(maintenance float64, scalingFactors *types.ScalingFactors) 
 	}
 }
 
+func (r *Engine) calculateAuctionMargin(e events.Margin, rf types.RiskFactor, o *types.Order) *types.MarginLevels {
+	factor := rf.Long
+	if o.Side == types.Side_SIDE_SELL {
+		factor = rf.Short
+	}
+	maintenance := float64(o.Size) * (factor * float64(o.Price))
+	return newMarginLevels(maintenance, r.marginCalculator.ScalingFactors)
+}
+
 // Implementation of the margin calculator per specs:
 // https://github.com/vegaprotocol/product/blob/master/specs/0019-margin-calculator.md
 func (r *Engine) calculateMargins(e events.Margin, markPrice int64, rf types.RiskFactor, withPotentialBuyAndSell bool) *types.MarginLevels {


### PR DESCRIPTION
Check margins for orders submitted during auction period. Closes #2042

This PR includes execution engine/market toggling auction trading on/off after depending on the configuration of the market framework. The current flow for margin checks has been reused as much as possible. If the market is in auction, a different function on the risk engine is called which calculates the collateral required for a given order based on the order size + price.

for order amends, the old order margin is subtracted from the new order, which can either increase the margin required or release some margin to the general account. A zero transfer is possible in theory (higher price, lower volume).