### PR TITLE
close channel in sender routine, once data is sent in stream events bus

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -116,7 +116,7 @@ steps:
         - pull_request
 
   - name: systemtests-PR
-    image: docker.pkg.github.com/vegaprotocol/system-tests/system-tests:latest
+    image: docker.pkg.github.com/vegaprotocol/system-tests/system-tests:develop
     pull: always
     environment:
       GITHUB_API_TOKEN:

--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -2128,9 +2128,9 @@ func (t *tradingDataService) recvEventRequest(
 ) (*protoapi.ObserveEventsRequest, error) {
 	readCtx, cfunc := context.WithTimeout(stream.Context(), 5*time.Second)
 	oebCh := make(chan protoapi.ObserveEventsRequest)
-	defer close(oebCh)
 	var err error
 	go func() {
+		defer close(oebCh)
 		nb := protoapi.ObserveEventsRequest{}
 		if err = stream.RecvMsg(&nb); err != nil {
 			cfunc()


### PR DESCRIPTION
We were closing the channel in the routine receiving the data if the timeout was done.
We now do it in he sender channel, once data is sent.

close #2532 