### PR TITLE
Better handling of zero expiresAt for amends

### DIFF
--- a/orders/service.go
+++ b/orders/service.go
@@ -194,7 +194,7 @@ func (s *Svc) PrepareAmendOrder(ctx context.Context, amendment *types.OrderAmend
 	// Check we have at least one field to update
 	if amendment.Price == nil &&
 		amendment.SizeDelta == 0 &&
-		amendment.ExpiresAt == nil &&
+		(amendment.ExpiresAt == nil || amendment.ExpiresAt.Value == 0) &&
 		amendment.TimeInForce == types.Order_TIF_UNSPECIFIED {
 		return ErrNoParamsInAmendRequest
 	}


### PR DESCRIPTION
We currently use the nil pointer to express no change to the expiresAt field when we place amends. However we should be handling the value 0 in the way way. This PR does just that.
Closes #2081 