### PR TITLE
reduce tm stats endpoint consumption

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -252,6 +252,7 @@ func (g *GRPCServer) Start() {
 		NetParamsService:        g.netParamsService,
 		ctx:                     g.ctx,
 	}
+	go tradingDataSvc.updateNetInfo(g.ctx)
 	g.tradingDataService = tradingDataSvc
 	protoapi.RegisterTradingDataServer(g.srv, tradingDataSvc)
 

--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"code.vegaprotocol.io/vega/events"
@@ -221,6 +223,15 @@ type tradingDataService struct {
 	MarketDepthService      *subscribers.MarketDepthBuilder
 	NetParamsService        NetParamsService
 	ctx                     context.Context
+
+	chainID                  string
+	genesisTime              time.Time
+	hasGenesisTimeAndChainID uint32
+	mu                       sync.Mutex
+
+	netInfo           *tmctypes.ResultNetInfo
+	netInfoMu         sync.RWMutex
+	netInfoLastUpdate time.Time
 }
 
 func (t *tradingDataService) NetworkParameters(ctx context.Context, req *protoapi.NetworkParametersRequest) (*protoapi.NetworkParametersResponse, error) {
@@ -1586,14 +1597,20 @@ func validateParty(ctx context.Context, log *logging.Logger, partyID string, par
 	return pty, err
 }
 
-func (t *tradingDataService) getTendermintStats(ctx context.Context) (backlogLength int,
-	numPeers int, genesis *time.Time, chainID string, err error) {
+func (t *tradingDataService) getTendermintStats(
+	ctx context.Context,
+) (
+	backlogLength, numPeers int,
+	genesis *time.Time,
+	chainID string,
+	err error,
+) {
 
 	if t.Stats == nil || t.Stats.Blockchain == nil {
 		return 0, 0, nil, "", apiError(codes.Internal, ErrChainNotConnected)
 	}
 
-	refused := "connection refused"
+	const refused = "connection refused"
 
 	// Unconfirmed TX count == current transaction backlog length
 	backlogLength, err = t.Client.GetUnconfirmedTxCount(ctx)
@@ -1604,30 +1621,76 @@ func (t *tradingDataService) getTendermintStats(ctx context.Context) (backlogLen
 		return 0, 0, nil, "", apiError(codes.Internal, ErrBlockchainBacklogLength, err)
 	}
 
+	if atomic.LoadUint32(&t.hasGenesisTimeAndChainID) == 0 {
+		if err = t.getGenesisTimeAndChainID(ctx); err != nil {
+			return 0, 0, nil, "", err
+		}
+	}
+
 	// Net info provides peer stats etc (block chain network info) == number of peers
-	netInfo, err := t.Client.GetNetworkInfo(ctx)
+	netInfo, err := t.getTMNetInfo(ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), refused) {
-			return backlogLength, 0, nil, "", nil
-		}
-		return backlogLength, 0, nil, "", apiError(codes.Internal, ErrBlockchainNetworkInfo, err)
+		return backlogLength, 0, &t.genesisTime, t.chainID, nil
 	}
 
+	return backlogLength, netInfo.NPeers, &t.genesisTime, t.chainID, nil
+}
+
+func (t *tradingDataService) getTMNetInfo(ctx context.Context) (tmctypes.ResultNetInfo, error) {
+	t.netInfoMu.RLock()
+	defer t.netInfoMu.RUnlock()
+
+	if t.netInfo == nil {
+		return tmctypes.ResultNetInfo{}, apiError(codes.Internal, ErrBlockchainNetworkInfo)
+	}
+
+	return *t.netInfo, nil
+}
+
+func (t *tradingDataService) updateNetInfo(ctx context.Context) {
+	// update the net info every 1 minutes
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			netInfo, err := t.Client.GetNetworkInfo(ctx)
+			if err != nil {
+				continue
+			}
+			t.netInfoMu.Lock()
+			t.netInfo = netInfo
+			t.netInfoMu.Unlock()
+		}
+	}
+}
+
+func (t *tradingDataService) getGenesisTimeAndChainID(ctx context.Context) error {
+	const refused = "connection refused"
+	// just lock in here, ideally we'ill come here only once, so not a big issue to lock
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var err error
 	// Genesis retrieves the current genesis date/time for the blockchain
-	genesisTime, err := t.Client.GetGenesisTime(ctx)
+	t.genesisTime, err = t.Client.GetGenesisTime(ctx)
 	if err != nil {
 		if strings.Contains(err.Error(), refused) {
-			return backlogLength, 0, nil, "", nil
+			return nil
 		}
-		return backlogLength, 0, nil, "", apiError(codes.Internal, ErrBlockchainGenesisTime, err)
+		return apiError(codes.Internal, ErrBlockchainGenesisTime, err)
 	}
 
-	chainId, err := t.Client.GetChainID(ctx)
+	t.chainID, err = t.Client.GetChainID(ctx)
 	if err != nil {
-		return backlogLength, 0, nil, "", apiError(codes.Internal, ErrBlockchainChainID, err)
+		return apiError(codes.Internal, ErrBlockchainChainID, err)
 	}
 
-	return backlogLength, netInfo.NPeers, &genesisTime, chainId, nil
+	atomic.StoreUint32(&t.hasGenesisTimeAndChainID, 1)
+	return nil
 }
 
 func (t *tradingDataService) OrderByID(ctx context.Context, in *protoapi.OrderByIDRequest) (*types.Order, error) {


### PR DESCRIPTION
update peers count every 1 minutes
update chain id and genesis time onlye once

these were consuming ~7/8% of cpu time on the nodes just becuase of marhsalling / unmarshalling the payload of the rest request to the tendermint node in order to get these stats.