### PR TITLE
prepare submit order, return invalid argument error

### DIFF
--- a/api/trading.go
+++ b/api/trading.go
@@ -70,7 +70,7 @@ func (s *tradingService) PrepareSubmitOrder(ctx context.Context, req *protoapi.S
 	defer metrics.APIRequestAndTimeGRPC("PrepareSubmitOrder", startTime)
 	err := s.tradeOrderService.PrepareSubmitOrder(ctx, req.Submission)
 	if err != nil {
-		return nil, apiError(codes.Internal, ErrMalformedRequest, err)
+		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
 	}
 	raw, err := proto.Marshal(req.Submission)
 	if err != nil {

--- a/api/trading_test.go
+++ b/api/trading_test.go
@@ -77,7 +77,8 @@ func waitForNode(t *testing.T, ctx context.Context, conn *grpc.ClientConn) {
 			t.Fatalf("Expected some sort of error, but got none.")
 		}
 		fmt.Println(err.Error())
-		if strings.Contains(err.Error(), "Internal error") {
+
+		if strings.Contains(err.Error(), "InvalidArgument") {
 			return
 		}
 		fmt.Printf("Sleeping for %d milliseconds\n", sleepTime)


### PR DESCRIPTION
When openned we were not returning the inner error from the submit order validations but we do now.
Only the error type was change from internal to invalid argument in case we have validation error here (there will still be details of why there's an error.
close #1824 