### PR TITLE
add fees to the integrations tests

### DIFF
--- a/integration/core_test.go
+++ b/integration/core_test.go
@@ -47,10 +47,9 @@ func initialiseMarket(row *gherkin.TableRow, mkt *proto.Market) {
 	release, _ := strconv.ParseFloat(row.Cells[8].Value, 64)
 	initial, _ := strconv.ParseFloat(row.Cells[9].Value, 64)
 	search, _ := strconv.ParseFloat(row.Cells[10].Value, 64)
-	lastIdx := len(row.Cells) - 1
-	openAuctionDuration, _ := strconv.ParseInt(row.Cells[lastIdx-1].Value, 10, 64)
-	if row.Cells[lastIdx].Value != "continuous" {
-		batchDuration, _ := strconv.ParseInt(row.Cells[lastIdx].Value, 10, 64)
+	openAuctionDuration, _ := strconv.ParseInt(row.Cells[11].Value, 10, 64)
+	if row.Cells[12].Value != "continuous" {
+		batchDuration, _ := strconv.ParseInt(row.Cells[12].Value, 10, 64)
 		mkt.TradingMode = &proto.Market_Discrete{
 			Discrete: &proto.DiscreteTrading{
 				DurationNs: batchDuration,

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -902,9 +902,9 @@ func baseMarket(row *gherkin.TableRow) proto.Market {
 		DecimalPlaces: 2,
 		Fees: &proto.Fees{
 			Factors: &proto.FeeFactors{
-				LiquidityFee:      "0",
-				InfrastructureFee: "0",
-				MakerFee:          "0",
+				LiquidityFee:      val(row, 17),
+				InfrastructureFee: val(row, 18),
+				MakerFee:          val(row, 19),
 			},
 		},
 		TradableInstrument: &proto.TradableInstrument{

--- a/integration/features/1779-cannot-place-network-order.feature
+++ b/integration/features/1779-cannot-place-network-order.feature
@@ -3,8 +3,8 @@ Feature: Cannot place an network order
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |      0.11 |       0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 |           0 | continuous   |        0 |                 0 |            0 |
 
   Scenario: an order is rejected if a trader try to place an order with type NETWORK
     Given the following traders:

--- a/integration/features/1847-closeout-long.feature
+++ b/integration/features/1847-closeout-long.feature
@@ -3,8 +3,8 @@ Feature: Long close-out test (see ln 293 of system-tests/grpc/trading/tradesTest
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://drive.google.com/file/d/1bYWbNJvG7E-tcqsK26JMu2uGwaqXqm0L/view
     # setup accounts

--- a/integration/features/1847-closeout-short.feature
+++ b/integration/features/1847-closeout-short.feature
@@ -3,8 +3,8 @@ Feature: Long close-out test (see ln 449 of system-tests/grpc/trading/tradesTest
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://drive.google.com/file/d/1bYWbNJvG7E-tcqsK26JMu2uGwaqXqm0L/view
     # setup accounts

--- a/integration/features/1919-close-out-occurs-above-maintenance.feature
+++ b/integration/features/1919-close-out-occurs-above-maintenance.feature
@@ -4,8 +4,8 @@ Feature: Setting up 5 traders so that at once all the orders are places they end
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://drive.google.com/file/d/1bYWbNJvG7E-tcqsK26JMu2uGwaqXqm0L/view
     # setup accounts

--- a/integration/features/1920-trader-with-no-pos-and-stopped-fok-should-have-0-margin.feature
+++ b/integration/features/1920-trader-with-no-pos-and-stopped-fok-should-have-0-margin.feature
@@ -3,8 +3,8 @@ Feature: test for issue 1920
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice |
-      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |      0.11 |       0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 |           0 | continuous   |        0 |                 0 |            0 |
 
   Scenario: a trader place a new order in the system, margin are calculated, then the order is stopped, the margin is released
     Given the following traders:

--- a/integration/features/596-Opened-positions-traded-out-but-there-is-still-money-sitting-in-a-margin-account.feature
+++ b/integration/features/596-Opened-positions-traded-out-but-there-is-still-money-sitting-in-a-margin-account.feature
@@ -3,8 +3,8 @@ Feature: Regression test for issue 596
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Traded out position but monies left in margin account
     Given the following traders:

--- a/integration/features/596-margin-account-non-zero-after-trading-out-market-order.feature
+++ b/integration/features/596-margin-account-non-zero-after-trading-out-market-order.feature
@@ -3,8 +3,8 @@ Feature: Regression test for issue 596
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Traded out position but monies left in margin account
     Given the following traders:

--- a/integration/features/598-open-position-with-zero-margin.feature
+++ b/integration/features/598-open-position-with-zero-margin.feature
@@ -3,10 +3,10 @@ Feature: Regression test for issue 598
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
-#     | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |                    0.1 |  0 |     0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
-#     | ETH/DEC19 | ETH      | BTC       | BTC   |         5 | forward    |       0.01 | 0.00011407711613050422 |  0 | 0.016 |  0.09 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
+#     | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |                    0.1 |  0 |     0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
+#     | ETH/DEC19 | ETH      | BTC       | BTC   |         5 | forward    |       0.01 | 0.00011407711613050422 |  0 | 0.016 |  0.09 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Open position but ZERO in margin account
     Given the following traders:

--- a/integration/features/614-margin-calculations-fixes.feature
+++ b/integration/features/614-margin-calculations-fixes.feature
@@ -3,8 +3,8 @@ Feature: test bugfix 614 for margin calculations
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   |        94 | simple     |        0.2 |      0.1 |  0 | 0 |     0 |              5 |              4 |           3.2 |             100 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |        94 | simple     |        0.2 |      0.1 |  0 | 0 |     0 |              5 |              4 |           3.2 |             100 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: CASE-1: Trader submits long order that will trade - new formula & high exit price
     Given the following traders:

--- a/integration/features/630-position-resolution-negative-insurance-pool.feature
+++ b/integration/features/630-position-resolution-negative-insurance-pool.feature
@@ -3,8 +3,8 @@ Feature: Regression test for issue 630
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |        0.2 |      0.1 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |        0.2 |      0.1 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Trader is being closed out.
 # setup accounts

--- a/integration/features/635-margin-calculation.feature
+++ b/integration/features/635-margin-calculation.feature
@@ -3,8 +3,8 @@ Feature: Regression test for issue 596
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |        0.2 |      0.1 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |        0.2 |      0.1 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Traded out position but monies left in margin account
 # setup accounts

--- a/integration/features/760_cancel_filled_order.feature
+++ b/integration/features/760_cancel_filled_order.feature
@@ -3,8 +3,8 @@ Feature: Close a filled order twice
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Traders place an order, a trade happens, and orders are cancelled after being filled
 # setup accounts

--- a/integration/features/762_missing_party_and_order.feature
+++ b/integration/features/762_missing_party_and_order.feature
@@ -4,8 +4,8 @@ Feature: Test crash on cancel of missing order
     Given the insurance pool initial balance for the markets is "0":
  #   And the markets starts on "2019-11-30T00:00:00Z" and expires on "2019-12-31T23:59:59Z"
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: A non-existent party attempts to place an order
     Given missing traders place following orders with references:

--- a/integration/features/767-margin-level-check.feature
+++ b/integration/features/767-margin-level-check.feature
@@ -3,8 +3,8 @@ Feature: Regression test for issue 767
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long |               tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | forward    |      0.001 | 0.00011407711613050422 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Traders place orders meeting the maintenance margin, but not the initial margin requirements, and can close out
     Given the following traders:

--- a/integration/features/amend-order.feature
+++ b/integration/features/amend-order.feature
@@ -3,8 +3,8 @@ Feature: Amend orders
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Amend rejected for non existing order
 # setup accounts

--- a/integration/features/building_trader_accounts.feature
+++ b/integration/features/building_trader_accounts.feature
@@ -3,9 +3,9 @@ Feature: Test trader accounts
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name         | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19    | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
-      | GBPUSD/DEC19 | GPB      | USD       | VUSD  |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name         | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19    | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
+      | GBPUSD/DEC19 | GPB      | USD       | VUSD  |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: a trader is added to the system. A general account is created for each asset
     Given the following traders:

--- a/integration/features/core.feature
+++ b/integration/features/core.feature
@@ -5,8 +5,8 @@ Feature: Test trading-core flow with future risk model
     ## With these values, we get risk factors:
     ## short=0.11000000665311127, long=0.10036253585651489
     Given the market:
-      | name      | markprice | risk model | lamd/long |    tau/short | mu | r |     sigma | release factor | initial factor | search factor | openAuction | trading mode |
-      | ETH/DEC19 |      1000 | future     |       0.01 | 0.000114077 |  0 | 0 | 3.6907199 |            1.4 |            1.2 |           1.1 | 0           | continuous   |
+      | name      | markprice | risk model | lamd/long |    tau/short | mu | r |     sigma | release factor | initial factor | search factor | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 |      1000 | future     |       0.01 | 0.000114077 |  0 | 0 | 3.6907199 |            1.4 |            1.2 |           1.1 | 0           | continuous   |        0 |                 0 |            0 |
     And the system accounts:
       | type       | asset | balance |
       | settlement | ETH   |       0 |

--- a/integration/features/margins.feature
+++ b/integration/features/margins.feature
@@ -3,8 +3,8 @@ Feature: Test trader accounts
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
   Scenario: a trader place a new order in the system, margin are calculated
     Given the following traders:
       | name    | amount |

--- a/integration/features/mark_to_mark_settlement_using_insurance_pool.feature
+++ b/integration/features/mark_to_mark_settlement_using_insurance_pool.feature
@@ -3,8 +3,8 @@ Feature: Test mark to market settlement with insurance pool
   Background:
     Given the insurance pool initial balance for the markets is "10000":
     And the executon engine have these markets:
-      | name      |baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 |BTC      | ETH       | ETH   | 1000      | simple     | 0.11       | 0.1      | 0  | 0 | 0     | 1.4            | 1.2            | 1.1           | 42              | 0           | continuous   |
+      | name      |baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 |BTC      | ETH       | ETH   | 1000      | simple     | 0.11       | 0.1      | 0  | 0 | 0     | 1.4            | 1.2            | 1.1           | 42              | 0           | continuous   |        0 |                 0 |            0 |
   Scenario: If settlement amount > trader’s margin account balance + trader’s general account balance for the asset, the full balance of the trader’s margin account is transferred to the market’s temporary settlement account, the full balance of the trader’s general account for the assets are transferred to the market’s temporary settlement account, the minimum insurance pool account balance for the market & asset, and the remainder, i.e. the difference between the total amount transferred from the trader’s margin + general accounts and the settlement amount, is transferred from the insurance pool account for the market to the temporary settlement account for the market
     Given the following traders:
       | name    | amount |

--- a/integration/features/mark_to_market_settlement.feature
+++ b/integration/features/mark_to_market_settlement.feature
@@ -3,8 +3,8 @@ Feature: Test mark to market settlement
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
   Scenario: If settlement amount <= the trader’s margin account balance entire settlement amount is transferred from trader’s margin account to the market’s temporary settlement account
     Given the following traders:
       | name    | amount |

--- a/integration/features/network-order-and-trades-sub.feature
+++ b/integration/features/network-order-and-trades-sub.feature
@@ -3,8 +3,8 @@ Feature: Ensure network trader are generated
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: Implement trade and order network
 # setup accounts

--- a/integration/features/settlement_at_expiry.feature
+++ b/integration/features/settlement_at_expiry.feature
@@ -3,8 +3,8 @@ Feature: Test mark to market settlement
   Background:
     Given the markets starts on "2019-11-30T00:00:00Z" and expires on "2019-12-31T23:59:59Z"
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlement price | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |               42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | settlement price | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |      1000 | simple     |       0.11 |      0.1 |  0 | 0 |     0 |            1.4 |            1.2 |           1.1 |               42 | 0           | continuous   |        0 |                 0 |            0 |
   Scenario: Order cannot be placed once the market is expired
     Given the following traders:
       | name    | amount |

--- a/integration/features/simple.feature
+++ b/integration/features/simple.feature
@@ -2,8 +2,8 @@ Feature: Test trading-core flow with simple risk model
 
     Background:
         Given the market:
-            | name      | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | openAuction | trading mode |
-            | ETH/DEC19 | 1000      | simple     | 0.11       | 0.1      | 0  | 0 | 0     | 1.4            | 1.2            | 1.1           | 0           | continuous   |
+            | name      | markprice | risk model | lamd/long | tau/short | mu | r | sigma | release factor | initial factor | search factor | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+            | ETH/DEC19 | 1000      | simple     | 0.11       | 0.1      | 0  | 0 | 0     | 1.4            | 1.2            | 1.1           | 0           | continuous   |        0 |                 0 |            0 |
         And the system accounts:
             | type       | asset | balance |
             | settlement | ETH   | 0       |

--- a/integration/features/verified-loss-socialization-case1.feature
+++ b/integration/features/verified-loss-socialization-case1.feature
@@ -4,8 +4,8 @@ Feature: Test loss socialization case 1
     Given the insurance pool initial balance for the markets is "0":
  #   And the markets starts on "2019-11-30T00:00:00Z" and expires on "2019-12-31T23:59:59Z"
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: case 1 from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
 # setup accounts

--- a/integration/features/verified-loss-socialization-case2.feature
+++ b/integration/features/verified-loss-socialization-case2.feature
@@ -3,8 +3,8 @@ Feature: Test loss socialization case 2
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: case 2 from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
 # setup accounts

--- a/integration/features/verified-loss-socialization-case3.feature
+++ b/integration/features/verified-loss-socialization-case3.feature
@@ -3,8 +3,8 @@ Feature: Test loss socialization case 3
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: case 3 from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
 # setup accounts

--- a/integration/features/verified-loss-socialization-case4.feature
+++ b/integration/features/verified-loss-socialization-case4.feature
@@ -3,8 +3,8 @@ Feature: Test loss socialization case 4
   Background:
     Given the insurance pool initial balance for the markets is "2900":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: case 4 from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
 # setup accounts

--- a/integration/features/verified-loss-socialization-case5.feature
+++ b/integration/features/verified-loss-socialization-case5.feature
@@ -3,8 +3,8 @@ Feature: Test loss socialization case 5
   Background:
     Given the insurance pool initial balance for the markets is "3000":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: case 5 from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
 # setup accounts

--- a/integration/features/verified-mark-to-market-settlement.feature
+++ b/integration/features/verified-mark-to-market-settlement.feature
@@ -2,8 +2,8 @@ Feature: MTM settlement tests
 # Reference spreadsheet: https://drive.google.com/open?id=1ZCj7WWvP236wiJDgiGD_f9Xsun9o8PsW
   Background:
     Given the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: case 1 - LONG - MORE LONG - one trade
 # setup accounts

--- a/integration/features/verified-positions-resolution-1.feature
+++ b/integration/features/verified-positions-resolution-1.feature
@@ -3,8 +3,8 @@ Feature: Position resolution case 1
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://docs.google.com/spreadsheets/d/1D433fpt7FUCk04dZ9FHDVy-4hA6Bw_a2/edit#gid=956988479
 # setup accounts

--- a/integration/features/verified-positions-resolution-2.feature
+++ b/integration/features/verified-positions-resolution-2.feature
@@ -3,8 +3,8 @@ Feature: Position resolution case 2
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://docs.google.com/spreadsheets/d/1D433fpt7FUCk04dZ9FHDVy-4hA6Bw_a2/edit#gid=1011478143
 # setup accounts

--- a/integration/features/verified-positions-resolution-3.feature
+++ b/integration/features/verified-positions-resolution-3.feature
@@ -3,8 +3,8 @@ Feature: Position resolution case 3
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://docs.google.com/spreadsheets/d/1D433fpt7FUCk04dZ9FHDVy-4hA6Bw_a2
 # setup accounts

--- a/integration/features/verified-positions-resolution-4.feature
+++ b/integration/features/verified-positions-resolution-4.feature
@@ -3,8 +3,8 @@ Feature: Position resolution case 4
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | ETH      | BTC       | BTC   |        94 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |              5 |              4 |           3.2 |              42 | 0           | continuous   |        0 |                 0 |            0 |
 
   Scenario: https://drive.google.com/file/d/1bYWbNJvG7E-tcqsK26JMu2uGwaqXqm0L/view
 # setup accounts

--- a/integration/features/verified_margins_case1.feature
+++ b/integration/features/verified_margins_case1.feature
@@ -4,8 +4,8 @@ Feature: CASE-1: Trader submits long order that will trade - new formula & high 
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |        0 |                 0 |            0 |
     And the following traders:
       | name       | amount     |
       | trader1    | 1000000000 |

--- a/integration/features/verified_margins_case2.feature
+++ b/integration/features/verified_margins_case2.feature
@@ -4,8 +4,8 @@ Feature: CASE-2: Trader submits long order that will trade - new formula & low e
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |        0 |                 0 |            0 |
     And the following traders:
       | name       | amount     |
       | trader1    | 1000000000 |

--- a/integration/features/verified_margins_case3.feature
+++ b/integration/features/verified_margins_case3.feature
@@ -4,8 +4,8 @@ Feature: CASE-3: Trader submits long order that will trade - new formula & zero 
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |        0 |                 0 |            0 |
     And the following traders:
       | name       | amount     |
       | trader1    | 1000000000 |

--- a/integration/features/verified_margins_case4.feature
+++ b/integration/features/verified_margins_case4.feature
@@ -4,8 +4,8 @@ Feature: CASE-4: Trader submits short order that will trade - new formula & high
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 9400000         | 0           | continuous   |        0 |                 0 |            0 |
     And the following traders:
       | name       | amount     |
       | trader1    | 1000000000 |

--- a/integration/features/verified_margins_case5.feature
+++ b/integration/features/verified_margins_case5.feature
@@ -4,8 +4,8 @@ Feature: CASE-5: Trader submits short order that will trade - new formula & low 
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode |
-      | ETH/DEC19 | BTC      | ETH       | ETH   | 9400000   | simple     | 0.1      | 0.2        | 0  | 0 | 0     | 5              | 4              | 3.2           | 940000          | 0           | continous   |
+      | name      | baseName | quoteName | asset | markprice | risk model | tau/short | lamd/long | mu | r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee |
+      | ETH/DEC19 | BTC      | ETH       | ETH   |   9400000 | simple     |       0.1 |       0.2 |  0 | 0 |     0 |              5 |              4 |           3.2 |          940000 |           0 | continous    |        0 |                 0 |            0 |
     And the following traders:
       | name       | amount       |
       | trader1    | 1000000000   |


### PR DESCRIPTION
This enable settings fees as part of the markets configuration for the integrations tests.

closes #2044 