### PR TITLE
do not pass a list of markets to the execution engine at startup

### DIFF
--- a/cmd/vega/node_pre.go
+++ b/cmd/vega/node_pre.go
@@ -538,7 +538,6 @@ func (l *NodeCommand) preRun(_ *cobra.Command, _ []string) (err error) {
 		l.Log,
 		l.conf.Execution,
 		l.timeService,
-		l.mktscfg,
 		l.collateral,
 		l.broker,
 	)

--- a/cmd/vegastream/main.go
+++ b/cmd/vegastream/main.go
@@ -53,9 +53,10 @@ func run(ctx context.Context, wg *sync.WaitGroup) error {
 
 	client := api.NewTradingDataClient(conn)
 	stream, err := client.ObserveEventBus(ctx, &api.ObserveEventsRequest{
-		MarketID: market,
-		PartyID:  party,
-		Type:     []proto.BusEventType{proto.BusEventType_BUS_EVENT_TYPE_ALL},
+		MarketID:  market,
+		PartyID:   party,
+		BatchSize: 10000,
+		Type:      []proto.BusEventType{proto.BusEventType_BUS_EVENT_TYPE_ALL},
 	})
 	if err != nil {
 		conn.Close()

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -71,18 +71,12 @@ func NewEngine(
 	log *logging.Logger,
 	executionConfig Config,
 	ts TimeService,
-	pmkts []types.Market,
 	collateral *collateral.Engine,
 	broker Broker,
 ) *Engine {
 	// setup logger
 	log = log.Named(namedLogger)
 	log.SetLevel(executionConfig.Level.Get())
-	// this is here because we're creating some markets here
-	// this isn't going to be the case in the final version
-	// so I'm using Background rather than TODO
-	ctx := context.Background()
-
 	e := &Engine{
 		log:        log,
 		Config:     executionConfig,
@@ -91,19 +85,6 @@ func NewEngine(
 		collateral: collateral,
 		idgen:      NewIDGen(),
 		broker:     broker,
-	}
-
-	var err error
-	// Add initial markets and flush to stores (if they're configured)
-	if len(pmkts) > 0 {
-		for _, mkt := range pmkts {
-			mkt := mkt
-			err = e.SubmitMarket(ctx, &mkt)
-			if err != nil {
-				e.log.Panic("Unable to submit market",
-					logging.Error(err))
-			}
-		}
 	}
 
 	// Add time change event handler

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -174,7 +174,12 @@ func getExecutionTestSetup(startTime time.Time, mkts []proto.Market) *executionT
 	}
 	execsetup.collateral.EnableAsset(context.Background(), tokAsset)
 
-	execsetup.engine = execution.NewEngine(execsetup.log, execsetup.cfg, execsetup.timesvc, mkts, execsetup.collateral, execsetup.broker)
+	execsetup.engine = execution.NewEngine(execsetup.log, execsetup.cfg, execsetup.timesvc, execsetup.collateral, execsetup.broker)
+
+	for _, mkt := range mkts {
+		mkt := mkt
+		execsetup.engine.SubmitMarket(context.Background(), &mkt)
+	}
 
 	// instanciate position plugin
 	execsetup.positionPlugin = plugins.NewPositions(context.Background())


### PR DESCRIPTION
Markets were sent twice, on genesis, when the assets are loaded, and when the execution engine was created.