### PR TITLE
Define governance asset in genesis block

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -8,10 +8,10 @@ import (
 
 	"code.vegaprotocol.io/vega/assets/builtin"
 	"code.vegaprotocol.io/vega/assets/erc20"
+	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/nodewallet"
 	types "code.vegaprotocol.io/vega/proto"
-	"golang.org/x/crypto/sha3"
 )
 
 var (
@@ -149,7 +149,7 @@ func (s *Service) assetHash(asset *Asset) []byte {
 		data.Symbol,
 		data.TotalSupply,
 		data.Decimals)
-	return hash([]byte(buf))
+	return crypto.Hash([]byte(buf))
 }
 
 func (s *Service) Get(assetID string) (*Asset, error) {
@@ -173,7 +173,7 @@ func (s *Service) GetByRef(ref string) (*Asset, error) {
 	return s.Get(id)
 }
 
-// GetAssetHash return an hash of the given asset to be used
+// AssetHash return an hash of the given asset to be used
 // signed to validate the asset on the vega chain
 func (s *Service) AssetHash(assetID string) ([]byte, error) {
 	asset, ok := s.assets[assetID]
@@ -185,10 +185,4 @@ func (s *Service) AssetHash(assetID string) ([]byte, error) {
 		return s.assetHash(asset), nil
 	}
 	return nil, ErrAssetDoesNotExist
-}
-
-func hash(key []byte) []byte {
-	hasher := sha3.New256()
-	hasher.Write([]byte(key))
-	return hasher.Sum(nil)
 }

--- a/assets/genesis_state.go
+++ b/assets/genesis_state.go
@@ -1,46 +1,81 @@
 package assets
 
 import (
+	"encoding/hex"
 	"encoding/json"
 
 	types "code.vegaprotocol.io/vega/proto"
+	"golang.org/x/crypto/sha3"
 )
 
 type GenesisState struct {
-	Builtins []types.BuiltinAsset
-	ERC20    []types.ERC20
+	Builtins map[string]types.BuiltinAsset
+	ERC20    map[string]types.ERC20
 }
 
+var (
+	defaultBuiltins = []types.BuiltinAsset{
+		{
+			Name:                "Ether",
+			Symbol:              "ETH",
+			TotalSupply:         "110436690",
+			Decimals:            5,
+			MaxFaucetAmountMint: "10000000", // 100ETH
+		},
+		{
+			Name:                "Bitcoin",
+			Symbol:              "BTC",
+			TotalSupply:         "21000000",
+			Decimals:            5,
+			MaxFaucetAmountMint: "1000000", // 10BTC
+		},
+		types.BuiltinAsset{
+			Name:                "VUSD",
+			Symbol:              "VUSD",
+			TotalSupply:         "21000000",
+			Decimals:            5,
+			MaxFaucetAmountMint: "500000000", // 5000VUSD
+		},
+	}
+
+	defaultERC20s = []types.ERC20{
+		{
+			ContractAddress: "0x308C71DE1FdA14db838555188211Fc87ef349272",
+		},
+	}
+)
+
 func DefaultGenesisState() GenesisState {
+	builtins := make(map[string]types.BuiltinAsset, len(defaultBuiltins))
+	erc20s := make(map[string]types.ERC20, len(defaultERC20s))
+
+	h := func(key []byte) []byte {
+		hasher := sha3.New256()
+		hasher.Write([]byte(key))
+		return hasher.Sum(nil)
+	}
+
+	for _, v := range defaultBuiltins {
+		assetSrc := types.AssetSource{
+			Source: &types.AssetSource_BuiltinAsset{
+				BuiltinAsset: &v,
+			},
+		}
+		builtins[hex.EncodeToString(h([]byte(assetSrc.String())))] = v
+	}
+
+	for _, v := range defaultERC20s {
+		assetSrc := types.AssetSource{
+			Source: &types.AssetSource_Erc20{
+				Erc20: &v,
+			},
+		}
+		erc20s[hex.EncodeToString(h([]byte(assetSrc.String())))] = v
+	}
+
 	return GenesisState{
-		Builtins: []types.BuiltinAsset{
-			{
-				Name:                "Ether",
-				Symbol:              "ETH",
-				TotalSupply:         "110436690",
-				Decimals:            5,
-				MaxFaucetAmountMint: "10000000", // 100ETH
-			},
-			{
-				Name:                "Bitcoin",
-				Symbol:              "BTC",
-				TotalSupply:         "21000000",
-				Decimals:            5,
-				MaxFaucetAmountMint: "1000000", // 10BTC
-			},
-			types.BuiltinAsset{
-				Name:                "VUSD",
-				Symbol:              "VUSD",
-				TotalSupply:         "21000000",
-				Decimals:            5,
-				MaxFaucetAmountMint: "500000000", // 5000VUSD
-			},
-		},
-		ERC20: []types.ERC20{
-			{
-				ContractAddress: "0x308C71DE1FdA14db838555188211Fc87ef349272",
-			},
-		},
+		Builtins: builtins,
+		ERC20:    erc20s,
 	}
 }
 

--- a/assets/genesis_state.go
+++ b/assets/genesis_state.go
@@ -19,7 +19,7 @@ var (
 		Symbol:              "VOTE",
 		TotalSupply:         "0",
 		Decimals:            5,
-		MaxFaucetAmountMint: "1000",
+		MaxFaucetAmountMint: "100000",
 	}
 
 	defaultBuiltins = []types.BuiltinAsset{

--- a/assets/genesis_state.go
+++ b/assets/genesis_state.go
@@ -14,6 +14,14 @@ type GenesisState struct {
 }
 
 var (
+	governanceAsset = types.BuiltinAsset{
+		Name:                "VOTE",
+		Symbol:              "VOTE",
+		TotalSupply:         "0",
+		Decimals:            5,
+		MaxFaucetAmountMint: "1000",
+	}
+
 	defaultBuiltins = []types.BuiltinAsset{
 		{
 			Name:                "Ether",
@@ -29,7 +37,7 @@ var (
 			Decimals:            5,
 			MaxFaucetAmountMint: "1000000", // 10BTC
 		},
-		types.BuiltinAsset{
+		{
 			Name:                "VUSD",
 			Symbol:              "VUSD",
 			TotalSupply:         "21000000",
@@ -54,6 +62,8 @@ func DefaultGenesisState() GenesisState {
 		hasher.Write([]byte(key))
 		return hasher.Sum(nil)
 	}
+
+	builtins["VOTE"] = governanceAsset
 
 	for _, v := range defaultBuiltins {
 		assetSrc := types.AssetSource{

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -12,13 +12,12 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/assets"
+	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/validators"
 	"github.com/prometheus/common/log"
-
-	"golang.org/x/crypto/sha3"
 )
 
 var (
@@ -563,7 +562,5 @@ type HasVegaAssetID interface {
 }
 
 func id(s fmt.Stringer, nonce uint64) string {
-	hasher := sha3.New256()
-	hasher.Write([]byte(fmt.Sprintf("%v%v", s.String(), nonce)))
-	return hex.EncodeToString(hasher.Sum(nil))
+	return hex.EncodeToString(crypto.Hash([]byte(fmt.Sprintf("%v%v", s.String(), nonce))))
 }

--- a/cmd/vega/genesis.go
+++ b/cmd/vega/genesis.go
@@ -36,6 +36,10 @@ func (opts *genesisCmd) Execute(_ []string) error {
 		return err
 	}
 
+	// just for a nicer output, if we do not enter a new line
+	// the genesis output is dump straight on the password field
+	fmt.Printf("\n")
+
 	// load tm pubkey
 	tmKey, err := loadTMPubkey(tmCfg)
 	if err != nil {

--- a/cmd/vega/node/node.go
+++ b/cmd/vega/node/node.go
@@ -36,6 +36,7 @@ import (
 	"code.vegaprotocol.io/vega/parties"
 	"code.vegaprotocol.io/vega/plugins"
 	"code.vegaprotocol.io/vega/pprof"
+	"code.vegaprotocol.io/vega/processor"
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/risk"
 	"code.vegaprotocol.io/vega/stats"
@@ -159,6 +160,8 @@ type NodeCommand struct {
 	assetPlugin      *plugins.Asset
 	withdrawalPlugin *plugins.Withdrawal
 	depositPlugin    *plugins.Deposit
+
+	app *processor.App
 
 	Version     string
 	VersionHash string

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -577,8 +577,8 @@ func (l *NodeCommand) setupNetParameters() error {
 	// now add some watcher for our netparams
 	err = l.netParams.Watch(
 		netparams.WatchParam{
-			netparams.GovernanceVoteAsset,
-			dispatch.GovernanceAssetUpdate(l.Log, l.assets, l.collateral),
+			Param:   netparams.GovernanceVoteAsset,
+			Watcher: dispatch.GovernanceAssetUpdate(l.Log, l.assets, l.collateral),
 		},
 	)
 	if err != nil {

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -506,10 +506,19 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 		return err
 	}
 
-	// TODO: Make OnGenesisAppStateLoaded accepts variadic args
-	l.genesisHandler.OnGenesisAppStateLoaded(l.UponGenesis)
-	l.genesisHandler.OnGenesisAppStateLoaded(l.netParams.UponGenesis)
-	l.genesisHandler.OnGenesisAppStateLoaded(l.topology.LoadValidatorsOnGenesis)
+	l.genesisHandler.OnGenesisAppStateLoaded(
+		// be sure to keep this in order.
+		// the node upon genesis will load all asset first in the node
+		// state. This is important to happend first as we will load the
+		// asset which will be considered as the governance token.
+		l.UponGenesis,
+		// This needs to happen always after, as it defined the network
+		// parameters, one of them is  the Governance Token asset ID.
+		// which if not loaded in the previous state, then will make the node
+		// panic at startup.
+		l.netParams.UponGenesis,
+		l.topology.LoadValidatorsOnGenesis,
+	)
 
 	l.notary = notary.New(l.Log, l.conf.Notary, l.topology, l.broker, commander)
 

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -517,8 +517,7 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 	l.banking = banking.New(l.Log, l.conf.Banking, l.collateral, l.erc, l.timeService, l.assets, l.notary, l.broker)
 
 	// now instanciate the blockchain layer
-	l.app, err = l.startABCI(l.ctx, commander)
-	if err != nil {
+	if l.app, err = l.startABCI(l.ctx, commander); err != nil {
 		return err
 	}
 

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math/big"
 	"sort"
 	"sync"
 	"time"
@@ -22,22 +23,6 @@ const (
 	// if needed
 	systemOwner = "*"
 	noMarket    = "!"
-
-	TokenAsset = "VOTE"
-)
-
-var (
-	TokenAssetSource = &types.AssetSource{
-		Source: &types.AssetSource_BuiltinAsset{
-			BuiltinAsset: &types.BuiltinAsset{
-				Name:                "VOTE",
-				Symbol:              "VOTE",
-				TotalSupply:         "0",
-				Decimals:            5,
-				MaxFaucetAmountMint: "1000",
-			},
-		},
-	}
 )
 
 var (
@@ -66,6 +51,8 @@ var (
 	ErrInvalidTransferTypeForFeeRequest = errors.New("an invalid transfer type was send to build a fee transfer request")
 	// ErrNotEnoughFundsToWithdraa a party requested to withdraw more than on its general account
 	ErrNotEnoughFundsToWithdraw = errors.New("not enough funds to withdraw")
+	// ErrGovernanceAssetIDMatchNoAsset
+	ErrGovernanceAssetIDMatchNoAsset = errors.New("governance asset ID match no asset")
 )
 
 // Broker send events
@@ -84,7 +71,6 @@ type Engine struct {
 	accs         map[string]*types.Account
 	hashableAccs []*types.Account
 	broker       Broker
-	totalTokens  uint64
 	// could be a unix.Time but storing it like this allow us to now time.UnixNano() all the time
 	currentTime int64
 
@@ -92,6 +78,11 @@ type Engine struct {
 
 	// asset ID to asset
 	enabledAssets map[string]types.Asset
+
+	// assetid -> total amount for the asset
+	totalAmounts map[string]*big.Int
+	// keep track of what's the current governanceAsset
+	governanceAsset string
 }
 
 // New instantiates a new collateral engine
@@ -172,7 +163,6 @@ func (e *Engine) ReloadConf(cfg Config) {
 // EnableAsset adds a new asset in the collateral engine
 // this enable the asset to be used by new markets or
 // parties to deposit funds
-// FIXME(): use the ID later on
 func (e *Engine) EnableAsset(ctx context.Context, asset types.Asset) error {
 	if e.AssetExists(asset.ID) {
 		return ErrAssetAlreadyEnabled
@@ -198,6 +188,28 @@ func (e *Engine) EnableAsset(ctx context.Context, asset types.Asset) error {
 	}
 	e.log.Info("new asset added successfully",
 		logging.String("asset-id", asset.ID))
+	return nil
+}
+
+func (e *Engine) UpdateGovernanceAsset(asset string) error {
+	if !e.AssetExists(asset) {
+		return ErrGovernanceAssetIDMatchNoAsset
+	}
+
+	var (
+		nextAsset = e.enabledAssets[asset]
+		prevAsset types.Asset
+	)
+	if len(e.governanceAsset) > 0 {
+		prevAsset = e.enabledAssets[e.governanceAsset]
+	}
+	e.log.Info("governance asset update successfully",
+		logging.String("new-asset-id", nextAsset.ID),
+		logging.String("new-asset", nextAsset.Symbol),
+		logging.String("prev-asset-id", prevAsset.ID),
+		logging.String("prev-asset", prevAsset.Symbol),
+	)
+	e.governanceAsset = asset
 	return nil
 }
 
@@ -1308,20 +1320,6 @@ func (e *Engine) CreatePartyGeneralAccount(ctx context.Context, partyID, asset s
 		e.broker.Send(events.NewPartyEvent(ctx, types.Party{Id: partyID}))
 		e.broker.Send(events.NewAccountEvent(ctx, acc))
 	}
-	tID := e.accountID(noMarket, partyID, TokenAsset, types.AccountType_ACCOUNT_TYPE_GENERAL)
-	if _, ok := e.accs[tID]; !ok {
-		acc := types.Account{
-			Id:       tID,
-			Asset:    TokenAsset,
-			MarketID: noMarket,
-			Balance:  0,
-			Owner:    partyID,
-			Type:     types.AccountType_ACCOUNT_TYPE_GENERAL,
-		}
-		e.accs[tID] = &acc
-		e.addAccountToHashableSlice(&acc)
-		e.broker.Send(events.NewAccountEvent(ctx, acc))
-	}
 
 	return generalID, nil
 }
@@ -1558,6 +1556,11 @@ func (e *Engine) Withdraw(ctx context.Context, partyID, asset string, amount uin
 	if err := e.DecrementBalance(ctx, acc.Id, amount); err != nil {
 		return err
 	}
+
+	// reduce the total amount for this asset
+	bal := e.totalAmounts[asset]
+	e.totalAmounts[asset] = bal.Sub(bal, big.NewInt(int64(amount)))
+
 	return nil
 }
 
@@ -1572,6 +1575,10 @@ func (e *Engine) Deposit(ctx context.Context, partyID, asset string, amount uint
 		return err
 	}
 
+	// increment balance of the given asset
+	bal := e.totalAmounts[asset]
+	e.totalAmounts[asset] = bal.Add(bal, big.NewInt(int64(amount)))
+
 	return e.IncrementBalance(ctx, accID, amount)
 }
 
@@ -1581,23 +1588,9 @@ func (e *Engine) UpdateBalance(ctx context.Context, id string, balance uint64) e
 	if !ok {
 		return ErrAccountDoesNotExist
 	}
-	if acc.Asset == TokenAsset {
-		e.totalTokens -= uint64(acc.Balance)
-		e.totalTokens += uint64(balance)
-		e.updateVoteToken(ctx)
-	}
 	acc.Balance = balance
 	e.broker.Send(events.NewAccountEvent(ctx, *acc))
 	return nil
-}
-
-func (e *Engine) updateVoteToken(ctx context.Context) {
-	tokAsset := e.enabledAssets[TokenAsset]
-	totalSupplyStr := fmt.Sprintf("%v", e.totalTokens)
-	tokAsset.TotalSupply = totalSupplyStr
-	tokAsset.GetSource().GetBuiltinAsset().TotalSupply = totalSupplyStr
-	e.enabledAssets[TokenAsset] = tokAsset
-	e.broker.Send(events.NewAssetEvent(ctx, tokAsset))
 }
 
 // IncrementBalance will increment the balance of a given account
@@ -1608,10 +1601,6 @@ func (e *Engine) IncrementBalance(ctx context.Context, id string, inc uint64) er
 		return ErrAccountDoesNotExist
 	}
 	acc.Balance += inc
-	if acc.Asset == TokenAsset {
-		e.totalTokens += inc
-		e.updateVoteToken(ctx)
-	}
 	e.broker.Send(events.NewAccountEvent(ctx, *acc))
 	return nil
 }
@@ -1624,10 +1613,6 @@ func (e *Engine) DecrementBalance(ctx context.Context, id string, dec uint64) er
 		return ErrAccountDoesNotExist
 	}
 	acc.Balance -= dec
-	if acc.Asset == TokenAsset {
-		e.totalTokens -= dec
-		e.updateVoteToken(ctx)
-	}
 	e.broker.Send(events.NewAccountEvent(ctx, *acc))
 	return nil
 }
@@ -1642,9 +1627,9 @@ func (e *Engine) GetAccountByID(id string) (*types.Account, error) {
 	return &acccpy, nil
 }
 
-// GetPartyTokenBalance - get the token account for a given user
+// GetPartyTokenAccount - get the token account for a given user
 func (e *Engine) GetPartyTokenAccount(id string) (*types.Account, error) {
-	tID := e.accountID(noMarket, id, TokenAsset, types.AccountType_ACCOUNT_TYPE_GENERAL)
+	tID := e.accountID(noMarket, id, e.governanceAsset, types.AccountType_ACCOUNT_TYPE_GENERAL)
 	acc, ok := e.accs[tID]
 	if !ok {
 		return nil, ErrPartyHasNoTokenAccount
@@ -1655,7 +1640,7 @@ func (e *Engine) GetPartyTokenAccount(id string) (*types.Account, error) {
 
 // GetTotalTokens - returns total amount of tokens in the network
 func (e *Engine) GetTotalTokens() uint64 {
-	return e.totalTokens
+	return e.totalAmounts[e.governanceAsset].Uint64()
 }
 
 func (e *Engine) removeAccount(id string) error {

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -112,7 +112,7 @@ func testCreateBondAccountSuccess(t *testing.T) {
 
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	assert.NoError(t, err)
 	bnd, err := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -143,7 +143,7 @@ func testReleasePartyMarginAccount(t *testing.T) {
 
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	gen, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	mar, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -173,7 +173,7 @@ func testFeeTransferContinuousNoFunds(t *testing.T) {
 
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err = eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -204,7 +204,7 @@ func testFeeTransferContinuousNotEnoughFunds(t *testing.T) {
 	defer eng.Finish()
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	general, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err = eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -239,7 +239,7 @@ func testFeeTransferContinuousOKWithEnoughInGenral(t *testing.T) {
 	defer eng.Finish()
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	general, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err = eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -276,7 +276,7 @@ func testFeeTransferContinuousOKWith0Amount(t *testing.T) {
 	defer eng.Finish()
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	general, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err = eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -315,7 +315,7 @@ func testFeeTransferContinuousOKWithEnoughInMargin(t *testing.T) {
 	defer eng.Finish()
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	margin, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -352,7 +352,7 @@ func testFeeTransferContinuousOKCheckAccountEvents(t *testing.T) {
 	defer eng.Finish()
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	margin, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -417,7 +417,7 @@ func testFeeTransferContinuousOKWithEnoughInGeneralAndMargin(t *testing.T) {
 	defer eng.Finish()
 	trader := "mytrader"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	general, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	margin, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -508,24 +508,34 @@ func testInitialTokens(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, acc)
 	assert.Equal(t, err, collateral.ErrPartyHasNoTokenAccount)
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(7)
 	_, err = eng.CreatePartyGeneralAccount(context.Background(), trader, "ETH")
+	assert.NoError(t, err)
+	_, err = eng.CreatePartyGeneralAccount(context.Background(), trader, "VOTE")
 	assert.NoError(t, err)
 	acc, err = eng.GetPartyTokenAccount(trader)
 	assert.NoError(t, err)
 	assert.NotNil(t, acc)
 	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
-	assert.NoError(t, eng.IncrementBalance(context.Background(), acc.Id, 10000))
+	assert.NoError(t, eng.Deposit(context.Background(), trader, "VOTE", 10000))
 	acc, err = eng.GetPartyTokenAccount(trader)
 	assert.NoError(t, err)
 	assert.NotNil(t, acc)
 	assert.Equal(t, uint64(acc.Balance), eng.GetTotalTokens())
 	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
-	assert.NoError(t, eng.UpdateBalance(context.Background(), acc.Id, acc.Balance/2)) // half the amount
+
+	// withdraw half the amount
+	assert.NoError(t, eng.LockFundsForWithdraw(context.Background(), trader, "VOTE", acc.Balance/2)) // half the amount
+	assert.NoError(t, eng.Withdraw(context.Background(), trader, "VOTE", acc.Balance/2))             // half the amount
+
 	acc.Balance /= 2
 	assert.Equal(t, uint64(acc.Balance), eng.GetTotalTokens())
 	// test subtracting something from the balance
 	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
+
+	assert.NoError(t, eng.LockFundsForWithdraw(context.Background(), trader, "VOTE", 100)) // half the amount
+	assert.NoError(t, eng.Withdraw(context.Background(), trader, "VOTE", 100))             // half the amount
+
 	assert.NoError(t, eng.DecrementBalance(context.Background(), acc.Id, 100))
 	acc.Balance -= 100
 	assert.Equal(t, uint64(acc.Balance), eng.GetTotalTokens())
@@ -541,7 +551,7 @@ func testAddMarginAccount(t *testing.T) {
 	defer eng.Finish()
 	trader := "funkytrader"
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	margin, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -569,7 +579,7 @@ func testAddTrader(t *testing.T) {
 	trader := "funkytrader"
 
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	general, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	margin, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -653,7 +663,7 @@ func testTransferComplexLoss(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	marginTrader, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -721,7 +731,7 @@ func testDistributeWin(t *testing.T) {
 	assert.Nil(t, err)
 
 	// create trader accounts, add balance for money trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(8)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err = eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -788,7 +798,7 @@ func testProcessBoth(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts
-	eng.broker.EXPECT().Send(gomock.Any()).Times(8)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -1057,7 +1067,7 @@ func testRemoveDistressedBalance(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts (calls buf.Add twice), and add balance (calls it a third time)
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	marginID, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -1102,7 +1112,7 @@ func testRemoveDistressedNoBalance(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts (calls buf.Add twice), and add balance (calls it a third time)
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	marginID, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -1214,7 +1224,7 @@ func TestInvalidMarketID(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -1246,7 +1256,7 @@ func TestEmptyTransfer(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -1277,7 +1287,7 @@ func TestNoMarginAccount(t *testing.T) {
 	defer eng.Finish()
 
 	// create trader accounts
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 
 	pos := []*types.Transfer{
@@ -1433,7 +1443,7 @@ func TestGetPartyMarginNoMarginAccounts(t *testing.T) {
 	eng := getTestEngine(t, testMarketID, price/2)
 	defer eng.Finish()
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), "test-trader", testMarketAsset)
 
 	marketPos := mtmFake{
@@ -1451,7 +1461,7 @@ func TestGetPartyMarginEmpty(t *testing.T) {
 	eng := getTestEngine(t, testMarketID, price/2)
 	defer eng.Finish()
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), "test-trader", testMarketAsset)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), "test-trader", testMarketID, testMarketAsset)
 
@@ -1553,7 +1563,7 @@ func testMarginUpdateOnOrderOK(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1594,7 +1604,7 @@ func testMarginUpdateOnOrderOKThenRollback(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1664,7 +1674,7 @@ func testMarginUpdateOnOrderFail(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	_, _ = eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -1696,7 +1706,7 @@ func TestMarginUpdates(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(7)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1731,7 +1741,7 @@ func TestClearMarket(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(7)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1751,7 +1761,7 @@ func TestClearMarketNoMargin(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 
@@ -1769,7 +1779,7 @@ func TestWithdrawalOK(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1812,7 +1822,7 @@ func TestWithdrawalExact(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1822,6 +1832,7 @@ func TestWithdrawalExact(t *testing.T) {
 		ae, ok := evt.(accEvt)
 		assert.True(t, ok)
 		acc := ae.Account()
+		// fmt.Printf("ACCOUNT: %v\n", acc)
 		if acc.Type == types.AccountType_ACCOUNT_TYPE_GENERAL {
 			assert.Equal(t, 0, int(acc.Balance))
 		} else if acc.Type == types.AccountType_ACCOUNT_TYPE_LOCK_WITHDRAW {
@@ -1855,7 +1866,7 @@ func TestWithdrawalNotEnough(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1872,7 +1883,7 @@ func TestWithdrawalInvalidAccount(t *testing.T) {
 	trader := "oktrader"
 
 	// create traders
-	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 	eng.Engine.IncrementBalance(context.Background(), acc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
@@ -1890,7 +1901,7 @@ func TestChangeBalance(t *testing.T) {
 	defer eng.Finish()
 	trader := "oktrader"
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
 	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
 
 	eng.broker.EXPECT().Send(gomock.Any()).Times(1)
@@ -1965,15 +1976,27 @@ func getTestEngine(t *testing.T, market string, insuranceBalance uint64) *testEn
 
 	// add the token asset
 	tokAsset := types.Asset{
-		ID:          collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Name:        collateral.TokenAssetSource.GetBuiltinAsset().Name,
-		Symbol:      collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Decimals:    collateral.TokenAssetSource.GetBuiltinAsset().Decimals,
-		TotalSupply: collateral.TokenAssetSource.GetBuiltinAsset().TotalSupply,
-		Source:      collateral.TokenAssetSource,
+		ID:          "VOTE",
+		Name:        "VOTE",
+		Symbol:      "VOTE",
+		Decimals:    5,
+		TotalSupply: "1000",
+		Source: &types.AssetSource{
+			Source: &types.AssetSource_BuiltinAsset{
+				BuiltinAsset: &types.BuiltinAsset{
+					Name:        "VOTE",
+					Symbol:      "VOTE",
+					Decimals:    5,
+					TotalSupply: "1000",
+				},
+			},
+		},
 	}
 	err = eng.EnableAsset(context.Background(), tokAsset)
 	assert.NoError(t, err)
+	err = eng.UpdateGovernanceAsset("VOTE")
+	assert.NoError(t, err)
+
 	// enable the assert for the tests
 	asset := types.Asset{
 		ID:     testMarketAsset,
@@ -2111,7 +2134,7 @@ func TestHash(t *testing.T) {
 
 	hash := eng.Hash()
 	require.Equal(t,
-		"4ed85cf7a65724ec9239022a4e1472583df3919fd3933e7c797c1d8a34f168d1",
+		"a9e053f94d07dcaa0f68807ae41e5268a8cfc8fd180642c8fa91a5cf0679dc31",
 		hex.EncodeToString(hash),
 		"It should match against the known hash",
 	)

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -61,13 +61,23 @@ func getTestMarket(t *testing.T, now time.Time, closingAt time.Time, pMonitorSet
 
 	// add the token asset
 	tokAsset := types.Asset{
-		ID:          collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Name:        collateral.TokenAssetSource.GetBuiltinAsset().Name,
-		Symbol:      collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Decimals:    collateral.TokenAssetSource.GetBuiltinAsset().Decimals,
-		TotalSupply: collateral.TokenAssetSource.GetBuiltinAsset().TotalSupply,
-		Source:      collateral.TokenAssetSource,
+		ID:          "VOTE",
+		Name:        "VOTE",
+		Symbol:      "VOTE",
+		Decimals:    5,
+		TotalSupply: "1000",
+		Source: &types.AssetSource{
+			Source: &types.AssetSource_BuiltinAsset{
+				BuiltinAsset: &types.BuiltinAsset{
+					Name:        "VOTE",
+					Symbol:      "VOTE",
+					Decimals:    5,
+					TotalSupply: "1000",
+				},
+			},
+		},
 	}
+
 	collateralEngine.EnableAsset(context.Background(), tokAsset)
 
 	if pMonitorSettings == nil {

--- a/genesis/handler.go
+++ b/genesis/handler.go
@@ -59,10 +59,10 @@ func (h *Handler) OnGenesis(
 	return nil
 }
 
-func (h *Handler) OnGenesisTimeLoaded(f func(context.Context, time.Time)) {
-	h.onGenesisTimeLoadedCB = append(h.onGenesisTimeLoadedCB, f)
+func (h *Handler) OnGenesisTimeLoaded(f ...func(context.Context, time.Time)) {
+	h.onGenesisTimeLoadedCB = append(h.onGenesisTimeLoadedCB, f...)
 }
 
-func (h *Handler) OnGenesisAppStateLoaded(f func(context.Context, []byte) error) {
-	h.onGenesisAppStateLoadedCB = append(h.onGenesisAppStateLoadedCB, f)
+func (h *Handler) OnGenesisAppStateLoaded(f ...func(context.Context, []byte) error) {
+	h.onGenesisAppStateLoadedCB = append(h.onGenesisAppStateLoadedCB, f...)
 }

--- a/governance/engine_test.go
+++ b/governance/engine_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"code.vegaprotocol.io/vega/collateral"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/governance"
 	"code.vegaprotocol.io/vega/governance/mocks"
@@ -740,7 +739,7 @@ func testMultipleProposalsLifecycle(t *testing.T) {
 		Id:      partyA + "-account",
 		Owner:   partyA,
 		Balance: 200,
-		Asset:   collateral.TokenAsset,
+		Asset:   "VOTE",
 	}
 	eng.accs.EXPECT().GetPartyTokenAccount(accountA.Owner).AnyTimes().Return(&accountA, nil)
 	partyB := "party-B"
@@ -748,7 +747,7 @@ func testMultipleProposalsLifecycle(t *testing.T) {
 		Id:      partyB + "-account",
 		Owner:   partyB,
 		Balance: 100,
-		Asset:   collateral.TokenAsset,
+		Asset:   "VOTE",
 	}
 	eng.accs.EXPECT().GetPartyTokenAccount(accountB.Owner).AnyTimes().Return(&accountB, nil)
 
@@ -941,7 +940,7 @@ func (e *tstEngine) makeValidPartyTimes(partyID string, balance uint64, times in
 		Id:      partyID + "-account",
 		Owner:   partyID,
 		Balance: balance,
-		Asset:   collateral.TokenAsset,
+		Asset:   "VOTE",
 	}
 	e.accs.EXPECT().GetPartyTokenAccount(partyID).Times(times).Return(&account, nil)
 	return &types.Party{Id: partyID}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"code.vegaprotocol.io/vega/collateral"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/proto"
 	types "code.vegaprotocol.io/vega/proto"
@@ -466,7 +465,8 @@ func allBalancesCumulatedAreWorth(amountstr string) error {
 		data = append(data, e.Account())
 	}
 	for _, v := range data {
-		if v.Asset != collateral.TokenAsset {
+		// remove vote token
+		if v.Asset != "VOTE" {
 			cumul += uint64(v.Balance)
 		}
 	}

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -82,12 +82,21 @@ func getMarketTestSetup(market *proto.Market) *marketTestSetup {
 	)
 
 	tokAsset := types.Asset{
-		ID:          collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Name:        collateral.TokenAssetSource.GetBuiltinAsset().Name,
-		Symbol:      collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Decimals:    collateral.TokenAssetSource.GetBuiltinAsset().Decimals,
-		TotalSupply: collateral.TokenAssetSource.GetBuiltinAsset().TotalSupply,
-		Source:      collateral.TokenAssetSource,
+		ID:          "VOTE",
+		Name:        "VOTE",
+		Symbol:      "VOTE",
+		Decimals:    5,
+		TotalSupply: "1000",
+		Source: &types.AssetSource{
+			Source: &types.AssetSource_BuiltinAsset{
+				BuiltinAsset: &types.BuiltinAsset{
+					Name:        "VOTE",
+					Symbol:      "VOTE",
+					Decimals:    5,
+					TotalSupply: "1000",
+				},
+			},
+		},
 	}
 	colE.EnableAsset(context.Background(), tokAsset)
 
@@ -165,12 +174,21 @@ func getExecutionTestSetup(startTime time.Time, mkts []proto.Market) *executionT
 	}
 
 	tokAsset := types.Asset{
-		ID:          collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Name:        collateral.TokenAssetSource.GetBuiltinAsset().Name,
-		Symbol:      collateral.TokenAssetSource.GetBuiltinAsset().Symbol,
-		Decimals:    collateral.TokenAssetSource.GetBuiltinAsset().Decimals,
-		TotalSupply: collateral.TokenAssetSource.GetBuiltinAsset().TotalSupply,
-		Source:      collateral.TokenAssetSource,
+		ID:          "VOTE",
+		Name:        "VOTE",
+		Symbol:      "VOTE",
+		Decimals:    5,
+		TotalSupply: "1000",
+		Source: &types.AssetSource{
+			Source: &types.AssetSource_BuiltinAsset{
+				BuiltinAsset: &types.BuiltinAsset{
+					Name:        "VOTE",
+					Symbol:      "VOTE",
+					Decimals:    5,
+					TotalSupply: "1000",
+				},
+			},
+		},
 	}
 	execsetup.collateral.EnableAsset(context.Background(), tokAsset)
 

--- a/netparams/checks/checks.go
+++ b/netparams/checks/checks.go
@@ -1,0 +1,38 @@
+package checks
+
+import (
+	"fmt"
+
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/netparams"
+)
+
+type Collateral interface {
+	AssetExists(asset string) bool
+}
+
+type Assets interface {
+	IsEnabled(asset string) bool
+}
+
+func GovernanceAssetUpdate(
+	log *logging.Logger,
+	assets Assets,
+	collateral Collateral,
+) netparams.StringRule {
+	return func(value string) error {
+		fmt.Printf("CHECK ASSET EXISTS YOOOO\n\n\n")
+		if !assets.IsEnabled(value) {
+			log.Error("tried to push a governance update with an non-enabled asset",
+				logging.String("asset-id", value))
+			return fmt.Errorf("invalid asset %v", value)
+		}
+
+		if !collateral.AssetExists(value) {
+			log.Error("unable to update governance asset in collateral",
+				logging.String("asset-id", value))
+			return fmt.Errorf("asset does not exists in collateral %v", value)
+		}
+		return nil
+	}
+}

--- a/netparams/checks/checks.go
+++ b/netparams/checks/checks.go
@@ -21,7 +21,6 @@ func GovernanceAssetUpdate(
 	collateral Collateral,
 ) netparams.StringRule {
 	return func(value string) error {
-		fmt.Printf("CHECK ASSET EXISTS YOOOO\n\n\n")
 		if !assets.IsEnabled(value) {
 			log.Error("tried to push a governance update with an non-enabled asset",
 				logging.String("asset-id", value))

--- a/netparams/checks/checks.go
+++ b/netparams/checks/checks.go
@@ -22,13 +22,13 @@ func GovernanceAssetUpdate(
 ) netparams.StringRule {
 	return func(value string) error {
 		if !assets.IsEnabled(value) {
-			log.Error("tried to push a governance update with an non-enabled asset",
+			log.Debug("tried to push a governance update with an non-enabled asset",
 				logging.String("asset-id", value))
 			return fmt.Errorf("invalid asset %v", value)
 		}
 
 		if !collateral.AssetExists(value) {
-			log.Error("unable to update governance asset in collateral",
+			log.Debug("unable to update governance asset in collateral",
 				logging.String("asset-id", value))
 			return fmt.Errorf("asset does not exists in collateral %v", value)
 		}

--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -65,5 +65,11 @@ func defaultNetParams() map[string]value {
 		GovernanceProposalUpdateNetParamRequiredMajority:      NewFloat(FloatGTE(0.5), FloatLTE(1)).Mutable(true).MustUpdate("0.66"),
 		GovernanceProposalUpdateNetParamMinProposerBalance:    NewFloat(FloatGTE(0), FloatLTE(1)).Mutable(true).MustUpdate("0.00001"),
 		GovernanceProposalUpdateNetParamMinVoterBalance:       NewFloat(FloatGTE(0), FloatLTE(1)).Mutable(true).MustUpdate("0.00001"),
+
+		// no validation for this initially as we configure the
+		// the bootstrapping asset.
+		// validation will be added at node startup, so we can use dynamic stuff
+		// e.g: assets and collateral when setting up a new ID.
+		GovernanceVoteAsset: NewString().Mutable(true).MustUpdate("VOTE"),
 	}
 }

--- a/netparams/dispatch/dispatch.go
+++ b/netparams/dispatch/dispatch.go
@@ -1,0 +1,37 @@
+package dispatch
+
+import (
+	"fmt"
+
+	"code.vegaprotocol.io/vega/logging"
+)
+
+type Collateral interface {
+	UpdateGovernanceAsset(id string) error
+}
+
+type Assets interface {
+	IsEnabled(string) bool
+}
+
+func GovernanceAssetUpdate(
+	log *logging.Logger,
+	assets Assets,
+	collateral Collateral,
+) func(value string) error {
+	return func(value string) error {
+		if !assets.IsEnabled(value) {
+			log.Error("tried to push a governance update with an non-enabled asset",
+				logging.String("asset-id", value))
+			return fmt.Errorf("invalid asset %v", value)
+		}
+
+		if err := collateral.UpdateGovernanceAsset(value); err != nil {
+			log.Error("unable to update governance asset in collateral",
+				logging.String("asset-id", value),
+				logging.Error(err))
+			return fmt.Errorf("unable to update governance asset in collateral %w", err)
+		}
+		return nil
+	}
+}

--- a/netparams/dispatch/dispatch.go
+++ b/netparams/dispatch/dispatch.go
@@ -21,13 +21,13 @@ func GovernanceAssetUpdate(
 ) func(value string) error {
 	return func(value string) error {
 		if !assets.IsEnabled(value) {
-			log.Error("tried to push a governance update with an non-enabled asset",
+			log.Debug("tried to push a governance update with an non-enabled asset",
 				logging.String("asset-id", value))
 			return fmt.Errorf("invalid asset %v", value)
 		}
 
 		if err := collateral.UpdateGovernanceAsset(value); err != nil {
-			log.Error("unable to update governance asset in collateral",
+			log.Debug("unable to update governance asset in collateral",
 				logging.String("asset-id", value),
 				logging.Error(err))
 			return fmt.Errorf("unable to update governance asset in collateral %w", err)

--- a/netparams/keys.go
+++ b/netparams/keys.go
@@ -19,6 +19,8 @@ const (
 	MarketPriceMonitoringDefaultParameters        = "market.monitor.price.defaultParameters"
 	MarketPriceMonitoringUpdateFrequency          = "market.monitor.price.updateFrequency"
 
+	GovernanceVoteAsset = "governance.vote.asset"
+
 	// market proposal parameters
 	GovernanceProposalMarketMinClose              = "governance.proposal.market.minClose"
 	GovernanceProposalMarketMaxClose              = "governance.proposal.market.maxClose"

--- a/netparams/netparams.go
+++ b/netparams/netparams.go
@@ -36,13 +36,18 @@ type value interface {
 	ToString() (string, error)
 	ToDuration() (time.Duration, error)
 	ToJSONStruct(Reset) error
+	AddRules(...interface{}) error
+	GetDispatch() func(interface{}) error
+	CheckDispatch(interface{}) error
 }
 
-type NetParamWatcher func(string, string)
-
 type WatchParam struct {
-	param   string
-	watcher NetParamWatcher
+	Param string
+	// this is to be cast to a function accepting the
+	// inner type of the parameters
+	// e.g: for a String value, the expected function
+	// is to be of the type: func(string) error
+	Watcher interface{}
 }
 
 type Store struct {
@@ -52,7 +57,7 @@ type Store struct {
 	mu     sync.RWMutex
 	broker Broker
 
-	watchers     map[string][]NetParamWatcher
+	watchers     map[string][]WatchParam
 	paramUpdates map[string]struct{}
 }
 
@@ -64,7 +69,7 @@ func New(log *logging.Logger, cfg Config, broker Broker) *Store {
 		cfg:          cfg,
 		store:        defaultNetParams(),
 		broker:       broker,
-		watchers:     map[string][]NetParamWatcher{},
+		watchers:     map[string][]WatchParam{},
 		paramUpdates: map[string]struct{}{},
 	}
 }
@@ -92,18 +97,50 @@ func (s *Store) UponGenesis(ctx context.Context, rawState []byte) error {
 		}
 	}
 
+	// now we can iterate again over ALL the net params,
+	// and dispatch the value of them all so any watchers can get updated
+	// with genesis values
+	for k := range s.store {
+		if err := s.dispatchUpdate(k); err != nil {
+			return fmt.Errorf("could not propagate netparams update to listener, %v: %v", k, err)
+		}
+	}
+
 	return nil
 }
 
 // Watch a list of parameters updates
-func (s *Store) Watch(wp ...WatchParam) {
+func (s *Store) Watch(wp ...WatchParam) error {
 	for _, v := range wp {
-		if watchers, ok := s.watchers[v.param]; ok {
-			s.watchers[v.param] = append(watchers, v.watcher)
+		// type check the function to dispatch updates to
+		if err := s.store[v.Param].CheckDispatch(v.Watcher); err != nil {
+			return err
+		}
+		if watchers, ok := s.watchers[v.Param]; ok {
+			s.watchers[v.Param] = append(watchers, v)
 		} else {
-			s.watchers[v.param] = []NetParamWatcher{v.watcher}
+			s.watchers[v.Param] = []WatchParam{v}
 		}
 	}
+	return nil
+}
+
+// dispatch the update of a network parameters to all the listeners
+func (s *Store) dispatchUpdate(p string) error {
+	val := s.store[p]
+	fn := val.GetDispatch()
+
+	var err error
+	for _, v := range s.watchers[p] {
+		if newerr := fn(v.Watcher); newerr != nil {
+			if err != nil {
+				err = fmt.Errorf("%v, %w", err, newerr)
+			} else {
+				err = newerr
+			}
+		}
+	}
+	return err
 }
 
 // OnChainTimeUpdate is trigger once per blocks
@@ -113,9 +150,8 @@ func (s *Store) OnChainTimeUpdate(_ time.Time) {
 		return
 	}
 	for k := range s.paramUpdates {
-		val, _ := s.Get(k)
-		for _, w := range s.watchers[k] {
-			w(k, val)
+		if err := s.dispatchUpdate(k); err != nil {
+			s.log.Error("unable to dispatch netparams update", logging.Error(err))
 		}
 	}
 	s.paramUpdates = map[string]struct{}{}
@@ -249,4 +285,15 @@ func (s *Store) GetJSONStruct(key string, v Reset) error {
 		return ErrUnknownKey
 	}
 	return svalue.ToJSONStruct(v)
+}
+
+func (s *Store) AddRules(key string, fns ...interface{}) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	value, ok := s.store[key]
+	if !ok {
+		return ErrUnknownKey
+	}
+	return value.AddRules(fns...)
+
 }

--- a/netparams/netparams.go
+++ b/netparams/netparams.go
@@ -151,7 +151,7 @@ func (s *Store) OnChainTimeUpdate(_ time.Time) {
 	}
 	for k := range s.paramUpdates {
 		if err := s.dispatchUpdate(k); err != nil {
-			s.log.Error("unable to dispatch netparams update", logging.Error(err))
+			s.log.Debug("unable to dispatch netparams update", logging.Error(err))
 		}
 	}
 	s.paramUpdates = map[string]struct{}{}

--- a/netparams/values.go
+++ b/netparams/values.go
@@ -59,6 +59,35 @@ func NewFloat(rules ...FloatRule) *Float {
 	}
 }
 
+func (f *Float) GetDispatch() func(interface{}) error {
+	return func(rawfn interface{}) error {
+		// there can't be errors here, as all dispatcher
+		// should have been check earlier when being register
+		fn := rawfn.(func(float64) error)
+		return fn(f.value)
+	}
+}
+
+func (f *Float) CheckDispatch(fn interface{}) error {
+	if _, ok := fn.(func(float64) error); !ok {
+		return errors.New("invalid type, expected func(float64) error")
+	}
+	return nil
+}
+
+func (f *Float) AddRules(fns ...interface{}) error {
+	for _, fn := range fns {
+		// asset they have the right type
+		v, ok := fn.(FloatRule)
+		if !ok {
+			return errors.New("floats require FloatRule functions")
+		}
+		f.rules = append(f.rules, v)
+	}
+
+	return nil
+}
+
 func (f *Float) ToFloat() (float64, error) {
 	return f.value, nil
 }
@@ -181,6 +210,35 @@ func NewInt(rules ...IntRule) *Int {
 		baseValue: &baseValue{},
 		rules:     rules,
 	}
+}
+
+func (i *Int) GetDispatch() func(interface{}) error {
+	return func(rawfn interface{}) error {
+		// there can't be errors here, as all dispatcher
+		// should have been check earlier when being register
+		fn := rawfn.(func(int64) error)
+		return fn(i.value)
+	}
+}
+
+func (i *Int) CheckDispatch(fn interface{}) error {
+	if _, ok := fn.(func(int64) error); !ok {
+		return errors.New("invalid type, expected func(int64) error")
+	}
+	return nil
+}
+
+func (i *Int) AddRules(fns ...interface{}) error {
+	for _, fn := range fns {
+		// asset they have the right type
+		v, ok := fn.(IntRule)
+		if !ok {
+			return errors.New("ints require IntRule functions")
+		}
+		i.rules = append(i.rules, v)
+	}
+
+	return nil
 }
 
 func (i *Int) ToInt() (int64, error) {
@@ -306,6 +364,35 @@ func NewDuration(rules ...DurationRule) *Duration {
 	}
 }
 
+func (d *Duration) GetDispatch() func(interface{}) error {
+	return func(rawfn interface{}) error {
+		// there can't be errors here, as all dispatcher
+		// should have been check earlier when being register
+		fn := rawfn.(func(time.Duration) error)
+		return fn(d.value)
+	}
+}
+
+func (d *Duration) CheckDispatch(fn interface{}) error {
+	if _, ok := fn.(func(time.Duration) error); !ok {
+		return errors.New("invalid type, expected func(time.Duration) error")
+	}
+	return nil
+}
+
+func (d *Duration) AddRules(fns ...interface{}) error {
+	for _, fn := range fns {
+		// asset they have the right type
+		v, ok := fn.(DurationRule)
+		if !ok {
+			return errors.New("durations require DurationRule functions")
+		}
+		d.rules = append(d.rules, v)
+	}
+
+	return nil
+}
+
 func (d *Duration) ToDuration() (time.Duration, error) {
 	return d.value, nil
 }
@@ -412,18 +499,18 @@ func DurationLT(i time.Duration) func(time.Duration) error {
 	}
 }
 
-type JSONValidate func(interface{}) error
+type JSONRule func(interface{}) error
 
 type JSON struct {
 	*baseValue
 	value   Reset
 	ty      reflect.Type
 	rawval  string
-	v       JSONValidate
+	rules   []JSONRule
 	mutable bool
 }
 
-func NewJSON(val Reset, validate JSONValidate) *JSON {
+func NewJSON(val Reset, rules ...JSONRule) *JSON {
 	if val == nil {
 		panic("JSON values requires non nil pointers")
 	}
@@ -433,7 +520,7 @@ func NewJSON(val Reset, validate JSONValidate) *JSON {
 	}
 	return &JSON{
 		baseValue: &baseValue{},
-		v:         validate,
+		rules:     rules,
 		ty:        ty,
 		value:     val,
 	}
@@ -452,6 +539,36 @@ func (j *JSON) ToJSONStruct(v Reset) error {
 	return json.Unmarshal([]byte(j.rawval), v)
 }
 
+func (j *JSON) GetDispatch() func(interface{}) error {
+	return func(rawfn interface{}) error {
+		// there can't be errors here, as all dispatcher
+		// should have been check earlier when being register
+		fn := rawfn.(func(interface{}) error)
+		json.Unmarshal([]byte(j.rawval), j.value)
+		return fn(j.value)
+	}
+}
+
+func (j *JSON) CheckDispatch(fn interface{}) error {
+	if _, ok := fn.(func(interface{}) error); !ok {
+		return errors.New("invalid type, expected func(float64) error")
+	}
+	return nil
+}
+
+func (j *JSON) AddRules(fns ...interface{}) error {
+	for _, fn := range fns {
+		// asset they have the right type
+		v, ok := fn.(JSONRule)
+		if !ok {
+			return errors.New("JSONs require JSONRule functions")
+		}
+		j.rules = append(j.rules, v)
+	}
+
+	return nil
+}
+
 func (j *JSON) validateValue(value []byte) error {
 	j.value.Reset()
 	d := json.NewDecoder(bytes.NewReader([]byte(value)))
@@ -468,7 +585,18 @@ func (j *JSON) Validate(value string) error {
 	if !j.mutable {
 		return errors.New("value is not mutable")
 	}
-	return j.v(j.value)
+
+	for _, fn := range j.rules {
+		if newerr := fn(j.value); newerr != nil {
+			if err != nil {
+				err = fmt.Errorf("%v, %w", err, newerr)
+			} else {
+				err = newerr
+			}
+		}
+	}
+
+	return err
 }
 
 func (j *JSON) Update(value string) error {
@@ -481,7 +609,17 @@ func (j *JSON) Update(value string) error {
 		return errors.New("value is not mutable")
 	}
 
-	if err = j.v(j.value); err != nil {
+	for _, fn := range j.rules {
+		if newerr := fn(j.value); newerr != nil {
+			if err != nil {
+				err = fmt.Errorf("%v, %w", err, newerr)
+			} else {
+				err = newerr
+			}
+		}
+	}
+
+	if err != nil {
 		return err
 	}
 
@@ -510,4 +648,112 @@ func JSONProtoValidator() func(interface{}) error {
 	return func(t interface{}) error {
 		return validators.CallValidatorIfExists(t)
 	}
+}
+
+type StringRule func(string) error
+
+type String struct {
+	*baseValue
+	rawval  string
+	rules   []StringRule
+	mutable bool
+}
+
+func NewString(rules ...StringRule) *String {
+	return &String{
+		baseValue: &baseValue{},
+		rules:     rules,
+	}
+}
+
+func (s *String) GetDispatch() func(interface{}) error {
+	return func(rawfn interface{}) error {
+		// there can't be errors here, as all dispatcher
+		// should have been check earlier when being register
+		fn := rawfn.(func(string) error)
+		return fn(s.rawval)
+	}
+}
+
+func (s *String) CheckDispatch(fn interface{}) error {
+	if _, ok := fn.(func(string) error); !ok {
+		return errors.New("invalid type, expected func(string) error")
+	}
+	return nil
+}
+
+func (s *String) AddRules(fns ...interface{}) error {
+	for _, fn := range fns {
+		// asset they have the right type
+		v, ok := fn.(StringRule)
+		if !ok {
+			return errors.New("strings require StringRule functions")
+		}
+		s.rules = append(s.rules, v)
+	}
+
+	return nil
+}
+
+func (s *String) ToString() (string, error) {
+	return s.rawval, nil
+}
+
+func (s *String) Validate(value string) error {
+	if !s.mutable {
+		return errors.New("value is not mutable")
+	}
+
+	var err error
+	for _, fn := range s.rules {
+		if newerr := fn(value); newerr != nil {
+			if err != nil {
+				err = fmt.Errorf("%v, %w", err, newerr)
+			} else {
+				err = newerr
+			}
+		}
+	}
+
+	return err
+}
+
+func (s *String) Update(value string) error {
+	if !s.mutable {
+		return errors.New("value is not mutable")
+	}
+
+	var err error
+	for _, fn := range s.rules {
+		if newerr := fn(value); newerr != nil {
+			if err != nil {
+				err = fmt.Errorf("%v, %w", err, newerr)
+			} else {
+				err = newerr
+			}
+		}
+	}
+
+	if err == nil {
+		s.rawval = value
+	}
+
+	return err
+}
+
+func (s *String) Mutable(b bool) *String {
+	s.mutable = b
+	return s
+}
+
+func (s *String) MustUpdate(value string) *String {
+	err := s.Update(value)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (s *String) String() string {
+	return s.rawval
 }

--- a/wallet/auth.go
+++ b/wallet/auth.go
@@ -10,10 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/logging"
+
 	"github.com/dgrijalva/jwt-go/v4"
 	"github.com/julienschmidt/httprouter"
-	"golang.org/x/crypto/sha3"
 )
 
 var (
@@ -163,9 +164,7 @@ func ExtractToken(f func(string, http.ResponseWriter, *http.Request, httprouter.
 }
 
 func genSession() string {
-	hasher := sha3.New256()
-	hasher.Write([]byte(randSeq(10)))
-	return hex.EncodeToString(hasher.Sum(nil))
+	return hex.EncodeToString(crypto.Hash([]byte(randSeq(10))))
 }
 
 var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")

--- a/wallet/crypto/ed25519.go
+++ b/wallet/crypto/ed25519.go
@@ -4,6 +4,8 @@ import (
 	"crypto"
 	"errors"
 
+	vcrypto "code.vegaprotocol.io/vega/crypto"
+
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -36,7 +38,7 @@ func (e *ed25519Sig) Sign(priv crypto.PrivateKey, buf []byte) ([]byte, error) {
 	if len(privBytes) != ed25519.PrivateKeySize {
 		return nil, ErrBadED25519PrivateKeyLength
 	}
-	return ed25519.Sign(privBytes, hash(buf)), nil
+	return ed25519.Sign(privBytes, vcrypto.Hash(buf)), nil
 }
 
 func (e *ed25519Sig) Verify(pub crypto.PublicKey, message, sig []byte) (bool, error) {
@@ -45,7 +47,7 @@ func (e *ed25519Sig) Verify(pub crypto.PublicKey, message, sig []byte) (bool, er
 	if len(pubBytes) != ed25519.PublicKeySize {
 		return false, ErrBadED25519PublicKeyLength
 	}
-	return ed25519.Verify(pubBytes, hash(message), sig), nil
+	return ed25519.Verify(pubBytes, vcrypto.Hash(message), sig), nil
 }
 
 func (e *ed25519Sig) Name() string {

--- a/wallet/crypto/encryption.go
+++ b/wallet/crypto/encryption.go
@@ -6,17 +6,11 @@ import (
 	"crypto/rand"
 	"io"
 
-	"golang.org/x/crypto/sha3"
+	"code.vegaprotocol.io/vega/crypto"
 )
 
-func hash(key []byte) []byte {
-	hasher := sha3.New256()
-	hasher.Write([]byte(key))
-	return hasher.Sum(nil)
-}
-
 func Encrypt(data []byte, passphrase string) ([]byte, error) {
-	block, _ := aes.NewCipher(hash([]byte(passphrase)))
+	block, _ := aes.NewCipher(crypto.Hash([]byte(passphrase)))
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, err
@@ -30,7 +24,7 @@ func Encrypt(data []byte, passphrase string) ([]byte, error) {
 }
 
 func Decrypt(data []byte, passphrase string) ([]byte, error) {
-	key := hash([]byte(passphrase))
+	key := crypto.Hash([]byte(passphrase))
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This add a few things:
- asset defined in the genesis block require an ID.
 - the one defined with the genesis command already have an ID.
- the governance asset is defined now as a normal asset in the list of genesis asset
- a new network parameter is introduce to specify what asset is the governance asset (setup to VOTE token initially).
- new function to dispatch, and add a custome validation rule for each values (this was needed so we can add non static checks. e.g: for now we could check simple rules like a string is not empty, etc, now we can introduce more complex checks like ensure that this ID exists in the collateral, or in the assets list, etc).

close #2515 
close #2391 