### PR TITLE
Allow zero price for pegged orders

### DIFF
--- a/orders/service.go
+++ b/orders/service.go
@@ -179,7 +179,8 @@ func (s *Svc) validateOrderSubmission(sub *types.OrderSubmission) error {
 		(sub.TimeInForce != types.Order_TIF_FOK && sub.TimeInForce != types.Order_TIF_IOC) {
 		return ErrInvalidTimeInForceForMarketOrder
 	}
-	if sub.Type == types.Order_TYPE_LIMIT && sub.Price == 0 {
+	if sub.Type == types.Order_TYPE_LIMIT && sub.Price == 0 &&
+		sub.PeggedOrder == nil {
 		return ErrInvalidPriceForLimitOrder
 	}
 	if sub.Type == types.Order_TYPE_NETWORK {


### PR DESCRIPTION
The code currently rejects a new order if the order type is LIMIT and a zero price is given. 
This breaks pegged orders which are also LIMIT orders and have a zero price.
I've fixed the validation logic to allow this to happen correctly