### PR TITLE
fix calculate indicative price

### DIFF
--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -2519,11 +2519,11 @@ func TestOrderBook_IndicativePriceAndVolume3(t *testing.T) {
 
 	// Get indicative auction price and volume
 	price, volume, side := book.GetIndicativePriceAndVolume()
-	assert.Equal(t, price, uint64(100))
-	assert.Equal(t, volume, uint64(45))
+	assert.Equal(t, int(price), 102)
+	assert.Equal(t, int(volume), 45)
 	assert.Equal(t, side, types.Side_SIDE_BUY)
 	price = book.GetIndicativePrice()
-	assert.Equal(t, price, uint64(100))
+	assert.Equal(t, int(price), 102)
 
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.LeaveAuction(time.Now())
@@ -2644,11 +2644,11 @@ func TestOrderBook_IndicativePriceAndVolume6(t *testing.T) {
 
 	// Get indicative auction price and volume
 	price, volume, side := book.GetIndicativePriceAndVolume()
-	assert.Equal(t, price, uint64(101))
-	assert.Equal(t, volume, uint64(10))
+	assert.Equal(t, int(price), 102)
+	assert.Equal(t, int(volume), 10)
 	assert.Equal(t, side, types.Side_SIDE_SELL)
 	price = book.GetIndicativePrice()
-	assert.Equal(t, price, uint64(101))
+	assert.Equal(t, int(price), 102)
 
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.LeaveAuction(time.Now())


### PR DESCRIPTION
After investigations, it appears that the node was bein slowed down and OOM because of us calculating the Indicative price in a slighlty inefficient way.

This fix both the slowness, and the OOM.
The slowness was due to the fact thatwe were inserting way too much price levels in the map used to calculate the indicative price: e.g
the bestBid is 100, the bestAsk is 0.00001, we would then endup inserting 10,000,000 price levels.
This at least twice when creating an order, a lot when uncrossing, and once at block commit and begin block.

This would also be the reason why we were running out of memory, as each entry in the map would have been: sizeof(uint64*6) which end up being a lot for 10,000,000 price levels for example. 

This is fixed by inserting only the price level that actually exist in the map.

Closes #2508 