### PR TITLE
Check auction times before converting to unix nanos

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -240,8 +240,13 @@ func (m *Market) GetMarketData() types.MarketData {
 	var auctionStart, auctionEnd int64
 	if m.matching.GetMarketState() == types.MarketState_MARKET_STATE_AUCTION {
 		indicativePrice, indicativeVolume, _ = m.matching.GetIndicativePriceAndVolume()
-		auctionStart = m.auctionStart.UnixNano()
-		auctionEnd = m.auctionEnd.UnixNano()
+		// Zero time does not equal 0 in UnixNanos, we need to check here before converting
+		if !m.auctionStart.IsZero() {
+			auctionStart = m.auctionStart.UnixNano()
+		}
+		if !m.auctionEnd.IsZero() {
+			auctionEnd = m.auctionEnd.UnixNano()
+		}
 	}
 
 	return types.MarketData{


### PR DESCRIPTION
We store the auction times internally as time.Time fields. When the auction is finished we set the value to it's default value. However when we convert that default value into UnixNanos the value is not 0 but a random large negative value.

This code change checks the time.Time value first before converting to prevent the large random number being used.