### PR TITLE
Add proposal ID to the Vote type

### DIFF
--- a/gateway/graphql/modelext.go
+++ b/gateway/graphql/modelext.go
@@ -842,9 +842,10 @@ func ProposalVoteFromProto(v *types.Vote, caster *types.Party) *ProposalVote {
 	value, _ := convertVoteValueFromProto(v.Value)
 	return &ProposalVote{
 		Vote: &Vote{
-			Party:    caster,
-			Value:    value,
-			Datetime: nanoTSToDatetime(v.Timestamp),
+			Party:      caster,
+			Value:      value,
+			Datetime:   nanoTSToDatetime(v.Timestamp),
+			ProposalID: v.ProposalID,
 		},
 		ProposalID: v.ProposalID,
 	}
@@ -1117,7 +1118,8 @@ func eventFromProto(e *types.BusEvent) Event {
 			Party: &types.Party{
 				Id: v.PartyID,
 			},
-			Datetime: nanoTSToDatetime(v.Timestamp),
+			Datetime:   nanoTSToDatetime(v.Timestamp),
+			ProposalID: v.ProposalID,
 		}
 	case types.BusEventType_BUS_EVENT_TYPE_MARKET_DATA:
 		return e.GetMarketData()

--- a/gateway/graphql/models.go
+++ b/gateway/graphql/models.go
@@ -689,6 +689,8 @@ type Vote struct {
 	Party *proto.Party `json:"party"`
 	// ISO-8601 time and date when the vote reached Vega network
 	Datetime string `json:"datetime"`
+	// The ID of the proposal this vote applies to
+	ProposalID string `json:"proposalId"`
 }
 
 func (Vote) IsEvent() {}

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -2064,6 +2064,9 @@ type Vote {
 
   "ISO-8601 time and date when the vote reached Vega network"
   datetime: String!
+
+  "The ID of the proposal this vote applies to"
+  proposalId: ID!
 }
 
 type ProposalVote {


### PR DESCRIPTION
The GQL vote type was missing the proposal ID field. This PR adds it

I've noticed we're using a `ProposalVote` type in other places which is the old `Vote` type + a proposal ID field. We should be able to unify the two types now. I can do this as part of the PR, if that works for @edd and @mattrussell36 