### PR TITLE
faucet also check if it's expired on a request

### DIFF
--- a/faucet/rate_limit.go
+++ b/faucet/rate_limit.go
@@ -38,8 +38,7 @@ func (r *RateLimit) NewRequest(pubkey, asset string) error {
 	if ok {
 		// just check in case the time is expired already, and
 		// we had not the cleanup run
-		if time.Now().Before(until) &&
-			!time.Now().Equal(until) {
+		if time.Now().Before(until) {
 			// we already have this asset greylisted,
 			// the trader is trying to get more fuunds while still greylisted
 			// give him a penalty

--- a/faucet/rate_limit.go
+++ b/faucet/rate_limit.go
@@ -36,11 +36,16 @@ func (r *RateLimit) NewRequest(pubkey, asset string) error {
 	}
 	until, ok := assets[asset]
 	if ok {
-		// we already have this asset greylisted,
-		// the trader is trying to get more fuunds while still greylisted
-		// give him a penalty
-		assets[asset] = until.Add(r.cfg.CoolDown.Duration)
-		return fmt.Errorf("you are greylisted - your pubkey is now greylisted for an extended period until %v", assets[asset])
+		// just check in case the time is expired already, and
+		// we had not the cleanup run
+		if time.Now().Before(until) &&
+			!time.Now().Equal(until) {
+			// we already have this asset greylisted,
+			// the trader is trying to get more fuunds while still greylisted
+			// give him a penalty
+			assets[asset] = until.Add(r.cfg.CoolDown.Duration)
+			return fmt.Errorf("you are greylisted - your pubkey is now greylisted for an extended period until %v", assets[asset])
+		}
 	}
 
 	// greylist for the minimal duration


### PR DESCRIPTION
This just ensure that if a cancel is done,and the cleanup routine haven't been triggered before, the mint request will pass anyway.