### PR TITLE
more optimizations on buildCumulativePriceLevels

### DIFF
--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -257,7 +257,9 @@ func (b *OrderBook) GetIndicativePriceAndVolume() (uint64, uint64, types.Side) {
 
 	// Find the maximum tradable amount
 	var maxTradableAmount uint64
-	for _, value := range cumulativeVolumes {
+	for k, value := range cumulativeVolumes {
+		value.maxTradableAmount = min(value.cumulativeAskVolume, value.cumulativeBidVolume)
+		cumulativeVolumes[k] = value
 		maxTradableAmount = max(maxTradableAmount, value.maxTradableAmount)
 	}
 
@@ -328,43 +330,72 @@ func (b *OrderBook) GetIndicativePrice() uint64 {
 func (b *OrderBook) buildCumulativePriceLevels(maxPrice, minPrice uint64) map[uint64]CumulativeVolumeLevel {
 	cumulativeVolumes := map[uint64]CumulativeVolumeLevel{}
 
+	type maybePriceLevel struct {
+		price uint64
+		pl    *PriceLevel
+	}
+
 	// Run through the bid prices and build cumulative volume
 	var cumulativeVolume uint64
-	for price := maxPrice; price >= minPrice; price-- {
-		volume, err := b.buy.GetVolume(price)
 
-		if err != nil {
-			continue
+	// we'll keep track of all the pl we encounter
+	mplm := map[uint64]maybePriceLevel{}
+
+	for i := len(b.buy.levels) - 1; i >= 0; i-- {
+		if b.buy.levels[i].price < minPrice {
+			break
 		}
-		cumulativeVolume += volume
-		cumulativeVolumes[price] = CumulativeVolumeLevel{
-			price:               price,
-			bidVolume:           volume,
+		cumulativeVolume += b.buy.levels[i].volume
+		cumulativeVolumes[b.buy.levels[i].price] = CumulativeVolumeLevel{
+			price:               b.buy.levels[i].price,
+			bidVolume:           b.buy.levels[i].volume,
 			cumulativeBidVolume: cumulativeVolume,
+		}
+
+		mplm[b.buy.levels[i].price] = maybePriceLevel{price: b.buy.levels[i].price}
+	}
+
+	// now we add all the sells
+	// to our list of pricelevel
+	// making sure we have no duplicates
+	for i := len(b.sell.levels) - 1; i >= 0; i-- {
+		var price = b.sell.levels[i].price
+		if price > maxPrice {
+			break
+		}
+
+		if mpl, ok := mplm[price]; ok {
+			mpl.pl = b.sell.levels[i]
+			mplm[price] = mpl
+		} else {
+			mplm[price] = maybePriceLevel{price: price, pl: b.sell.levels[i]}
 		}
 	}
 
-	// Now do the same for the ask prices but reuse the price levels already made
+	// now we insert them all in the slice.
+	// so we can sort them
+	mpls := make([]maybePriceLevel, 0, len(mplm))
+	for _, v := range mplm {
+		mpls = append(mpls, v)
+	}
+
+	// sort the slice so we can go through each levels nicely
+	sort.Slice(mpls, func(i, j int) bool { return mpls[i].price > mpls[j].price })
+
+	// now we iterate other all the OK price levels
 	cumulativeVolume = 0
-	for price := minPrice; price <= maxPrice; price++ {
-		volume, err := b.sell.GetVolume(price)
-
+	for i := len(mpls) - 1; i >= 0; i-- {
 		// Lookup the existing structure from the map
-		cvl, ok := cumulativeVolumes[price]
+		cvl := cumulativeVolumes[mpls[i].price]
 
-		if !ok && err != nil {
-			// nothing to do
-			continue
-		}
-
-		if err == nil {
-			cumulativeVolume += volume
-			cvl.askVolume = volume
+		if mpls[i].pl != nil {
+			cumulativeVolume += mpls[i].pl.volume
+			cvl.askVolume = mpls[i].pl.volume
 		}
 
 		cvl.cumulativeAskVolume = cumulativeVolume
 		cvl.maxTradableAmount = min(cvl.cumulativeAskVolume, cvl.cumulativeBidVolume)
-		cumulativeVolumes[price] = cvl
+		cumulativeVolumes[mpls[i].price] = cvl
 	}
 
 	return cumulativeVolumes

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -2729,11 +2729,11 @@ func TestOrderBook_IndicativePriceAndVolume8(t *testing.T) {
 
 	// Get indicative auction price and volume
 	price, volume, side := book.GetIndicativePriceAndVolume()
-	assert.Equal(t, price, uint64(100))
-	assert.Equal(t, volume, uint64(38))
+	assert.Equal(t, int(price), 100)
+	assert.Equal(t, int(volume), 38)
 	assert.Equal(t, side, types.Side_SIDE_BUY)
 	price = book.GetIndicativePrice()
-	assert.Equal(t, price, uint64(100))
+	assert.Equal(t, int(price), 100)
 
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.LeaveAuction(time.Now())


### PR DESCRIPTION
This is a follow up fix for the #2520.

the previous PR remove the eccess usage of the map, and the adding of ALL the price levels in the map.
This one also stop trying to retrieve ALL prices levels even the non existing one, which require a call to sort.Search, which is computation heavy.

Instead we now get for each size the price levels comprised in the range of the bestBid <-> bestAsk and calculate cumulative pricelevels for these only.

This reduce a lot the iteration in the function, also remove lots of unneeded checks, and calls to getPriceLevels.

I like to make PRs without descriptions