### PR TITLE
Added handling of pegged orders for cancel all (#2589)

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1673,6 +1673,9 @@ func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.
 		return nil, err
 	}
 
+	// Create a slive ready to store the generated events in
+	evts := make([]events.Event, 0, len(m.parkedOrders)+len(cancellations))
+
 	// Check the parked order list of any orders from that same party
 	var parkedCancels []*types.OrderCancellationConfirmation
 	for _, order := range m.parkedOrders {
@@ -1680,7 +1683,7 @@ func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.
 			order.Status = types.Order_STATUS_CANCELLED
 			m.removePeggedOrder(order)
 			order.UpdatedAt = m.currentTime.UnixNano()
-			m.broker.Send(events.NewOrderEvent(ctx, order))
+			evts = append(evts, events.NewOrderEvent(ctx, order))
 
 			parkedCancel := &types.OrderCancellationConfirmation{
 				Order: order,
@@ -1697,7 +1700,7 @@ func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.
 
 		// Update the order in our stores (will be marked as cancelled)
 		cancellation.Order.UpdatedAt = m.currentTime.UnixNano()
-		m.broker.Send(events.NewOrderEvent(ctx, cancellation.Order))
+		evts = append(evts, events.NewOrderEvent(ctx, cancellation.Order))
 		_, err = m.position.UnregisterOrder(cancellation.Order)
 		if err != nil {
 			m.log.Error("Failure unregistering order in positions engine (cancel)",
@@ -1705,6 +1708,9 @@ func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.
 				logging.Error(err))
 		}
 	}
+
+	// Send off all the events in one big batch
+	m.broker.SendBatch(evts)
 
 	m.checkForReferenceMoves(ctx)
 

--- a/execution/market.go
+++ b/execution/market.go
@@ -1673,7 +1673,28 @@ func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.
 		return nil, err
 	}
 
+	// Check the parked order list of any orders from that same party
+	var parkedCancels []*types.OrderCancellationConfirmation
+	for _, order := range m.parkedOrders {
+		if order.PartyID == partyID {
+			order.Status = types.Order_STATUS_CANCELLED
+			m.removePeggedOrder(order)
+			order.UpdatedAt = m.currentTime.UnixNano()
+			m.broker.Send(events.NewOrderEvent(ctx, order))
+
+			parkedCancel := &types.OrderCancellationConfirmation{
+				Order: order,
+			}
+			parkedCancels = append(parkedCancels, parkedCancel)
+		}
+	}
+
 	for _, cancellation := range cancellations {
+		// if the order was a pegged order, remove from pegged list
+		if cancellation.Order.PeggedOrder != nil {
+			m.removePeggedOrder(cancellation.Order)
+		}
+
 		// Update the order in our stores (will be marked as cancelled)
 		cancellation.Order.UpdatedAt = m.currentTime.UnixNano()
 		m.broker.Send(events.NewOrderEvent(ctx, cancellation.Order))
@@ -1687,6 +1708,7 @@ func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.
 
 	m.checkForReferenceMoves(ctx)
 
+	cancellations = append(cancellations, parkedCancels...)
 	return cancellations, nil
 }
 


### PR DESCRIPTION
The code to handle cancelAll did not check the parked order list.
This PR addresses that emission.
