### PR TITLE
Ensure the api-node runs validation on external resources as well.

### DIFF
--- a/validators/ext_res_checker.go
+++ b/validators/ext_res_checker.go
@@ -172,13 +172,10 @@ func (e *ExtResChecker) StartCheck(
 
 	e.resources[id] = rs
 
-	if e.top.IsValidator() {
-		go e.start(ctx, rs)
-	} else {
-		// if weare not a validator, let's just set to voteSent
-		// and wait for all validators to verify
-		atomic.StoreUint32(&rs.state, voteSent)
-	}
+	// validtor or not, we start the routine to validatate the
+	// internall data as th resource may require retrieve data from the
+	// foreign chains
+	go e.start(ctx, rs)
 	return nil
 }
 
@@ -224,7 +221,7 @@ func (e ExtResChecker) start(ctx context.Context, r *res) {
 			e.log.Error("resource checking context done",
 				logging.Error(ctx.Err()))
 			return
-		case _ = <-ticker.C:
+		case <-ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
By fixing the non-validators / validators behaviour in the ttopology, we also disable some checks in the ExtResChecker type.
By doing so, the APIs nodes are not validating the external resources anymore, and then not retrieving information / storing information about them.
Meaning that he resource is considered OK, but the state in the banking package is never updated.

We disable the check for validator in the ExtResChecker when starting the routing to check the resources, but keep it enabled at the time we send the node vote.

Which basically means most of the behaviour apart voting is the same than in validators.

close #2478 