### PR TITLE
uses default value in proposal when fields are not specified to handle invalid submitted proposals

### DIFF
--- a/gateway/graphql/modelext.go
+++ b/gateway/graphql/modelext.go
@@ -356,7 +356,7 @@ func TradingModeFromProto(ptm interface{}) (TradingMode, error) {
 // NewMarketTradingModeFromProto ...
 func NewMarketTradingModeFromProto(ptm interface{}) (TradingMode, error) {
 	if ptm == nil {
-		return nil, ErrNilTradingMode
+		ptm = defaultTradingMode()
 	}
 	switch ptmimpl := ptm.(type) {
 	case *types.NewMarketConfiguration_Continuous:
@@ -602,6 +602,9 @@ func MarketFromProto(pmkt *types.Market) (*Market, error) {
 }
 
 func (i *InstrumentConfiguration) assignProductFromProto(instrument *types.InstrumentConfiguration) error {
+	if instrument == nil {
+		instrument = defaultInstrumentConfiguration()
+	}
 	if future := instrument.GetFuture(); future != nil {
 		i.FutureProduct = &FutureProduct{
 			Asset:    &Asset{ID: future.Asset},
@@ -615,6 +618,9 @@ func (i *InstrumentConfiguration) assignProductFromProto(instrument *types.Instr
 
 // RiskConfigurationFromProto ...
 func RiskConfigurationFromProto(newMarket *types.NewMarketConfiguration) (RiskModel, error) {
+	if newMarket.RiskParameters == nil {
+		newMarket.RiskParameters = defaultRiskParameters()
+	}
 	switch params := newMarket.RiskParameters.(type) {
 	case *types.NewMarketConfiguration_Simple:
 		return &SimpleRiskModel{
@@ -641,7 +647,7 @@ func RiskConfigurationFromProto(newMarket *types.NewMarketConfiguration) (RiskMo
 // NewMarketFromProto ...
 func NewMarketFromProto(newMarket *types.NewMarketConfiguration) (*NewMarket, error) {
 	if newMarket == nil {
-		return nil, ErrNilMarket
+		newMarket = defaultNewMarket()
 	}
 	risk, err := RiskConfigurationFromProto(newMarket)
 	if err != nil {
@@ -663,6 +669,7 @@ func NewMarketFromProto(newMarket *types.NewMarketConfiguration) (*NewMarket, er
 		RiskParameters: risk,
 		TradingMode:    mode,
 	}
+
 	result.Instrument.assignProductFromProto(newMarket.Instrument)
 	return result, nil
 }
@@ -1089,4 +1096,55 @@ func NewAssetFromProto(newAsset *types.NewAsset) (*NewAsset, error) {
 	return &NewAsset{
 		Source: source,
 	}, nil
+}
+
+func defaultFutureProductConfiguration() *types.InstrumentConfiguration_Future {
+	return &types.InstrumentConfiguration_Future{
+		Future: &types.FutureProduct{
+			Asset:    "",
+			Maturity: "",
+		},
+	}
+}
+
+func defaultInstrumentConfiguration() *types.InstrumentConfiguration {
+	return &types.InstrumentConfiguration{
+		Name:      "",
+		Code:      "",
+		BaseName:  "",
+		QuoteName: "",
+		Product:   defaultFutureProductConfiguration(),
+	}
+}
+
+func defaultRiskParameters() *types.NewMarketConfiguration_LogNormal {
+	return &types.NewMarketConfiguration_LogNormal{
+		LogNormal: &types.LogNormalRiskModel{
+			RiskAversionParameter: 0,
+			Tau:                   0,
+			Params: &types.LogNormalModelParams{
+				Mu:    0,
+				R:     0,
+				Sigma: 0,
+			},
+		},
+	}
+}
+
+func defaultTradingMode() *types.NewMarketConfiguration_Continuous {
+	return &types.NewMarketConfiguration_Continuous{
+		Continuous: &types.ContinuousTrading{
+			TickSize: "0",
+		},
+	}
+}
+
+func defaultNewMarket() *types.NewMarketConfiguration {
+	return &types.NewMarketConfiguration{
+		Instrument:     defaultInstrumentConfiguration(),
+		RiskParameters: defaultRiskParameters(),
+		Metadata:       []string{},
+		DecimalPlaces:  0,
+		TradingMode:    defaultTradingMode(),
+	}
 }

--- a/gateway/graphql/modelext_test.go
+++ b/gateway/graphql/modelext_test.go
@@ -583,6 +583,47 @@ func TestModelConverters(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, protoTerms)
 	})
+
+	t.Run("ProposalTermsFromProto with invalid proposa uses defaults", func(t *testing.T) {
+		pm := &proto.NewMarketConfiguration{
+			Instrument: &proto.InstrumentConfiguration{
+				Name:      "December 2020 ETH vs VUSD future",
+				Code:      "CRYPTO:ETHVUSD/DEC20",
+				BaseName:  "ETH",
+				QuoteName: "VUSD",
+				Product: &proto.InstrumentConfiguration_Future{
+					Future: &proto.FutureProduct{
+						Asset:    "VUSD",
+						Maturity: "2020-12-31T23:59:59Z",
+					},
+				},
+			},
+			// we use a nil risk parameters
+			RiskParameters: nil,
+			Metadata: []string{
+				"asset_class:fx/crypto",
+				"product:futures",
+			},
+			DecimalPlaces: 5,
+			TradingMode: &proto.NewMarketConfiguration_Continuous{
+				Continuous: &proto.ContinuousTrading{
+					TickSize: "0.1",
+				},
+			},
+		}
+
+		protoTerms, err := gql.ProposalTermsFromProto(&proto.ProposalTerms{
+			ClosingTimestamp:   1234567,
+			EnactmentTimestamp: 1234568,
+			Change: &proto.ProposalTerms_NewMarket{
+				NewMarket: &proto.NewMarket{
+					Changes: pm,
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, protoTerms)
+	})
 }
 
 func intptr(i int) *int {


### PR DESCRIPTION
This is a temporary fix (this API may need to be redone) to handle through the graphql API the proposal with missing information which got rejected after being submitted to the chain.

As the graphql API expect all fields to be valid (non-nil) we just set default/zero values for the fields which are nils so they do not get rejected / produce error when being resolved.

Ultimately we will want to have a specific api to handle rejected proposal, but this would unblock the front-end in the meantime.

closes #2056 