### PR TITLE
Reordered order events

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -835,14 +835,13 @@ func (m *Market) SubmitOrder(ctx context.Context, order *types.Order) (*types.Or
 		}
 	}
 
-	// Insert aggressive remaining order
-	m.broker.Send(events.NewOrderEvent(ctx, order))
-
 	// we replace the trades in the confirmation with the one we got initially
 	// the contains the fees informations
 	confirmation.Trades = trades
 
 	m.handleConfirmation(ctx, order, confirmation)
+
+	m.broker.Send(events.NewOrderEvent(ctx, order))
 
 	orderValidity = "valid" // used in deferred func.
 	return confirmation, nil


### PR DESCRIPTION
Filled orders are handled in the market depth service before new orders are added to prevent negative spreads from occuring.

Closes #2344 