### PR TITLE
panic when genesis load produce error

### DIFF
--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -342,7 +342,7 @@ func (l *NodeCommand) loadAsset(id string, v *proto.AssetSource) error {
 		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to instanciate new asset %v", err)
+		return fmt.Errorf("unable to instanciate new asset err=%v, asset-source=%s", err, v.String())
 	}
 	if err := l.assets.Enable(aid); err != nil {
 		return fmt.Errorf("unable to enable asset: %v", err)

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -197,7 +197,7 @@ func (app *App) OnInitChain(req tmtypes.RequestInitChain) tmtypes.ResponseInitCh
 
 	app.top.UpdateValidatorSet(vators)
 	if err := app.ghandler.OnGenesis(ctx, req.Time, req.AppStateBytes, vators); err != nil {
-		app.log.Error("something happened when initializing vega with the genesis block", logging.Error(err))
+		app.log.Fatal("something happened when initializing vega with the genesis block", logging.Error(err))
 	}
 
 	return tmtypes.ResponseInitChain{}


### PR DESCRIPTION
We panic when the genesis state cannot be loaded by one of the package / engine which require state from genesis.
Add more details to the error when an asset cannot be loaded.