### PR TITLE
ABCI records to a path

### DIFF
--- a/cmd/vega/node.go
+++ b/cmd/vega/node.go
@@ -192,8 +192,8 @@ func (l *NodeCommand) addFlags() {
 	flagSet.BoolVarP(&l.withPPROF, "with-pprof", "", false, "start the node with pprof support")
 	flagSet.BoolVarP(&l.noChain, "no-chain", "", false, "start the node using the noop chain")
 	flagSet.BoolVarP(&l.noStores, "no-stores", "", false, "start the node without stores support")
-	flagSet.StringVarP(&l.record, "abci-record", "", "", "If set, it will record ABCI operations into this file")
-	flagSet.StringVarP(&l.replay, "abci-replay", "", "", "If set, it will replay ABCI operations from this file")
+	flagSet.StringVarP(&l.record, "abci-record", "", "", "ABCI recording dir path. If seti t will record ABCI operations into <path>/abci-record-<timestamp>")
+	flagSet.StringVarP(&l.replay, "abci-replay", "", "", "ABCI replaying file path. If set, it will replay ABCI operations from this file path")
 }
 
 // runNode is the entry of node command.

--- a/cmd/vega/node.go
+++ b/cmd/vega/node.go
@@ -192,7 +192,7 @@ func (l *NodeCommand) addFlags() {
 	flagSet.BoolVarP(&l.withPPROF, "with-pprof", "", false, "start the node with pprof support")
 	flagSet.BoolVarP(&l.noChain, "no-chain", "", false, "start the node using the noop chain")
 	flagSet.BoolVarP(&l.noStores, "no-stores", "", false, "start the node without stores support")
-	flagSet.StringVarP(&l.record, "abci-record", "", "", "ABCI recording dir path. If set, it will record ABCI operations into <path>/abci-record-<timestamp>")
+	flagSet.StringVarP(&l.record, "abci-record", "", "", "ABCI recording dir path. If set, it will record ABCI operations into <path>/abci-record-<now()>")
 	flagSet.StringVarP(&l.replay, "abci-replay", "", "", "ABCI replaying file path. If set, it will replay ABCI operations from this file path")
 }
 

--- a/cmd/vega/node.go
+++ b/cmd/vega/node.go
@@ -192,7 +192,7 @@ func (l *NodeCommand) addFlags() {
 	flagSet.BoolVarP(&l.withPPROF, "with-pprof", "", false, "start the node with pprof support")
 	flagSet.BoolVarP(&l.noChain, "no-chain", "", false, "start the node using the noop chain")
 	flagSet.BoolVarP(&l.noStores, "no-stores", "", false, "start the node without stores support")
-	flagSet.StringVarP(&l.record, "abci-record", "", "", "ABCI recording dir path. If seti t will record ABCI operations into <path>/abci-record-<timestamp>")
+	flagSet.StringVarP(&l.record, "abci-record", "", "", "ABCI recording dir path. If set, it will record ABCI operations into <path>/abci-record-<timestamp>")
 	flagSet.StringVarP(&l.replay, "abci-replay", "", "", "ABCI replaying file path. If set, it will replay ABCI operations from this file path")
 }
 

--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -438,7 +438,7 @@ func (l *NodeCommand) startABCI(ctx context.Context, commander *nodewallet.Comma
 
 	var abciApp tmtypes.Application
 	if l.record != "" {
-		path := filepath.Join(l.record, fmt.Sprintf("abci-record-%d", time.Now().Unix()))
+		path := filepath.Join(l.record, fmt.Sprintf("abci-record-%s", time.Now().Format("2006-01-02-15-04-05")))
 		l.Log.Info("Recording mode", logging.String("path", path))
 		rec, err := recorder.NewRecord(path, afero.NewOsFs())
 		if err != nil {

--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -438,8 +438,7 @@ func (l *NodeCommand) startABCI(ctx context.Context, commander *nodewallet.Comma
 
 	var abciApp tmtypes.Application
 	if l.record != "" {
-		path := strings.TrimSuffix(l.record, "/")
-		path = fmt.Sprintf("%s/abci-record-%d", path, time.Now().Unix())
+		path := filepath.Join(l.record, fmt.Sprintf("abci-record-%d", time.Now().Unix()))
 		l.Log.Info("Recording mode", logging.String("path", path))
 		rec, err := recorder.NewRecord(path, afero.NewOsFs())
 		if err != nil {

--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -438,7 +438,10 @@ func (l *NodeCommand) startABCI(ctx context.Context, commander *nodewallet.Comma
 
 	var abciApp tmtypes.Application
 	if l.record != "" {
-		rec, err := recorder.NewRecord(l.record, afero.NewOsFs())
+		path := strings.TrimSuffix(l.record, "/")
+		path = fmt.Sprintf("%s/abci-record-%d", path, time.Now().Unix())
+		l.Log.Info("Recording mode", logging.String("path", path))
+		rec, err := recorder.NewRecord(path, afero.NewOsFs())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When path is specified it will use it to create a file with the format `abci-record-<timestamp>`