### PR TITLE
ensure time.Now is used instead of vegatime in grpc endpoints

### DIFF
--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -206,6 +206,7 @@ type tradingDataService struct {
 }
 
 func (t *tradingDataService) EstimateFee(ctx context.Context, req *protoapi.EstimateFeeRequest) (*protoapi.EstimateFeeResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("EstimateFee")()
 	if req.Order == nil {
 		return nil, apiError(codes.InvalidArgument, errors.New("missing order"))
 	}
@@ -221,6 +222,7 @@ func (t *tradingDataService) EstimateFee(ctx context.Context, req *protoapi.Esti
 }
 
 func (t *tradingDataService) ERC20WithdrawalApproval(ctx context.Context, req *protoapi.ERC20WithdrawalApprovalRequest) (*protoapi.ERC20WithdrawalApprovalResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("ERC20WithdrawalApproval")()
 	if len(req.WithdrawalID) <= 0 {
 		return nil, ErrMissingWithdrawalID
 	}
@@ -275,6 +277,7 @@ func (t *tradingDataService) ERC20WithdrawalApproval(ctx context.Context, req *p
 }
 
 func (t *tradingDataService) Withdrawal(ctx context.Context, req *protoapi.WithdrawalRequest) (*protoapi.WithdrawalResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("Withdrawal")()
 	if len(req.ID) <= 0 {
 		return nil, ErrMissingWithdrawalID
 	}
@@ -288,6 +291,7 @@ func (t *tradingDataService) Withdrawal(ctx context.Context, req *protoapi.Withd
 }
 
 func (t *tradingDataService) Withdrawals(ctx context.Context, req *protoapi.WithdrawalsRequest) (*protoapi.WithdrawalsResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("Withdrawals")()
 	if len(req.PartyID) <= 0 {
 		return nil, ErrMissingPartyID
 	}
@@ -303,6 +307,7 @@ func (t *tradingDataService) Withdrawals(ctx context.Context, req *protoapi.With
 }
 
 func (t *tradingDataService) AssetByID(ctx context.Context, req *protoapi.AssetByIDRequest) (*protoapi.AssetByIDResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("AssetByID")()
 	if len(req.ID) <= 0 {
 		return nil, apiError(codes.InvalidArgument, errors.New("missing ID"))
 	}
@@ -318,6 +323,7 @@ func (t *tradingDataService) AssetByID(ctx context.Context, req *protoapi.AssetB
 }
 
 func (t *tradingDataService) Assets(ctx context.Context, req *protoapi.AssetsRequest) (*protoapi.AssetsResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("Assets")()
 	assets, _ := t.AssetService.GetAll()
 	out := make([]*types.Asset, 0, len(assets))
 	for _, v := range assets {
@@ -331,6 +337,7 @@ func (t *tradingDataService) Assets(ctx context.Context, req *protoapi.AssetsReq
 
 func (t *tradingDataService) GetNodeSignaturesAggregate(ctx context.Context,
 	req *protoapi.GetNodeSignaturesAggregateRequest) (*protoapi.GetNodeSignaturesAggregateResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("GetNodeSignaturesAggregate")()
 	if len(req.ID) <= 0 {
 		return nil, apiError(codes.InvalidArgument, errors.New("missing ID"))
 	}
@@ -356,8 +363,7 @@ func (t *tradingDataService) GetNodeSignaturesAggregate(ctx context.Context,
 // Returns a list of orders sorted by timestamp descending (most recent first).
 func (t *tradingDataService) OrdersByMarket(ctx context.Context,
 	request *protoapi.OrdersByMarketRequest) (*protoapi.OrdersByMarketResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrdersByMarket", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrdersByMarket")()
 
 	err := request.Validate()
 	if err != nil {
@@ -387,8 +393,7 @@ func (t *tradingDataService) OrdersByMarket(ctx context.Context,
 // Returns a list of orders sorted by timestamp descending (most recent first).
 func (t *tradingDataService) OrdersByParty(ctx context.Context,
 	request *protoapi.OrdersByPartyRequest) (*protoapi.OrdersByPartyResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrdersByParty", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrdersByParty")()
 
 	err := request.Validate()
 	if err != nil {
@@ -415,8 +420,7 @@ func (t *tradingDataService) OrdersByParty(ctx context.Context,
 
 // Markets provides a list of all current markets that exist on the VEGA platform.
 func (t *tradingDataService) Markets(ctx context.Context, request *empty.Empty) (*protoapi.MarketsResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("Markets", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("Markets")()
 	markets, err := t.MarketService.GetAll(ctx)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrMarketServiceGetMarkets, err)
@@ -429,8 +433,7 @@ func (t *tradingDataService) Markets(ctx context.Context, request *empty.Empty) 
 // OrdersByMarketAndID provides the given order, searching by Market and (Order)Id.
 func (t *tradingDataService) OrderByMarketAndID(ctx context.Context,
 	request *protoapi.OrderByMarketAndIdRequest) (*protoapi.OrderByMarketAndIdResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrderByMarketAndID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrderByMarketAndID")()
 
 	err := request.Validate()
 	if err != nil {
@@ -449,8 +452,7 @@ func (t *tradingDataService) OrderByMarketAndID(ctx context.Context,
 
 // OrderByReference provides the (possibly not yet accepted/rejected) order.
 func (t *tradingDataService) OrderByReference(ctx context.Context, req *protoapi.OrderByReferenceRequest) (*protoapi.OrderByReferenceResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrderByReference", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrderByReference")()
 
 	err := req.Validate()
 	if err != nil {
@@ -471,8 +473,7 @@ func (t *tradingDataService) OrderByReference(ctx context.Context, req *protoapi
 // SinceTimestamp must be in RFC3339 string format.
 func (t *tradingDataService) Candles(ctx context.Context,
 	request *protoapi.CandlesRequest) (*protoapi.CandlesResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("Candles", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("Candles")()
 
 	err := request.Validate()
 	if err != nil {
@@ -496,8 +497,7 @@ func (t *tradingDataService) Candles(ctx context.Context,
 // MarketDepth provides the order book for a given market, and also returns the most recent trade
 // for the given market.
 func (t *tradingDataService) MarketDepth(ctx context.Context, req *protoapi.MarketDepthRequest) (*protoapi.MarketDepthResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketDepth", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketDepth")()
 
 	err := req.Validate()
 	if err != nil {
@@ -529,8 +529,7 @@ func (t *tradingDataService) MarketDepth(ctx context.Context, req *protoapi.Mark
 // TradesByMarket provides a list of trades for a given market.
 // Pagination: Optional. If not provided, defaults are used.
 func (t *tradingDataService) TradesByMarket(ctx context.Context, request *protoapi.TradesByMarketRequest) (*protoapi.TradesByMarketResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("TradesByMarket", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("TradesByMarket")()
 
 	err := request.Validate()
 	if err != nil {
@@ -553,8 +552,7 @@ func (t *tradingDataService) TradesByMarket(ctx context.Context, request *protoa
 
 // PositionsByParty provides a list of positions for a given party.
 func (t *tradingDataService) PositionsByParty(ctx context.Context, request *protoapi.PositionsByPartyRequest) (*protoapi.PositionsByPartyResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("PositionsByParty", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("PositionsByParty")()
 
 	err := request.Validate()
 	if err != nil {
@@ -580,8 +578,7 @@ func (t *tradingDataService) PositionsByParty(ctx context.Context, request *prot
 
 // MarginLevels returns the current margin levels for a given party and market.
 func (t *tradingDataService) MarginLevels(_ context.Context, req *protoapi.MarginLevelsRequest) (*protoapi.MarginLevelsResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarginLevels", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarginLevels")()
 
 	err := req.Validate()
 	if err != nil {
@@ -604,8 +601,7 @@ func (t *tradingDataService) MarginLevels(_ context.Context, req *protoapi.Margi
 
 // MarketDataByID provides market data for the given ID.
 func (t *tradingDataService) MarketDataByID(_ context.Context, req *protoapi.MarketDataByIDRequest) (*protoapi.MarketDataByIDResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketDataByID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketDataByID")()
 
 	err := req.Validate()
 	if err != nil {
@@ -623,8 +619,7 @@ func (t *tradingDataService) MarketDataByID(_ context.Context, req *protoapi.Mar
 
 // MarketsData provides all market data for all markets on this network.
 func (t *tradingDataService) MarketsData(_ context.Context, _ *empty.Empty) (*protoapi.MarketsDataResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketsData", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketsData")()
 	mds := t.MarketService.GetMarketsData()
 	mdptrs := make([]*types.MarketData, 0, len(mds))
 	for _, v := range mds {
@@ -640,8 +635,7 @@ func (t *tradingDataService) MarketsData(_ context.Context, _ *empty.Empty) (*pr
 // Blockchain height, backlog length, current time, orders and trades per block, tendermint version
 // Vega counts for parties, markets, order actions (amend, cancel, submit), Vega version
 func (t *tradingDataService) Statistics(ctx context.Context, request *empty.Empty) (*types.Statistics, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("Statistics", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("Statistics")()
 	// Call tendermint and related services to get information for statistics
 	// We load read-only internal statistics through each package level statistics structs
 	epochTime, err := t.TimeService.GetTimeNow()
@@ -705,8 +699,7 @@ func (t *tradingDataService) Statistics(ctx context.Context, request *empty.Empt
 // GetVegaTime returns the latest blockchain header timestamp, in UnixNano format.
 // Example: "1568025900111222333" corresponds to 2019-09-09T10:45:00.111222333Z.
 func (t *tradingDataService) GetVegaTime(ctx context.Context, request *empty.Empty) (*protoapi.VegaTimeResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetVegaTime", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetVegaTime")()
 	ts, err := t.TimeService.GetTimeNow()
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrTimeServiceGetTimeNow, err)
@@ -720,8 +713,7 @@ func (t *tradingDataService) GetVegaTime(ctx context.Context, request *empty.Emp
 // TransferResponsesSubscribe opens a subscription to transfer response data provided by the transfer response service.
 func (t *tradingDataService) TransferResponsesSubscribe(
 	req *empty.Empty, srv protoapi.TradingData_TransferResponsesSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("TransferResponseSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("TransferResponseSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan in error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -782,8 +774,7 @@ func (t *tradingDataService) TransferResponsesSubscribe(
 // MarketsDataSubscribe opens a subscription to market data provided by the markets service.
 func (t *tradingDataService) MarketsDataSubscribe(req *protoapi.MarketsDataSubscribeRequest,
 	srv protoapi.TradingData_MarketsDataSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketsDataSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketsDataSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -840,8 +831,7 @@ func (t *tradingDataService) MarketsDataSubscribe(req *protoapi.MarketsDataSubsc
 
 // AccountsSubscribe opens a subscription to the Margin Levels provided by the risk service.
 func (t *tradingDataService) MarginLevelsSubscribe(req *protoapi.MarginLevelsSubscribeRequest, srv protoapi.TradingData_MarginLevelsSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarginLevelsSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarginLevelsSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -906,8 +896,7 @@ func (t *tradingDataService) MarginLevelsSubscribe(req *protoapi.MarginLevelsSub
 // AccountsSubscribe opens a subscription to the Accounts service.
 func (t *tradingDataService) AccountsSubscribe(req *protoapi.AccountsSubscribeRequest,
 	srv protoapi.TradingData_AccountsSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("AccountsSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("AccountsSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -971,8 +960,7 @@ func (t *tradingDataService) AccountsSubscribe(req *protoapi.AccountsSubscribeRe
 // PartyID: Optional.
 func (t *tradingDataService) OrdersSubscribe(
 	req *protoapi.OrdersSubscribeRequest, srv protoapi.TradingData_OrdersSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrdersSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrdersSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -1046,8 +1034,7 @@ func (t *tradingDataService) OrdersSubscribe(
 // TradesSubscribe opens a subscription to the Trades service.
 func (t *tradingDataService) TradesSubscribe(req *protoapi.TradesSubscribeRequest,
 	srv protoapi.TradingData_TradesSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("TradesSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("TradesSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -1118,8 +1105,7 @@ func (t *tradingDataService) TradesSubscribe(req *protoapi.TradesSubscribeReques
 // CandlesSubscribe opens a subscription to the Candles service.
 func (t *tradingDataService) CandlesSubscribe(req *protoapi.CandlesSubscribeRequest,
 	srv protoapi.TradingData_CandlesSubscribeServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("CandlesSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("CandlesSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -1186,8 +1172,7 @@ func (t *tradingDataService) MarketDepthSubscribe(
 	req *protoapi.MarketDepthSubscribeRequest,
 	srv protoapi.TradingData_MarketDepthSubscribeServer,
 ) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketDepthSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketDepthSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -1252,8 +1237,7 @@ func (t *tradingDataService) PositionsSubscribe(
 	req *protoapi.PositionsSubscribeRequest,
 	srv protoapi.TradingData_PositionsSubscribeServer,
 ) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("PositionsSubscribe", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("PositionsSubscribe")()
 	// Wrap context from the request into cancellable. We can close internal chan on error.
 	ctx, cancel := context.WithCancel(srv.Context())
 	defer cancel()
@@ -1307,8 +1291,7 @@ func (t *tradingDataService) PositionsSubscribe(
 
 // MarketByID provides the given market.
 func (t *tradingDataService) MarketByID(ctx context.Context, req *protoapi.MarketByIDRequest) (*protoapi.MarketByIDResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketByID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketByID")()
 	mkt, err := validateMarket(ctx, req.MarketID, t.MarketService)
 	if err != nil {
 		return nil, err // validateMarket already returns an API error, no need to additionally wrap
@@ -1321,8 +1304,7 @@ func (t *tradingDataService) MarketByID(ctx context.Context, req *protoapi.Marke
 
 // Parties provides a list of all parties.
 func (t *tradingDataService) Parties(ctx context.Context, req *empty.Empty) (*protoapi.PartiesResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("Parties", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("Parties")()
 	parties, err := t.PartyService.GetAll(ctx)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrPartyServiceGetAll, err)
@@ -1334,8 +1316,7 @@ func (t *tradingDataService) Parties(ctx context.Context, req *empty.Empty) (*pr
 
 // PartyByID provides the given party.
 func (t *tradingDataService) PartyByID(ctx context.Context, req *protoapi.PartyByIDRequest) (*protoapi.PartyByIDResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("PartyByID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("PartyByID")()
 	pty, err := validateParty(ctx, t.log, req.PartyID, t.PartyService)
 	if err != nil {
 		return nil, err // validateParty already returns an API error, no need to additionally wrap
@@ -1349,8 +1330,7 @@ func (t *tradingDataService) PartyByID(ctx context.Context, req *protoapi.PartyB
 // Pagination: Optional. If not provided, defaults are used.
 func (t *tradingDataService) TradesByParty(ctx context.Context,
 	req *protoapi.TradesByPartyRequest) (*protoapi.TradesByPartyResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("TradesByParty", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("TradesByParty")()
 
 	p := defaultPagination
 	if req.Pagination != nil {
@@ -1367,8 +1347,7 @@ func (t *tradingDataService) TradesByParty(ctx context.Context,
 // TradesByOrder provides a list of the trades that correspond to a given order.
 func (t *tradingDataService) TradesByOrder(ctx context.Context,
 	req *protoapi.TradesByOrderRequest) (*protoapi.TradesByOrderResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("TradesByOrder", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("TradesByOrder")()
 	trades, err := t.TradeService.GetByOrderID(ctx, req.OrderID)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrTradeServiceGetByOrderID, err)
@@ -1381,8 +1360,7 @@ func (t *tradingDataService) TradesByOrder(ctx context.Context,
 // LastTrade provides the last trade for the given market.
 func (t *tradingDataService) LastTrade(ctx context.Context,
 	req *protoapi.LastTradeRequest) (*protoapi.LastTradeResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("LastTrade", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("LastTrade")()
 	if len(req.MarketID) <= 0 {
 		return nil, apiError(codes.InvalidArgument, ErrEmptyMissingMarketID)
 	}
@@ -1400,8 +1378,7 @@ func (t *tradingDataService) LastTrade(ctx context.Context,
 
 func (t *tradingDataService) MarketAccounts(_ context.Context,
 	req *protoapi.MarketAccountsRequest) (*protoapi.MarketAccountsResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("MarketAccounts", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("MarketAccounts")()
 	accs, err := t.AccountsService.GetMarketAccounts(req.MarketID, req.Asset)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrAccountServiceGetMarketAccounts, err)
@@ -1413,8 +1390,7 @@ func (t *tradingDataService) MarketAccounts(_ context.Context,
 
 func (t *tradingDataService) FeeInfrastructureAccounts(_ context.Context,
 	req *protoapi.FeeInfrastructureAccountsRequest) (*protoapi.FeeInfrastructureAccountsResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("FeeInfrastructureAccounts", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("FeeInfrastructureAccounts")()
 	accs, err := t.AccountsService.GetFeeInfrastructureAccounts(req.Asset)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrAccountServiceGetFeeInfrastructureAccounts, err)
@@ -1426,8 +1402,7 @@ func (t *tradingDataService) FeeInfrastructureAccounts(_ context.Context,
 
 func (t *tradingDataService) PartyAccounts(_ context.Context,
 	req *protoapi.PartyAccountsRequest) (*protoapi.PartyAccountsResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("PartyAccounts", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("PartyAccounts")()
 	accs, err := t.AccountsService.GetPartyAccounts(req.PartyID, req.MarketID, req.Asset, req.Type)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrAccountServiceGetPartyAccounts, err)
@@ -1514,8 +1489,7 @@ func (t *tradingDataService) getTendermintStats(ctx context.Context) (backlogLen
 }
 
 func (t *tradingDataService) OrderByID(ctx context.Context, in *protoapi.OrderByIDRequest) (*types.Order, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrderByID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrderByID")()
 	if len(in.OrderID) == 0 {
 		// Invalid parameter
 		return nil, ErrMissingOrderIDParameter
@@ -1535,8 +1509,7 @@ func (t *tradingDataService) OrderVersionsByID(
 	ctx context.Context,
 	in *protoapi.OrderVersionsByIDRequest,
 ) (*protoapi.OrderVersionsResponse, error) {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("OrderVersionsByID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("OrderVersionsByID")()
 
 	err := in.Validate()
 	if err != nil {
@@ -1562,9 +1535,7 @@ func (t *tradingDataService) OrderVersionsByID(
 func (t *tradingDataService) GetProposals(_ context.Context,
 	in *protoapi.GetProposalsRequest,
 ) (*protoapi.GetProposalsResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetProposals", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetProposals")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1581,9 +1552,7 @@ func (t *tradingDataService) GetProposals(_ context.Context,
 func (t *tradingDataService) GetProposalsByParty(_ context.Context,
 	in *protoapi.GetProposalsByPartyRequest,
 ) (*protoapi.GetProposalsByPartyResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetProposalsByParty", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetProposalsByParty")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1600,9 +1569,7 @@ func (t *tradingDataService) GetProposalsByParty(_ context.Context,
 func (t *tradingDataService) GetVotesByParty(_ context.Context,
 	in *protoapi.GetVotesByPartyRequest,
 ) (*protoapi.GetVotesByPartyResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetVotesByParty", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetVotesByParty")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1615,9 +1582,7 @@ func (t *tradingDataService) GetVotesByParty(_ context.Context,
 func (t *tradingDataService) GetNewMarketProposals(_ context.Context,
 	in *protoapi.GetNewMarketProposalsRequest,
 ) (*protoapi.GetNewMarketProposalsResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetNewMarketProposals", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetNewMarketProposals")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1635,9 +1600,7 @@ func (t *tradingDataService) GetNewMarketProposals(_ context.Context,
 func (t *tradingDataService) GetUpdateMarketProposals(_ context.Context,
 	in *protoapi.GetUpdateMarketProposalsRequest,
 ) (*protoapi.GetUpdateMarketProposalsResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetUpdateMarketProposals", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetUpdateMarketProposals")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1655,9 +1618,7 @@ func (t *tradingDataService) GetUpdateMarketProposals(_ context.Context,
 func (t *tradingDataService) GetNetworkParametersProposals(_ context.Context,
 	in *protoapi.GetNetworkParametersProposalsRequest,
 ) (*protoapi.GetNetworkParametersProposalsResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetNetworkParametersProposals", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetNetworkParametersProposals")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1674,9 +1635,7 @@ func (t *tradingDataService) GetNetworkParametersProposals(_ context.Context,
 func (t *tradingDataService) GetNewAssetProposals(_ context.Context,
 	in *protoapi.GetNewAssetProposalsRequest,
 ) (*protoapi.GetNewAssetProposalsResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetNewAssetProposals", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetNewAssetProposals")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1693,9 +1652,7 @@ func (t *tradingDataService) GetNewAssetProposals(_ context.Context,
 func (t *tradingDataService) GetProposalByID(_ context.Context,
 	in *protoapi.GetProposalByIDRequest,
 ) (*protoapi.GetProposalByIDResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetProposalByID", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetProposalByID")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1710,9 +1667,7 @@ func (t *tradingDataService) GetProposalByID(_ context.Context,
 func (t *tradingDataService) GetProposalByReference(_ context.Context,
 	in *protoapi.GetProposalByReferenceRequest,
 ) (*protoapi.GetProposalByReferenceResponse, error) {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("GetProposalByReference", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("GetProposalByReference")()
 
 	if err := in.Validate(); err != nil {
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1728,9 +1683,7 @@ func (t *tradingDataService) ObserveGovernance(
 	_ *empty.Empty,
 	stream protoapi.TradingData_ObserveGovernanceServer,
 ) error {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("ObserveGovernance", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("ObserveGovernance")()
 	ctx, cfunc := context.WithCancel(stream.Context())
 	defer cfunc()
 	if t.log.GetLevel() == logging.DebugLevel {
@@ -1762,9 +1715,7 @@ func (t *tradingDataService) ObservePartyProposals(
 	in *protoapi.ObservePartyProposalsRequest,
 	stream protoapi.TradingData_ObservePartyProposalsServer,
 ) error {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("ObservePartyProposals", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("ObservePartyProposals")()
 
 	if err := in.Validate(); err != nil {
 		return apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1802,9 +1753,7 @@ func (t *tradingDataService) ObservePartyVotes(
 	in *protoapi.ObservePartyVotesRequest,
 	stream protoapi.TradingData_ObservePartyVotesServer,
 ) error {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("ObservePartyVotes", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("ObservePartyVotes")()
 
 	if err := in.Validate(); err != nil {
 		return apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1842,9 +1791,7 @@ func (t *tradingDataService) ObserveProposalVotes(
 	in *protoapi.ObserveProposalVotesRequest,
 	stream protoapi.TradingData_ObserveProposalVotesServer,
 ) error {
-
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("ObserveProposalVotes", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("ObserveProposalVotes")()
 
 	if err := in.Validate(); err != nil {
 		return apiError(codes.InvalidArgument, ErrMalformedRequest, err)
@@ -1879,8 +1826,7 @@ func (t *tradingDataService) ObserveProposalVotes(
 }
 
 func (t *tradingDataService) ObserveEventBus(in *protoapi.ObserveEventsRequest, stream protoapi.TradingData_ObserveEventBusServer) error {
-	startTime := vegatime.Now()
-	defer metrics.APIRequestAndTimeGRPC("ObserveEventBus", startTime)
+	defer metrics.StartAPIRequestAndTimeGRPC("ObserveEventBus")()
 	if err := in.Validate(); err != nil {
 		return apiError(codes.InvalidArgument, ErrMalformedRequest, err)
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -477,3 +477,16 @@ func APIRequestAndTimeGraphQL(request string, time float64) {
 	apiRequestCallCounter.WithLabelValues("GraphQL", request).Inc()
 	apiRequestTimeCounter.WithLabelValues("GraphQL", request).Add(time)
 }
+
+// APIRequestAndTimeGRPC updates the metrics for GRPC API calls
+func StartAPIRequestAndTimeGRPC(request string) func() {
+	startTime := time.Now()
+	return func() {
+		if apiRequestCallCounter == nil || apiRequestTimeCounter == nil {
+			return
+		}
+		apiRequestCallCounter.WithLabelValues("GRPC", request).Inc()
+		duration := time.Now().Sub(startTime).Seconds()
+		apiRequestTimeCounter.WithLabelValues("GRPC", request).Add(duration)
+	}
+}


### PR DESCRIPTION
close #1619 