### PR TITLE
remove ctx from Commander struct

### DIFF
--- a/api/mocks/evt_forwarder_mock.go
+++ b/api/mocks/evt_forwarder_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	proto "code.vegaprotocol.io/vega/proto"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -34,15 +35,15 @@ func (m *MockEvtForwarder) EXPECT() *MockEvtForwarderMockRecorder {
 }
 
 // Forward mocks base method
-func (m *MockEvtForwarder) Forward(arg0 *proto.ChainEvent, arg1 string) error {
+func (m *MockEvtForwarder) Forward(arg0 context.Context, arg1 *proto.ChainEvent, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Forward", arg0, arg1)
+	ret := m.ctrl.Call(m, "Forward", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Forward indicates an expected call of Forward
-func (mr *MockEvtForwarderMockRecorder) Forward(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockEvtForwarderMockRecorder) Forward(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Forward", reflect.TypeOf((*MockEvtForwarder)(nil).Forward), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Forward", reflect.TypeOf((*MockEvtForwarder)(nil).Forward), arg0, arg1, arg2)
 }

--- a/api/trading.go
+++ b/api/trading.go
@@ -48,7 +48,7 @@ type GovernanceService interface {
 // EvtForwarder
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/evt_forwarder_mock.go -package mocks code.vegaprotocol.io/vega/api  EvtForwarder
 type EvtForwarder interface {
-	Forward(e *types.ChainEvent, pk string) error
+	Forward(ctx context.Context, e *types.ChainEvent, pk string) error
 }
 
 // Blockchain ...
@@ -248,7 +248,7 @@ func (s *tradingService) PropagateChainEvent(ctx context.Context, req *protoapi.
 	}
 
 	var ok = true
-	err = s.evtForwarder.Forward(req.Evt, req.PubKey)
+	err = s.evtForwarder.Forward(ctx, req.Evt, req.PubKey)
 	if err != nil {
 		s.log.Error("unable to forward chain event",
 			logging.String("pubkey", req.PubKey),

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -39,7 +39,7 @@ type Assets interface {
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/notary_mock.go -package mocks code.vegaprotocol.io/vega/banking Notary
 type Notary interface {
 	StartAggregate(resID string, kind types.NodeSignatureKind) error
-	SendSignature(id string, sig []byte, kind types.NodeSignatureKind) error
+	SendSignature(ctx context.Context, id string, sig []byte, kind types.NodeSignatureKind) error
 	IsSigned(id string, kind types.NodeSignatureKind) ([]types.NodeSignature, bool)
 }
 
@@ -368,7 +368,7 @@ func (e *Engine) LockWithdrawalERC20(ctx context.Context, party, assetID string,
 	}
 
 	err = e.notary.SendSignature(
-		w.Id, sig, types.NodeSignatureKind_NODE_SIGNATURE_KIND_ASSET_WITHDRAWAL)
+		ctx, w.Id, sig, types.NodeSignatureKind_NODE_SIGNATURE_KIND_ASSET_WITHDRAWAL)
 	if err != nil {
 		// we don't cancel it here
 		// we may not be able to sign for some reason, but other may be able

--- a/banking/mocks/notary_mock.go
+++ b/banking/mocks/notary_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	proto "code.vegaprotocol.io/vega/proto"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -49,17 +50,17 @@ func (mr *MockNotaryMockRecorder) IsSigned(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // SendSignature mocks base method
-func (m *MockNotary) SendSignature(arg0 string, arg1 []byte, arg2 proto.NodeSignatureKind) error {
+func (m *MockNotary) SendSignature(arg0 context.Context, arg1 string, arg2 []byte, arg3 proto.NodeSignatureKind) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendSignature", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SendSignature", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendSignature indicates an expected call of SendSignature
-func (mr *MockNotaryMockRecorder) SendSignature(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockNotaryMockRecorder) SendSignature(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSignature", reflect.TypeOf((*MockNotary)(nil).SendSignature), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSignature", reflect.TypeOf((*MockNotary)(nil).SendSignature), arg0, arg1, arg2, arg3)
 }
 
 // StartAggregate mocks base method

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -502,7 +502,7 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 	)
 	// we cannot pass the Chain dependency here (that's set by the blockchain)
 	wal, _ := l.nodeWallet.Get(nodewallet.Vega)
-	commander, err := nodewallet.NewCommander(l.ctx, nil, wal)
+	commander, err := nodewallet.NewCommander(nil, wal)
 	if err != nil {
 		return err
 	}

--- a/evtforward/evtforward.go
+++ b/evtforward/evtforward.go
@@ -32,7 +32,7 @@ type TimeService interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/evtforward Commander
 type Commander interface {
-	Command(cmd txn.Command, payload proto.Message) error
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message) error
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/validator_topology_mock.go -package mocks code.vegaprotocol.io/vega/evtforward ValidatorTopology
@@ -154,7 +154,7 @@ func (e *EvtForwarder) isWhitelisted(pubkey string) bool {
 
 // Forward will forward an ChainEvent to the tendermint network
 // we expect the pubkey to be an ed25519 pubkey hex encoded
-func (e *EvtForwarder) Forward(evt *types.ChainEvent, pubkey string) error {
+func (e *EvtForwarder) Forward(ctx context.Context, evt *types.ChainEvent, pubkey string) error {
 	// check if the sender of the event is whitelisted
 	if !e.isWhitelisted(pubkey) {
 		return ErrPubKeyNotWhitelisted
@@ -172,7 +172,7 @@ func (e *EvtForwarder) Forward(evt *types.ChainEvent, pubkey string) error {
 	e.evts[key] = tsEvt{ts: e.currentTime, evt: evt}
 	if e.isSender(evt) {
 		// we are selected to send the event, let's do it.
-		return e.send(evt)
+		return e.send(ctx, evt)
 	}
 	return nil
 }
@@ -206,8 +206,8 @@ func (e *EvtForwarder) getEvt(key string) (evt *types.ChainEvent, ok bool, acked
 	return nil, false, false
 }
 
-func (e *EvtForwarder) send(evt *types.ChainEvent) error {
-	return e.cmd.Command(txn.ChainEventCommand, evt)
+func (e *EvtForwarder) send(ctx context.Context, evt *types.ChainEvent) error {
+	return e.cmd.Command(ctx, txn.ChainEventCommand, evt)
 }
 
 func (e *EvtForwarder) isSender(evt *types.ChainEvent) bool {
@@ -223,7 +223,7 @@ func (e *EvtForwarder) isSender(evt *types.ChainEvent) bool {
 	return node.node == e.self
 }
 
-func (e *EvtForwarder) onTick(_ context.Context, t time.Time) {
+func (e *EvtForwarder) onTick(ctx context.Context, t time.Time) {
 	e.currentTime = t
 
 	// get an updated list of validators from the topology
@@ -244,7 +244,7 @@ func (e *EvtForwarder) onTick(_ context.Context, t time.Time) {
 			e.evts[k] = tsEvt{ts: t, evt: evt.evt}
 			if e.isSender(evt.evt) {
 				// we are selected to send the event, let's do it.
-				if err := e.send(evt.evt); err != nil {
+				if err := e.send(ctx, evt.evt); err != nil {
 					e.log.Error("unable to send event", logging.Error(err))
 				}
 			}

--- a/evtforward/evtforward_test.go
+++ b/evtforward/evtforward_test.go
@@ -83,7 +83,7 @@ func testEventEmitterNotWhitelisted(t *testing.T) {
 	evtfwd.top.EXPECT().AllPubKeys().Times(1).Return(testAllPubKeys)
 	// set the time so the hash match our current node
 	evtfwd.cb(context.Background(), time.Unix(11, 0))
-	err := evtfwd.Forward(evt, "not whitelisted")
+	err := evtfwd.Forward(context.Background(), evt, "not whitelisted")
 	assert.EqualError(t, err, evtforward.ErrPubKeyNotWhitelisted.Error())
 }
 
@@ -91,11 +91,11 @@ func testForwardSuccessNodeIsForwarder(t *testing.T) {
 	evtfwd := getTestEvtFwd(t)
 	defer evtfwd.ctrl.Finish()
 	evt := getTestChainEvent()
-	evtfwd.cmd.EXPECT().Command(gomock.Any(), gomock.Any()).Return(nil)
+	evtfwd.cmd.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	evtfwd.top.EXPECT().AllPubKeys().Times(1).Return(testAllPubKeys)
 	// set the time so the hash match our current node
 	evtfwd.cb(context.Background(), time.Unix(11, 0))
-	err := evtfwd.Forward(evt, okEventEmitter)
+	err := evtfwd.Forward(context.Background(), evt, okEventEmitter)
 	assert.NoError(t, err)
 }
 
@@ -103,14 +103,14 @@ func testForwardFailureDuplicateEvent(t *testing.T) {
 	evtfwd := getTestEvtFwd(t)
 	defer evtfwd.ctrl.Finish()
 	evt := getTestChainEvent()
-	evtfwd.cmd.EXPECT().Command(gomock.Any(), gomock.Any()).Return(nil)
+	evtfwd.cmd.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	evtfwd.top.EXPECT().AllPubKeys().Times(1).Return(testAllPubKeys)
 	// set the time so the hash match our current node
 	evtfwd.cb(context.Background(), time.Unix(11, 0))
-	err := evtfwd.Forward(evt, okEventEmitter)
+	err := evtfwd.Forward(context.Background(), evt, okEventEmitter)
 	assert.NoError(t, err)
 	// now the event should exist, let's try toforward againt
-	err = evtfwd.Forward(evt, okEventEmitter)
+	err = evtfwd.Forward(context.Background(), evt, okEventEmitter)
 	assert.EqualError(t, err, evtforward.ErrEvtAlreadyExist.Error())
 }
 

--- a/evtforward/mocks/commander_mock.go
+++ b/evtforward/mocks/commander_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	txn "code.vegaprotocol.io/vega/txn"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	protoiface "google.golang.org/protobuf/runtime/protoiface"
 	reflect "reflect"
@@ -35,15 +36,15 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 txn.Command, arg1 protoiface.MessageV1) error {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Command", arg0, arg1)
+	ret := m.ctrl.Call(m, "Command", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Command indicates an expected call of Command
-func (mr *MockCommanderMockRecorder) Command(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1, arg2)
 }

--- a/nodewallet/commander.go
+++ b/nodewallet/commander.go
@@ -19,7 +19,6 @@ type Chain interface {
 }
 
 type Commander struct {
-	ctx context.Context
 	bc  Chain
 	wal Wallet
 }
@@ -35,12 +34,11 @@ var (
 // NewCommander - used to sign and send transaction from core
 // e.g. NodeRegistration, NodeVote
 // chain argument can't be passed in in cmd package, but is used for tests
-func NewCommander(ctx context.Context, bc Chain, wal Wallet) (*Commander, error) {
+func NewCommander(bc Chain, wal Wallet) (*Commander, error) {
 	if Blockchain(wal.Chain()) != Vega {
 		return nil, ErrVegaWalletRequired
 	}
 	return &Commander{
-		ctx: ctx,
 		bc:  bc,
 		wal: wal,
 	}, nil
@@ -52,7 +50,7 @@ func (c *Commander) SetChain(bc *blockchain.Client) {
 }
 
 // Command - send command to chain
-func (c *Commander) Command(cmd txn.Command, payload proto.Message) error {
+func (c *Commander) Command(ctx context.Context, cmd txn.Command, payload proto.Message) error {
 	raw, err := proto.Marshal(payload)
 	if err != nil {
 		return err
@@ -88,7 +86,7 @@ func (c *Commander) Command(cmd txn.Command, payload proto.Message) error {
 			Version: c.wal.Version(),
 		},
 	}
-	_, err = c.bc.SubmitTransaction(c.ctx, wrapped)
+	_, err = c.bc.SubmitTransaction(ctx, wrapped)
 	return err
 }
 

--- a/nodewallet/commander_test.go
+++ b/nodewallet/commander_test.go
@@ -35,7 +35,7 @@ func getTestCommander(t *testing.T) *testCommander {
 	ctrl := gomock.NewController(t)
 	chain := mocks.NewMockChain(ctrl)
 	wal := &stubWallet{chain: string(nodewallet.Vega)}
-	cmd, err := nodewallet.NewCommander(ctx, chain, wal)
+	cmd, err := nodewallet.NewCommander(chain, wal)
 	assert.NoError(t, err)
 	return &testCommander{
 		Commander: cmd,
@@ -64,8 +64,10 @@ func testSignedCommandSuccess(t *testing.T) {
 
 	cmd := txn.NodeVoteCommand
 	payload := &types.NodeVote{}
-	commander.chain.EXPECT().SubmitTransaction(commander.ctx, gomock.Any()).Times(1)
-	assert.NoError(t, commander.Command(cmd, payload))
+	ctx := context.Background()
+
+	commander.chain.EXPECT().SubmitTransaction(ctx, gomock.Any()).Times(1)
+	assert.NoError(t, commander.Command(ctx, cmd, payload))
 }
 
 func (t *testCommander) Finish() {

--- a/notary/mocks/commander_mock.go
+++ b/notary/mocks/commander_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	txn "code.vegaprotocol.io/vega/txn"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	protoiface "google.golang.org/protobuf/runtime/protoiface"
 	reflect "reflect"
@@ -35,15 +36,15 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 txn.Command, arg1 protoiface.MessageV1) error {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Command", arg0, arg1)
+	ret := m.ctrl.Call(m, "Command", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Command indicates an expected call of Command
-func (mr *MockCommanderMockRecorder) Command(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1, arg2)
 }

--- a/notary/notary.go
+++ b/notary/notary.go
@@ -33,7 +33,7 @@ type Broker interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/processor Commander
 type Commander interface {
-	Command(cmd txn.Command, payload proto.Message) error
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message) error
 }
 
 // Notary will aggregate all signatures of a node for
@@ -145,7 +145,7 @@ func (n *Notary) IsSigned(resID string, kind types.NodeSignatureKind) ([]types.N
 	return nil, false
 }
 
-func (n *Notary) SendSignature(id string, sig []byte, kind types.NodeSignatureKind) error {
+func (n *Notary) SendSignature(ctx context.Context, id string, sig []byte, kind types.NodeSignatureKind) error {
 	if !n.top.IsValidator() {
 		return nil
 	}
@@ -154,7 +154,7 @@ func (n *Notary) SendSignature(id string, sig []byte, kind types.NodeSignatureKi
 		Sig:  sig,
 		Kind: kind,
 	}
-	if err := n.cmd.Command(txn.NodeSignatureCommand, nsig); err != nil {
+	if err := n.cmd.Command(ctx, txn.NodeSignatureCommand, nsig); err != nil {
 		// do nothing for now, we'll need a retry mechanism for this and all command soon
 		n.log.Error("unable to send command for notary", logging.Error(err))
 	}

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -541,7 +541,7 @@ func (app *App) enactAsset(ctx context.Context, prop *types.Proposal, _ *types.A
 		Sig:  sig,
 		Kind: types.NodeSignatureKind_NODE_SIGNATURE_KIND_ASSET_NEW,
 	}
-	if err := app.cmd.Command(txn.NodeSignatureCommand, payload); err != nil {
+	if err := app.cmd.Command(ctx, txn.NodeSignatureCommand, payload); err != nil {
 		// do nothing for now, we'll need a retry mechanism for this and all command soon
 		app.log.Error("unable to send command for notary",
 			logging.Error(err))

--- a/processor/mocks/commander_mock.go
+++ b/processor/mocks/commander_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	txn "code.vegaprotocol.io/vega/txn"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	protoiface "google.golang.org/protobuf/runtime/protoiface"
 	reflect "reflect"
@@ -35,15 +36,15 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 txn.Command, arg1 protoiface.MessageV1) error {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Command", arg0, arg1)
+	ret := m.ctrl.Call(m, "Command", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Command indicates an expected call of Command
-func (mr *MockCommanderMockRecorder) Command(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1, arg2)
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -111,7 +111,7 @@ type Assets interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/processor Commander
 type Commander interface {
-	Command(cmd txn.Command, payload proto.Message) error
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message) error
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/validator_topology_mock.go -package mocks code.vegaprotocol.io/vega/processor ValidatorTopology

--- a/validators/ext_res_checker.go
+++ b/validators/ext_res_checker.go
@@ -29,7 +29,7 @@ type TimeService interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/validators Commander
 type Commander interface {
-	Command(cmd txn.Command, payload proto.Message) error
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message) error
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/validator_topology_mock.go -package mocks code.vegaprotocol.io/vega/validators ValidatorTopology
@@ -226,7 +226,7 @@ func (e ExtResChecker) start(ctx context.Context, r *res) {
 	}
 }
 
-func (e *ExtResChecker) OnTick(_ context.Context, t time.Time) {
+func (e *ExtResChecker) OnTick(ctx context.Context, t time.Time) {
 	e.now = t
 	topLen := e.top.Len()
 
@@ -264,7 +264,7 @@ func (e *ExtResChecker) OnTick(_ context.Context, t time.Time) {
 					PubKey:    e.top.SelfVegaPubKey(),
 					Reference: v.res.GetID(),
 				}
-				err := e.cmd.Command(txn.NodeVoteCommand, nv)
+				err := e.cmd.Command(ctx, txn.NodeVoteCommand, nv)
 				if err != nil {
 					e.log.Error("unable to send command", logging.Error(err))
 					continue

--- a/validators/ext_res_checker_test.go
+++ b/validators/ext_res_checker_test.go
@@ -222,7 +222,7 @@ func testOnChainTimeUpdate(t *testing.T) {
 	<-ch
 
 	// first on chain time update, we send our own vote
-	erc.cmd.EXPECT().Command(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	erc.cmd.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	newNow := erc.startTime.Add(1 * time.Second)
 	erc.OnTick(context.Background(), newNow)
 
@@ -266,7 +266,7 @@ func testOnChainTimeUpdateNonValidator(t *testing.T) {
 	assert.NoError(t, err)
 
 	// first on chain time update, we send our own vote
-	erc.cmd.EXPECT().Command(gomock.Any(), gomock.Any()).Times(0).Return(nil)
+	erc.cmd.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any()).Times(0).Return(nil)
 	newNow := erc.startTime.Add(1 * time.Second)
 	erc.OnTick(context.Background(), newNow)
 

--- a/validators/mocks/commander_mock.go
+++ b/validators/mocks/commander_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	txn "code.vegaprotocol.io/vega/txn"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	protoiface "google.golang.org/protobuf/runtime/protoiface"
 	reflect "reflect"
@@ -35,15 +36,15 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 txn.Command, arg1 protoiface.MessageV1) error {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Command", arg0, arg1)
+	ret := m.ctrl.Call(m, "Command", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Command indicates an expected call of Command
-func (mr *MockCommanderMockRecorder) Command(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockCommander)(nil).Command), arg0, arg1, arg2)
 }


### PR DESCRIPTION
While storing the context inside struct might be convenient in some cases, but in the long run, storing and re-using them defeats its purpose.

The documentation states [1]:
> Programs that use Contexts should follow these rules to keep interfaces consistent across packages and enable static analysis tools to check context propagation:
...
  Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it. The Context should be the first parameter, typically named ctx: 
...
  Use context Values only for request-scoped data that transits processes and APIs, not for passing optional parameters to functions.

This is an attempt to remove context from some structs.

[1]: https://golang.org/pkg/context/