### PR TITLE
Send batches over channels

### DIFF
--- a/broker/mocks/subscriber_mock.go
+++ b/broker/mocks/subscriber_mock.go
@@ -48,10 +48,10 @@ func (mr *MockSubscriberMockRecorder) Ack() *gomock.Call {
 }
 
 // C mocks base method
-func (m *MockSubscriber) C() chan<- events.Event {
+func (m *MockSubscriber) C() chan<- []events.Event {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "C")
-	ret0, _ := ret[0].(chan<- events.Event)
+	ret0, _ := ret[0].(chan<- []events.Event)
 	return ret0
 }
 

--- a/integration/stubs_test.go
+++ b/integration/stubs_test.go
@@ -50,15 +50,15 @@ func (b *brokerStub) SendBatch(evts []events.Event) {
 				sub.Push(evts...)
 				continue
 			}
-			for _, e := range evts {
-				select {
-				case <-sub.Closed():
-					continue
-				case <-sub.Skip():
-					continue
-				case sub.C() <- e:
-					continue
-				}
+			select {
+			case <-sub.Closed():
+				continue
+			case <-sub.Skip():
+				continue
+			case sub.C() <- evts:
+				continue
+			default:
+				continue
 			}
 		}
 	}
@@ -82,7 +82,9 @@ func (b *brokerStub) Send(e events.Event) {
 					continue
 				case <-sub.Skip():
 					continue
-				case sub.C() <- e:
+				case sub.C() <- []events.Event{e}:
+					continue
+				default:
 					continue
 				}
 			}

--- a/subscribers/account_events.go
+++ b/subscribers/account_events.go
@@ -44,7 +44,7 @@ func (a *AccountSub) loop(ctx context.Context) {
 			return
 		case e := <-a.ch:
 			if a.isRunning() {
-				a.Push(e)
+				a.Push(e...)
 			}
 		}
 	}

--- a/subscribers/base.go
+++ b/subscribers/base.go
@@ -11,7 +11,7 @@ type Base struct {
 	ctx     context.Context
 	cfunc   context.CancelFunc
 	sCh     chan struct{}
-	ch      chan events.Event
+	ch      chan []events.Event
 	ack     bool
 	running bool
 	id      int
@@ -23,7 +23,7 @@ func NewBase(ctx context.Context, buf int, ack bool) *Base {
 		ctx:     ctx,
 		cfunc:   cfunc,
 		sCh:     make(chan struct{}),
-		ch:      make(chan events.Event, buf),
+		ch:      make(chan []events.Event, buf),
 		ack:     ack,
 		running: !ack, // assume the implementation will start a routine asap
 	}
@@ -64,7 +64,7 @@ func (b Base) isRunning() bool {
 }
 
 // C returns the event channel for optional subscribers
-func (b *Base) C() chan<- events.Event {
+func (b *Base) C() chan<- []events.Event {
 	return b.ch
 }
 

--- a/subscribers/governance.go
+++ b/subscribers/governance.go
@@ -99,7 +99,7 @@ func (g *GovernanceSub) loop(ctx context.Context) {
 			return
 		case e := <-g.ch:
 			if g.isRunning() {
-				g.Push(e)
+				g.Push(e...)
 			}
 		}
 	}

--- a/subscribers/governance_data.go
+++ b/subscribers/governance_data.go
@@ -38,7 +38,7 @@ func (g *GovernanceDataSub) loop(ctx context.Context) {
 			return
 		case e := <-g.ch:
 			if g.isRunning() {
-				g.Push(e)
+				g.Push(e...)
 			}
 		}
 	}

--- a/subscribers/margin_levels.go
+++ b/subscribers/margin_levels.go
@@ -43,7 +43,7 @@ func (m *MarginLevelSub) loop(ctx context.Context) {
 			return
 		case e := <-m.ch:
 			if m.isRunning() {
-				m.Push(e)
+				m.Push(e...)
 			}
 		}
 	}

--- a/subscribers/market_created.go
+++ b/subscribers/market_created.go
@@ -40,7 +40,7 @@ func (m *Market) loop(ctx context.Context) {
 			return
 		case e := <-m.ch:
 			if m.isRunning() {
-				m.Push(e)
+				m.Push(e...)
 			}
 		}
 	}

--- a/subscribers/market_data.go
+++ b/subscribers/market_data.go
@@ -44,7 +44,7 @@ func (m *MarketDataSub) loop(ctx context.Context) {
 			return
 		case e := <-m.ch:
 			if m.isRunning() {
-				m.Push(e)
+				m.Push(e...)
 			}
 		}
 	}

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -81,7 +81,7 @@ func (mdb *MarketDepthBuilder) loop(ctx context.Context) {
 			return
 		case e := <-mdb.ch:
 			if mdb.isRunning() {
-				mdb.Push(e)
+				mdb.Push(e...)
 			}
 		}
 	}

--- a/subscribers/market_events.go
+++ b/subscribers/market_events.go
@@ -40,9 +40,7 @@ func (m *MarketEvent) loop() {
 			return
 		case e := <-m.ch:
 			if m.isRunning() {
-				if me, ok := e.(ME); ok {
-					m.write(me)
-				}
+				m.Push(e...)
 			}
 		}
 	}

--- a/subscribers/order_events.go
+++ b/subscribers/order_events.go
@@ -52,7 +52,7 @@ func (o *OrderEvent) loop(ctx context.Context) {
 			return
 		case e := <-o.ch:
 			if o.isRunning() {
-				o.Push(e)
+				o.Push(e...)
 			}
 		}
 	}

--- a/subscribers/party_events.go
+++ b/subscribers/party_events.go
@@ -44,7 +44,7 @@ func (a *PartySub) loop(ctx context.Context) {
 			return
 		case e := <-a.ch:
 			if a.isRunning() {
-				a.Push(e)
+				a.Push(e...)
 			}
 		}
 	}

--- a/subscribers/risk_factors.go
+++ b/subscribers/risk_factors.go
@@ -44,7 +44,7 @@ func (m *RiskFactorSub) loop(ctx context.Context) {
 			return
 		case e := <-m.ch:
 			if m.isRunning() {
-				m.Push(e)
+				m.Push(e...)
 			}
 		}
 	}

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -101,7 +101,7 @@ func (s *StreamSub) loop(ctx context.Context) {
 			if !ok {
 				return
 			}
-			s.Push(e)
+			s.Push(e...)
 		}
 	}
 }

--- a/subscribers/stream_subscriber_test.go
+++ b/subscribers/stream_subscriber_test.go
@@ -182,9 +182,7 @@ func testBatchedStreamSubscriber(t *testing.T) {
 		}),
 	}
 	sendRoutine := func(ch chan struct{}, sub *tstStreamSub, set []events.Event) {
-		for _, e := range set {
-			sub.C() <- e
-		}
+		sub.C() <- set
 		close(ch)
 	}
 	go sendRoutine(sent, sub, set1)
@@ -278,19 +276,16 @@ func testCloseChannelWrite(t *testing.T) {
 		// keep iterating until the context was closed, ensuring
 		// the context is cancelled mid-send
 		for {
-			for _, e := range set {
-				// ch := sub.C()
-				select {
-				case <-sub.Closed():
-					return
-				case <-sub.Skip():
-					return
-				case sub.C() <- e:
-					// case ch <- e:
-					if !first {
-						first = true
-						close(started)
-					}
+			select {
+			case <-sub.Closed():
+				return
+			case <-sub.Skip():
+				return
+			case sub.C() <- set:
+				// case ch <- e:
+				if !first {
+					first = true
+					close(started)
 				}
 			}
 		}

--- a/subscribers/trade_event.go
+++ b/subscribers/trade_event.go
@@ -44,7 +44,7 @@ func (t *TradeSub) loop(ctx context.Context) {
 			return
 		case e := <-t.ch:
 			if t.isRunning() {
-				t.Push(e)
+				t.Push(e...)
 			}
 		}
 	}

--- a/subscribers/transfer_response.go
+++ b/subscribers/transfer_response.go
@@ -52,7 +52,7 @@ func (t *TransferResponse) loop() {
 			return
 		case e := <-t.ch:
 			if t.isRunning() {
-				t.Push(e)
+				t.Push(e...)
 			}
 		}
 	}

--- a/subscribers/transfer_response_test.go
+++ b/subscribers/transfer_response_test.go
@@ -106,7 +106,7 @@ func testChannelOptionalSuccess(t *testing.T) {
 		skipped = true
 	case <-tr.Closed():
 		t.FailNow()
-	case tr.C() <- evt:
+	case tr.C() <- []events.Event{evt}:
 		skipped = false
 	}
 	assert.False(t, skipped)
@@ -119,7 +119,7 @@ func testChannelOptionalSuccess(t *testing.T) {
 		wg.Done()
 	})
 	// push time event
-	tr.C() <- time
+	tr.C() <- []events.Event{time}
 	// Make sure the time event triggers the call to the storage
 	wg.Wait()
 }
@@ -139,7 +139,7 @@ func testChannelOptionalSkip(t *testing.T) {
 	select {
 	case <-tr.Skip():
 		skipped = true
-	case tr.C() <- evt:
+	case tr.C() <- []events.Event{evt}:
 		skipped = false
 	}
 	assert.True(t, skipped)

--- a/subscribers/votes.go
+++ b/subscribers/votes.go
@@ -59,7 +59,7 @@ func (v *VoteSub) loop(ctx context.Context) {
 			return
 		case e := <-v.ch:
 			if v.isRunning() {
-				v.Push(e)
+				v.Push(e...)
 			}
 		}
 	}


### PR DESCRIPTION
The core often sends events to the broker as a batch (e.g. settlements or trades). Optional subscribers (like the ones used for the event stream) rely on an internal channel to receive these events one by one. If we send a batch of trade events to the subscriber, this means the broker will iterate over each event trying to send each trade event one by one. This may seem harmless at first, but if there's a lot of streams open, especially if some of them are behind (ie the internal channel buffer is full), this leads to a lot of overhead, increase CPU usage, and actual data/events making it out to the subscribers slower and slower. With this change, batched events from the core make their way to the subscribers as a batch, and do so quickly (as fast as a single event). How the subscribers process the individual events from that point on is less of a concern to the core/broker, and doesn't impact performance as much.