### PR TITLE
Validation of amend orders with GFN and GFA

### DIFF
--- a/orders/amend_order_test.go
+++ b/orders/amend_order_test.go
@@ -34,6 +34,8 @@ func TestPrepareAmendOrder(t *testing.T) {
 	t.Run("Prepare amend order empty - fail", testPrepareAmendOrderEmptyFail)
 	t.Run("Prepare amend order nil - fail", testPrepareAmendOrderNilFail)
 	t.Run("Prepare amend order invalid expiry type - fail", testPrepareAmendOrderInvalidExpiryFail)
+	t.Run("Prepare amend order tif to GFA - fail", testPrepareAmendOrderToGFA)
+	t.Run("Prepare amend order tif to GFN - fail", testPrepareAmendOrderToGFN)
 }
 
 func testPrepareAmendOrderJustPriceSuccess(t *testing.T) {
@@ -166,4 +168,32 @@ func testPrepareAmendOrderPastExpiry(t *testing.T) {
 
 	err := svc.svc.PrepareAmendOrder(context.Background(), &arg)
 	assert.NoError(t, err)
+}
+
+func testPrepareAmendOrderToGFN(t *testing.T) {
+	arg := proto.OrderAmendment{
+		OrderID:     "orderid",
+		PartyID:     "partyid",
+		TimeInForce: proto.Order_TIF_GFN,
+		ExpiresAt:   &proto.Timestamp{Value: 10},
+	}
+	svc := getTestService(t)
+	defer svc.ctrl.Finish()
+
+	err := svc.svc.PrepareAmendOrder(context.Background(), &arg)
+	assert.Error(t, err)
+}
+
+func testPrepareAmendOrderToGFA(t *testing.T) {
+	arg := proto.OrderAmendment{
+		OrderID:     "orderid",
+		PartyID:     "partyid",
+		TimeInForce: proto.Order_TIF_GFA,
+		ExpiresAt:   &proto.Timestamp{Value: 10},
+	}
+	svc := getTestService(t)
+	defer svc.ctrl.Finish()
+
+	err := svc.svc.PrepareAmendOrder(context.Background(), &arg)
+	assert.Error(t, err)
 }

--- a/orders/service.go
+++ b/orders/service.go
@@ -49,6 +49,10 @@ var (
 	ErrUnAuthorizedOrderType = errors.New("unauthorized order type")
 	// ErrCancelOrderWithOrderIDRequireMarketID a cancel order request with an orderID specified requires the marketID in which the order exists
 	ErrCancelOrderWithOrderIDRequireMarketID = errors.New("cancel order with orderID require marketID")
+	// ErrCannotAmendToGFA it is not allowed to amend an order to GFA time in force
+	ErrCannotAmendToGFA = errors.New("cannot amend to time in force GFA")
+	// ErrCannotAmendToGFN it is not allowed to amend an order to GFN time in force
+	ErrCannotAmendToGFN = errors.New("cannot amend to time in force GFN")
 )
 
 // TimeService ...
@@ -189,6 +193,16 @@ func (s *Svc) PrepareAmendOrder(ctx context.Context, amendment *types.OrderAmend
 	}
 	if err := amendment.Validate(); err != nil {
 		return errors.Wrap(err, "order amendment validation failed")
+	}
+
+	// Check we are not trying to amend to a GFA
+	if amendment.TimeInForce == types.Order_TIF_GFA {
+		return ErrCannotAmendToGFA
+	}
+
+	// Check we are not trying to amend to a GFN
+	if amendment.TimeInForce == types.Order_TIF_GFN {
+		return ErrCannotAmendToGFN
 	}
 
 	// Check we have at least one field to update


### PR DESCRIPTION
Added code to catch the user trying to amend the TIF to either GFN or GFA which are both not allowed.
Added a test to check this works.