### PR TITLE
partyid in orders returned from the grpc API are always valid

### DIFF
--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -1422,13 +1422,7 @@ func (r *myOrderResolver) Party(ctx context.Context, order *types.Order) (*types
 	if len(order.PartyID) == 0 {
 		return nil, errors.New("invalid party")
 	}
-	req := protoapi.PartyByIDRequest{PartyID: order.PartyID}
-	res, err := r.tradingDataClient.PartyByID(ctx, &req)
-	if err != nil {
-		r.log.Error("tradingData client", logging.Error(err))
-		return nil, customErrorFromStatus(err)
-	}
-	return res.Party, nil
+	return &types.Party{Id: order.PartyID}, nil
 }
 
 // END: Order Resolver


### PR DESCRIPTION
When submitting an order with a public key with no funds deposited, the party has never been created in the colateral engine or the store etc.
The order is then rejected with an error status.

The issue happen when in the subscription the resolver try t resolve the party by id.
If we are not able to get the party by id, we then return an error and nil for the given order.

A party is always valid, even if it does not exists in the stores, so we just return the party ID from the order now.

closes #2099 