### PR TITLE
refactor ABCI caching

### DIFF
--- a/blockchain/abci/app.go
+++ b/blockchain/abci/app.go
@@ -101,3 +101,22 @@ func (app *App) removeTxFromCache(in []byte) {
 	key := string(in)
 	delete(app.checkedTxs, key)
 }
+
+// getTx returns an internal Tx given a []byte.
+// if no errors were found during decoding and validation, the resulting Tx
+// will be cached.
+// An error code different from 0 is returned if decoding or validation fails
+// with its the corresponding error
+func (app *App) getTx(bytes []byte) (Tx, uint32, error) {
+	if tx := app.txFromCache(bytes); tx != nil {
+		return tx, 0, nil
+	}
+
+	tx, code, err := app.decodeAndValidateTx(bytes)
+	if err != nil {
+		return nil, code, err
+	}
+
+	app.cacheTx(bytes, tx)
+	return tx, 0, nil
+}


### PR DESCRIPTION
Remove duplication of CheckTx and DeliverTx since they are both retrieving the Tx in the same way
