### PR TITLE
add fees payed by distressed traders in the trade between distressed trader and the network

### DIFF
--- a/fee/engine.go
+++ b/fee/engine.go
@@ -294,9 +294,10 @@ func (e *Engine) CalculateFeeForPositionResolution(
 	trades []*types.Trade,
 	// the positions of the traders being closed out.
 	closedMPs []events.MarketPosition,
-) (events.FeesTransfer, error) {
+) (events.FeesTransfer, map[string]*types.Fee, error) {
 	var (
 		totalFeesAmounts = map[string]uint64{}
+		partiesFees      = map[string]*types.Fee{}
 		// this is the share of each party to be paid
 		partiesShare     = map[string]*feeShare{}
 		totalAbsolutePos uint64
@@ -311,6 +312,9 @@ func (e *Engine) CalculateFeeForPositionResolution(
 		}
 		totalAbsolutePos += uint64(size)
 		partiesShare[v.Party()] = &feeShare{pos: uint64(size)}
+
+		// while we are at it, we initial the map of all fees per party
+		partiesFees[v.Party()] = &types.Fee{}
 	}
 
 	// no we accumulated all the absolute position, we
@@ -338,7 +342,7 @@ func (e *Engine) CalculateFeeForPositionResolution(
 		// now we iterate over all parties,
 		// and create a pay for each distressed parties
 		for _, v := range closedMPs {
-			partyTransfers, feesAmount := e.getPositionResolutionFeesTransfers(
+			partyTransfers, fees, feesAmount := e.getPositionResolutionFeesTransfers(
 				v.Party(), partiesShare[v.Party()].share, fees)
 
 			if prevTotalFee, ok := totalFeesAmounts[v.Party()]; !ok {
@@ -347,6 +351,14 @@ func (e *Engine) CalculateFeeForPositionResolution(
 				totalFeesAmounts[v.Party()] = prevTotalFee + feesAmount
 			}
 			transfers = append(transfers, partyTransfers...)
+
+			// increase the party full fees
+			pf := partiesFees[v.Party()]
+			pf.MakerFee += fees.MakerFee
+			pf.InfrastructureFee += fees.InfrastructureFee
+			pf.LiquidityFee += fees.LiquidityFee
+			partiesFees[v.Party()] = pf
+
 		}
 
 		// then 1 receive transfer for the good party
@@ -365,44 +377,49 @@ func (e *Engine) CalculateFeeForPositionResolution(
 	return &feesTransfer{
 		totalFeesAmountsPerParty: totalFeesAmounts,
 		transfers:                transfers,
-	}, nil
+	}, partiesFees, nil
 }
 
 // this will calculate the transfer the distressed party needs
 // to do
 func (e *Engine) getPositionResolutionFeesTransfers(
 	party string, share float64, fees *types.Fee,
-) ([]*types.Transfer, uint64) {
+) ([]*types.Transfer, *types.Fee, uint64) {
 	makerFee := int64(math.Ceil(share * float64(fees.MakerFee)))
 	infraFee := int64(math.Ceil(share * float64(fees.InfrastructureFee)))
 	liquiFee := int64(math.Ceil(share * float64(fees.LiquidityFee)))
 
 	return []*types.Transfer{
-		&types.Transfer{
-			Owner: party,
-			Amount: &types.FinancialAmount{
-				Asset:  e.asset,
-				Amount: makerFee,
+			&types.Transfer{
+				Owner: party,
+				Amount: &types.FinancialAmount{
+					Asset:  e.asset,
+					Amount: makerFee,
+				},
+				Type: types.TransferType_TRANSFER_TYPE_MAKER_FEE_PAY,
 			},
-			Type: types.TransferType_TRANSFER_TYPE_MAKER_FEE_PAY,
-		},
-		&types.Transfer{
-			Owner: party,
-			Amount: &types.FinancialAmount{
-				Asset:  e.asset,
-				Amount: infraFee,
+			&types.Transfer{
+				Owner: party,
+				Amount: &types.FinancialAmount{
+					Asset:  e.asset,
+					Amount: infraFee,
+				},
+				Type: types.TransferType_TRANSFER_TYPE_INFRASTRUCTURE_FEE_PAY,
 			},
-			Type: types.TransferType_TRANSFER_TYPE_INFRASTRUCTURE_FEE_PAY,
-		},
-		&types.Transfer{
-			Owner: party,
-			Amount: &types.FinancialAmount{
-				Asset:  e.asset,
-				Amount: liquiFee,
+			&types.Transfer{
+				Owner: party,
+				Amount: &types.FinancialAmount{
+					Asset:  e.asset,
+					Amount: liquiFee,
+				},
+				Type: types.TransferType_TRANSFER_TYPE_LIQUIDITY_FEE_PAY,
 			},
-			Type: types.TransferType_TRANSFER_TYPE_LIQUIDITY_FEE_PAY,
 		},
-	}, uint64(makerFee + infraFee + liquiFee)
+		&types.Fee{
+			MakerFee:          uint64(makerFee),
+			InfrastructureFee: uint64(infraFee),
+			LiquidityFee:      uint64(liquiFee),
+		}, uint64(makerFee + infraFee + liquiFee)
 }
 
 type feeShare struct {

--- a/fee/engine_test.go
+++ b/fee/engine_test.go
@@ -56,7 +56,7 @@ func TestFeeEngine(t *testing.T) {
 	t.Run("calculate batch auction trading fee empty trade", testCalcBatchAuctionTradingErrorEmptyTrade)
 	t.Run("calcualte batch auction trading fee same batch", testCalcBatchAuctionTradingSameBatch)
 	t.Run("calcualte batch auction trading fee different batches", testCalcBatchAuctionTradingDifferentBatches)
-
+	t.Run("calculate position resolution", testCalcPositionResolution)
 }
 
 func testUpdateFeeFactors(t *testing.T) {
@@ -442,8 +442,9 @@ func testCalcPositionResolution(t *testing.T) {
 		fakeMktPos{party: "bad-party4", size: 10},
 	}
 
-	ft, err := eng.CalculateFeeForPositionResolution(trades, positions)
+	ft, partiesFee, err := eng.CalculateFeeForPositionResolution(trades, positions)
 	assert.NotNil(t, ft)
+	assert.NotNil(t, partiesFee)
 	assert.Nil(t, err)
 
 	// get the amounts map
@@ -460,6 +461,12 @@ func testCalcPositionResolution(t *testing.T) {
 	party4Amount, ok := feeAmounts["bad-party4"]
 	assert.True(t, ok)
 	assert.Equal(t, 307, int(party4Amount))
+
+	// check the details of the parties
+	// 307 as expected
+	assert.Equal(t, int(90), int(partiesFee["bad-party1"].InfrastructureFee))
+	assert.Equal(t, int(37), int(partiesFee["bad-party1"].MakerFee))
+	assert.Equal(t, int(180), int(partiesFee["bad-party1"].LiquidityFee))
 
 	// get the transfer and check we have enough of each types
 	transfers := ft.Transfers()


### PR DESCRIPTION
During position resolution, in order to 0 out the position of all distressed parties, the network is placing an order in the orderbook of the market against the good trader.

This order is backed by monies from the distressed trader, and a fee is payed as this is an aggressive order.

However, while the funds comes from the distressed traders, it looks like the fee is paying paid by the network(which is actually placing the order).

The details of the fees, paid by each distressed traders now appear in the trade between the network and the distress trader when 0ing out the position.

Adding all the fees paid by the distressed traders to the network, should give an equal number to the fees paid by the network to the good traders.

close #2129