### PR TITLE
Fixes for event stream API

### DIFF
--- a/events/account.go
+++ b/events/account.go
@@ -18,6 +18,18 @@ func NewAccountEvent(ctx context.Context, a types.Account) *Acc {
 	}
 }
 
+func (a Acc) IsParty(id string) bool {
+	return (a.a.Owner == id)
+}
+
+func (a Acc) PartyID() string {
+	return a.a.Owner
+}
+
+func (a Acc) MarketID() string {
+	return a.a.MarketID
+}
+
 func (a *Acc) Account() types.Account {
 	return a.a
 }

--- a/events/auction.go
+++ b/events/auction.go
@@ -30,6 +30,10 @@ func NewAuctionEvent(ctx context.Context, marketID string, leave bool, start, st
 	}
 }
 
+func (a Auction) MarketID() string {
+	return a.marketID
+}
+
 // Auction returns the action performed (either true=leave auction, or false=entering auction)
 func (a *Auction) Auction() bool {
 	return a.leave

--- a/events/bus.go
+++ b/events/bus.go
@@ -27,7 +27,7 @@ type marketFilterable interface {
 // simple interface for event filtering on party ID
 type partyFilterable interface {
 	Event
-	PartyID() string
+	IsParty(id string) bool
 }
 
 // simple interface for event filtering by party and market ID
@@ -297,7 +297,7 @@ func GetPartyIDFilter(pID string) func(Event) bool {
 		if !ok {
 			return false
 		}
-		return (pe.PartyID() == pID)
+		return pe.IsParty(pID)
 	}
 }
 

--- a/events/deposit.go
+++ b/events/deposit.go
@@ -22,6 +22,10 @@ func (d *Deposit) Deposit() types.Deposit {
 	return d.d
 }
 
+func (d Deposit) IsParty(id string) bool {
+	return (d.d.PartyID == id)
+}
+
 func (d Deposit) PartyID() string { return d.d.PartyID }
 
 func (d Deposit) Proto() types.Deposit {

--- a/events/governance_proposal.go
+++ b/events/governance_proposal.go
@@ -27,6 +27,10 @@ func (p *Proposal) ProposalID() string {
 	return p.p.ID
 }
 
+func (p Proposal) IsParty(id string) bool {
+	return (p.p.PartyID == id)
+}
+
 // PartyID - for combined subscriber, communal interface
 func (p *Proposal) PartyID() string {
 	return p.p.PartyID

--- a/events/loss_socialization.go
+++ b/events/loss_socialization.go
@@ -24,6 +24,10 @@ func NewLossSocializationEvent(ctx context.Context, partyID, marketID string, am
 	}
 }
 
+func (l LossSoc) IsParty(id string) bool {
+	return (l.partyID == id)
+}
+
 func (l LossSoc) PartyID() string {
 	return l.partyID
 }

--- a/events/margin_levels.go
+++ b/events/margin_levels.go
@@ -23,6 +23,10 @@ func (m MarginLevels) MarginLevels() types.MarginLevels {
 	return m.l
 }
 
+func (m MarginLevels) IsParty(id string) bool {
+	return (m.l.PartyID == id)
+}
+
 func (m MarginLevels) PartyID() string {
 	return m.l.PartyID
 }

--- a/events/market_data.go
+++ b/events/market_data.go
@@ -18,6 +18,10 @@ func NewMarketDataEvent(ctx context.Context, md types.MarketData) *MarketData {
 	}
 }
 
+func (m MarketData) MarketID() string {
+	return m.md.Market
+}
+
 func (m MarketData) MarketData() types.MarketData {
 	return m.md
 }

--- a/events/market_event.go
+++ b/events/market_event.go
@@ -24,6 +24,10 @@ func (m Market) MarketEvent() string {
 	return fmt.Sprintf("Market ID %s created (%s)", m.m.Id, m.m.String())
 }
 
+func (m Market) MarketID() string {
+	return m.m.Id
+}
+
 func (m Market) Market() types.Market {
 	return m.m
 }

--- a/events/order.go
+++ b/events/order.go
@@ -18,6 +18,18 @@ func NewOrderEvent(ctx context.Context, o *types.Order) *Order {
 	}
 }
 
+func (o Order) IsParty(id string) bool {
+	return (o.o.PartyID == id)
+}
+
+func (o Order) PartyID() string {
+	return o.o.PartyID
+}
+
+func (o Order) MarketID() string {
+	return o.o.MarketID
+}
+
 func (o *Order) Order() *types.Order {
 	return o.o
 }

--- a/events/party.go
+++ b/events/party.go
@@ -18,6 +18,10 @@ func NewPartyEvent(ctx context.Context, p types.Party) *Party {
 	}
 }
 
+func (p Party) IsParty(id string) bool {
+	return (p.p.Id == id)
+}
+
 func (p *Party) Party() types.Party {
 	return p.p
 }

--- a/events/settle_distressed.go
+++ b/events/settle_distressed.go
@@ -26,6 +26,10 @@ func NewSettleDistressed(ctx context.Context, partyID, marketID string, price, m
 	}
 }
 
+func (s SettleDistressed) IsParty(id string) bool {
+	return (s.partyID == id)
+}
+
 func (s SettleDistressed) PartyID() string {
 	return s.partyID
 }

--- a/events/settle_position.go
+++ b/events/settle_position.go
@@ -30,6 +30,10 @@ func (s SettlePos) MarketID() string {
 	return s.marketID
 }
 
+func (s SettlePos) IsParty(id string) bool {
+	return (s.partyID == id)
+}
+
 func (s SettlePos) PartyID() string {
 	return s.partyID
 }

--- a/events/trade.go
+++ b/events/trade.go
@@ -18,6 +18,14 @@ func NewTradeEvent(ctx context.Context, t types.Trade) *Trade {
 	}
 }
 
+func (t Trade) MarketID() string {
+	return t.t.MarketID
+}
+
+func (t Trade) IsParty(id string) bool {
+	return (t.t.Buyer == id || t.t.Seller == id)
+}
+
 func (t *Trade) Trade() types.Trade {
 	return t.t
 }

--- a/events/transfer_response.go
+++ b/events/transfer_response.go
@@ -24,6 +24,17 @@ func (t *TransferResponse) TransferResponses() []*types.TransferResponse {
 	return t.responses
 }
 
+func (t TransferResponse) IsParty(id string) bool {
+	for _, r := range t.responses {
+		for _, e := range r.Transfers {
+			if e.FromAccount == id || e.ToAccount == id {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (t *TransferResponse) Proto() types.TransferResponses {
 	return types.TransferResponses{
 		Responses: t.responses,

--- a/events/vote.go
+++ b/events/vote.go
@@ -28,6 +28,11 @@ func (v *Vote) ProposalID() string {
 	return v.v.ProposalID
 }
 
+// IsParty - used in event stream API filter
+func (v Vote) IsParty(id string) bool {
+	return (v.v.PartyID == id)
+}
+
 // PartyID - return the PartyID for subscribers' convenience
 func (v *Vote) PartyID() string {
 	return v.v.PartyID

--- a/events/withdrawal.go
+++ b/events/withdrawal.go
@@ -22,6 +22,10 @@ func (w *Withdrawal) Withdrawal() types.Withdrawal {
 	return w.w
 }
 
+func (w Withdrawal) IsParty(id string) bool {
+	return (w.w.PartyID == id)
+}
+
 func (w Withdrawal) PartyID() string { return w.w.PartyID }
 
 func (w Withdrawal) Proto() types.Withdrawal {

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -67,7 +67,7 @@ type Engine struct {
 func NewEngine(
 	log *logging.Logger,
 	executionConfig Config,
-	time TimeService,
+	ts TimeService,
 	pmkts []types.Market,
 	collateral *collateral.Engine,
 	broker Broker,
@@ -84,7 +84,7 @@ func NewEngine(
 		log:        log,
 		Config:     executionConfig,
 		markets:    map[string]*Market{},
-		time:       time,
+		time:       ts,
 		collateral: collateral,
 		idgen:      NewIDGen(),
 		broker:     broker,

--- a/settlement/engine.go
+++ b/settlement/engine.go
@@ -184,7 +184,7 @@ func (e *Engine) SettleMTM(ctx context.Context, markPrice uint64, positions []ev
 			tradeset = append(tradeset, t)
 		}
 		// create (and add position to buffer)
-		evts = append(evts, events.NewSettlePositionEvent(ctx, evt.Party(), e.market, evt.Price(), tradeset, e.currentTime.UnixNano()))
+		evts = append(evts, events.NewSettlePositionEvent(ctx, party, e.market, evt.Price(), tradeset, e.currentTime.UnixNano()))
 		// no changes in position, and the MTM price hasn't changed, we don't need to do anything
 		if !hasTraded && current.price == markPrice {
 			// no changes in position and markPrice hasn't changed -> nothing needs to be marked


### PR DESCRIPTION
A couple of fixes to the event stream API:

* Filtering accounts, orders, settle position, settle distressed, transfer responses, etc... by party ID fixed
* small tweaks to subscriber (append before closing channel)
* Remove extraneous call to Party method on market position event in settlement engine