### PR TITLE
Prevent concurrent devnet deployments

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -176,6 +176,8 @@ steps:
     volumes:
       - name: gopkg
         path: /go/pkg
+      - name: mutex
+        path: /mutex
     environment:
       DEVNET_DEPLOY_SSH_PRIVATE_KEY:
         from_secret: DEVNET_DEPLOY_SSH_PRIVATE_KEY
@@ -203,15 +205,20 @@ steps:
       # - DEVNET_DEPLOY_SSH_KNOWN_HOSTS
       # - DEVNET_DEPLOY_SSH_PRIVATE_KEY
       # - SLACK_HOOK_URL
-      - cp -a cmd/vega/vega-linux-amd64 cmd/vega/vega
-      - /usr/local/bin/deploy-trading-core.sh devnet vega
-      # Set up wallets, keypairs and free money.
-      - /usr/local/bin/init-wallets-tokenbalances.py
+      - (
+          if ! flock -n 9 ; then
+            echo "Another devnet deployment is in progress." ;
+            exit 1 ;
+          fi ;
+          cp -a cmd/vega/vega-linux-amd64 cmd/vega/vega &&
+          /usr/local/bin/deploy-trading-core.sh devnet vega &&
+          /usr/local/bin/init-wallets-tokenbalances.py
             --faucetserver "$$DEVNET_FAUCET_SERVER"
             --wallets "$$(echo "$$VEGANET_USERS" | tr " " ",")"
             --walletserver "$$DEVNET_WALLET_SERVER"
             --passphrase "$$DEVNET_WALLET_PASSPHRASE"
             --veganode "$$DEVNET_VEGA_GRPCNODE"
+       ) 9>/mutex/devnet_deploy
     depends_on:
       - build-branch
     when:
@@ -323,6 +330,9 @@ volumes:
   - name: gopkg
     host:
       path: /var/lib/drone/volumes/vega/gopkg
+  - name: mutex
+    host:
+      path: /var/lib/drone/volumes/vega/mutex
 
 image_pull_secrets:
   - dockerconfig


### PR DESCRIPTION
This PR updates CI to prevent concurrent devnet deployments by using `flock`.