### PR TITLE
clear opening auction only once the very first LeaveAuction call is processed fully

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -536,11 +536,6 @@ func (m *Market) EnterAuction(ctx context.Context) {
 
 // LeaveAuction : Return the orderbook and market to continuous trading
 func (m *Market) LeaveAuction(ctx context.Context) {
-	// If we were an opening auction, clear it
-	if m.isOpeningAuction() {
-		m.mkt.OpeningAuction = nil
-	}
-
 	// @TODO this ought to come from m.mkt
 	m.tradeMode = types.MarketState_MARKET_STATE_CONTINUOUS
 	if fba := m.mkt.GetDiscrete(); fba != nil {
@@ -579,6 +574,12 @@ func (m *Market) LeaveAuction(ctx context.Context) {
 			m.log.Error("Unable to apply fees to order", logging.String("OrderID", uo.Order.Id))
 		}
 	}
+
+	// If we were an opening auction, clear it
+	if m.isOpeningAuction() {
+		m.mkt.OpeningAuction = nil
+	}
+
 	// Send an event bus update
 	m.broker.Send(events.NewAuctionEvent(ctx,
 		m.mkt.Id,


### PR DESCRIPTION
Right now, the call isOpeningAuction is checking if there's opening auction config in the market config to know if it's currently ongoing an opening auction.
Also as soon as we enter the LeaveAuction call, we call isOpeningAuction, and if the return value is true, we straight away set the opening auction config to nil.
By doing this, when finishing to process the LeaveAuction function, and going through the applyFee function, the market thinking it's in continuous mode, and never process the fees as in opening auction mode (no fees), but as in a continuous market.

close #2339 