### PR TITLE
load initial assets from genesis state

### DIFF
--- a/assets/config.go
+++ b/assets/config.go
@@ -1,27 +1,17 @@
 package assets
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"code.vegaprotocol.io/vega/config/encoding"
 	"code.vegaprotocol.io/vega/logging"
-	types "code.vegaprotocol.io/vega/proto"
-
-	"github.com/golang/protobuf/jsonpb"
 )
 
 const (
-	namedLogger  = "assets"
-	devAssetPath = "dev_assets.json"
+	namedLogger = "assets"
 )
 
 type Config struct {
-	Level               encoding.LogLevel
-	DevAssetSourcesPath string
-	ERC20               ERC20Config
+	Level encoding.LogLevel
+	ERC20 ERC20Config
 }
 
 type ERC20Config struct {
@@ -33,98 +23,9 @@ type ERC20Config struct {
 func NewDefaultConfig(defaultRootPath string) Config {
 
 	return Config{
-		Level:               encoding.LogLevel{Level: logging.InfoLevel},
-		DevAssetSourcesPath: filepath.Join(defaultRootPath, devAssetPath),
+		Level: encoding.LogLevel{Level: logging.InfoLevel},
 		ERC20: ERC20Config{
 			BridgeAddress: "0xf6C9d3e937fb2dA4995272C1aC3f3D466B7c23fC",
 		},
 	}
-}
-
-func GenDevAssetSourcesPath(defaultRootPath string) error {
-	assets := types.DevAssets{Sources: []*types.AssetSource{
-		&types.AssetSource{
-			Source: &types.AssetSource_BuiltinAsset{
-				BuiltinAsset: &types.BuiltinAsset{
-					Name:                "Ether",
-					Symbol:              "ETH",
-					TotalSupply:         "110436690",
-					Decimals:            5,
-					MaxFaucetAmountMint: "10000000", // 100ETH
-				},
-			},
-		},
-		&types.AssetSource{
-			Source: &types.AssetSource_BuiltinAsset{
-				BuiltinAsset: &types.BuiltinAsset{
-					Name:                "Bitcoin",
-					Symbol:              "BTC",
-					TotalSupply:         "21000000",
-					Decimals:            5,
-					MaxFaucetAmountMint: "1000000", // 10BTC
-				},
-			},
-		},
-		&types.AssetSource{
-			Source: &types.AssetSource_BuiltinAsset{
-				BuiltinAsset: &types.BuiltinAsset{
-					Name:                "VUSD",
-					Symbol:              "VUSD",
-					TotalSupply:         "21000000",
-					Decimals:            5,
-					MaxFaucetAmountMint: "500000000", // 1000VUSD
-
-				},
-			},
-		},
-		// FIXME(): enable these assets again when we can supportt higher number
-		// of decimals and we have properly tester erc20 token support.
-		// this is the VUSD5
-		// &types.AssetSource{
-		// 	Source: &types.AssetSource_Erc20{
-		// 		Erc20: &types.ERC20{
-		// 			ContractAddress: "0x308C71DE1FdA14db838555188211Fc87ef349272",
-		// 		},
-		// 	},
-		// },
-		//this is the VUSD
-		// &types.AssetSource{
-		// 	Source: &types.AssetSource_Erc20{
-		// 		Erc20: &types.ERC20{
-		// 			ContractAddress: "0x955C6789A7fbee203B4bE0F01428E769308813f2",
-		// 		},
-		// 	},
-		// },
-	}}
-
-	m := jsonpb.Marshaler{
-		Indent: "  ",
-	}
-	buf, err := m.MarshalToString(&assets)
-	if err != nil {
-		return err
-	}
-	f, err := os.Create(filepath.Join(defaultRootPath, devAssetPath))
-	if err != nil {
-		return err
-	}
-
-	if _, err = f.WriteString(string(buf)); err != nil {
-		return err
-	}
-	return nil
-}
-
-func LoadDevAssets(cfg Config) ([]*types.AssetSource, error) {
-	path := filepath.Join(cfg.DevAssetSourcesPath)
-	buf, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	assets := types.DevAssets{}
-	err = jsonpb.Unmarshal(strings.NewReader(string(buf)), &assets)
-	if err != nil {
-		return nil, err
-	}
-	return assets.Sources, nil
 }

--- a/assets/genesis_state.go
+++ b/assets/genesis_state.go
@@ -1,0 +1,57 @@
+package assets
+
+import (
+	"encoding/json"
+
+	types "code.vegaprotocol.io/vega/proto"
+)
+
+type GenesisState struct {
+	Builtins []types.BuiltinAsset
+	ERC20    []types.ERC20
+}
+
+func DefaultGenesisState() GenesisState {
+	return GenesisState{
+		Builtins: []types.BuiltinAsset{
+			{
+				Name:                "Ether",
+				Symbol:              "ETH",
+				TotalSupply:         "110436690",
+				Decimals:            5,
+				MaxFaucetAmountMint: "10000000", // 100ETH
+			},
+			{
+				Name:                "Bitcoin",
+				Symbol:              "BTC",
+				TotalSupply:         "21000000",
+				Decimals:            5,
+				MaxFaucetAmountMint: "1000000", // 10BTC
+			},
+			types.BuiltinAsset{
+				Name:                "VUSD",
+				Symbol:              "VUSD",
+				TotalSupply:         "21000000",
+				Decimals:            5,
+				MaxFaucetAmountMint: "500000000", // 1000VUSD
+
+			},
+		},
+		ERC20: []types.ERC20{
+			{
+				ContractAddress: "0x308C71DE1FdA14db838555188211Fc87ef349272",
+			},
+		},
+	}
+}
+
+func LoadGenesisState(bytes []byte) (*GenesisState, error) {
+	state := struct {
+		Assets *GenesisState `json:"assets"`
+	}{}
+	err := json.Unmarshal(bytes, &state)
+	if err != nil {
+		return nil, err
+	}
+	return state.Assets, nil
+}

--- a/assets/genesis_state.go
+++ b/assets/genesis_state.go
@@ -33,8 +33,7 @@ func DefaultGenesisState() GenesisState {
 				Symbol:              "VUSD",
 				TotalSupply:         "21000000",
 				Decimals:            5,
-				MaxFaucetAmountMint: "500000000", // 1000VUSD
-
+				MaxFaucetAmountMint: "500000000", // 5000VUSD
 			},
 		},
 		ERC20: []types.ERC20{

--- a/cmd/vega/init.go
+++ b/cmd/vega/init.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"code.vegaprotocol.io/vega/assets"
 	"code.vegaprotocol.io/vega/config"
 	"code.vegaprotocol.io/vega/execution"
 	"code.vegaprotocol.io/vega/faucet"
@@ -161,11 +160,6 @@ func RunInit(rootPath string, force bool, logger *logging.Logger, nodeWalletPass
 
 	// init the nodewallet
 	if err := nodeWalletInit(cfg, nodeWalletPassphrase, genDevNodeWallet); err != nil {
-		return err
-	}
-
-	// init the devAssets
-	if err := assets.GenDevAssetSourcesPath(rootPath); err != nil {
 		return err
 	}
 

--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -284,15 +284,22 @@ func (l *NodeCommand) loadAssets(col *collateral.Engine) error {
 		return err
 	}
 
-	// TODO: remove that once we have infrastructure to use token through governance
-	assetSrcs, err := assets.LoadDevAssets(l.conf.Assets)
+	err = l.loadAsset(collateral.TokenAsset, collateral.TokenAssetSource)
 	if err != nil {
 		return err
 	}
 
-	err = l.loadAsset(collateral.TokenAsset, collateral.TokenAssetSource)
+	return nil
+}
+
+// load all asset from genesis state
+func (l *NodeCommand) UponGenesis(rawstate []byte) error {
+	state, err := assets.LoadGenesisState(rawstate)
 	if err != nil {
 		return err
+	}
+	if state == nil {
+		return nil
 	}
 
 	h := func(key []byte) []byte {
@@ -301,12 +308,44 @@ func (l *NodeCommand) loadAssets(col *collateral.Engine) error {
 		return hasher.Sum(nil)
 	}
 
+	assetSrcs := []proto.AssetSource{}
+	for _, v := range state.Builtins {
+		v := v
+		assetSrc := proto.AssetSource{
+			Source: &proto.AssetSource_BuiltinAsset{
+				BuiltinAsset: &v,
+			},
+		}
+		assetSrcs = append(assetSrcs, assetSrc)
+	}
+	for _, v := range state.ERC20 {
+		v := v
+		assetSrc := proto.AssetSource{
+			Source: &proto.AssetSource_Erc20{
+				Erc20: &v,
+			},
+		}
+		assetSrcs = append(assetSrcs, assetSrc)
+	}
+
 	for _, v := range assetSrcs {
 		v := v
 		id := hex.EncodeToString(h([]byte(v.String())))
-		err := l.loadAsset(id, v)
+		err := l.loadAsset(id, &v)
 		if err != nil {
 			return err
+		}
+	}
+
+	// then we load the markets
+	if len(l.mktscfg) > 0 {
+		for _, mkt := range l.mktscfg {
+			mkt := mkt
+			err = l.executionEngine.SubmitMarket(l.ctx, &mkt)
+			if err != nil {
+				l.Log.Panic("Unable to submit market",
+					logging.Error(err))
+			}
 		}
 	}
 
@@ -503,6 +542,10 @@ func (l *NodeCommand) preRun(_ *cobra.Command, _ []string) (err error) {
 		func(cfg config.Config) { l.accountsService.ReloadConf(cfg.Accounts) },
 		func(cfg config.Config) { l.partyService.ReloadConf(cfg.Parties) },
 		func(cfg config.Config) { l.feeService.ReloadConf(cfg.Execution.Fee) },
+	)
+
+	l.genesisHandler.OnGenesisAppStateLoaded(
+		l.UponGenesis,
 	)
 
 	l.timeService.NotifyOnTick(l.cfgwatchr.OnTimeUpdate)

--- a/genesis/encoding.go
+++ b/genesis/encoding.go
@@ -4,16 +4,19 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"code.vegaprotocol.io/vega/assets"
 	"code.vegaprotocol.io/vega/governance"
 )
 
 type GenesisState struct {
 	Governance governance.GenesisState `json:"governance"`
+	Assets     assets.GenesisState     `json:"assets"`
 }
 
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
 		Governance: governance.DefaultGenesisState(),
+		Assets:     assets.DefaultGenesisState(),
 	}
 }
 


### PR DESCRIPTION
This configure the initial set of assets through the genesis block state.
This is still imperfect for a few reason:
- the it's handled for now in thee cmd package mostly (which may stay as this though)
- as we need to instanciate markets with assets ID, the markets aren't instanciated until the assets ar loaded.


closes #2085 