### PR TITLE
Fix 2 issues with event stream: removing expired orders no valid ID

### DIFF
--- a/events/order.go
+++ b/events/order.go
@@ -12,9 +12,10 @@ type Order struct {
 }
 
 func NewOrderEvent(ctx context.Context, o *types.Order) *Order {
+	cpy := *o
 	return &Order{
 		Base: newBase(ctx, OrderEvent),
-		o:    o,
+		o:    &cpy,
 	}
 }
 

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -434,7 +434,7 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 
 // Process any data updates (including state changes)
 // e.g. removing expired orders from matching engine.
-func (e *Engine) removeExpiredOrders(ctx, t time.Time) {
+func (e *Engine) removeExpiredOrders(ctx context.Context, t time.Time) {
 	timer := metrics.NewTimeCounter("-", "execution", "removeExpiredOrders")
 	if e.log.GetLevel() == logging.DebugLevel {
 		e.log.Debug("Removing expiring orders from matching engine")

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -402,7 +402,7 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 	// remove expired orders
 	// TODO(FIXME): this should be remove, and handled inside the market directly
 	// when call with the new time (see the next for loop)
-	e.removeExpiredOrders(t)
+	e.removeExpiredOrders(ctx, t)
 
 	// notify markets of the time expiration
 	toDelete := []string{}
@@ -434,7 +434,7 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 
 // Process any data updates (including state changes)
 // e.g. removing expired orders from matching engine.
-func (e *Engine) removeExpiredOrders(t time.Time) {
+func (e *Engine) removeExpiredOrders(ctx, t time.Time) {
 	timer := metrics.NewTimeCounter("-", "execution", "removeExpiredOrders")
 	if e.log.GetLevel() == logging.DebugLevel {
 		e.log.Debug("Removing expiring orders from matching engine")
@@ -457,7 +457,7 @@ func (e *Engine) removeExpiredOrders(t time.Time) {
 	}
 	for _, order := range expiringOrders {
 		order := order
-		evt := events.NewOrderEvent(context.Background(), &order)
+		evt := events.NewOrderEvent(ctx, &order)
 		e.broker.Send(evt)
 		metrics.OrderGaugeAdd(-1, order.MarketID) // decrement gauge
 	}


### PR DESCRIPTION
ctx was missing & orders in events should be a copy, not a pointer to an object that can get fields (like status) reassigned before the event is sent to the client (leading to inconsistent data)