### PR TITLE
Hotfix/close stream

### DIFF
--- a/subscribers/service.go
+++ b/subscribers/service.go
@@ -51,7 +51,7 @@ func (s *Service) ObserveEvents(ctx context.Context, retries int, eTypes []event
 				ret = retries
 			default:
 				// wait for actual changes
-				data := sub.GetData()
+				data := sub.GetData(ctx)
 				// this is a very rare thing, but it can happen
 				if len(data) == 0 {
 					continue

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -201,7 +201,10 @@ func (s *StreamSub) GetData(ctx context.Context) []*types.BusEvent {
 	s.changeCount = 0
 	// copy the data for return, clear the internal slice
 	data := s.data
-	if s.bufSize == 0 || len(s.data) == s.bufSize {
+	if s.bufSize == 0 {
+		// if we use s.data = s.data[:0] here, we get a data race somehow
+		s.data = make([]StreamEvent, 0, cap(s.data))
+	} else if len(s.data) == s.bufSize {
 		s.data = s.data[:0]
 	} else {
 		data = data[:s.bufSize]     // only get the batch requested

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -198,16 +198,11 @@ func (s *StreamSub) GetData(ctx context.Context) []*types.BusEvent {
 		s.mu.Unlock()
 		return nil
 	}
-	dc := s.bufSize
 	s.changeCount = 0
 	// copy the data for return, clear the internal slice
 	data := s.data
-	if s.bufSize == 0 {
-		dc = cap(s.data)
-		s.data = make([]StreamEvent, 0, dc)
-	} else if len(s.data) == s.bufSize {
-		// data var is exactly the right size, data has to be emptied, allocate new slice
-		s.data = make([]StreamEvent, 0, dc)
+	if s.bufSize == 0 || len(s.data) == s.bufSize {
+		s.data = s.data[:0]
 	} else {
 		data = data[:s.bufSize]     // only get the batch requested
 		s.data = s.data[s.bufSize:] // leave rest in the buffer

--- a/subscribers/stream_subscriber_test.go
+++ b/subscribers/stream_subscriber_test.go
@@ -291,7 +291,7 @@ func testCloseChannelWrite(t *testing.T) {
 	}()
 	<-started
 	// wait for sub to be confirmed closed down
-	data := sub.GetData(context.Background())
+	data := sub.GetData(sub.ctx)
 	sub.cfunc()
 	wg.Wait()
 	// we received at least the first event, which is valid (filtered)


### PR DESCRIPTION
Some fixes to reduce CPU load. This does change the behaviour of the event stream API significantly:

When no batch size is specified, the stream will default to the behaviour of old (disconnect if the client fails to receive data N number of times).
Specifying a batch size will block data server-side until the client acknowledges a message by sending the batch size paramter again.

The code receiving from stream was taking up around 45% of CPU time, this should fix that, but requires the clients to use the API in a different way