### PR TITLE
add max deposit amount for VOTE token

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -27,10 +27,11 @@ var (
 	TokenAssetSource = &types.AssetSource{
 		Source: &types.AssetSource_BuiltinAsset{
 			BuiltinAsset: &types.BuiltinAsset{
-				Name:        "VOTE",
-				Symbol:      "VOTE",
-				TotalSupply: "0",
-				Decimals:    5,
+				Name:                "VOTE",
+				Symbol:              "VOTE",
+				TotalSupply:         "0",
+				Decimals:            5,
+				MaxFaucetAmountMint: "1000",
 			},
 		},
 	}


### PR DESCRIPTION
We missed the vote token when adding the max allowed deposit for assets.

@3jtechtest asked for a max deposit of 1000 for now which is the max he's requiring in the system-tests as of now.