### PR TITLE
Change Amount in example request to be int

### DIFF
--- a/faucet/README.md
+++ b/faucet/README.md
@@ -59,7 +59,7 @@ POST /api/v1/mint
 ```json
 {
 	"party": "party_pub_key",
-	"amount": "amount_to_be_deposited",
+	"amount": amount_to_be_deposited,
 	"asset": "asset_id"
 }
 ```


### PR DESCRIPTION
The web service returns an error if the amount field is a string

- Update example body

Sending a string results in:

```
{
"error": "json: cannot unmarshal string into Go struct field MintRequest.amount of type uint64"
}
```