### PR TITLE
add json value for netparams

### DIFF
--- a/netparams/netparams.go
+++ b/netparams/netparams.go
@@ -31,6 +31,7 @@ type value interface {
 	ToBool() (bool, error)
 	ToString() (string, error)
 	ToDuration() (time.Duration, error)
+	ToJSONStruct(interface{}) error
 }
 
 type NetParamWatcher func(string, string)
@@ -233,4 +234,15 @@ func (s *Store) GetString(key string) (string, error) {
 		return "", ErrUnknownKey
 	}
 	return svalue.ToString()
+}
+
+// GetJSONStruct a value associated to the given key
+func (s *Store) GetJSONStruct(key string, v interface{}) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	svalue, ok := s.store[key]
+	if !ok {
+		return ErrUnknownKey
+	}
+	return svalue.ToJSONStruct(v)
 }

--- a/netparams/netparams.go
+++ b/netparams/netparams.go
@@ -31,7 +31,7 @@ type value interface {
 	ToBool() (bool, error)
 	ToString() (string, error)
 	ToDuration() (time.Duration, error)
-	ToJSONStruct(interface{}) error
+	ToJSONStruct(interface{ Reset() }) error
 }
 
 type NetParamWatcher func(string, string)
@@ -237,7 +237,7 @@ func (s *Store) GetString(key string) (string, error) {
 }
 
 // GetJSONStruct a value associated to the given key
-func (s *Store) GetJSONStruct(key string, v interface{}) error {
+func (s *Store) GetJSONStruct(key string, v interface{ Reset() }) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	svalue, ok := s.store[key]

--- a/netparams/values.go
+++ b/netparams/values.go
@@ -36,7 +36,7 @@ func (b *baseValue) ToString() (string, error) {
 	return "", errors.New("not a string value")
 }
 
-func (b *baseValue) ToJSONStruct(v interface{}) error {
+func (b *baseValue) ToJSONStruct(v interface{ Reset() }) error {
 	return errors.New("not a JSON value")
 }
 

--- a/netparams/values_test.go
+++ b/netparams/values_test.go
@@ -1,0 +1,75 @@
+package netparams_test
+
+import (
+	"errors"
+	"testing"
+
+	"code.vegaprotocol.io/vega/netparams"
+	"github.com/stretchr/testify/assert"
+)
+
+type A struct {
+	S string
+	I int
+}
+
+func (a *A) Reset() { *a = A{} }
+
+type B struct {
+	F  float32
+	SS []string
+}
+
+func (b *B) Reset() { *b = B{} }
+
+func TestJSONValues(t *testing.T) {
+	validator := func(v interface{}) error {
+		a, ok := v.(*A)
+		if !ok {
+			return errors.New("invalid type")
+		}
+
+		if len(a.S) <= 0 {
+			return errors.New("empty string")
+		}
+		if a.I < 0 {
+			return errors.New("I negative")
+		}
+		return nil
+	}
+
+	// happy case, all good
+	j := netparams.NewJSON(&A{}, validator).Mutable(true).MustUpdate(`{"s": "notempty", "i": 42}`)
+	assert.NotNil(t, j)
+	err := j.Validate(`{"s": "notempty", "i": 84}`)
+	assert.NoError(t, err)
+
+	err = j.Update(`{"s": "notempty", "i": 84}`)
+	assert.NoError(t, err)
+
+	a := &A{}
+	err = j.ToJSONStruct(a)
+	assert.NoError(t, err)
+
+	assert.Equal(t, a.I, 84)
+	assert.Equal(t, a.S, "notempty")
+
+	// errors cases now
+
+	// invalid field
+	err = j.Validate(`{"s": "notempty", "i": 84, "nope": 3.2}`)
+	assert.EqualError(t, err, "unable to unmarshal value, json: unknown field \"nope\"")
+
+	err = j.Update(`{"s": "notempty", "i": 84, "nope": 3.2}`)
+	assert.EqualError(t, err, "unable to unmarshal value, json: unknown field \"nope\"")
+
+	// invalid type
+	b := &B{}
+	err = j.ToJSONStruct(b)
+	assert.EqualError(t, err, "incompatible type")
+
+	// valid type, field validation failed
+	err = j.Update(`{"s": "", "i": 84}`)
+	assert.EqualError(t, err, "empty string")
+
+}


### PR DESCRIPTION
This is adding support for "complex" types to be unmarshalled from json into custom structs.
This keep the layout of the netparameters as simple key / value strings.

@witgaw you may need this for some of your PRs.