### PR TITLE
Prevent closing an opening auction early

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -311,7 +311,9 @@ func (m *Market) OnChainTimeUpdate(t time.Time) (closed bool) {
 
 	// TODO(): handle market start time
 
-	m.auctionModeTimeBasedSemaphore(ctx, t)
+	if !m.isOpeningAuction() {
+		m.auctionModeTimeBasedSemaphore(ctx, t)
+	}
 
 	if m.log.GetLevel() == logging.DebugLevel {
 		m.log.Debug("Calculating risk factors (if required)",


### PR DESCRIPTION
Currently the code to see if we should come out of an auction due to liquidity or price movement is called during the opening auction. This is incorrect so I have prevented this check being made during opening auctions.

Closes #2274 