### PR TITLE
Fixing some GQL/gRPC event bus stream issues

### DIFF
--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -1885,7 +1885,8 @@ func (t *tradingDataService) ObserveEventBus(in *protoapi.ObserveEventsRequest, 
 			filters = append(filters, events.GetPartyIDFilter(in.PartyID))
 		}
 	}
-	ch := t.eventService.ObserveEvents(ctx, t.Config.StreamRetries, types, filters...)
+	// number of retries to -1 to have pretty much unlimited retries
+	ch := t.eventService.ObserveEvents(ctx, -1, types, filters...)
 	for {
 		select {
 		case data, ok := <-ch:

--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -1886,7 +1886,7 @@ func (t *tradingDataService) ObserveEventBus(in *protoapi.ObserveEventsRequest, 
 		}
 	}
 	// number of retries to -1 to have pretty much unlimited retries
-	ch := t.eventService.ObserveEvents(ctx, -1, types, filters...)
+	ch := t.eventService.ObserveEvents(ctx, t.Config.StreamRetries, types, filters...)
 	for {
 		select {
 		case data, ok := <-ch:

--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -3725,8 +3725,8 @@ type Subscription {
 
   "Subscribe to event data from the event bus"
   busEvents(
-    "the types to subscribe to"
-    types: [BusEventType!]
+    "the types to subscribe to has to be an array"
+    types: [BusEventType!]!
     "optional filter by market ID"
     marketID: String
     "optional filter by party ID"
@@ -6509,7 +6509,7 @@ func (ec *executionContext) field_Subscription_busEvents_args(ctx context.Contex
 	args := map[string]interface{}{}
 	var arg0 []BusEventType
 	if tmp, ok := rawArgs["types"]; ok {
-		arg0, err = ec.unmarshalOBusEventType2ᚕcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventTypeᚄ(ctx, tmp)
+		arg0, err = ec.unmarshalNBusEventType2ᚕcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventTypeᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -24952,6 +24952,63 @@ func (ec *executionContext) marshalNBusEventType2codeᚗvegaprotocolᚗioᚋvega
 	return v
 }
 
+func (ec *executionContext) unmarshalNBusEventType2ᚕcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventTypeᚄ(ctx context.Context, v interface{}) ([]BusEventType, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]BusEventType, len(vSlice))
+	for i := range vSlice {
+		res[i], err = ec.unmarshalNBusEventType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventType(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNBusEventType2ᚕcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []BusEventType) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNBusEventType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventType(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
 func (ec *executionContext) marshalNCandle2codeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐCandle(ctx context.Context, sel ast.SelectionSet, v proto.Candle) graphql.Marshaler {
 	return ec._Candle(ctx, sel, &v)
 }
@@ -26175,66 +26232,6 @@ func (ec *executionContext) marshalOBusEvent2ᚕᚖcodeᚗvegaprotocolᚗioᚋve
 				defer wg.Done()
 			}
 			ret[i] = ec.marshalNBusEvent2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEvent(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-	return ret
-}
-
-func (ec *executionContext) unmarshalOBusEventType2ᚕcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventTypeᚄ(ctx context.Context, v interface{}) ([]BusEventType, error) {
-	var vSlice []interface{}
-	if v != nil {
-		if tmp1, ok := v.([]interface{}); ok {
-			vSlice = tmp1
-		} else {
-			vSlice = []interface{}{v}
-		}
-	}
-	var err error
-	res := make([]BusEventType, len(vSlice))
-	for i := range vSlice {
-		res[i], err = ec.unmarshalNBusEventType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventType(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalOBusEventType2ᚕcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []BusEventType) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNBusEventType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐBusEventType(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)

--- a/gateway/graphql/modelext.go
+++ b/gateway/graphql/modelext.go
@@ -1371,7 +1371,7 @@ func eventTypeToProto(btypes ...BusEventType) []types.BusEventType {
 	for _, t := range btypes {
 		switch t {
 		case BusEventTypeAll:
-			r = append(r, types.BusEventType_BUS_EVENT_TYPE_UNSPECIFIED)
+			r = append(r, types.BusEventType_BUS_EVENT_TYPE_ALL)
 		case BusEventTypeTimeUpdate:
 			r = append(r, types.BusEventType_BUS_EVENT_TYPE_TIME_UPDATE)
 		case BusEventTypeTransferResponses:

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -2596,6 +2596,10 @@ func (r *mySubscriptionResolver) BusEvents(ctx context.Context, types []BusEvent
 			if isStreamClosed(err, r.log) {
 				return
 			}
+			if err != nil {
+				r.log.Error("Event bus stream error", logging.Error(err))
+				return
+			}
 			be := busEventFromProto(data.Events...)
 			out <- be
 		}

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -222,8 +222,8 @@ type Subscription {
 
   "Subscribe to event data from the event bus"
   busEvents(
-    "the types to subscribe to"
-    types: [BusEventType!]
+    "the types to subscribe to has to be an array"
+    types: [BusEventType!]!
     "optional filter by market ID"
     marketID: String
     "optional filter by party ID"

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -29,6 +29,10 @@ func NewStreamSub(ctx context.Context, types []events.Type, filters ...EventFilt
 	trades := false
 	expandedTypes := make([]events.Type, 0, len(types))
 	for _, t := range types {
+		if t == events.All {
+			expandedTypes = nil
+			break
+		}
 		if t == events.MarketEvent {
 			expandedTypes = append(expandedTypes, events.MarketEvents()...)
 		} else {
@@ -58,9 +62,8 @@ func NewStreamSub(ctx context.Context, types []events.Type, filters ...EventFilt
 		filters: filters,
 		updated: make(chan struct{}), // create a blocking channel for these
 	}
-	if s.isRunning() {
-		go s.loop(s.ctx)
-	}
+	// running or not, we're using the channel
+	go s.loop(s.ctx)
 	return s
 }
 
@@ -80,9 +83,7 @@ func (s *StreamSub) loop(ctx context.Context) {
 			s.Halt()
 			return
 		case e := <-s.ch:
-			if s.isRunning() {
-				s.Push(e)
-			}
+			s.Push(e)
 		}
 	}
 }

--- a/subscribers/stream_subscriber_test.go
+++ b/subscribers/stream_subscriber_test.go
@@ -55,6 +55,10 @@ func TestFilteredSubscription(t *testing.T) {
 	t.Run("Stream subscriber with filter - some valid events", testFilteredSomeValidEvents)
 }
 
+func TestSubscriberTypes(t *testing.T) {
+	t.Run("Stream subscriber for all event types", testFilterAll)
+}
+
 func testUnfilteredNoEvents(t *testing.T) {
 	sub := getTestStreamSub([]events.Type{events.AccountEvent})
 	wg := sync.WaitGroup{}
@@ -143,4 +147,9 @@ func testFilteredSomeValidEvents(t *testing.T) {
 	data := sub.GetData()
 	// we expect to see no events
 	assert.Equal(t, 1, len(data))
+}
+
+func testFilterAll(t *testing.T) {
+	sub := getTestStreamSub([]events.Type{events.All})
+	assert.Nil(t, sub.Types())
 }


### PR DESCRIPTION
> So when you send that GQL query, we're creating a new subscriber that receives all events of the specified types and buffers them. Once there's data ready, we try to push that on a blocking internal channel. If that channel isn't being read, we skip that data set-and retry. As soon as we've hit a certain number of retries, we assume the client isn't receiving any more data, and we close the stream. Although I'm not 100%, the retry limit might be a problem here. Even if it isn't, it's a variable that I'd prefer to see removed for now, so it's one less thing to worry about.

Slack ref: https://vegaprotocol.slack.com/archives/C9E6XA8GK/p1600249413031800?thread_ts=1600247729.016400&cid=C9E6XA8GK

Closes #2260 & Closes #2259 
