### PR TITLE
fix pointer issue when amendingInPlace

### DIFF
--- a/matching/2500_GTT_amended_to_GTC_expires_test.go
+++ b/matching/2500_GTT_amended_to_GTC_expires_test.go
@@ -1,0 +1,42 @@
+package matching
+
+import (
+	"testing"
+
+	types "code.vegaprotocol.io/vega/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGTTAmendToGTCAmendInPlace_OrderGetExpired(t *testing.T) {
+	market := "testmarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	originalOrder := types.Order{
+		MarketID:    market,
+		Status:      types.Order_STATUS_ACTIVE,
+		PartyID:     "A",
+		Side:        types.Side_SIDE_BUY,
+		Price:       100,
+		Size:        4,
+		Remaining:   4,
+		TimeInForce: types.Order_TIF_GTT,
+		ExpiresAt:   10,
+		Type:        types.Order_TYPE_LIMIT,
+		Id:          "v0000000000000-0000001",
+	}
+	amendedOrder := originalOrder
+	amendedOrder.TimeInForce = types.Order_TIF_GTC
+	amendedOrder.ExpiresAt = 0
+
+	_, err := book.SubmitOrder(&originalOrder)
+	assert.NoError(t, err)
+
+	// now we send the amended order
+	err = book.AmendOrder(&originalOrder, &amendedOrder)
+	assert.NoError(t, err)
+
+	// now we call the remove expires orders
+	removedOrders := book.RemoveExpiredOrders(11)
+	assert.Len(t, removedOrders, 0)
+}

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -510,6 +510,9 @@ func (b *OrderBook) CancelOrder(order *types.Order) (*types.OrderCancellationCon
 		return nil, err
 	}
 
+	// we remove the order from the expiring list as well.
+	b.removePendingGttOrder(*order)
+
 	order, err := b.DeleteOrder(order)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In amend in place, by amending the pointer, we change the content of the original order, by the content of the amended pointer (the order pointer was originaly retrieve at the begining of the amend).
By doing so, check at the end of amend order to insert / expire an order never worked, as it was always comparing the state of the amended order with itself.

We now make a copy of the orginal order before executing the checks / amends, and then do the stuff.

closes #2500 