### PR TITLE
Ensure slice cannot be empty:

### DIFF
--- a/subscribers/stream_subscriber_test.go
+++ b/subscribers/stream_subscriber_test.go
@@ -227,10 +227,10 @@ func testCloseChannelWrite(t *testing.T) {
 		}
 	}()
 	<-started
-	sub.cfunc()
 	// wait for sub to be confirmed closed down
-	wg.Wait()
 	data := sub.GetData()
+	sub.cfunc()
+	wg.Wait()
 	// we received at least the first event, which is valid (filtered)
 	// so this slice ought not to be empty
 	assert.NotEmpty(t, data)


### PR DESCRIPTION
get data before subscriber context is cancelled