### PR TITLE
Actually add channel to map so we only create 1 routine

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -76,9 +76,10 @@ func (b *Broker) startSending(t events.Type, evts []events.Event) {
 	if !ok {
 		subs := b.getSubsByType(t)
 		ch = make(chan []events.Event, len(subs)*10+20) // create a channel with buffer
+		b.eChans[t] = ch                                // assign the newly created channel
 	}
-	ch <- evts
 	b.mu.Unlock()
+	ch <- evts
 	if ok {
 		// we already started the routine to consume the channel
 		// we can return here


### PR DESCRIPTION
Maintaining event order through an internal broker channel is indeed a valid approach. Unfortunately, things go kind of badly wrong if you then fail to actually store the channel and reuse it. Failing to do so results in new routines spawning for each event we're sending. That was the way the broker worked before, but the new routines are written in a way to never return, they assume the channel will be reused, which it isn't...

This explains that the runtime.newproc1 showed up in the pprof memory profile the way it did.