### PR TITLE
Fix out of bounds index crash

### DIFF
--- a/subscribers/service.go
+++ b/subscribers/service.go
@@ -52,6 +52,10 @@ func (s *Service) ObserveEvents(ctx context.Context, retries int, eTypes []event
 			default:
 				// wait for actual changes
 				data := sub.GetData()
+				// this is a very rare thing, but it can happen
+				if len(data) == 0 {
+					continue
+				}
 				select {
 				case <-ctx.Done():
 					return


### PR DESCRIPTION
In very specific cases, it was possible to attempt and access out of bounds memory (slice index). 

If the update channel was closed, then the stream batch size was called (draining the buffer, acquiring a mutex lock), and then the GetData call acquired the lock, assuming the data slice contained events, we would attempt to access out of bounds memory.

If the batch size is 1, and we only had a single event, the attempt to shift the event we sent from the slice would point to an invalid offset, too: `[]evt{}`with size and cap of 1, then `evts[1:]` is out of bounds. 