### PR TITLE
Refactor liquidity calcs

### DIFF
--- a/liquidity/supplied/engine.go
+++ b/liquidity/supplied/engine.go
@@ -48,13 +48,13 @@ type Engine struct {
 }
 
 // NewEngine returns a reference to a new supplied liquidity calculation engine
-func NewEngine(riskModel RiskModel, priceMonitor PriceMonitor) (*Engine, error) {
+func NewEngine(riskModel RiskModel, priceMonitor PriceMonitor) *Engine {
 	return &Engine{
 		rm: riskModel,
 		pm: priceMonitor,
 
 		horizon: riskModel.GetProjectionHorizon(),
-	}, nil
+	}
 }
 
 // CalculateSuppliedLiquidity returns the current supplied liquidity per specified current mark price and order set

--- a/liquidity/supplied/engine.go
+++ b/liquidity/supplied/engine.go
@@ -11,8 +11,7 @@ import (
 // This could happen when for a given side (buy or sell) limit orders don't supply enough liquidity and there aren't any
 // valid pegged orders (all the prives are invalid) to cover it with.
 var (
-	ErrNoValidOrders   = errors.New("no valid orders to cover the liquidity obligation with")
-	ErrNoYearFractions = errors.New("price monitor returned no trigger horizon year fractions")
+	ErrNoValidOrders = errors.New("no valid orders to cover the liquidity obligation with")
 )
 
 // LiquidityOrder contains information required to compute volume required to fullfil liquidity obligation per set of liquidity provision orders for one side of the order book
@@ -27,12 +26,12 @@ type LiquidityOrder struct {
 // RiskModel allows calculation of min/max price range and a probability of trading.
 type RiskModel interface {
 	ProbabilityOfTrading(currentPrice, yearFraction, orderPrice float64, isBid bool, applyMinMax bool, minPrice float64, maxPrice float64) float64
+	GetProjectionHorizon() float64
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/price_monitor_mock.go -package mocks code.vegaprotocol.io/vega/liquidity/supplied PriceMonitor
 // PriceMonitor provides the range of valid prices, that is prices that wouldn't trade the current trading mode
 type PriceMonitor interface {
-	GetHorizonYearFractions() []float64
 	GetValidPriceRange() (float64, float64)
 }
 
@@ -41,7 +40,6 @@ type Engine struct {
 	rm RiskModel
 	pm PriceMonitor
 
-	horizon   float64 // price projection horizon expressed as year fraction
 	cachedMin float64
 	cachedMax float64
 	bCache    map[uint64]float64
@@ -50,15 +48,9 @@ type Engine struct {
 
 // NewEngine returns a reference to a new supplied liquidity calculation engine
 func NewEngine(riskModel RiskModel, priceMonitor PriceMonitor) (*Engine, error) {
-	yfs := priceMonitor.GetHorizonYearFractions()
-	if len(yfs) == 0 {
-		return nil, ErrNoYearFractions
-	}
-
 	return &Engine{
-		rm:      riskModel,
-		pm:      priceMonitor,
-		horizon: yfs[0],
+		rm: riskModel,
+		pm: priceMonitor,
 	}, nil
 }
 
@@ -167,7 +159,7 @@ func (e *Engine) getProbabilityOfTrading(currentPrice float64, orderPrice uint64
 	}
 
 	if prob, ok := cache[orderPrice]; !ok {
-		prob = e.rm.ProbabilityOfTrading(currentPrice, e.horizon, float64(orderPrice), isBid, true, minPrice, maxPrice)
+		prob = e.rm.ProbabilityOfTrading(currentPrice, e.rm.GetProjectionHorizon(), float64(orderPrice), isBid, true, minPrice, maxPrice)
 		cache[orderPrice] = prob
 	}
 	return cache[orderPrice]

--- a/liquidity/supplied/engine.go
+++ b/liquidity/supplied/engine.go
@@ -40,6 +40,7 @@ type Engine struct {
 	rm RiskModel
 	pm PriceMonitor
 
+	horizon   float64 // projection horizon used in probability calculations
 	cachedMin float64
 	cachedMax float64
 	bCache    map[uint64]float64
@@ -51,6 +52,8 @@ func NewEngine(riskModel RiskModel, priceMonitor PriceMonitor) (*Engine, error) 
 	return &Engine{
 		rm: riskModel,
 		pm: priceMonitor,
+
+		horizon: riskModel.GetProjectionHorizon(),
 	}, nil
 }
 
@@ -159,7 +162,7 @@ func (e *Engine) getProbabilityOfTrading(currentPrice float64, orderPrice uint64
 	}
 
 	if prob, ok := cache[orderPrice]; !ok {
-		prob = e.rm.ProbabilityOfTrading(currentPrice, e.rm.GetProjectionHorizon(), float64(orderPrice), isBid, true, minPrice, maxPrice)
+		prob = e.rm.ProbabilityOfTrading(currentPrice, e.horizon, float64(orderPrice), isBid, true, minPrice, maxPrice)
 		cache[orderPrice] = prob
 	}
 	return cache[orderPrice]

--- a/liquidity/supplied/engine_test.go
+++ b/liquidity/supplied/engine_test.go
@@ -30,8 +30,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	// No orders
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(1)
 
-	engine, err := supplied.NewEngine(riskModel, priceMonitor)
-	require.NoError(t, err)
+	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
 	liquidity, err := engine.CalculateSuppliedLiquidity(MarkPrice, []types.Order{})
@@ -137,13 +136,12 @@ func Test_InteralConsistency(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(buy.Price), true, true, minPrice, maxPrice).Return(validBuy1Prob).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(sell.Price), false, true, minPrice, maxPrice).Return(validSell1Prob).Times(1)
 
-	engine, err := supplied.NewEngine(riskModel, priceMonitor)
-	require.NoError(t, err)
+	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
 	// Negative liquidity obligation -> 0 sizes on all orders
 	liquidityObligation := 100.0
-	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
+	err := engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
 	require.NoError(t, err)
 
 	var zero uint64 = 0
@@ -218,13 +216,12 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(validSell1.Price), false, true, minPrice, maxPrice).Return(validSell1Prob).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(validSell2.Price), false, true, minPrice, maxPrice).Return(validSell2Prob).Times(1)
 
-	engine, err := supplied.NewEngine(riskModel, priceMonitor)
-	require.NoError(t, err)
+	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
 	// Negative liquidity obligation -> 0 sizes on all orders
 	liquidityObligation := -2.5
-	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
+	err := engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
 	require.NoError(t, err)
 
 	var zero uint64 = 0
@@ -342,8 +339,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(validSell1.Price), false, true, minPrice, maxPrice).Return(0.22).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(validSell2.Price), false, true, minPrice, maxPrice).Return(0.11).Times(1)
 
-	engine, err := supplied.NewEngine(riskModel, priceMonitor)
-	require.NoError(t, err)
+	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
 	liquidityObligation := 123.45
@@ -564,13 +560,12 @@ func TestCalculateLiquidityImpliedSizes_NoValidOrders(t *testing.T) {
 	}
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(invalidBuy.Price), true, true, minPrice, maxPrice).Return(0.0).Times(1)
 
-	engine, err := supplied.NewEngine(riskModel, priceMonitor)
-	require.NoError(t, err)
+	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
 	liquidityObligation := 20.0
 	// Expecting an error as limit orders don't cover the obligation there are no valid orders to calculate size for
-	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
+	err := engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
 	require.Error(t, err)
 
 	// Same when there just aren't any buy/sell shapes
@@ -612,8 +607,7 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(order1.Price), true, true, minPrice, maxPrice).Return(0.123).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(order2.Price), false, true, minPrice, maxPrice).Return(0.234).Times(1)
 
-	engine, err := supplied.NewEngine(riskModel, priceMonitor)
-	require.NoError(t, err)
+	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
 	liquidity1, err := engine.CalculateSuppliedLiquidity(MarkPrice, orders)

--- a/liquidity/supplied/engine_test.go
+++ b/liquidity/supplied/engine_test.go
@@ -22,7 +22,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	defer ctrl.Finish()
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
-	priceMonitor.EXPECT().GetHorizonYearFractions().Return([]float64{Horizon}).Times(1)
+	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 
 	minPrice := 89.2
 	maxPrice := 111.1
@@ -105,7 +105,7 @@ func Test_InteralConsistency(t *testing.T) {
 	defer ctrl.Finish()
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
-	priceMonitor.EXPECT().GetHorizonYearFractions().Return([]float64{Horizon}).Times(1)
+	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 	minPrice := 89.2
 	maxPrice := 111.1
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(2)
@@ -162,7 +162,7 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 	defer ctrl.Finish()
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
-	priceMonitor.EXPECT().GetHorizonYearFractions().Return([]float64{Horizon}).Times(1)
+	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 	minPrice := 89.2
 	maxPrice := 111.1
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(6)
@@ -292,7 +292,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 	defer ctrl.Finish()
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
-	priceMonitor.EXPECT().GetHorizonYearFractions().Return([]float64{Horizon}).Times(1)
+	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 	minPrice := 89.2
 	maxPrice := 111.1
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(12)
@@ -537,7 +537,7 @@ func TestCalculateLiquidityImpliedSizes_NoValidOrders(t *testing.T) {
 	defer ctrl.Finish()
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
-	priceMonitor.EXPECT().GetHorizonYearFractions().Return([]float64{Horizon}).Times(1)
+	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 	minPrice := 89.2
 	maxPrice := 111.1
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(2)
@@ -583,7 +583,7 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	defer ctrl.Finish()
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
-	priceMonitor.EXPECT().GetHorizonYearFractions().Return([]float64{Horizon}).Times(1)
+	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 	minPrice := 89.2
 	maxPrice := 111.1
 

--- a/liquidity/supplied/mocks/price_monitor_mock.go
+++ b/liquidity/supplied/mocks/price_monitor_mock.go
@@ -32,20 +32,6 @@ func (m *MockPriceMonitor) EXPECT() *MockPriceMonitorMockRecorder {
 	return m.recorder
 }
 
-// GetHorizonYearFractions mocks base method
-func (m *MockPriceMonitor) GetHorizonYearFractions() []float64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHorizonYearFractions")
-	ret0, _ := ret[0].([]float64)
-	return ret0
-}
-
-// GetHorizonYearFractions indicates an expected call of GetHorizonYearFractions
-func (mr *MockPriceMonitorMockRecorder) GetHorizonYearFractions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHorizonYearFractions", reflect.TypeOf((*MockPriceMonitor)(nil).GetHorizonYearFractions))
-}
-
 // GetValidPriceRange mocks base method
 func (m *MockPriceMonitor) GetValidPriceRange() (float64, float64) {
 	m.ctrl.T.Helper()

--- a/liquidity/supplied/mocks/risk_model_mock.go
+++ b/liquidity/supplied/mocks/risk_model_mock.go
@@ -32,6 +32,20 @@ func (m *MockRiskModel) EXPECT() *MockRiskModelMockRecorder {
 	return m.recorder
 }
 
+// GetProjectionHorizon mocks base method
+func (m *MockRiskModel) GetProjectionHorizon() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProjectionHorizon")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetProjectionHorizon indicates an expected call of GetProjectionHorizon
+func (mr *MockRiskModelMockRecorder) GetProjectionHorizon() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectionHorizon", reflect.TypeOf((*MockRiskModel)(nil).GetProjectionHorizon))
+}
+
 // ProbabilityOfTrading mocks base method
 func (m *MockRiskModel) ProbabilityOfTrading(arg0, arg1, arg2 float64, arg3, arg4 bool, arg5, arg6 float64) float64 {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Small change to now rely on ProjectionHorizon returned by the risk model