### PR TITLE
Feature/2070 faucet requests limits

### DIFF
--- a/faucet/README.md
+++ b/faucet/README.md
@@ -5,6 +5,12 @@ The faucet takes the form of an http server exposing a REST API which triggers n
 
 In order to control exactly who is allowed to broadcast events to the network, the [node configuration](../config/) contains a list of public keys allowed to broadcast chain events. The faucet's keypairs must be on this list before it can start allocating assets.
 
+## Request rate limiting
+To prevent the users to request unlimited amount of funds, the CoolDown field in the configuration allow operator to specify a minimum amount of time between 2 request for funds.
+
+## Spam prevention
+In order to prevent spam from non-validator node, the faucet needs to be connected to a validator node.
+
 ## Configuration
 
 The configuration of the faucet is done through the vega config.toml file.

--- a/faucet/config.go
+++ b/faucet/config.go
@@ -18,7 +18,7 @@ const (
 	namedLogger     = "faucet"
 	defaultWallet   = "faucet-wallet"
 	configFile      = "faucet.toml"
-	defaultCoolDown = 5 * time.Hour
+	defaultCoolDown = 1 * time.Minute
 )
 
 type Config struct {

--- a/faucet/rate_limit.go
+++ b/faucet/rate_limit.go
@@ -36,14 +36,14 @@ func (r *RateLimit) NewRequest(pubkey, asset string) error {
 	}
 	until, ok := assets[asset]
 	if ok {
-		// we already have this asset whitelist,
-		// the trader is trying to get more fuunds while still blacklisted
+		// we already have this asset greylisted,
+		// the trader is trying to get more fuunds while still greylisted
 		// give him a penalty
 		assets[asset] = until.Add(r.cfg.CoolDown.Duration)
-		return fmt.Errorf("you are greylist - your pubkey is now greylisted for an extended period until %v", assets[asset])
+		return fmt.Errorf("you are greylisted - your pubkey is now greylisted for an extended period until %v", assets[asset])
 	}
 
-	// grey list for the minimal duration
+	// greylist for the minimal duration
 	assets[asset] = time.Now().Add(r.cfg.CoolDown.Duration)
 
 	return nil
@@ -67,7 +67,7 @@ func (r *RateLimit) startCleanup(ctx context.Context) {
 						delete(assets, asset)
 					}
 				}
-				// if no assets blacklisted anymore for this pubkey
+				// if no assets greylisted anymore for this pubkey
 				// we remove the pubkey
 				if len(assets) <= 0 {
 					delete(r.requests, pubkey)

--- a/faucet/rate_limit.go
+++ b/faucet/rate_limit.go
@@ -1,0 +1,79 @@
+package faucet
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type RateLimit struct {
+	cfg Config
+	// map of pubkeys -> assets id -> time until request can be allowed
+	requests map[string]map[string]time.Time
+
+	mu sync.RWMutex
+}
+
+func NewRateLimit(ctx context.Context, cfg Config) *RateLimit {
+	r := &RateLimit{
+		cfg:      cfg,
+		requests: map[string]map[string]time.Time{},
+	}
+	go r.startCleanup(ctx)
+	return r
+}
+
+// NewRequest returns nil if the party can request new funds
+func (r *RateLimit) NewRequest(pubkey, asset string) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	assets, ok := r.requests[pubkey]
+	if !ok {
+		r.requests[pubkey] = map[string]time.Time{}
+		assets = r.requests[pubkey]
+	}
+	until, ok := assets[asset]
+	if ok {
+		// we already have this asset whitelist,
+		// the trader is trying to get more fuunds while still blacklisted
+		// give him a penalty
+		assets[asset] = until.Add(r.cfg.CoolDown.Duration)
+		return fmt.Errorf("you are greylist - your pubkey is now greylisted for an extended period until %v", assets[asset])
+	}
+
+	// grey list for the minimal duration
+	assets[asset] = time.Now().Add(r.cfg.CoolDown.Duration)
+
+	return nil
+}
+
+func (r *RateLimit) startCleanup(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _ = <-ticker.C:
+			now := time.Now()
+			r.mu.Lock()
+			for pubkey, assets := range r.requests {
+				for asset, tim := range assets {
+					// if time is elapsed, remove from the map
+					if tim.Before(now) {
+						delete(assets, asset)
+					}
+				}
+				// if no assets blacklisted anymore for this pubkey
+				// we remove the pubkey
+				if len(assets) <= 0 {
+					delete(r.requests, pubkey)
+				}
+			}
+			r.mu.Unlock()
+		}
+	}
+}


### PR DESCRIPTION
add requests number limit to the faucet.
user are grey listed when they do a request to the faucet for a given asset for the duration of the cool down setted up  in config.
close #2075 