### PR TITLE
Fix update order of message when cancelling a pegged order

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1735,15 +1735,16 @@ func (m *Market) CancelOrder(ctx context.Context, partyID, orderID string) (*typ
 		}
 	}
 
-	// Update the order in our stores (will be marked as cancelled)
-	order.UpdatedAt = m.currentTime.UnixNano()
-	m.broker.Send(events.NewOrderEvent(ctx, order))
-
 	// If this is a pegged order, remove from pegged and parked lists
 	if order.PeggedOrder != nil {
 		m.removePeggedOrder(order)
 		order.Status = types.Order_STATUS_CANCELLED
 	}
+
+	// Publish the changed order details
+	order.UpdatedAt = m.currentTime.UnixNano()
+	m.broker.Send(events.NewOrderEvent(ctx, order))
+
 	m.checkForReferenceMoves(ctx)
 	return &types.OrderCancellationConfirmation{Order: order}, nil
 }


### PR DESCRIPTION
The cancel event was being sent out before the status was set.
This PR changes that so the status is set before the event is published.