### PR TITLE
Cancelling a parked pegged order now sets the correct status

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1727,21 +1727,22 @@ func (m *Market) CancelOrder(ctx context.Context, partyID, orderID string) (*typ
 			}
 			return nil, err
 		}
+		_, err = m.position.UnregisterOrder(order)
+		if err != nil {
+			m.log.Error("Failure unregistering order in positions engine (cancel)",
+				logging.Order(*order),
+				logging.Error(err))
+		}
 	}
 
 	// Update the order in our stores (will be marked as cancelled)
 	order.UpdatedAt = m.currentTime.UnixNano()
 	m.broker.Send(events.NewOrderEvent(ctx, order))
-	_, err = m.position.UnregisterOrder(order)
-	if err != nil {
-		m.log.Error("Failure unregistering order in positions engine (cancel)",
-			logging.Order(*order),
-			logging.Error(err))
-	}
 
 	// If this is a pegged order, remove from pegged and parked lists
 	if order.PeggedOrder != nil {
 		m.removePeggedOrder(order)
+		order.Status = types.Order_STATUS_CANCELLED
 	}
 	m.checkForReferenceMoves(ctx)
 	return &types.OrderCancellationConfirmation{Order: order}, nil

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -623,6 +623,7 @@ func TestPeggedOrders(t *testing.T) {
 	t.Run("pegged orders are handled correctly when moving out of auction", testPeggedOrdersLeavingAuction)
 	t.Run("pegged orders amend to move reference", testPeggedOrderAmendToMoveReference)
 	t.Run("pegged orders are removed when expired", testPeggedOrderExpiring)
+	t.Run("pegged order cancel a parked order", testPeggedOrderCancelParked)
 }
 
 func testPeggedOrderAmendToMoveReference(t *testing.T) {
@@ -938,6 +939,28 @@ func testPeggedOrderTypes(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func testPeggedOrderCancelParked(t *testing.T) {
+	now := time.Unix(10, 0)
+	closeSec := int64(10000000000)
+	closingAt := time.Unix(closeSec, 0)
+	tm := getTestMarket(t, now, closingAt, nil)
+
+	addAccount(tm, "party1")
+	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	// Pegged order will be parked as no reference prices
+	order := getOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, 0, types.Side_SIDE_BUY, "party1", 10, 100)
+	order.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Offset: -3}
+	confirmation, err := tm.market.SubmitOrder(context.Background(), &order)
+	require.NotNil(t, confirmation)
+	assert.NoError(t, err)
+
+	// Attempt to cancel the parked order
+	cancelled, err := tm.market.CancelOrderByID(confirmation.Order.Id)
+	require.NotNil(t, cancelled)
+	assert.Equal(t, types.Order_STATUS_CANCELLED, cancelled.Order.Status)
+}
+
 func testPeggedOrderTIFs(t *testing.T) {
 	now := time.Unix(10, 0)
 	closeSec := int64(10000000000)
@@ -1156,9 +1179,6 @@ func testPeggedOrderParkWhenPriceRepricesBelowZero(t *testing.T) {
 	amendOrder(t, tm, "buyer", buy.Id, 0, 1, types.Order_TIF_UNSPECIFIED, 0, true)
 
 	assert.Equal(t, types.Order_STATUS_PARKED.String(), confirmation.Order.Status.String())
-	//	assert.Equal(t,
-	//		types.Order_STATUS_PARKED.String(),
-	//		confirmation.Order.Status.String(), "When pegged price below zero (MIDPRICE - OFFSET) <= 0")
 }
 
 func testPeggedOrderRepricing(t *testing.T) {


### PR DESCRIPTION
When a pegged order is parked and then cancelled, we did not set the order status to cancelled.
This PR fixes that.