### PR TITLE
Feature/hash optimizations

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -80,9 +80,10 @@ type Engine struct {
 	log   *logging.Logger
 	cfgMu sync.Mutex
 
-	accs        map[string]*types.Account
-	broker      Broker
-	totalTokens uint64
+	accs         map[string]*types.Account
+	hashableAccs []*types.Account
+	broker       Broker
+	totalTokens  uint64
 	// could be a unix.Time but storing it like this allow us to now time.UnixNano() all the time
 	currentTime int64
 
@@ -101,6 +102,7 @@ func New(log *logging.Logger, conf Config, broker Broker, now time.Time) (*Engin
 		log:           log,
 		Config:        conf,
 		accs:          make(map[string]*types.Account, initialAccountSize),
+		hashableAccs:  []*types.Account{},
 		broker:        broker,
 		currentTime:   now.UnixNano(),
 		idbuf:         make([]byte, 256),
@@ -114,18 +116,37 @@ func (e *Engine) OnChainTimeUpdate(_ context.Context, t time.Time) {
 	e.currentTime = t.UnixNano()
 }
 
-func (e *Engine) Hash() []byte {
-	keys := make([]string, 0, len(e.accs))
-	for k := range e.accs {
-		keys = append(keys, k)
+func (e *Engine) removeAccountFromHashableSlice(id string) {
+	i := sort.Search(len(e.hashableAccs), func(i int) bool {
+		return e.hashableAccs[i].Id >= id
+	})
+
+	copy(e.hashableAccs[i:], e.hashableAccs[i+1:])
+	e.hashableAccs = e.hashableAccs[:len(e.hashableAccs)-1]
+}
+
+func (e *Engine) addAccountToHashableSlice(acc *types.Account) {
+	// sell side levels should be ordered in ascending
+	i := sort.Search(len(e.hashableAccs), func(i int) bool {
+		return e.hashableAccs[i].Id >= acc.Id
+	})
+
+	if i < len(e.hashableAccs) && e.hashableAccs[i].Id == acc.Id {
+		// for some reason it was already there, return now
+		return
 	}
 
-	output := make([]byte, 0, len(keys)*8)
-	sort.Strings(keys)
-	i := [8]byte{}
-	for _, k := range keys {
-		binary.BigEndian.PutUint64(i[0:], e.accs[k].Balance)
-		output = append(output, i[0:]...)
+	e.hashableAccs = append(e.hashableAccs, nil)
+	copy(e.hashableAccs[i+1:], e.hashableAccs[i:])
+	e.hashableAccs[i] = acc
+}
+
+func (e *Engine) Hash() []byte {
+	output := make([]byte, len(e.hashableAccs)*8)
+	var i int
+	for _, k := range e.hashableAccs {
+		binary.BigEndian.PutUint64(output[i:], k.Balance)
+		i += 8
 	}
 
 	return crypto.Hash(output)
@@ -171,6 +192,7 @@ func (e *Engine) EnableAsset(ctx context.Context, asset types.Asset) error {
 			Type:     types.AccountType_ACCOUNT_TYPE_FEES_INFRASTRUCTURE,
 		}
 		e.accs[infraFeeID] = infraFeeAcc
+		e.addAccountToHashableSlice(infraFeeAcc)
 		e.broker.Send(events.NewAccountEvent(ctx, *infraFeeAcc))
 	}
 	e.log.Info("new asset added successfully",
@@ -1222,6 +1244,7 @@ func (e *Engine) CreatePartyMarginAccount(ctx context.Context, partyID, marketID
 			Type:     types.AccountType_ACCOUNT_TYPE_MARGIN,
 		}
 		e.accs[marginID] = &acc
+		e.addAccountToHashableSlice(&acc)
 		e.broker.Send(events.NewAccountEvent(ctx, acc))
 	}
 	return marginID, nil
@@ -1244,6 +1267,7 @@ func (e *Engine) CreatePartyGeneralAccount(ctx context.Context, partyID, asset s
 			Type:     types.AccountType_ACCOUNT_TYPE_GENERAL,
 		}
 		e.accs[generalID] = &acc
+		e.addAccountToHashableSlice(&acc)
 		e.broker.Send(events.NewPartyEvent(ctx, types.Party{Id: partyID}))
 		e.broker.Send(events.NewAccountEvent(ctx, acc))
 	}
@@ -1258,6 +1282,7 @@ func (e *Engine) CreatePartyGeneralAccount(ctx context.Context, partyID, asset s
 			Type:     types.AccountType_ACCOUNT_TYPE_GENERAL,
 		}
 		e.accs[tID] = &acc
+		e.addAccountToHashableSlice(&acc)
 		e.broker.Send(events.NewAccountEvent(ctx, acc))
 	}
 
@@ -1285,6 +1310,7 @@ func (e *Engine) GetOrCreatePartyLockWithdrawAccount(ctx context.Context, partyI
 			Type:     types.AccountType_ACCOUNT_TYPE_LOCK_WITHDRAW,
 		}
 		e.accs[id] = acc
+		e.addAccountToHashableSlice(acc)
 		e.broker.Send(events.NewAccountEvent(ctx, *acc))
 	}
 
@@ -1389,6 +1415,7 @@ func (e *Engine) CreateMarketAccounts(ctx context.Context, marketID, asset strin
 			Type:     types.AccountType_ACCOUNT_TYPE_INSURANCE,
 		}
 		e.accs[insuranceID] = insAcc
+		e.addAccountToHashableSlice(insAcc)
 		e.broker.Send(events.NewAccountEvent(ctx, *insAcc))
 
 	}
@@ -1404,6 +1431,7 @@ func (e *Engine) CreateMarketAccounts(ctx context.Context, marketID, asset strin
 			Type:     types.AccountType_ACCOUNT_TYPE_SETTLEMENT,
 		}
 		e.accs[settleID] = setAcc
+		e.addAccountToHashableSlice(setAcc)
 		e.broker.Send(events.NewAccountEvent(ctx, *setAcc))
 	}
 
@@ -1420,6 +1448,7 @@ func (e *Engine) CreateMarketAccounts(ctx context.Context, marketID, asset strin
 			Type:     types.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY,
 		}
 		e.accs[liquidityFeeID] = liquidityFeeAcc
+		e.addAccountToHashableSlice(liquidityFeeAcc)
 		e.broker.Send(events.NewAccountEvent(ctx, *liquidityFeeAcc))
 	}
 	makerFeeID := e.accountID(marketID, "", asset, types.AccountType_ACCOUNT_TYPE_FEES_MAKER)
@@ -1434,6 +1463,7 @@ func (e *Engine) CreateMarketAccounts(ctx context.Context, marketID, asset strin
 			Type:     types.AccountType_ACCOUNT_TYPE_FEES_MAKER,
 		}
 		e.accs[makerFeeID] = makerFeeAcc
+		e.addAccountToHashableSlice(makerFeeAcc)
 		e.broker.Send(events.NewAccountEvent(ctx, *makerFeeAcc))
 	}
 
@@ -1593,6 +1623,7 @@ func (e *Engine) GetTotalTokens() uint64 {
 
 func (e *Engine) removeAccount(id string) error {
 	delete(e.accs, id)
+	e.removeAccountFromHashableSlice(id)
 	return nil
 }
 

--- a/matching/side.go
+++ b/matching/side.go
@@ -30,12 +30,13 @@ type OrderBookSide struct {
 }
 
 func (s *OrderBookSide) Hash() []byte {
-	output := make([]byte, 0, len(s.levels)*16)
-	var i [16]byte
+	output := make([]byte, len(s.levels)*16)
+	var i int
 	for _, l := range s.levels {
-		binary.BigEndian.PutUint64(i[0:], l.price)
-		binary.BigEndian.PutUint64(i[8:], l.volume)
-		output = append(output, i[0:]...)
+		binary.BigEndian.PutUint64(output[i:], l.price)
+		i += 8
+		binary.BigEndian.PutUint64(output[i:], l.volume)
+		i += 8
 	}
 	return crypto.Hash(output)
 }

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -106,8 +106,8 @@ func New(log *logging.Logger, config Config) *Engine {
 }
 
 func (e *Engine) Hash() []byte {
-	output := make([]byte, 0, len(e.positionsCpy)*8*5)
-	i := [8]byte{}
+	output := make([]byte, len(e.positionsCpy)*8*5)
+	var i int
 	for _, p := range e.positionsCpy {
 		values := []uint64{
 			uint64(p.Size()),
@@ -118,8 +118,8 @@ func (e *Engine) Hash() []byte {
 		}
 
 		for _, v := range values {
-			binary.BigEndian.PutUint64(i[0:], v)
-			output = append(output, i[0:]...)
+			binary.BigEndian.PutUint64(output[i:], v)
+			i += 8
 		}
 	}
 

--- a/subscribers/order_events.go
+++ b/subscribers/order_events.go
@@ -74,11 +74,13 @@ func (o *OrderEvent) write(e OE) {
 	o.mu.Lock()
 	o.buf = append(o.buf, *e.Order())
 	o.mu.Unlock()
-	o.log.Debug("ORDER EVENT",
-		logging.String("trace-id", e.TraceID()),
-		logging.String("type", e.Type().String()),
-		logging.Order(*e.Order()),
-	)
+	if o.log.GetLevel() <= logging.DebugLevel {
+		o.log.Debug("ORDER EVENT",
+			logging.String("trace-id", e.TraceID()),
+			logging.String("type", e.Type().String()),
+			logging.Order(*e.Order()),
+		)
+	}
 }
 
 func (o *OrderEvent) flush() {


### PR DESCRIPTION
Small optimizations.
We were spending 4/5 % of the time iterating / copying stuff from the accounts map,
some time assigning to a slice then copying into another.
Also spent 3% doing reflectiong/marshaling on logging.Order -> added a guard for this in subscribers/order_event.go