### PR TITLE
Speed up PR CI by making some tests conditional

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -63,7 +63,7 @@ steps:
     pull: always
     environment: {}
     commands:
-      - if test "$$DRONE_TARGET_BRANCH" = master -o "$$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ; then
+      - if test "$$DRONE_TARGET_BRANCH" = master -o "$$(grep -c '\.md$$' git_diff.txt)" -gt 0 ; then
           mdspell --en-gb --ignore-acronyms --ignore-numbers --no-suggestions --report '*.md' 'docs/**/*.md' || exit 1 ;
         else
           echo "No md files changed. Skipping mdspell." ;

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -46,7 +46,7 @@ steps:
       # changed in this PR.
       - git diff --name-only "$$DRONE_COMMIT_BEFORE...$$DRONE_COMMIT_AFTER" >git_diff.txt
       - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$$' git_diff.txt)" -gt 0 ]] ; then
-          # Build normal executable
+          echo "Building executable" ;
           ./script/build.sh -a build -t linux/amd64 || exit 1;
         else
           echo "No Go files changed. Skipping building of binary." ;

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -45,7 +45,7 @@ steps:
       # Get a list of files that changed in this PR, in order to limit CI to only test things that
       # changed in this PR.
       - git diff --name-only "$$DRONE_COMMIT_BEFORE...$$DRONE_COMMIT_AFTER" >git_diff.txt
-      - if [[ "$DRONE_TARGET_BRANCH" == master -o "$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$' git_diff.txt)" -gt 0]] ; then
+      - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$$' git_diff.txt)" -gt 0 ]] ; then
           # Build normal executable
           ./script/build.sh -a build -t linux/amd64 || exit 1;
         else
@@ -63,7 +63,7 @@ steps:
     pull: always
     environment: {}
     commands:
-      - if [[ "$DRONE_TARGET_BRANCH" == master -o "$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ]] ; then
+      - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ]] ; then
           mdspell --en-gb --ignore-acronyms --ignore-numbers --no-suggestions --report '*.md' 'docs/**/*.md' || exit 1 ;
         else
           echo "No md files changed. Skipping mdspell." ;
@@ -89,7 +89,7 @@ steps:
         from_secret: SLACK_HOOK_URL
     commands:
       - failed=""
-      - if [[ "$DRONE_TARGET_BRANCH" == master -o "$(grep -cE '(^go.(mod|sum)|\.go)$' git_diff.txt)" -gt 0]] ; then
+      - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -cE '(^go.(mod|sum)|\.go)$$' git_diff.txt)" -gt 0 ]] ; then
           make retest || exit 1 ;
           for target in gqlgen_check print_check proto_check race vet ;
           do

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -45,7 +45,7 @@ steps:
       # Get a list of files that changed in this PR, in order to limit CI to only test things that
       # changed in this PR.
       - git diff --name-only "$$DRONE_COMMIT_BEFORE...$$DRONE_COMMIT_AFTER" >git_diff.txt
-      - if [[ "$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$' git_diff.txt)" -gt 0]] ; then
+      - if [[ "$DRONE_TARGET_BRANCH" == master -o "$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$' git_diff.txt)" -gt 0]] ; then
           # Build normal executable
           ./script/build.sh -a build -t linux/amd64 || exit 1;
         else
@@ -63,7 +63,7 @@ steps:
     pull: always
     environment: {}
     commands:
-      - if [[ "$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ]] ; then
+      - if [[ "$DRONE_TARGET_BRANCH" == master -o "$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ]] ; then
           mdspell --en-gb --ignore-acronyms --ignore-numbers --no-suggestions --report '*.md' 'docs/**/*.md' || exit 1 ;
         else
           echo "No md files changed. Skipping mdspell." ;
@@ -89,7 +89,7 @@ steps:
         from_secret: SLACK_HOOK_URL
     commands:
       - failed=""
-      - if [[ "$(grep -cE '(^go.(mod|sum)|\.go)$' git_diff.txt)" -gt 0]] ; then
+      - if [[ "$DRONE_TARGET_BRANCH" == master -o "$(grep -cE '(^go.(mod|sum)|\.go)$' git_diff.txt)" -gt 0]] ; then
           make retest || exit 1 ;
           for target in gqlgen_check print_check proto_check race vet ;
           do

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -45,7 +45,7 @@ steps:
       # Get a list of files that changed in this PR, in order to limit CI to only test things that
       # changed in this PR.
       - git diff --name-only "$$DRONE_COMMIT_BEFORE...$$DRONE_COMMIT_AFTER" >git_diff.txt
-      - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$$' git_diff.txt)" -gt 0 ]] ; then
+      - if test "$$DRONE_TARGET_BRANCH" = master -o "$$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$$' git_diff.txt)" -gt 0 ; then
           echo "Building executable" ;
           ./script/build.sh -a build -t linux/amd64 || exit 1;
         else
@@ -63,7 +63,7 @@ steps:
     pull: always
     environment: {}
     commands:
-      - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ]] ; then
+      - if test "$$DRONE_TARGET_BRANCH" = master -o "$$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ; then
           mdspell --en-gb --ignore-acronyms --ignore-numbers --no-suggestions --report '*.md' 'docs/**/*.md' || exit 1 ;
         else
           echo "No md files changed. Skipping mdspell." ;
@@ -89,7 +89,7 @@ steps:
         from_secret: SLACK_HOOK_URL
     commands:
       - failed=""
-      - if [[ "$$DRONE_TARGET_BRANCH" == master -o "$$(grep -cE '(^go.(mod|sum)|\.go)$$' git_diff.txt)" -gt 0 ]] ; then
+      - if test "$$DRONE_TARGET_BRANCH" = master -o "$$(grep -cE '(^go.(mod|sum)|\.go)$$' git_diff.txt)" -gt 0 ; then
           make retest || exit 1 ;
           for target in gqlgen_check print_check proto_check race vet ;
           do

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -42,8 +42,16 @@ steps:
       - echo "$${GITHUB_DEPLOY_SSH_PRIVATE_KEY}" >~/.ssh/id_rsa ; chmod 0600 ~/.ssh/id_rsa
       - ssh-keyscan github.com 1>~/.ssh/known_hosts 2>/dev/null ; chmod 0644 ~/.ssh/known_hosts
       - unset GITHUB_DEPLOY_SSH_PRIVATE_KEY
-      # Build normal executable
-      - ./script/build.sh -a build -t linux/amd64
+      # Get a list of files that changed in this PR, in order to limit CI to only test things that
+      # changed in this PR.
+      - git diff --name-only "$$DRONE_COMMIT_BEFORE...$$DRONE_COMMIT_AFTER" >git_diff.txt
+      - if [[ "$(grep -cE '(^go.(mod|sum)|\.go|\.feature)$' git_diff.txt)" -gt 0]] ; then
+          # Build normal executable
+          ./script/build.sh -a build -t linux/amd64 || exit 1;
+        else
+          echo "No Go files changed. Skipping building of binary." ;
+          rm -f cmd/vega/vega-* ;
+        fi
     depends_on:
       - fetch
     when:
@@ -55,8 +63,11 @@ steps:
     pull: always
     environment: {}
     commands:
-      # Make sure the mdspell command matches the one in Makefile.
-      - mdspell --en-gb --ignore-acronyms --ignore-numbers --no-suggestions --report '*.md' 'docs/**/*.md'
+      - if [[ "$(grep -c '\.md$$' ~/git_diff.txt)" -gt 0 ]] ; then
+          mdspell --en-gb --ignore-acronyms --ignore-numbers --no-suggestions --report '*.md' 'docs/**/*.md' || exit 1 ;
+        else
+          echo "No md files changed. Skipping mdspell." ;
+        fi
     depends_on:
       - build-PR
     when:
@@ -77,16 +88,26 @@ steps:
       SLACK_HOOK_URL:
         from_secret: SLACK_HOOK_URL
     commands:
-      - make retest
-      # More small checks. Run all, instead of exiting after first failure.
       - failed=""
-      - for target in codeowners_check gqlgen_check print_check proto_check race vet ; do
-          echo "$$COL_CYAN$$target$$COL_RESET" ; make "$$target" || failed="$$failed $$target" ; done
+      - if [[ "$(grep -cE '(^go.(mod|sum)|\.go)$' git_diff.txt)" -gt 0]] ; then
+          make retest || exit 1 ;
+          for target in gqlgen_check print_check proto_check race vet ;
+          do
+            echo "$$COL_CYAN$$target$$COL_RESET" ;
+            make "$$target" || failed="$$failed $$target" ;
+          done ;
+        else
+          echo "No Go files changed. Skipping go tests" ;
+        fi
+      - for target in codeowners_check ; do
+          echo "$$COL_CYAN$$target$$COL_RESET" ;
+          make "$$target" || failed="$$failed $$target" ;
+        done
       - /usr/local/bin/check-rest-endpoints.py
           --bindings gateway/rest/grpc-rest-bindings.yml
           --swagger proto/api/trading.swagger.json || failed="$$failed rest_check"
-      - /usr/local/bin/multilint || failed="$$failed multilint"
-      - make staticcheck || true  # Ignore failures until they're all fixed.
+      - difflint "$$DRONE_COMMIT_BEFORE" "$$DRONE_COMMIT_AFTER" || failed="$$failed multilint"
+      # - make staticcheck  # No point running this until warnings are fixed.
       - if test -n "$$failed" ; then echo "Failed checks:$$failed" ; exit 1 ; fi ; echo "$${COL_GREEN}OK$$COL_RESET"
     depends_on:
       - build-PR
@@ -104,7 +125,11 @@ steps:
         from_secret: SLACK_HOOK_URL
     commands:
       # https://github.com/vegaprotocol/system-tests/blob/master/ci.sh
-      - /usr/local/bin/ci.sh
+      - if test -x cmd/vega/vega-linux-amd64 ; then
+          /usr/local/bin/ci.sh ;
+        else
+          echo "No vega binary. Skipping system-tests." ;
+        fi
     depends_on:
       - test-PR
     when:


### PR DESCRIPTION
This PR changes CI so that PRs (excl. PRs to master) may skip tests if files are not changed.

## files changed -> tests to be run
- `go.mod`, `go.sum`, `*.go`, `*.feature` -> build binary, run `go test`, `go test -race`, `go vet`, run system-tests etc.
- `*.md` -> run markdown spellchecker