### PR TITLE
Updated OrderEvent to copy by value (#2353)

### DIFF
--- a/events/order.go
+++ b/events/order.go
@@ -8,14 +8,15 @@ import (
 
 type Order struct {
 	*Base
-	o *types.Order
+	o types.Order
 }
 
 func NewOrderEvent(ctx context.Context, o *types.Order) *Order {
-	return &Order{
+	order := &Order{
 		Base: newBase(ctx, OrderEvent),
-		o:    o,
+		o:    *o,
 	}
+	return order
 }
 
 func (o Order) IsParty(id string) bool {
@@ -31,15 +32,15 @@ func (o Order) MarketID() string {
 }
 
 func (o *Order) Order() *types.Order {
-	return o.o
+	return &o.o
 }
 
 func (o Order) Proto() types.Order {
-	return *o.o
+	return o.o
 }
 
 func (o Order) StreamMessage() *types.BusEvent {
-	cpy := *o.o
+	cpy := o.o
 	return &types.BusEvent{
 		ID:    o.eventID(),
 		Block: o.TraceID(),

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -436,9 +436,6 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 // e.g. removing expired orders from matching engine.
 func (e *Engine) removeExpiredOrders(ctx context.Context, t time.Time) {
 	timer := metrics.NewTimeCounter("-", "execution", "removeExpiredOrders")
-	if e.log.GetLevel() == logging.DebugLevel {
-		e.log.Debug("Removing expiring orders from matching engine")
-	}
 	expiringOrders := []types.Order{}
 	timeNow := t.UnixNano()
 	for _, mkt := range e.marketsCpy {
@@ -451,19 +448,11 @@ func (e *Engine) removeExpiredOrders(ctx context.Context, t time.Time) {
 		expiringOrders = append(
 			expiringOrders, orders...)
 	}
-	if e.log.GetLevel() == logging.DebugLevel {
-		e.log.Debug("Removed expired orders from matching engine",
-			logging.Int("orders-removed", len(expiringOrders)))
-	}
 	for _, order := range expiringOrders {
 		order := order
 		evt := events.NewOrderEvent(ctx, &order)
 		e.broker.Send(evt)
 		metrics.OrderGaugeAdd(-1, order.MarketID) // decrement gauge
-	}
-	if e.log.GetLevel() == logging.DebugLevel {
-		e.log.Debug("Updated expired orders in stores",
-			logging.Int("orders-removed", len(expiringOrders)))
 	}
 	timer.EngineTimeCounterAdd()
 }

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -402,7 +402,7 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 	// remove expired orders
 	// TODO(FIXME): this should be remove, and handled inside the market directly
 	// when call with the new time (see the next for loop)
-	e.removeExpiredOrders(t)
+	e.removeExpiredOrders(ctx, t)
 
 	// notify markets of the time expiration
 	toDelete := []string{}
@@ -434,7 +434,7 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 
 // Process any data updates (including state changes)
 // e.g. removing expired orders from matching engine.
-func (e *Engine) removeExpiredOrders(t time.Time) {
+func (e *Engine) removeExpiredOrders(ctx context.Context, t time.Time) {
 	timer := metrics.NewTimeCounter("-", "execution", "removeExpiredOrders")
 	if e.log.GetLevel() == logging.DebugLevel {
 		e.log.Debug("Removing expiring orders from matching engine")
@@ -457,7 +457,7 @@ func (e *Engine) removeExpiredOrders(t time.Time) {
 	}
 	for _, order := range expiringOrders {
 		order := order
-		evt := events.NewOrderEvent(context.Background(), &order)
+		evt := events.NewOrderEvent(ctx, &order)
 		e.broker.Send(evt)
 		metrics.OrderGaugeAdd(-1, order.MarketID) // decrement gauge
 	}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -404,7 +404,7 @@ func tradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			continue
 		}
 
-		o, err := execsetup.broker.getByReference(val(row, 0), val(row, 1))
+		o, err := execsetup.broker.getFirstByReference(val(row, 0), val(row, 1))
 		if err != nil {
 			return err
 		}

--- a/integration/stubs_test.go
+++ b/integration/stubs_test.go
@@ -265,15 +265,18 @@ func (b *brokerStub) getFirstByReference(party, ref string) (proto.Order, error)
 
 func (b *brokerStub) getByReference(party, ref string) (proto.Order, error) {
 	data := b.GetOrderEvents()
-	var last *proto.Order // we need the most recent event, the order object is not updated (copy v pointer, issue 2353)
+
+	var last proto.Order // we need the most recent event, the order object is not updated (copy v pointer, issue 2353)
+	var matched bool = false
 	for _, o := range data {
 		v := o.Order()
 		if v.Reference == ref && v.PartyID == party {
-			last = v
+			last = *v
+			matched = true
 		}
 	}
-	if last != nil {
-		return *last, nil
+	if matched == true {
+		return last, nil
 	}
 	return proto.Order{}, fmt.Errorf("no order for party %v and referrence %v", party, ref)
 }

--- a/integration/stubs_test.go
+++ b/integration/stubs_test.go
@@ -252,13 +252,28 @@ func (b *brokerStub) getTraderGeneralAccount(trader, asset string) (proto.Accoun
 	return proto.Account{}, errors.New("account does not exist")
 }
 
-func (b *brokerStub) getByReference(party, ref string) (proto.Order, error) {
+func (b *brokerStub) getFirstByReference(party, ref string) (proto.Order, error) {
 	data := b.GetOrderEvents()
 	for _, o := range data {
 		v := o.Order()
 		if v.Reference == ref && v.PartyID == party {
 			return *v, nil
 		}
+	}
+	return proto.Order{}, fmt.Errorf("no order for party %v and referrence %v", party, ref)
+}
+
+func (b *brokerStub) getByReference(party, ref string) (proto.Order, error) {
+	data := b.GetOrderEvents()
+	var last *proto.Order // we need the most recent event, the order object is not updated (copy v pointer, issue 2353)
+	for _, o := range data {
+		v := o.Order()
+		if v.Reference == ref && v.PartyID == party {
+			last = v
+		}
+	}
+	if last != nil {
+		return *last, nil
 	}
 	return proto.Order{}, fmt.Errorf("no order for party %v and referrence %v", party, ref)
 }


### PR DESCRIPTION
Updated the code so that the OrderEvent contains a copy of the order and not a pointer to it. This prevents the order changing while the event is waiting to be broadcast.