### PR TITLE
Make the pricelevel wash trade check configurable

### DIFF
--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -345,7 +345,7 @@ func (b *OrderBook) uncrossBook() ([]*types.OrderConfirmation, error) {
 
 		// Uncross each one
 		for _, order := range uncrossOrders {
-			trades, affectedOrders, _, err := b.sell.uncross(order)
+			trades, affectedOrders, _, err := b.sell.uncross(order, false)
 
 			if err != nil {
 				return nil, err
@@ -372,7 +372,7 @@ func (b *OrderBook) uncrossBook() ([]*types.OrderConfirmation, error) {
 
 		// Uncross each one
 		for _, order := range uncrossOrders {
-			trades, affectedOrders, _, err := b.buy.uncross(order)
+			trades, affectedOrders, _, err := b.buy.uncross(order, false)
 
 			if err != nil {
 				return nil, err
@@ -583,7 +583,7 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 
 	if b.marketState != types.MarketState_MARKET_STATE_AUCTION {
 		// uncross with opposite
-		trades, impactedOrders, lastTradedPrice, err = b.getOppositeSide(order.Side).uncross(order)
+		trades, impactedOrders, lastTradedPrice, err = b.getOppositeSide(order.Side).uncross(order, true)
 		if lastTradedPrice != 0 {
 			b.lastTradedPrice = lastTradedPrice
 		}

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -2887,3 +2887,35 @@ func TestOrderBook_GetTradesInLineWithSubmitOrderDuringAuction(t *testing.T) {
 	assert.NotNil(t, order)
 	assert.Nil(t, err)
 }
+
+func TestOrderBook_AuctionUncrossWashTrades(t *testing.T) {
+	market := "testOrderbook"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	logger := logging.NewTestLogger()
+	defer logger.Sync()
+
+	// Switch to auction mode
+	book.EnterAuction()
+
+	bo1 := getOrder(t, book, market, "BuyOrder01", types.Side_SIDE_BUY, 100, "party01", 5)
+	bo1.TimeInForce = types.Order_TIF_GFA
+	book.SubmitOrder(bo1)
+
+	so1 := getOrder(t, book, market, "SellOrder01", types.Side_SIDE_SELL, 100, "party01", 5)
+	so1.TimeInForce = types.Order_TIF_GFA
+	book.SubmitOrder(so1)
+
+	// Get indicative auction price and volume
+	price, volume, side := book.GetIndicativePriceAndVolume()
+	assert.Equal(t, price, uint64(100))
+	assert.Equal(t, volume, uint64(5))
+	assert.Equal(t, side, types.Side_SIDE_BUY)
+
+	// Leave auction and uncross the book
+	uncrossedOrders, cancels, err := book.LeaveAuction()
+	assert.Nil(t, err)
+	assert.Equal(t, len(uncrossedOrders), 1)
+	assert.Equal(t, len(cancels), 0)
+}

--- a/matching/pricelevel.go
+++ b/matching/pricelevel.go
@@ -95,7 +95,7 @@ func (l *PriceLevel) fakeUncross(o *types.Order) (agg *types.Order, trades []*ty
 	return
 }
 
-func (l *PriceLevel) uncross(agg *types.Order) (filled bool, trades []*types.Trade, impactedOrders []*types.Order, err error) {
+func (l *PriceLevel) uncross(agg *types.Order, checkWashTrades bool) (filled bool, trades []*types.Trade, impactedOrders []*types.Order, err error) {
 	// for some reason sometimes it seems the pricelevels are not deleted when getting empty
 	// no big deal, just return early
 	if len(l.orders) <= 0 {
@@ -110,9 +110,11 @@ func (l *PriceLevel) uncross(agg *types.Order) (filled bool, trades []*types.Tra
 	// l.orders is always sorted by timestamps, that is why when iterating we always start from the beginning
 	for i, order := range l.orders {
 		// prevent wash trade
-		if order.PartyID == agg.PartyID {
-			err = ErrWashTrade
-			break
+		if checkWashTrades {
+			if order.PartyID == agg.PartyID {
+				err = ErrWashTrade
+				break
+			}
 		}
 
 		// Get size and make newTrade

--- a/matching/pricelevel_test.go
+++ b/matching/pricelevel_test.go
@@ -78,7 +78,7 @@ func TestUncross(t *testing.T) {
 		TimeInForce: types.Order_TIF_GTC,
 		CreatedAt:   0,
 	}
-	filled, trades, impactedOrders, err := l.uncross(aggresiveOrder)
+	filled, trades, impactedOrders, err := l.uncross(aggresiveOrder, true)
 	assert.Equal(t, true, filled)
 	assert.Equal(t, 1, len(trades))
 	assert.Equal(t, 1, len(impactedOrders))

--- a/matching/side.go
+++ b/matching/side.go
@@ -424,7 +424,7 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order) (bool, []*types.Trade, err
 	return filled, trades, nil
 }
 
-func (s *OrderBookSide) uncross(agg *types.Order) ([]*types.Trade, []*types.Order, uint64, error) {
+func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, []*types.Order, uint64, error) {
 	timer := metrics.NewTimeCounter("-", "matching", "OrderBookSide.uncross")
 
 	var (
@@ -504,7 +504,7 @@ func (s *OrderBookSide) uncross(agg *types.Order) ([]*types.Trade, []*types.Orde
 		// also it will allow us to reduce allocations
 		for !filled && idx >= 0 {
 			if s.levels[idx].price >= agg.Price || agg.Type == types.Order_TYPE_MARKET || agg.Type == types.Order_TYPE_NETWORK {
-				filled, ntrades, nimpact, err = s.levels[idx].uncross(agg)
+				filled, ntrades, nimpact, err = s.levels[idx].uncross(agg, checkWashTrades)
 				trades = append(trades, ntrades...)
 				impactedOrders = append(impactedOrders, nimpact...)
 				// break if a wash trade is detected
@@ -540,7 +540,7 @@ func (s *OrderBookSide) uncross(agg *types.Order) ([]*types.Trade, []*types.Orde
 		// also it will allow us to reduce allocations
 		for !filled && idx >= 0 {
 			if s.levels[idx].price <= agg.Price || agg.Type == types.Order_TYPE_MARKET || agg.Type == types.Order_TYPE_NETWORK {
-				filled, ntrades, nimpact, err = s.levels[idx].uncross(agg)
+				filled, ntrades, nimpact, err = s.levels[idx].uncross(agg, checkWashTrades)
 				trades = append(trades, ntrades...)
 				impactedOrders = append(impactedOrders, nimpact...)
 				if err != nil && err == ErrWashTrade {

--- a/matching/side_test.go
+++ b/matching/side_test.go
@@ -157,6 +157,6 @@ func TestMemoryAllocationPriceLevelUncrossSide(t *testing.T) {
 		Remaining:   1,
 		TimeInForce: types.Order_TIF_GTC,
 	}
-	side.uncross(aggressiveOrder)
+	side.uncross(aggressiveOrder, true)
 	assert.Len(t, side.levels, 1)
 }


### PR DESCRIPTION
To make sure that wash trades are allowed in auctions, we have made the uncrossing code configurable so the wash trade checking can be turned on or off as needed.

Added a unit test to confirm that wash trades are allowed in an auction