### PR TITLE
Add sequence ID to events

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -5,10 +5,13 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"code.vegaprotocol.io/vega/broker"
 	"code.vegaprotocol.io/vega/broker/mocks"
+	"code.vegaprotocol.io/vega/contextutil"
 	"code.vegaprotocol.io/vega/events"
+	types "code.vegaprotocol.io/vega/proto"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -56,6 +59,11 @@ func (b *brokerTst) Finish() {
 	b.ctrl.Finish()
 }
 
+func TestSequenceIDGen(t *testing.T) {
+	t.Run("Sequence ID is correctly - events dispatched per block (ordered)", testSequenceIDGenSeveralBlocksOrdered)
+	t.Run("Sequence ID is correctly - events dispatched for several blocks at the same time", testSequenceIDGenSeveralBlocksUnordered)
+}
+
 func TestSubscribe(t *testing.T) {
 	t.Run("Subscribe and unsubscribe required - success", testSubUnsubSuccess)
 	t.Run("Subscribe reuses keys", testSubReuseKey)
@@ -69,6 +77,101 @@ func TestSendEvent(t *testing.T) {
 	t.Run("Stop sending if context is cancelled", testStopCtx)
 	t.Run("Skip subscriber based on channel state", testSubscriberSkip)
 	t.Run("Send only to typed subscriber", testEventTypeSubscription)
+}
+
+func testSequenceIDGenSeveralBlocksOrdered(t *testing.T) {
+	tstBroker := getBroker(t)
+	defer tstBroker.Finish()
+	ctxH1, ctxH2 := contextutil.WithTraceID(tstBroker.ctx, "hash-1"), contextutil.WithTraceID(tstBroker.ctx, "hash-2")
+	dataH1 := []events.Event{
+		events.NewTime(ctxH1, time.Now()),
+		events.NewPartyEvent(ctxH1, types.Party{Id: "test-party-h1"}),
+	}
+	dataH2 := []events.Event{
+		events.NewTime(ctxH2, time.Now()),
+		events.NewPartyEvent(ctxH2, types.Party{Id: "test-party-h2"}),
+	}
+	allData := make([]events.Event, 0, len(dataH1)+len(dataH2))
+	done := make(chan struct{})
+	sub := mocks.NewMockSubscriber(tstBroker.ctrl)
+	sub.EXPECT().Types().Times(2).Return(nil)
+	sub.EXPECT().Ack().Times(1).Return(true)
+	sub.EXPECT().Skip().AnyTimes().Return(tstBroker.ctx.Done())
+	sub.EXPECT().Closed().AnyTimes().Return(tstBroker.ctx.Done())
+	sub.EXPECT().Push(gomock.Any()).AnyTimes().Do(func(evts ...events.Event) {
+		allData = append(allData, evts...)
+		if len(allData) >= cap(allData) {
+			close(done)
+		}
+	})
+	k := tstBroker.Subscribe(sub)
+	// send batches for both events - hash 2 after hash 1
+	tstBroker.SendBatch(dataH1)
+	tstBroker.SendBatch(dataH2)
+	seqH1 := []uint64{}
+	seqH2 := []uint64{}
+	for i := range dataH1 {
+		e1, ok := dataH1[i].(broker.SeqEvent)
+		assert.True(t, ok)
+		seqH1 = append(seqH1, e1.Sequence())
+		e2, ok := dataH2[i].(broker.SeqEvent)
+		assert.True(t, ok)
+		seqH2 = append(seqH2, e2.Sequence())
+	}
+	assert.Equal(t, seqH1, seqH2)
+	<-done
+	tstBroker.Unsubscribe(k)
+	assert.NotEqual(t, seqH1[0], seqH2[1]) // the two are equal, we can compare X-slice
+	assert.Equal(t, len(allData), len(dataH1)+len(dataH2))
+}
+
+func testSequenceIDGenSeveralBlocksUnordered(t *testing.T) {
+	tstBroker := getBroker(t)
+	defer tstBroker.Finish()
+	ctxH1, ctxH2 := contextutil.WithTraceID(tstBroker.ctx, "hash-1"), contextutil.WithTraceID(tstBroker.ctx, "hash-2")
+	dataH1 := []events.Event{
+		events.NewTime(ctxH1, time.Now()),
+		events.NewPartyEvent(ctxH1, types.Party{Id: "test-party-h1"}),
+	}
+	dataH2 := []events.Event{
+		events.NewTime(ctxH2, time.Now()),
+		events.NewPartyEvent(ctxH2, types.Party{Id: "test-party-h2"}),
+	}
+	allData := make([]events.Event, 0, len(dataH1)+len(dataH2))
+	done := make(chan struct{})
+	sub := mocks.NewMockSubscriber(tstBroker.ctrl)
+	sub.EXPECT().Types().Times(2).Return(nil)
+	sub.EXPECT().Ack().Times(1).Return(true)
+	sub.EXPECT().Skip().AnyTimes().Return(tstBroker.ctx.Done())
+	sub.EXPECT().Closed().AnyTimes().Return(tstBroker.ctx.Done())
+	sub.EXPECT().Push(gomock.Any()).AnyTimes().Do(func(evts ...events.Event) {
+		allData = append(allData, evts...)
+		if len(allData) >= cap(allData) {
+			close(done)
+		}
+	})
+	k := tstBroker.Subscribe(sub)
+	// We can't use sendBatch here: we use the traceID of the fisrt event in the batch to determine
+	// the hash (batch-sending events can only happen within a single block)
+	for i := range dataH1 {
+		tstBroker.Send(dataH1[i])
+		tstBroker.Send(dataH2[i])
+	}
+	seqH1 := []uint64{}
+	seqH2 := []uint64{}
+	for i := range dataH1 {
+		e1, ok := dataH1[i].(broker.SeqEvent)
+		assert.True(t, ok)
+		seqH1 = append(seqH1, e1.Sequence())
+		e2, ok := dataH2[i].(broker.SeqEvent)
+		assert.True(t, ok)
+		seqH2 = append(seqH2, e2.Sequence())
+	}
+	assert.Equal(t, seqH1, seqH2)
+	<-done
+	tstBroker.Unsubscribe(k)
+	assert.NotEqual(t, seqH1[0], seqH2[1]) // the two are equal, we can compare X-slice
+	assert.Equal(t, len(allData), len(dataH1)+len(dataH2))
 }
 
 func testSubUnsubSuccess(t *testing.T) {

--- a/broker/sequence_generator.go
+++ b/broker/sequence_generator.go
@@ -1,0 +1,69 @@
+package broker
+
+import (
+	"sync"
+
+	"code.vegaprotocol.io/vega/events"
+)
+
+type SeqEvent interface {
+	events.Event
+	SetSequenceID(s uint64)
+	Sequence() uint64 // this isn't used apart from in tests
+}
+
+type gen struct {
+	mu       sync.Mutex
+	blockSeq map[string]uint64
+	blocks   []string
+}
+
+func newGen() *gen {
+	return &gen{
+		blockSeq: map[string]uint64{},
+		blocks:   []string{},
+	}
+}
+
+// setSequence adds sequence ID to the event objects, returns the arguments because
+// the events might be passed by value (interface values)
+// returns the more restrictive event object - once seq ID is set, it should be treated as RO
+func (g *gen) setSequence(evts ...events.Event) []events.Event {
+	ln := uint64(len(evts))
+	if ln == 0 {
+		return nil
+	}
+	hash := evts[0].TraceID()
+	g.mu.Lock()
+	cur, ok := g.blockSeq[hash]
+	if !ok {
+		g.blocks = append(g.blocks, hash)
+		cur = 1
+		g.blockSeq[hash] = cur
+		// if we're adding a new hash, check if we're up to 3, and remove it if needed
+		defer g.cleanID()
+	}
+	// set sequence ID to the next sequence ID available
+	g.blockSeq[hash] += ln
+	g.mu.Unlock()
+	ret := make([]events.Event, 0, len(evts))
+	// create slice of ids
+	for i := range evts {
+		e, ok := evts[i].(SeqEvent)
+		if !ok {
+			continue
+		}
+		e.SetSequenceID(uint64(i) + cur)
+		ret = append(ret, e)
+	}
+	return ret
+}
+
+func (g *gen) cleanID() {
+	g.mu.Lock()
+	if len(g.blocks) == 3 {
+		delete(g.blockSeq, g.blocks[0])
+		g.blocks = g.blocks[1:]
+	}
+	g.mu.Unlock()
+}

--- a/events/account.go
+++ b/events/account.go
@@ -40,7 +40,7 @@ func (a Acc) Proto() types.Account {
 
 func (a Acc) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   a.traceID,
+		ID:   a.eventID(),
 		Type: a.et.ToProto(),
 		Event: &types.BusEvent_Account{
 			Account: &a.a,

--- a/events/asset.go
+++ b/events/asset.go
@@ -28,7 +28,7 @@ func (a Asset) Proto() types.Asset {
 
 func (a Asset) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   a.traceID,
+		ID:   a.eventID(),
 		Type: a.et.ToProto(),
 		Event: &types.BusEvent_Asset{
 			Asset: &a.a,

--- a/events/bus.go
+++ b/events/bus.go
@@ -248,6 +248,10 @@ func (b Base) Type() Type {
 	return b.et
 }
 
+func (b Base) eventID() string {
+	return fmt.Sprintf("%s-%d", b.traceID, b.seq)
+}
+
 // MarketEvents return all the possible market events
 func MarketEvents() []Type {
 	return marketEvents

--- a/events/bus.go
+++ b/events/bus.go
@@ -41,7 +41,7 @@ type marketPartyFilterable interface {
 type Base struct {
 	ctx     context.Context
 	traceID string
-	seq     int
+	seq     uint64
 	et      Type
 }
 
@@ -229,8 +229,12 @@ func (b Base) TraceID() string {
 	return b.traceID
 }
 
+func (b *Base) SetSequenceID(s uint64) {
+	b.seq = s
+}
+
 // Sequence returns event sequence number
-func (b Base) Sequence() int {
+func (b Base) Sequence() uint64 {
 	return b.seq
 }
 

--- a/events/deposit.go
+++ b/events/deposit.go
@@ -35,7 +35,7 @@ func (d Deposit) Proto() types.Deposit {
 func (d Deposit) StreamMessage() *types.BusEvent {
 	dep := d.d
 	return &types.BusEvent{
-		ID:   d.traceID,
+		ID:   d.eventID(),
 		Type: d.et.ToProto(),
 		Event: &types.BusEvent_Deposit{
 			Deposit: &dep,

--- a/events/governance_proposal.go
+++ b/events/governance_proposal.go
@@ -42,7 +42,7 @@ func (p Proposal) Proto() types.Proposal {
 
 func (p Proposal) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   p.traceID,
+		ID:   p.eventID(),
 		Type: p.et.ToProto(),
 		Event: &types.BusEvent_Proposal{
 			Proposal: &p.p,

--- a/events/loss_socialization.go
+++ b/events/loss_socialization.go
@@ -59,7 +59,7 @@ func (l LossSoc) Proto() types.LossSocialization {
 func (l LossSoc) StreamMessage() *types.BusEvent {
 	p := l.Proto()
 	return &types.BusEvent{
-		ID:   l.traceID,
+		ID:   l.eventID(),
 		Type: l.et.ToProto(),
 		Event: &types.BusEvent_LossSocialization{
 			LossSocialization: &p,

--- a/events/margin_levels.go
+++ b/events/margin_levels.go
@@ -45,7 +45,7 @@ func (m MarginLevels) Proto() types.MarginLevels {
 
 func (m MarginLevels) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   m.traceID,
+		ID:   m.eventID(),
 		Type: m.et.ToProto(),
 		Event: &types.BusEvent_MarginLevels{
 			MarginLevels: &m.l,

--- a/events/market_data.go
+++ b/events/market_data.go
@@ -32,7 +32,7 @@ func (m MarketData) Proto() types.MarketData {
 
 func (m MarketData) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   m.traceID,
+		ID:   m.eventID(),
 		Type: m.et.ToProto(),
 		Event: &types.BusEvent_MarketData{
 			MarketData: &m.md,

--- a/events/market_event.go
+++ b/events/market_event.go
@@ -46,7 +46,7 @@ func (m Market) MarketProto() types.MarketEvent {
 func (m Market) StreamMessage() *types.BusEvent {
 	p := m.MarketProto()
 	return &types.BusEvent{
-		ID:   m.traceID,
+		ID:   m.eventID(),
 		Type: m.et.ToProto(),
 		Event: &types.BusEvent_Market{
 			Market: &p,

--- a/events/market_tick.go
+++ b/events/market_tick.go
@@ -51,7 +51,7 @@ func (m MarketTick) MarketProto() types.MarketEvent {
 func (m MarketTick) StreamMessage() *types.BusEvent {
 	p := m.Proto()
 	return &types.BusEvent{
-		ID:   m.traceID,
+		ID:   m.eventID(),
 		Type: m.et.ToProto(),
 		Event: &types.BusEvent_MarketTick{
 			MarketTick: &p,

--- a/events/node_signature.go
+++ b/events/node_signature.go
@@ -29,7 +29,7 @@ func (n NodeSignature) Proto() types.NodeSignature {
 
 func (n NodeSignature) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   n.traceID,
+		ID:   n.eventID(),
 		Type: n.et.ToProto(),
 		Event: &types.BusEvent_NodeSignature{
 			NodeSignature: &n.e,

--- a/events/order.go
+++ b/events/order.go
@@ -41,7 +41,7 @@ func (o Order) Proto() types.Order {
 func (o Order) StreamMessage() *types.BusEvent {
 	cpy := *o.o
 	return &types.BusEvent{
-		ID:   o.traceID,
+		ID:   o.eventID(),
 		Type: o.et.ToProto(),
 		Event: &types.BusEvent_Order{
 			Order: &cpy,

--- a/events/party.go
+++ b/events/party.go
@@ -32,7 +32,7 @@ func (p Party) Proto() types.Party {
 
 func (p Party) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   p.traceID,
+		ID:   p.eventID(),
 		Type: p.et.ToProto(),
 		Event: &types.BusEvent_Party{
 			Party: &p.p,

--- a/events/position_resolution_event.go
+++ b/events/position_resolution_event.go
@@ -65,7 +65,7 @@ func (p PosRes) MarketProto() types.MarketEvent {
 func (p PosRes) StreamMessage() *types.BusEvent {
 	pr := p.Proto()
 	return &types.BusEvent{
-		ID:   p.traceID,
+		ID:   p.eventID(),
 		Type: p.et.ToProto(),
 		Event: &types.BusEvent_PositionResolution{
 			PositionResolution: &pr,

--- a/events/settle_distressed.go
+++ b/events/settle_distressed.go
@@ -62,7 +62,7 @@ func (s SettleDistressed) Proto() types.SettleDistressed {
 func (s SettleDistressed) StreamMessage() *types.BusEvent {
 	p := s.Proto()
 	return &types.BusEvent{
-		ID:   s.traceID,
+		ID:   s.eventID(),
 		Type: s.et.ToProto(),
 		Event: &types.BusEvent_SettleDistressed{
 			SettleDistressed: &p,

--- a/events/settle_position.go
+++ b/events/settle_position.go
@@ -69,7 +69,7 @@ func (s SettlePos) Proto() types.SettlePosition {
 func (s SettlePos) StreamMessage() *types.BusEvent {
 	p := s.Proto()
 	return &types.BusEvent{
-		ID:   s.traceID,
+		ID:   s.eventID(),
 		Type: s.et.ToProto(),
 		Event: &types.BusEvent_SettlePosition{
 			SettlePosition: &p,

--- a/events/time.go
+++ b/events/time.go
@@ -35,7 +35,7 @@ func (t Time) Proto() types.TimeUpdate {
 func (t Time) StreamMessage() *types.BusEvent {
 	p := t.Proto()
 	return &types.BusEvent{
-		ID:   t.traceID,
+		ID:   t.eventID(),
 		Type: t.et.ToProto(),
 		Event: &types.BusEvent_TimeUpdate{
 			TimeUpdate: &p,

--- a/events/trade.go
+++ b/events/trade.go
@@ -36,7 +36,7 @@ func (t Trade) Proto() types.Trade {
 
 func (t Trade) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   t.traceID,
+		ID:   t.eventID(),
 		Type: t.et.ToProto(),
 		Event: &types.BusEvent_Trade{
 			Trade: &t.t,

--- a/events/transfer_response.go
+++ b/events/transfer_response.go
@@ -44,7 +44,7 @@ func (t *TransferResponse) Proto() types.TransferResponses {
 func (t TransferResponse) StreamMessage() *types.BusEvent {
 	p := t.Proto()
 	return &types.BusEvent{
-		ID:   t.traceID,
+		ID:   t.eventID(),
 		Type: t.et.ToProto(),
 		Event: &types.BusEvent_TransferResponses{
 			TransferResponses: &p,

--- a/events/vote.go
+++ b/events/vote.go
@@ -49,7 +49,7 @@ func (v Vote) Proto() types.Vote {
 
 func (v Vote) StreamMessage() *types.BusEvent {
 	return &types.BusEvent{
-		ID:   v.traceID,
+		ID:   v.eventID(),
 		Type: v.et.ToProto(),
 		Event: &types.BusEvent_Vote{
 			Vote: &v.v,

--- a/events/withdrawal.go
+++ b/events/withdrawal.go
@@ -35,7 +35,7 @@ func (w Withdrawal) Proto() types.Withdrawal {
 func (w Withdrawal) StreamMessage() *types.BusEvent {
 	wit := w.w
 	return &types.BusEvent{
-		ID:   w.traceID,
+		ID:   w.eventID(),
 		Type: w.et.ToProto(),
 		Event: &types.BusEvent_Withdrawal{
 			Withdrawal: &wit,


### PR DESCRIPTION
Broker generates sequence ID per block and sets them on the event. Added some tests to ensure that the sequence ID is indeed unique per block.

Despite the branch name, this PR closes #2276 