### PR TITLE
return empty struct on nil opening auction

### DIFF
--- a/gateway/graphql/modelext.go
+++ b/gateway/graphql/modelext.go
@@ -588,7 +588,7 @@ func FeesFromProto(pf *types.Fees) (*Fees, error) {
 
 func AuctionDurationFromProto(pad *types.AuctionDuration) (*AuctionDuration, error) {
 	if pad == nil {
-		return nil, ErrNilAuctionDuration
+		return &AuctionDuration{}, nil
 	}
 
 	return &AuctionDuration{

--- a/gateway/graphql/resolvers_test.go
+++ b/gateway/graphql/resolvers_test.go
@@ -147,9 +147,9 @@ func TestNewResolverRoot_Resolver(t *testing.T) {
 
 	name := "BTC/DEC19"
 	vMarkets, err := root.Query().Markets(ctx, &name)
-	assert.NotNil(t, err)
-	assert.Nil(t, vMarkets)
-	assert.Len(t, vMarkets, 0)
+	assert.Nil(t, err)
+	assert.NotNil(t, vMarkets)
+	assert.Len(t, vMarkets, 1)
 
 	name = "ETH/USD18"
 	vMarkets, err = root.Query().Markets(ctx, &name)


### PR DESCRIPTION
Fixes an error in the GraphQL resolver when markets are in auction mode.

Closes #2439