### PR TITLE
Revert "ensure all proposal timestamps are not equal"

### DIFF
--- a/governance/engine.go
+++ b/governance/engine.go
@@ -309,15 +309,15 @@ func (e *Engine) validateOpenProposal(proposal types.Proposal) (types.ProposalEr
 		return types.ProposalError_PROPOSAL_ERROR_ENACT_TIME_TOO_LATE, ErrProposalEnactTimeTooLate
 	}
 
-	if proposal.Terms.ClosingTimestamp <= proposal.Terms.ValidationTimestamp {
-		e.log.Debug("proposal closing time can't be smaller or equal than validation time",
+	if proposal.Terms.ClosingTimestamp < proposal.Terms.ValidationTimestamp {
+		e.log.Debug("proposal closing time can't be smaller than validation time",
 			logging.Int64("closing-time", proposal.Terms.ClosingTimestamp),
 			logging.Int64("validation-time", proposal.Terms.ValidationTimestamp),
 			logging.String("id", proposal.ID))
 		return types.ProposalError_PROPOSAL_ERROR_INCOMPATIBLE_TIMESTAMPS, ErrIncompatibleTimestamps
 	}
-	if proposal.Terms.EnactmentTimestamp <= proposal.Terms.ClosingTimestamp {
-		e.log.Debug("proposal enactment time can't be smaller or equal than closing time",
+	if proposal.Terms.EnactmentTimestamp < proposal.Terms.ClosingTimestamp {
+		e.log.Debug("proposal enactment time can't be smaller than closing time",
 			logging.Int64("enactment-time", proposal.Terms.EnactmentTimestamp),
 			logging.Int64("closing-time", proposal.Terms.ClosingTimestamp),
 			logging.String("id", proposal.ID))

--- a/governance/engine_test.go
+++ b/governance/engine_test.go
@@ -277,7 +277,7 @@ func testEnactmentTime(t *testing.T) {
 	assert.EqualError(t, err, governance.ErrProposalEnactTimeTooLate.Error())
 
 	atClosingTime := eng.newOpenProposal(party.Id, now)
-	atClosingTime.Terms.EnactmentTimestamp = atClosingTime.Terms.ClosingTimestamp + 10
+	atClosingTime.Terms.EnactmentTimestamp = atClosingTime.Terms.ClosingTimestamp
 	eng.accs.EXPECT().GetTotalTokens().Times(1).Return(uint64(1))
 	eng.broker.EXPECT().Send(gomock.Any()).Times(1).Do(func(e events.Event) {
 		pe, ok := e.(*events.Proposal)
@@ -299,21 +299,12 @@ func testValidateTimestamps(t *testing.T) {
 	// this will need to be refactored
 	eng.accs.GetPartyTokenAccount(party.Id)
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(1)
 
-	// validate first timestamps in the wrong order
 	now := time.Now()
 	prop := eng.newOpenProposal(party.Id, now)
 	prop.Terms.ValidationTimestamp = prop.Terms.ClosingTimestamp + 10
 	err := eng.SubmitProposal(context.Background(), prop)
-	assert.EqualError(t, err, governance.ErrIncompatibleTimestamps.Error())
-
-	// then timestamps all the sames
-	now = time.Now()
-	prop = eng.newOpenProposal(party.Id, now)
-	prop.Terms.ValidationTimestamp = prop.Terms.ClosingTimestamp
-	prop.Terms.EnactmentTimestamp = prop.Terms.ClosingTimestamp
-	err = eng.SubmitProposal(context.Background(), prop)
 	assert.EqualError(t, err, governance.ErrIncompatibleTimestamps.Error())
 }
 

--- a/governance/service.go
+++ b/governance/service.go
@@ -408,7 +408,7 @@ func (s *Svc) validateTerms(terms *types.ProposalTerms) error {
 	}
 
 	// we should be able to enact a proposal as soon as the voting is closed (and the proposal passed)
-	if terms.EnactmentTimestamp <= terms.ClosingTimestamp || (terms.ValidationTimestamp > 0 && terms.ValidationTimestamp >= terms.ClosingTimestamp) {
+	if terms.EnactmentTimestamp < terms.ClosingTimestamp || (terms.ValidationTimestamp > 0 && terms.ValidationTimestamp > terms.ClosingTimestamp) {
 		return ErrInvalidProposalTerms
 	}
 

--- a/governance/service_test.go
+++ b/governance/service_test.go
@@ -136,34 +136,6 @@ func testPrepareProposalNormal(t *testing.T) {
 	assert.EqualValues(t, terms, *proposal.Terms)
 }
 
-func testPrepareProposalWithAllSameTimestamps(t *testing.T) {
-	svc := newTestService(t)
-	defer svc.ctrl.Finish()
-
-	updateNetwork := types.UpdateNetwork{
-		Changes: &types.NetworkConfiguration{
-			MinCloseInSeconds: 100 * 24 * 60 * 60,
-			MaxCloseInSeconds: 1000 * 24 * 60 * 60,
-		},
-	}
-
-	ts := time.Now().Add(time.Hour * 24 * 2).UTC().Unix()
-
-	terms := types.ProposalTerms{
-		ValidationTimestamp: ts,
-		ClosingTimestamp:    ts,
-		EnactmentTimestamp:  ts,
-		Change: &types.ProposalTerms_UpdateNetwork{
-			UpdateNetwork: &updateNetwork,
-		},
-	}
-
-	testAuthor := "test-author"
-	_, err := svc.PrepareProposal(svc.ctx, testAuthor, "", &terms)
-
-	assert.EqualError(t, err, governance.ErrInvalidProposalTerms.Error())
-}
-
 func testPrepareProposalEmpty(t *testing.T) {
 	svc := newTestService(t)
 	defer svc.ctrl.Finish()
@@ -185,6 +157,5 @@ func testPrepareProposalEmpty(t *testing.T) {
 
 func TestPrepareProposal(t *testing.T) {
 	t.Run("Prepare a normal proposal", testPrepareProposalNormal)
-	t.Run("Prepare a proposal - fail same timestamps", testPrepareProposalWithAllSameTimestamps)
 	t.Run("Prepare an empty proposal", testPrepareProposalEmpty)
 }


### PR DESCRIPTION
Reverts vegaprotocol/vega#2174

This fix is incorrect. The original bug specifies that the error message is bad, not that the timestamps matching is incorrect. https://github.com/vegaprotocol/product/blob/master/specs/0028-governance.md#when-a-proposal-is-enacted specifies how this should be checked and enacted.