### PR TITLE
Cancel Order bulk

### DIFF
--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -204,7 +204,7 @@ func TestCancelWithWrongPartyID(t *testing.T) {
 		MarketID: confirmation.GetOrder().MarketID,
 		PartyID:  party2,
 	}
-	cancelconf, err := tm.market.CancelOrder(context.TODO(), cancelOrder)
+	cancelconf, err := tm.market.CancelOrder(context.TODO(), cancelOrder.PartyID, cancelOrder.OrderID)
 	assert.Nil(t, cancelconf)
 	assert.Error(t, err, types.ErrInvalidPartyID)
 }

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -55,6 +55,226 @@ func TestOrderBook_GetClosePNL(t *testing.T) {
 	t.Run("Get Best offer price and volume", testBestOfferPriceAndVolume)
 }
 
+func TestOrderBook_CancelBulk(t *testing.T) {
+	t.Run("Cancel all order for a party", cancelAllOrderForAParty)
+	t.Run("Get all order for a party", getAllOrderForAParty)
+	t.Run("Party with no order cancel nothing", partyWithNoOrderCancelNothing)
+}
+
+func cancelAllOrderForAParty(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+	orders := []*types.Order{
+		{
+			Id:          "1111111111111111111111",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       100,
+			Size:        1,
+			Remaining:   1,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "2222222222222222222222",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       300,
+			Size:        5,
+			Remaining:   5,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "3333333333333333333333",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "B",
+			Side:        types.Side_SIDE_BUY,
+			Price:       200,
+			Size:        1,
+			Remaining:   1,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "4444444444444444444444",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       300,
+			Size:        10,
+			Remaining:   10,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+	}
+	for _, o := range orders {
+		confirm, err := book.SubmitOrder(o)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(confirm.Trades))
+	}
+	confs, err := book.CancelAllOrders("A")
+	assert.NoError(t, err)
+	assert.Len(t, confs, 3)
+	expectedIDs := map[string]struct{}{
+		"1111111111111111111111": {},
+		"2222222222222222222222": {},
+		"4444444444444444444444": {},
+	}
+	for _, conf := range confs {
+		if _, ok := expectedIDs[conf.Order.Id]; ok {
+			delete(expectedIDs, conf.Order.Id)
+		} else {
+			t.Fatalf("unexpected order has been cancelled %v", conf.Order)
+		}
+	}
+}
+
+func getAllOrderForAParty(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+	orders := []*types.Order{
+		{
+			Id:          "1111111111111111111111",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       100,
+			Size:        1,
+			Remaining:   1,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "2222222222222222222222",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       300,
+			Size:        5,
+			Remaining:   5,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "3333333333333333333333",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "B",
+			Side:        types.Side_SIDE_BUY,
+			Price:       200,
+			Size:        1,
+			Remaining:   1,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "4444444444444444444444",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       300,
+			Size:        10,
+			Remaining:   10,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+	}
+	for _, o := range orders {
+		confirm, err := book.SubmitOrder(o)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(confirm.Trades))
+	}
+	ordersLs := book.GetOrdersPerParty("A")
+	assert.Len(t, ordersLs, 3)
+	expectedIDs := map[string]struct{}{
+		"1111111111111111111111": {},
+		"2222222222222222222222": {},
+		"4444444444444444444444": {},
+	}
+	for _, o := range ordersLs {
+		if _, ok := expectedIDs[o.Id]; ok {
+			delete(expectedIDs, o.Id)
+		} else {
+			t.Fatalf("unexpected order has been cancelled %v", o)
+		}
+	}
+}
+
+func partyWithNoOrderCancelNothing(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+	orders := []*types.Order{
+		{
+			Id:          "1111111111111111111111",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       100,
+			Size:        1,
+			Remaining:   1,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "2222222222222222222222",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       300,
+			Size:        5,
+			Remaining:   5,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "3333333333333333333333",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "B",
+			Side:        types.Side_SIDE_BUY,
+			Price:       200,
+			Size:        1,
+			Remaining:   1,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+		{
+			Id:          "4444444444444444444444",
+			Status:      types.Order_STATUS_ACTIVE,
+			Type:        types.Order_TYPE_LIMIT,
+			MarketID:    market,
+			PartyID:     "A",
+			Side:        types.Side_SIDE_BUY,
+			Price:       300,
+			Size:        10,
+			Remaining:   10,
+			TimeInForce: types.Order_TIF_GTC,
+		},
+	}
+	for _, o := range orders {
+		confirm, err := book.SubmitOrder(o)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(confirm.Trades))
+	}
+	ordersLs := book.GetOrdersPerParty("X")
+	assert.Len(t, ordersLs, 0)
+}
+
 func testBestBidPriceAndVolume(t *testing.T) {
 	market := "testMarket"
 	book := getTestOrderBook(t, market)

--- a/processor/mocks/execution_engine_mock.go
+++ b/processor/mocks/execution_engine_mock.go
@@ -50,10 +50,10 @@ func (mr *MockExecutionEngineMockRecorder) AmendOrder(arg0, arg1 interface{}) *g
 }
 
 // CancelOrder mocks base method
-func (m *MockExecutionEngine) CancelOrder(arg0 context.Context, arg1 *proto.OrderCancellation) (*proto.OrderCancellationConfirmation, error) {
+func (m *MockExecutionEngine) CancelOrder(arg0 context.Context, arg1 *proto.OrderCancellation) ([]*proto.OrderCancellationConfirmation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelOrder", arg0, arg1)
-	ret0, _ := ret[0].(*proto.OrderCancellationConfirmation)
+	ret0, _ := ret[0].([]*proto.OrderCancellationConfirmation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -55,7 +55,7 @@ type TimeService interface {
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/execution_engine_mock.go -package mocks code.vegaprotocol.io/vega/processor ExecutionEngine
 type ExecutionEngine interface {
 	SubmitOrder(ctx context.Context, order *types.Order) (*types.OrderConfirmation, error)
-	CancelOrder(ctx context.Context, order *types.OrderCancellation) (*types.OrderCancellationConfirmation, error)
+	CancelOrder(ctx context.Context, order *types.OrderCancellation) ([]*types.OrderCancellationConfirmation, error)
 	AmendOrder(ctx context.Context, order *types.OrderAmendment) (*types.OrderConfirmation, error)
 	Generate() error
 	SubmitMarket(ctx context.Context, marketConfig *types.Market) error
@@ -668,7 +668,9 @@ func (p *Processor) cancelOrder(ctx context.Context, order *types.OrderCancellat
 		return err
 	}
 	if p.LogOrderCancelDebug {
-		p.log.Debug("Order cancelled", logging.Order(*msg.Order))
+		for _, v := range msg {
+			p.log.Debug("Order cancelled", logging.Order(*v.Order))
+		}
 	}
 
 	return nil

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -380,7 +380,7 @@ func testProcessCommandSuccess(t *testing.T) {
 	proc.stat.EXPECT().IncCurrentOrdersInBatch().Times(1)
 
 	proc.eng.EXPECT().SubmitOrder(gomock.Any(), gomock.Any()).Times(1).Return(&types.OrderConfirmation{}, nil)
-	proc.eng.EXPECT().CancelOrder(gomock.Any(), gomock.Any()).Times(1).Return(&types.OrderCancellationConfirmation{}, nil)
+	proc.eng.EXPECT().CancelOrder(gomock.Any(), gomock.Any()).Times(1).Return([]*types.OrderCancellationConfirmation{}, nil)
 	// proc.eng.EXPECT().AmendOrder(gomock.Any(), gomock.Any()).Times(1).Return(&types.OrderConfirmation{}, nil)
 	proc.gov.EXPECT().AddVote(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	proc.gov.EXPECT().SubmitProposal(gomock.Any(), gomock.Any()).Times(1).Return(nil)


### PR DESCRIPTION
Implements bulk cancel orders
cancel all orders
cancel all orders in markets
cancel a single order in a market.

add a lookup table in the orderbook to find order per parties

closes #2106 

