### PR TITLE
add a map of all seen tx in banking to protect against double spending

### DIFF
--- a/banking/asset_action.go
+++ b/banking/asset_action.go
@@ -6,6 +6,8 @@ import (
 	"code.vegaprotocol.io/vega/assets"
 	"code.vegaprotocol.io/vega/assets/common"
 	types "code.vegaprotocol.io/vega/proto"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 var (
@@ -105,6 +107,10 @@ func (t *assetAction) checkBuiltinAssetDeposit() error {
 		partyID: t.builtinD.PartyID,
 		assetID: t.builtinD.VegaAssetID,
 	}
+	asset, _ := t.asset.BuiltinAsset()
+	// builtin deposits do not have hash, and we don't need one
+	// so let's just add some random id
+	t.ref = txRef{asset.GetAssetClass(), uuid.NewV4().String()}
 	return nil
 }
 

--- a/banking/engine_test.go
+++ b/banking/engine_test.go
@@ -55,6 +55,7 @@ func getTestEngine(t *testing.T) *testEngine {
 
 func TestBanking(t *testing.T) {
 	t.Run("test deposit success", testDepositSuccess)
+	t.Run("test deposit success - no tx duplicate", testDepositSuccessNoTxDuplicate)
 	t.Run("test deposit failure", testDepositFailure)
 	t.Run("test deposit error - start check fail", testDepositError)
 }
@@ -74,6 +75,53 @@ func testDepositSuccess(t *testing.T) {
 
 	// call the deposit function
 	err := eng.DepositBuiltinAsset(bad, 42)
+	assert.NoError(t, err)
+
+	// then we call the callback from the fake erc
+	eng.erc.r.Check()
+	eng.erc.f(eng.erc.r, true)
+
+	// then we call time update, which should call the collateral to
+	// to do the deposit
+	eng.col.EXPECT().Deposit(gomock.Any(), bad.PartyID, bad.VegaAssetID, bad.Amount).Times(1).Return(nil)
+
+	eng.OnTick(context.Background(), now.Add(1*time.Second))
+}
+
+func testDepositSuccessNoTxDuplicate(t *testing.T) {
+	eng := getTestEngine(t)
+	defer eng.ctrl.Finish()
+
+	now := time.Now()
+	eng.tsvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
+	bad := &types.BuiltinAssetDeposit{
+		VegaAssetID: "someasset",
+		PartyID:     "someparty",
+		Amount:      42,
+	}
+
+	// call the deposit function
+	err := eng.DepositBuiltinAsset(bad)
+	assert.NoError(t, err)
+
+	// then we call the callback from the fake erc
+	eng.erc.r.Check()
+	eng.erc.f(eng.erc.r, true)
+
+	// then we call time update, which should call the collateral to
+	// to do the deposit
+	eng.col.EXPECT().Deposit(gomock.Any(), bad.PartyID, bad.VegaAssetID, bad.Amount).Times(1).Return(nil)
+
+	eng.OnTick(context.Background(), now.Add(1*time.Second))
+	eng.tsvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
+	bad = &types.BuiltinAssetDeposit{
+		VegaAssetID: "someasset",
+		PartyID:     "someparty",
+		Amount:      42,
+	}
+
+	// call the deposit function
+	err = eng.DepositBuiltinAsset(bad)
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc

--- a/banking/engine_test.go
+++ b/banking/engine_test.go
@@ -92,16 +92,17 @@ func testDepositSuccessNoTxDuplicate(t *testing.T) {
 	eng := getTestEngine(t)
 	defer eng.ctrl.Finish()
 
+	eng.assets.EXPECT().Get(gomock.Any()).Times(2).Return(testAsset, nil)
 	now := time.Now()
-	eng.tsvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
+	eng.tsvc.EXPECT().GetTimeNow().Times(2).Return(now, nil)
 	bad := &types.BuiltinAssetDeposit{
-		VegaAssetID: "someasset",
+		VegaAssetID: "VGT",
 		PartyID:     "someparty",
 		Amount:      42,
 	}
 
 	// call the deposit function
-	err := eng.DepositBuiltinAsset(bad)
+	err := eng.DepositBuiltinAsset(bad, 42)
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc
@@ -113,15 +114,9 @@ func testDepositSuccessNoTxDuplicate(t *testing.T) {
 	eng.col.EXPECT().Deposit(gomock.Any(), bad.PartyID, bad.VegaAssetID, bad.Amount).Times(1).Return(nil)
 
 	eng.OnTick(context.Background(), now.Add(1*time.Second))
-	eng.tsvc.EXPECT().GetTimeNow().Times(1).Return(now, nil)
-	bad = &types.BuiltinAssetDeposit{
-		VegaAssetID: "someasset",
-		PartyID:     "someparty",
-		Amount:      42,
-	}
 
 	// call the deposit function
-	err = eng.DepositBuiltinAsset(bad)
+	err = eng.DepositBuiltinAsset(bad, 43)
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/ethereum/go-ethereum v1.9.12
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.4.0
 	github.com/google/btree v1.0.0


### PR DESCRIPTION
This adds a map to prevent the banking package to process twice the same transaction sent from the blockchain queue.
This use just a map as of now, but we could use later on a persistent database (we may have to store a lot of them).


closes #1986 