### PR TITLE
Add test covering context cancel mid data-sending

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -56,6 +56,9 @@ func New(ctx context.Context) *Broker {
 
 func (b *Broker) sendChannel(sub Subscriber, evts []events.Event) (unsub bool) {
 	for _, e := range evts {
+		// assign before select to remove overhead of call in select (it's implicit anyway)
+		// but this way we ensure that more recent states of ctx, Skip and Closed are checked
+		ch := sub.C()
 		select {
 		case <-b.ctx.Done():
 			return
@@ -64,7 +67,7 @@ func (b *Broker) sendChannel(sub Subscriber, evts []events.Event) (unsub bool) {
 		case <-sub.Closed():
 			unsub = true
 			return
-		case sub.C() <- e:
+		case ch <- e:
 			continue
 		default:
 			continue

--- a/subscribers/base.go
+++ b/subscribers/base.go
@@ -85,7 +85,7 @@ func (b *Base) Halt() {
 	// allow attempted writes during shutdown, unless this is an acking sub, with a potential blocking channel
 	defer func() {
 		if !b.ack {
-			time.Sleep(20 * time.Millisecond) // add sleep to avoid race (send on closed channel), 50ms should be plenty
+			time.Sleep(20 * time.Millisecond) // add sleep to avoid race (send on closed channel), 20ms should be plenty
 		}
 		close(b.ch) // close the event channel after pause (skip) and cfunc (closed) are toggled
 	}()

--- a/subscribers/base.go
+++ b/subscribers/base.go
@@ -2,6 +2,7 @@ package subscribers
 
 import (
 	"context"
+	"time"
 
 	"code.vegaprotocol.io/vega/events"
 )
@@ -79,9 +80,17 @@ func (b *Base) Skip() <-chan struct{} {
 
 // Halt is called by the broker on shutdown, this closes the open channels
 func (b *Base) Halt() {
-	b.cfunc()   // cancels the subscriber context, which breaks the loop
-	b.Pause()   // close the skip channel
-	close(b.ch) // close the event channel
+	// This is a hacky fix, but the fact remains: closing this channel occasionally causes a data race
+	// we're using select, hoist the channel assignment, but the fact is: select is not atomic
+	// allow attempted writes during shutdown, unless this is an acking sub, with a potential blocking channel
+	defer func() {
+		if !b.ack {
+			time.Sleep(20 * time.Millisecond) // add sleep to avoid race (send on closed channel), 50ms should be plenty
+		}
+		close(b.ch) // close the event channel after pause (skip) and cfunc (closed) are toggled
+	}()
+	b.cfunc() // cancels the subscriber context, which breaks the loop
+	b.Pause() // close the skip channel
 }
 
 // SetID set the ID (exposed only to broker)

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -84,6 +84,7 @@ func (s *StreamSub) Halt() {
 }
 
 func (s *StreamSub) loop(ctx context.Context) {
+	s.running = true // allow for Pause to work (ensures the pause channel can, and will be closed)
 	for {
 		select {
 		case <-ctx.Done():

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -80,7 +80,7 @@ func (s *StreamSub) Halt() {
 		close(s.updated)
 	}
 	s.mu.Unlock()
-	s.Base.Halt() // close channel inside lock, just in case this is a problem
+	s.Base.Halt() // close channel outside of the lock. to avoid race
 }
 
 func (s *StreamSub) loop(ctx context.Context) {


### PR DESCRIPTION
Add a test to ensure the stream subscriber doesn't have a data race in cases where the context is cancelled mid-event push onto channel.

As in the test, change broker to assign the event channel first, before checking the sub close channels (they are hoisted, but because we explicitly assign the channel before the select statement, we're certain to check more recent versions of ctx.Done() - we do the same thing in the subscriber test)