### PR TITLE
Improve cmdline rate-limit args for faucet and wallet

### DIFF
--- a/faucet/config.go
+++ b/faucet/config.go
@@ -24,7 +24,7 @@ const (
 
 type Config struct {
 	Level      encoding.LogLevel     `long:"level" description:"Log level"`
-	RateLimit  vhttp.RateLimitConfig `long:"rateLimit" description:" "`
+	RateLimit  vhttp.RateLimitConfig `group:"RateLimit" namespace:"rateLimit"`
 	WalletPath string                `long:"wallet-path" description:" "`
 	Port       int                   `long:"port" description:"Listen for connections on port <port>"`
 	IP         string                `long:"ip" description:"Bind to address <ip>"`
@@ -42,7 +42,7 @@ func NewDefaultConfig(defaultDirPath string) Config {
 		Level: encoding.LogLevel{Level: logging.InfoLevel},
 		RateLimit: vhttp.RateLimitConfig{
 			CoolDown:  encoding.Duration{Duration: defaultCoolDown},
-			AllowList: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fe80::/10"},
+			AllowList: []string{"10.0.0.0/8", "127.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fe80::/10"},
 		},
 		WalletPath: filepath.Join(defaultDirPath, defaultWallet),
 		Node: NodeConfig{

--- a/http/rate_limit.go
+++ b/http/rate_limit.go
@@ -11,10 +11,9 @@ import (
 )
 
 type RateLimitConfig struct {
-	CoolDown encoding.Duration `long:"coolDown"`
+	CoolDown encoding.Duration `long:"coolDown" description:"rate-limit duration, e.g. 10s, 1m30s, 24h0m0s"`
 
-	// AllowList is a list of ip/subnets, e.g. "10.0.0.0/8", "192.168.0.0/16"
-	AllowList []string `long:"allowList"`
+	AllowList []string `long:"allowList" description:"a list of ip/subnets, e.g. 10.0.0.0/8, 192.168.0.0/16"`
 
 	allowList []net.IPNet
 }

--- a/wallet/config.go
+++ b/wallet/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	IP          string                `long:"ip"`
 	Node        NodeConfig            `group:"Node" namespace:"node"`
 	RsaKey      string                `long:"rsa-key"`
-	RateLimit   vhttp.RateLimitConfig `long:"rateLimit"`
+	RateLimit   vhttp.RateLimitConfig `group:"RateLimit" namespace:"rateLimit"`
 }
 
 type NodeConfig struct {
@@ -64,7 +64,7 @@ func NewDefaultConfig() Config {
 		RsaKey: rsaKeyPath,
 		RateLimit: vhttp.RateLimitConfig{
 			CoolDown:  encoding.Duration{Duration: defaultCoolDown},
-			AllowList: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fe80::/10"},
+			AllowList: []string{"10.0.0.0/8", "127.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fe80::/10"},
 		},
 	}
 }


### PR DESCRIPTION
This PR improves the command line rate-limit help for the faucet and wallet.