### PR TITLE
use the nodewallet to access the vega wallet when running vega genesis

### DIFF
--- a/cmd/vega/genesis.go
+++ b/cmd/vega/genesis.go
@@ -4,34 +4,38 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 
 	"code.vegaprotocol.io/vega/config"
 	"code.vegaprotocol.io/vega/genesis"
-	"code.vegaprotocol.io/vega/nodewallet/vega"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/nodewallet"
+
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/jessevdk/go-flags"
 	tmconfig "github.com/tendermint/tendermint/config"
 )
 
 type genesisCmd struct {
+	config.RootPathFlag
 	// We've unified the passphrase flag as config.PassphraseFlag, which uses --passphrase.
 	// As systemtests uses --vega-wallet-passphrase we'll define the flag directly here
 	// TODO: uncomment this line and remove the Passphrase field.
 	// config.PassphraseFlag
 	Passphrase config.Passphrase `short:"p" long:"vega-wallet-passphrase" description:"A file containing the passphrase for the wallet, if empty will prompt for input"`
 
-	InPlace    bool   `short:"i" long:"in-place" description:"Edit the genesis file in-place"`
-	TmRoot     string `short:"t" long:"tm-root" description:"The root path of tendermint"`
-	WalletPath string `short:"v" long:"vega-wallet-path" description:"The path of vega wallet" required:"true"`
+	InPlace bool   `short:"i" long:"in-place" description:"Edit the genesis file in-place"`
+	TmRoot  string `short:"t" long:"tm-root" description:"The root path of tendermint"`
 }
 
 func (opts *genesisCmd) Execute(_ []string) error {
 	tmCfg := tmconfig.DefaultConfig()
 	tmCfg.SetRoot(os.ExpandEnv(opts.TmRoot))
 
-	pass, err := opts.Passphrase.Get("vega wallet")
+	pass, err := opts.Passphrase.Get("node wallet")
 	if err != nil {
 		return err
 	}
@@ -43,10 +47,16 @@ func (opts *genesisCmd) Execute(_ []string) error {
 	// load tm pubkey
 	tmKey, err := loadTMPubkey(tmCfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to load TM pubkey: %w", err)
 	}
 
-	vegaKey, err := loadVegaPubKey(opts.WalletPath, pass)
+	log := logging.NewLoggerFromConfig(
+		logging.NewDefaultConfig(),
+	)
+	defer log.AtExit()
+
+	// load vega pubkey
+	vegaKey, err := loadVegaPubKey(log, opts.RootPath, pass)
 	if err != nil {
 		return err
 	}
@@ -88,10 +98,26 @@ func loadTMPubkey(cfg *tmconfig.Config) (string, error) {
 	return pvKey.PubKey.Value, nil
 }
 
-func loadVegaPubKey(path, pass string) (string, error) {
-	w, err := vega.New(os.ExpandEnv(path), pass)
+func loadVegaPubKey(log *logging.Logger, rootPath, pass string) (string, error) {
+	conf, err := config.Read(rootPath)
 	if err != nil {
 		return "", err
+	}
+
+	// instanciate the ETHClient
+	ethclt, err := ethclient.Dial(conf.NodeWallet.ETH.Address)
+	if err != nil {
+		return "", err
+	}
+
+	nw, err := nodewallet.New(log, conf.NodeWallet, pass, ethclt)
+	if err != nil {
+		return "", err
+	}
+
+	w, ok := nw.Get(nodewallet.Blockchain("vega"))
+	if !ok {
+		return "", errors.New("no vega wallet stored in node wallet")
 	}
 
 	vegaKey := w.PubKeyOrAddress()
@@ -99,12 +125,14 @@ func loadVegaPubKey(path, pass string) (string, error) {
 }
 
 func Genesis(ctx context.Context, parser *flags.Parser) error {
+	rootPath := config.NewRootPathFlag()
 	_, err := parser.AddCommand(
 		"genesis",
 		"Generates the genesis file",
 		"Generate a default genesis state for a vega network",
 		&genesisCmd{
-			TmRoot: "$HOME/.tendermint",
+			RootPathFlag: rootPath,
+			TmRoot:       "$HOME/.tendermint",
 		},
 	)
 	return err

--- a/cmd/vega/genesis.go
+++ b/cmd/vega/genesis.go
@@ -25,7 +25,7 @@ type genesisCmd struct {
 	// As systemtests uses --vega-wallet-passphrase we'll define the flag directly here
 	// TODO: uncomment this line and remove the Passphrase field.
 	// config.PassphraseFlag
-	Passphrase config.Passphrase `short:"p" long:"vega-wallet-passphrase" description:"A file containing the passphrase for the wallet, if empty will prompt for input"`
+	Passphrase config.Passphrase `short:"p" long:"nodewallet-passphrase" description:"A file containing the passphrase for the nodewallet, if empty will prompt for input"`
 
 	InPlace bool   `short:"i" long:"in-place" description:"Edit the genesis file in-place"`
 	TmRoot  string `short:"t" long:"tm-root" description:"The root path of tendermint"`


### PR DESCRIPTION
follow up on: https://github.com/vegaprotocol/vega/pull/2226

Change passphrase option to use a file, or prompt for the password if none specified.
Use the node wallet to access the vega wallet as asked by @ashleyvega 