### PR TITLE
Wrap critical functions with mutex

### DIFF
--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -43,7 +43,7 @@ type MarketDepth struct {
 // used to build the live market depth structure
 type MarketDepthBuilder struct {
 	*Base
-	mu sync.Mutex
+	mu sync.RWMutex
 	// Map of all the markets to their market depth
 	marketDepths map[string]*MarketDepth
 }
@@ -326,8 +326,8 @@ func min(x, y uint64) uint64 {
 
 // GetMarketDepth builds up the structure to be sent out to any market depth listeners
 func (mdb *MarketDepthBuilder) GetMarketDepth(ctx context.Context, market string, limit uint64) (*types.MarketDepth, error) {
-	mdb.mu.Lock()
-	defer mdb.mu.Unlock()
+	mdb.mu.RLock()
+	defer mdb.mu.RUnlock()
 	md, ok := mdb.marketDepths[market]
 	if !ok || md == nil {
 		// When a market is new with no orders there will not be any market depth/order book

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -228,6 +228,9 @@ func (md *MarketDepth) removePriceLevel(order *types.Order) {
 }
 
 func (mdb *MarketDepthBuilder) updateMarketDepth(order *types.Order) {
+	mdb.mu.Lock()
+	defer mdb.mu.Unlock()
+
 	// Non persistent and network orders do not matter
 	if order.Type == types.Order_TYPE_MARKET ||
 		order.TimeInForce == types.Order_TIF_FOK ||
@@ -323,6 +326,8 @@ func min(x, y uint64) uint64 {
 
 // GetMarketDepth builds up the structure to be sent out to any market depth listeners
 func (mdb *MarketDepthBuilder) GetMarketDepth(ctx context.Context, market string, limit uint64) (*types.MarketDepth, error) {
+	mdb.mu.Lock()
+	defer mdb.mu.Unlock()
 	md, ok := mdb.marketDepths[market]
 	if !ok || md == nil {
 		// When a market is new with no orders there will not be any market depth/order book


### PR DESCRIPTION
Parts of the market depth service can be accessed concurrently and were not protected by any access control.
This is now handled by using a mutex to control access to the price level structures.

Closes #2253