### PR TITLE
fix graphql parser library to get appropriates errors

### DIFF
--- a/gateway/graphql/helpers.go
+++ b/gateway/graphql/helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"google.golang.org/grpc/status"
 
 	types "code.vegaprotocol.io/vega/proto"
@@ -30,14 +30,12 @@ func customErrorFromStatus(err error) error {
 		customInner := ""
 		customMessage := st.Message()
 		errorDetails := st.Details()
-		if errorDetails != nil {
-			for _, s := range errorDetails {
-				det := s.(*types.ErrorDetail)
-				customDetail = det.Message
-				customCode = fmt.Sprintf("%d", det.Code)
-				customInner = det.Inner
-				break
-			}
+		for _, s := range errorDetails {
+			det := s.(*types.ErrorDetail)
+			customDetail = det.Message
+			customCode = fmt.Sprintf("%d", det.Code)
+			customInner = det.Inner
+			break
 		}
 		return &gqlerror.Error{
 			Message: customMessage,

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -2119,7 +2119,6 @@ func (r *myMutationResolver) PrepareProposal(
 		Proposal:  terms,
 	})
 	if err != nil {
-		fmt.Printf("ERORR: %v\n", err)
 		return nil, customErrorFromStatus(err)
 	}
 	return &PreparedProposal{

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -2119,6 +2119,7 @@ func (r *myMutationResolver) PrepareProposal(
 		Proposal:  terms,
 	})
 	if err != nil {
+		fmt.Printf("ERORR: %v\n", err)
 		return nil, customErrorFromStatus(err)
 	}
 	return &PreparedProposal{

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tendermint/tendermint v0.33.1-dev3.0.20200615111712-b8b50733f0a8
 	github.com/vegaprotocol/modvendor v0.0.2 // indirect
-	github.com/vektah/gqlparser v1.3.1
 	github.com/vektah/gqlparser/v2 v2.0.1
 	github.com/zannen/toml v0.3.2
 	go.elastic.co/apm/module/apmhttp v1.8.0


### PR DESCRIPTION
Unilt now we were using internall the wrong graphl parser library  to generate graphql errors, which ended up providing poor errors messages like these:
```
{
  "errors": [
    {
      "message": "InvalidArgument error",
      "path": [
        "prepareProposal"
      ],
  ],
  "data": null
}
```

By updating the library version, the gqlgen library can reflect properly the type of the error, and provide enriched graphql errors to the clients. like these
```
{
  "errors": [
    {
      "message": "InvalidArgument error",
      "path": [
        "prepareProposal"
      ],
      "extensions": {
        "code": "10015",
        "detail": "malformed request",
        "inner": "invalid field Proposal.NewMarket.Changes.PriceMonitoringSettings.UpdateFrequency: value '0' must be greater than '0'"
      }
    }
  ],
  "data": null
}
```
