### PR TITLE
Do not send in routine by default, only use as fallback

### DIFF
--- a/subscribers/stream_subscriber.go
+++ b/subscribers/stream_subscriber.go
@@ -32,13 +32,45 @@ type StreamSub struct {
 	marketEvtsOnly bool
 }
 
+// pass in requested batch size + expanded event types
+func getBufSize(batch int, types []events.Type) int {
+	if batch < 0 {
+		batch = 0
+	}
+	// subscribed to all
+	if len(types) == 0 {
+		// at least 2k buffer
+		if batch < 2000 {
+			return 2000
+		}
+		return batch
+	}
+	multipliers := 1
+	for _, t := range types {
+		// each one of these events are high volume, and ought to double the buffer size
+		switch t {
+		case events.TradeEvent, events.TransferResponses, events.AccountEvent:
+			multipliers++
+		}
+	}
+	base := batch
+	if base == 0 {
+		base = 100
+	}
+	base *= len(types) * multipliers
+	if base > 1000 && (multipliers > 1 || len(types) > 5) {
+		return 1000
+	}
+	return base
+}
+
 func NewStreamSub(ctx context.Context, types []events.Type, batchSize int, filters ...EventFilter) *StreamSub {
 	// we can ignore this value throughout the call-chain, but internally we have to account for it
 	// this is equivalent to 0, but used for GQL mapping
 	if batchSize == -1 {
 		batchSize = 0
 	}
-	trades, meo := false, (len(types) == 1 && types[0] == events.MarketEvent)
+	meo := (len(types) == 1 && types[0] == events.MarketEvent)
 	expandedTypes := make([]events.Type, 0, len(types))
 	for _, t := range types {
 		if t == events.All {
@@ -48,42 +80,16 @@ func NewStreamSub(ctx context.Context, types []events.Type, batchSize int, filte
 		if t == events.MarketEvent {
 			expandedTypes = append(expandedTypes, events.MarketEvents()...)
 		} else {
-			if t == events.TradeEvent {
-				trades = true
-			}
 			expandedTypes = append(expandedTypes, t)
 		}
 	}
-	base := batchSize
-	factor := len(expandedTypes)
-	if expandedTypes == nil {
-		// ~20 events
-		trades = true
-		factor = 20
-	}
-	// we've got filtering going on? increase internal buffer
-	if len(filters) > 0 {
-		factor *= 10
-	}
-	if base == 0 {
-		base = 100
-		if trades {
-			base *= 2
-		}
-	}
-	// @TODO find a more intellegent way than this messy thing. We don't want to allocate 2k events per stream unless we have to
-	// but we don't want to run into issues because the event stream is using too small of a local buffer
-	// size of a given batch and then some (in case batch size is increased
-	bufLen := base * factor
-	// not sure if we can even have a 0 bufLen here
-	if bufLen == 0 {
-		bufLen = 1000 * factor
-		if trades {
-			bufLen = 2000 * factor
-		}
+	bufLen := getBufSize(batchSize, expandedTypes)
+	cbuf := bufLen
+	if fl := len(filters); fl > 0 {
+		bufLen *= cbuf
 	}
 	s := &StreamSub{
-		Base:           NewBase(ctx, bufLen, false),
+		Base:           NewBase(ctx, cbuf, false),
 		mu:             &sync.Mutex{},
 		types:          expandedTypes,
 		data:           make([]StreamEvent, 0, bufLen), // cap to batch size


### PR DESCRIPTION
Instead of sending events to channel subscribers in a routine every time, first try to send synchronously, then spin up a routine. This ought to cut down the total number of routines created for stream subscribers as long as they have channel buffer available.

The result should be improved performance, and more consistent ordering of events received by the client. The internal channel buffer size is also going to be increased so we're far less likely to hit the channel buffer