### PR TITLE
sort slice in GetHorizonYearFractions pricemonitoring

### DIFF
--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -134,6 +134,8 @@ func (e *Engine) GetHorizonYearFractions() []float64 {
 	for _, v := range e.fpHorizons {
 		h = append(h, v)
 	}
+
+	sort.Slice(h, func(i, j int) bool { return h[i] < h[j] })
 	return h
 }
 


### PR DESCRIPTION
The GetHorizonYearFracions in pricemonitoring expect the slice to be sorted.
Although the slice is created from a map, which are unordered in Go, therefore the slice can't be guaranteed to be sorted if we do not sort it.