### PR TITLE
Fix event bus streaming (GQL/gRPC)

### DIFF
--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -2073,12 +2073,10 @@ func (t *tradingDataService) ObserveEventBus(
 
 	if req.BatchSize > 0 {
 		err := t.observeEventsWithAck(ctx, stream, req.BatchSize, ch, bCh)
-		fmt.Printf("ERR EVENT BUS ACK: %v\n", err)
 		return err
 
 	}
 	err = t.observeEvents(ctx, stream, ch)
-	fmt.Printf("ERR EVENT BUS ACK: %v\n", err)
 	return err
 }
 

--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -2073,10 +2073,13 @@ func (t *tradingDataService) ObserveEventBus(
 
 	if req.BatchSize > 0 {
 		err := t.observeEventsWithAck(ctx, stream, req.BatchSize, ch, bCh)
+		fmt.Printf("ERR EVENT BUS ACK: %v\n", err)
 		return err
 
 	}
-	return t.observeEvents(ctx, stream, ch)
+	err = t.observeEvents(ctx, stream, ch)
+	fmt.Printf("ERR EVENT BUS ACK: %v\n", err)
+	return err
 }
 
 func (t *tradingDataService) observeEvents(

--- a/blockchain/abci/app.go
+++ b/blockchain/abci/app.go
@@ -46,6 +46,7 @@ func New(codec Codec) *App {
 		checkTxs:        map[txn.Command]TxHandler{},
 		deliverTxs:      map[txn.Command]TxHandler{},
 		checkedTxs:      map[string]Tx{},
+		ctx:             context.Background(),
 	}
 }
 

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -2,7 +2,6 @@ package broker
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -257,11 +256,9 @@ func (b *Broker) rmSubs(keys ...int) {
 			return
 		}
 		types := s.Types()
-		fmt.Printf("REMOVING TYPES: %v\n", types)
 		if len(types) == 0 {
 			types = []events.Type{events.All}
 		}
-		fmt.Printf("\ntsubs: %#v\n", b.tSubs)
 		if len(types) == 0 || len(types) == 1 && types[0] == events.All {
 			// remove in all subscribers then
 			for _, v := range b.tSubs {
@@ -272,12 +269,7 @@ func (b *Broker) rmSubs(keys ...int) {
 				delete(b.tSubs[t], k) // remove key from typed subs map
 			}
 		}
-		fmt.Printf("\ntsubs: %#v\n", b.tSubs)
-		fmt.Printf("\nsubs: %#v\n", b.subs)
 		delete(b.subs, k)
-		fmt.Printf("\nsubs: %#v\n", b.subs)
-		fmt.Printf("\nkeys: %#v\n", b.keys)
 		b.keys = append(b.keys, k)
-		fmt.Printf("\nkeys: %#v\n", b.keys)
 	}
 }

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -256,13 +257,27 @@ func (b *Broker) rmSubs(keys ...int) {
 			return
 		}
 		types := s.Types()
+		fmt.Printf("REMOVING TYPES: %v\n", types)
 		if len(types) == 0 {
 			types = []events.Type{events.All}
 		}
-		for _, t := range types {
-			delete(b.tSubs[t], k) // remove key from typed subs map
+		fmt.Printf("\ntsubs: %#v\n", b.tSubs)
+		if len(types) == 0 || len(types) == 1 && types[0] == events.All {
+			// remove in all subscribers then
+			for _, v := range b.tSubs {
+				delete(v, k)
+			}
+		} else {
+			for _, t := range types {
+				delete(b.tSubs[t], k) // remove key from typed subs map
+			}
 		}
+		fmt.Printf("\ntsubs: %#v\n", b.tSubs)
+		fmt.Printf("\nsubs: %#v\n", b.subs)
 		delete(b.subs, k)
+		fmt.Printf("\nsubs: %#v\n", b.subs)
+		fmt.Printf("\nkeys: %#v\n", b.keys)
 		b.keys = append(b.keys, k)
+		fmt.Printf("\nkeys: %#v\n", b.keys)
 	}
 }

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -2753,8 +2753,6 @@ func (r *mySubscriptionResolver) BusEvents(ctx context.Context, types []BusEvent
 			close(out)
 		}()
 
-		fmt.Printf("BATCH SIZE: %v\n", batchSize)
-
 		if batchSize == 0 {
 			r.busEvents(ctx, stream, out)
 		} else {

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -2753,6 +2753,8 @@ func (r *mySubscriptionResolver) BusEvents(ctx context.Context, types []BusEvent
 			close(out)
 		}()
 
+		fmt.Printf("BATCH SIZE: %v\n", batchSize)
+
 		if batchSize == 0 {
 			r.busEvents(ctx, stream, out)
 		} else {

--- a/subscribers/service.go
+++ b/subscribers/service.go
@@ -2,7 +2,6 @@ package subscribers
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"code.vegaprotocol.io/vega/broker"
@@ -67,7 +66,6 @@ func (s *Service) ObserveEvents(ctx context.Context, retries int, eTypes []event
 		}
 
 		for {
-			fmt.Printf("RETRIES: %v\n", ret)
 			select {
 			case <-ctx.Done():
 				return

--- a/subscribers/service.go
+++ b/subscribers/service.go
@@ -2,6 +2,7 @@ package subscribers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"code.vegaprotocol.io/vega/broker"
@@ -66,6 +67,7 @@ func (s *Service) ObserveEvents(ctx context.Context, retries int, eTypes []event
 		}
 
 		for {
+			fmt.Printf("RETRIES: %v\n", ret)
 			select {
 			case <-ctx.Done():
 				return

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -130,7 +130,9 @@ func (s *StreamSub) Push(evts ...events.Event) {
 	}
 	s.mu.Lock()
 	// update channel is eligible for closing if no events are in buffer, or the nr of changes are less than the buffer size
-	closeUpdate := (s.changeCount == 0 || s.changeCount > s.bufSize)
+	// closeUpdate := (s.changeCount == 0 || s.changeCount >= s.bufSize)
+	closeUpdate := true
+	// fmt.Printf("BEFORE: clolseUpdate(%v) | bufSize(%v) | changeCount(%v)\n", closeUpdate, s.bufSize, s.changeCount)
 	save := make([]StreamEvent, 0, len(evts))
 	for _, e := range evts {
 		var se StreamEvent
@@ -159,7 +161,7 @@ func (s *StreamSub) Push(evts ...events.Event) {
 	}
 	s.changeCount += len(save)
 	s.data = append(s.data, save...)
-	fmt.Printf("bufSize(%v) | changeCount(%v)\n", s.bufSize, s.changeCount)
+	fmt.Printf("clolseUpdate(%v) | bufSize(%v) | changeCount(%v)\n", closeUpdate, s.bufSize, s.changeCount)
 	if closeUpdate && ((s.bufSize > 0 && s.changeCount >= s.bufSize) || (s.bufSize == 0 && s.changeCount > 0)) {
 		fmt.Printf("CLOSING UPDATED\n")
 		close(s.updated)

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -2,7 +2,6 @@ package subscribers
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
@@ -132,7 +131,6 @@ func (s *StreamSub) Push(evts ...events.Event) {
 	// update channel is eligible for closing if no events are in buffer, or the nr of changes are less than the buffer size
 	// closeUpdate := (s.changeCount == 0 || s.changeCount >= s.bufSize)
 	closeUpdate := true
-	// fmt.Printf("BEFORE: clolseUpdate(%v) | bufSize(%v) | changeCount(%v)\n", closeUpdate, s.bufSize, s.changeCount)
 	save := make([]StreamEvent, 0, len(evts))
 	for _, e := range evts {
 		var se StreamEvent
@@ -161,9 +159,7 @@ func (s *StreamSub) Push(evts ...events.Event) {
 	}
 	s.changeCount += len(save)
 	s.data = append(s.data, save...)
-	fmt.Printf("clolseUpdate(%v) | bufSize(%v) | changeCount(%v)\n", closeUpdate, s.bufSize, s.changeCount)
 	if closeUpdate && ((s.bufSize > 0 && s.changeCount >= s.bufSize) || (s.bufSize == 0 && s.changeCount > 0)) {
-		fmt.Printf("CLOSING UPDATED\n")
 		close(s.updated)
 		s.updated = make(chan struct{})
 	}

--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -100,7 +100,11 @@ func NewStreamSub(ctx context.Context, types []events.Type, batchSize int, filte
 func (s *StreamSub) Halt() {
 	s.mu.Lock()
 	if s.changeCount == 0 || s.changeCount < s.bufSize {
-		close(s.updated)
+		select {
+		case <-s.updated:
+		default:
+			close(s.updated)
+		}
 	}
 	s.mu.Unlock()
 	s.Base.Halt() // close channel outside of the lock. to avoid race

--- a/subscribers/stream_subscriber_test.go
+++ b/subscribers/stream_subscriber_test.go
@@ -2,7 +2,6 @@ package subscribers_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 
@@ -102,6 +101,7 @@ func testUnfilteredWithEventsPush(t *testing.T) {
 		data = sub.GetData(context.Background())
 		done <- struct{}{}
 	}
+
 	go getData()
 
 	<-done
@@ -208,7 +208,6 @@ func testBatchedStreamSubscriber(t *testing.T) {
 			MarketID: "other-market",
 		}),
 	}
-	fmt.Printf("1\n")
 	sendRoutine := func(ch chan struct{}, sub *tstStreamSub, set []events.Event) {
 		sub.C() <- set
 		close(ch)
@@ -226,20 +225,14 @@ func testBatchedStreamSubscriber(t *testing.T) {
 	// ensure all events were sent
 	<-sent
 	// now start receiving, this should not receive any events:
-	fmt.Printf("2\n")
-	fmt.Printf("3\n")
 	// let's send a new batch, this ought to fill the buffer
 	sent = make(chan struct{})
-	fmt.Printf("4\n")
 	go sendRoutine(sent, sub, set1)
-	fmt.Printf("5\n")
 	<-rec
-	fmt.Printf("6\n")
 	// buffer max reached, data sent
 	assert.Equal(t, 5, len(data))
 	// a total of 6 events were now sent to the subscriber, changing the buffer size ought to return 1 event
 	<-sent
-	fmt.Printf("yolo\n")
 	data = sub.UpdateBatchSize(sub.ctx, len(set1)) // set batch size to match test-data set
 	assert.Equal(t, 1, len(data))                  // we should have drained the buffer
 	sent = make(chan struct{})

--- a/subscribers/stream_subscriber_test.go
+++ b/subscribers/stream_subscriber_test.go
@@ -213,16 +213,20 @@ func testBatchedStreamSubscriber(t *testing.T) {
 		sub.C() <- set
 		close(ch)
 	}
+
+	var data []*types.BusEvent
+	go func() {
+		rec <- struct{}{}
+		data = sub.GetData(context.Background())
+		close(rec)
+	}()
+	<-rec
+
 	go sendRoutine(sent, sub, set1)
 	// ensure all events were sent
 	<-sent
 	// now start receiving, this should not receive any events:
 	fmt.Printf("2\n")
-	var data []*types.BusEvent
-	go func() {
-		data = sub.GetData(context.Background())
-		close(rec)
-	}()
 	fmt.Printf("3\n")
 	// let's send a new batch, this ought to fill the buffer
 	sent = make(chan struct{})


### PR DESCRIPTION
This bring a bunch of fixes to the event bus.

- gRPC / Graphql no works properly with no batch (batch size 0)
- batches size of 1 / small batches works to, but are not recommended as the server expecting acknowledgment when working with batches, the node won't send a second batch(of 1...) before the acknowlegement.
-  batches of any sizes works
- no connections drops after 1 batch in GQL
- now the event bus stream will retry for 2 seconds before droping a connection (almost instant before), it will do 200 retries, with a tick of 10ms each if the channel is not ready to read the data.
- The internals of the event bus did not remove properly the subscribers from the event types -> subscribers map, which means that subscribers where being broken if e.g: first someone subscribed for all events, then close the connection, then another connection open, and the same ID would be reused internally, but the list of subscribtion would have been different.
- Also full batches would have been dropped before if it was not possible to write in the stream. Now if we cannot write after 10ms, we just concatenate the next batch into the current one. meaning that if the client is too slow, and requested batches of 10, he may get batches of 20 if he was not able to consume the previous batch straight away. which also mean that he's jst accumulating delay, but that's the client problem, he'll get closed at some point.

closes #2323
closes #2444 
closes #2336 