### PR TITLE
Update GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -175,6 +175,7 @@ In order to develop trading core, more tools are needed. Install them with:
 
 ```bash
 # get the dev tools
+make gettools_develop
 make gqlgen_check # warning: This may take a minute, with no output.
 make proto_check
 ```


### PR DESCRIPTION
Add missing `make gettools_develop` step to the `developing trading-core` section.