### PR TITLE
keep track of all balances and reject transaction from pubkey with no balances

### DIFF
--- a/banking/engine.go
+++ b/banking/engine.go
@@ -52,6 +52,7 @@ type Collateral interface {
 	Withdraw(ctx context.Context, partyID, asset string, amount uint64) error
 	LockFundsForWithdraw(ctx context.Context, partyID, asset string, amount uint64) error
 	EnableAsset(ctx context.Context, asset types.Asset) error
+	HasBalance(party string) bool
 }
 
 // ExtResChecker provide foreign chain resources validations
@@ -139,6 +140,10 @@ func (e *Engine) ReloadConf(cfg Config) {
 	}
 
 	e.cfg = cfg
+}
+
+func (e *Engine) HasBalance(party string) bool {
+	return e.col.HasBalance(party)
 }
 
 func (e *Engine) onCheckDone(i interface{}, valid bool) {

--- a/banking/mocks/collateral_mock.go
+++ b/banking/mocks/collateral_mock.go
@@ -62,6 +62,20 @@ func (mr *MockCollateralMockRecorder) EnableAsset(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableAsset", reflect.TypeOf((*MockCollateral)(nil).EnableAsset), arg0, arg1)
 }
 
+// HasBalance mocks base method
+func (m *MockCollateral) HasBalance(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasBalance", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasBalance indicates an expected call of HasBalance
+func (mr *MockCollateralMockRecorder) HasBalance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBalance", reflect.TypeOf((*MockCollateral)(nil).HasBalance), arg0)
+}
+
 // LockFundsForWithdraw mocks base method
 func (m *MockCollateral) LockFundsForWithdraw(arg0 context.Context, arg1, arg2 string, arg3 uint64) error {
 	m.ctrl.T.Helper()

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -133,7 +133,7 @@ func testPartyWithAccountsClearedOutHasNoBalance(t *testing.T) {
 
 	party := "myparty"
 	// create trader
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	acc, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
 	assert.NoError(t, err)
 
@@ -141,7 +141,11 @@ func testPartyWithAccountsClearedOutHasNoBalance(t *testing.T) {
 	err = eng.Engine.UpdateBalance(context.Background(), acc, 500)
 	assert.Nil(t, err)
 
-	assert.True(t, eng.HasBalance(party))
+	// then add some monites
+	err = eng.Engine.DecrementBalance(context.Background(), acc, 500)
+	assert.Nil(t, err)
+
+	assert.False(t, eng.HasBalance(party))
 }
 
 func testCreateBondAccountFailureNoGeneral(t *testing.T) {

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -80,6 +80,12 @@ func TestEnableAssets(t *testing.T) {
 	t.Run("create new account for bad asset - failure", testCreateNewAccountForBadAsset)
 }
 
+func TestBalanceTracking(t *testing.T) {
+	t.Run("test a party without any account has no balance", testPartyWithoutAccountHasNoBalance)
+	t.Run("test a party with an account has a balance", testPartyWithAccountHasABalance)
+	t.Run("test a party with accounts cleared out has no balance", testPartyWithAccountsClearedOutHasNoBalance)
+}
+
 func TestCollateralContinuousTradingFeeTransfer(t *testing.T) {
 	t.Run("Fees transfer continuous - no transfer", testFeesTransferContinuousNoTransfer)
 	t.Run("fees transfer continuous - not funds", testFeeTransferContinuousNoFunds)
@@ -94,6 +100,48 @@ func TestCollateralContinuousTradingFeeTransfer(t *testing.T) {
 func TestCreateBondAccount(t *testing.T) {
 	t.Run("create a bond account with success", testCreateBondAccountSuccess)
 	t.Run("create a bond account with - failure no general account", testCreateBondAccountFailureNoGeneral)
+}
+
+func testPartyWithoutAccountHasNoBalance(t *testing.T) {
+	eng := getTestEngine(t, "test-market", 0)
+	defer eng.Finish()
+
+	party := "myparty"
+	assert.False(t, eng.HasBalance(party))
+}
+
+func testPartyWithAccountHasABalance(t *testing.T) {
+	eng := getTestEngine(t, "test-market", 0)
+	defer eng.Finish()
+
+	party := "myparty"
+	// create trader
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	acc, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
+	assert.NoError(t, err)
+
+	// then add some monites
+	err = eng.Engine.UpdateBalance(context.Background(), acc, 500)
+	assert.Nil(t, err)
+
+	assert.True(t, eng.HasBalance(party))
+}
+
+func testPartyWithAccountsClearedOutHasNoBalance(t *testing.T) {
+	eng := getTestEngine(t, "test-market", 0)
+	defer eng.Finish()
+
+	party := "myparty"
+	// create trader
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	acc, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
+	assert.NoError(t, err)
+
+	// then add some monites
+	err = eng.Engine.UpdateBalance(context.Background(), acc, 500)
+	assert.Nil(t, err)
+
+	assert.True(t, eng.HasBalance(party))
 }
 
 func testCreateBondAccountFailureNoGeneral(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -41,4 +41,5 @@ require (
 	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a // indirect
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.23.0
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -811,6 +811,7 @@ gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/processor/abci_test.go
+++ b/processor/abci_test.go
@@ -12,10 +12,10 @@ import (
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/txn"
 	vegacrypto "code.vegaprotocol.io/vega/wallet/crypto"
-	"gotest.tools/assert"
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmtypes "github.com/tendermint/tendermint/abci/types"
 )

--- a/processor/abci_test.go
+++ b/processor/abci_test.go
@@ -204,7 +204,7 @@ func (s *AbciTestSuite) testBeginCallsCommanderOnce(t *testing.T, app *processor
 }
 
 func (s *AbciTestSuite) testOnCheckTxFailWithNoBalances(t *testing.T, app *processor.App, proc *procTest) {
-	proc.top.EXPECT().Exists(gomock.Any()).AnyTimes().Return(true)
+	proc.top.EXPECT().Exists(gomock.Any()).AnyTimes().Return(false)
 	proc.bank.EXPECT().HasBalance(gomock.Any()).AnyTimes().Return(false)
 
 	tx := txStub{pubkey: []byte("some pubkey")}
@@ -213,7 +213,7 @@ func (s *AbciTestSuite) testOnCheckTxFailWithNoBalances(t *testing.T, app *proce
 }
 
 func (s *AbciTestSuite) testOnCheckTxSuccessWithBalance(t *testing.T, app *processor.App, proc *procTest) {
-	proc.top.EXPECT().Exists(gomock.Any()).AnyTimes().Return(true)
+	proc.top.EXPECT().Exists(gomock.Any()).AnyTimes().Return(false)
 	proc.bank.EXPECT().HasBalance(gomock.Any()).AnyTimes().Return(true)
 
 	tx := txStub{pubkey: []byte("some pubkey")}

--- a/processor/abci_test.go
+++ b/processor/abci_test.go
@@ -1,6 +1,7 @@
 package processor_test
 
 import (
+	"context"
 	"crypto"
 	"encoding/hex"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/txn"
 	vegacrypto "code.vegaprotocol.io/vega/wallet/crypto"
+	"gotest.tools/assert"
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
@@ -201,6 +203,24 @@ func (s *AbciTestSuite) testBeginCallsCommanderOnce(t *testing.T, app *processor
 	})
 }
 
+func (s *AbciTestSuite) testOnCheckTxFailWithNoBalances(t *testing.T, app *processor.App, proc *procTest) {
+	proc.top.EXPECT().Exists(gomock.Any()).AnyTimes().Return(true)
+	proc.bank.EXPECT().HasBalance(gomock.Any()).AnyTimes().Return(false)
+
+	tx := txStub{pubkey: []byte("some pubkey")}
+	_, resp := app.OnCheckTx(context.Background(), tmtypes.RequestCheckTx{}, tx)
+	assert.Equal(t, resp.Code, uint32(51))
+}
+
+func (s *AbciTestSuite) testOnCheckTxSuccessWithBalance(t *testing.T, app *processor.App, proc *procTest) {
+	proc.top.EXPECT().Exists(gomock.Any()).AnyTimes().Return(true)
+	proc.bank.EXPECT().HasBalance(gomock.Any()).AnyTimes().Return(true)
+
+	tx := txStub{pubkey: []byte("some pubkey")}
+	_, resp := app.OnCheckTx(context.Background(), tmtypes.RequestCheckTx{}, tx)
+	assert.Equal(t, resp.Code, uint32(0))
+}
+
 func TestAbci(t *testing.T) {
 	sig := vegacrypto.NewEd25519()
 	s := &AbciTestSuite{
@@ -215,6 +235,8 @@ func TestAbci(t *testing.T) {
 
 		{"Call Begin and Commit - success", s.testBeginCommitSuccess},
 		{"Call Begin twice, only calls commander once", s.testBeginCallsCommanderOnce},
+		{"OnCheckTx fail with no balance", s.testOnCheckTxFailWithNoBalances},
+		{"OnCheckTx success with balance", s.testOnCheckTxSuccessWithBalance},
 	}
 
 	for _, test := range tests {
@@ -229,3 +251,15 @@ func TestAbci(t *testing.T) {
 		})
 	}
 }
+
+type txStub struct {
+	pubkey []byte
+}
+
+func (txStub) Command() txn.Command        { return txn.SubmitOrderCommand }
+func (txStub) Unmarshal(interface{}) error { return nil }
+func (t txStub) PubKey() []byte            { return t.pubkey }
+func (txStub) Hash() []byte                { return nil }
+func (txStub) Signature() []byte           { return nil }
+func (txStub) Validate() error             { return nil }
+func (txStub) BlockHeight() uint64         { return 0 }

--- a/processor/mocks/banking_mock.go
+++ b/processor/mocks/banking_mock.go
@@ -90,6 +90,20 @@ func (mr *MockBankingMockRecorder) EnableERC20(arg0, arg1, arg2, arg3 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableERC20", reflect.TypeOf((*MockBanking)(nil).EnableERC20), arg0, arg1, arg2, arg3)
 }
 
+// HasBalance mocks base method
+func (m *MockBanking) HasBalance(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasBalance", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasBalance indicates an expected call of HasBalance
+func (mr *MockBankingMockRecorder) HasBalance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBalance", reflect.TypeOf((*MockBanking)(nil).HasBalance), arg0)
+}
+
 // LockWithdrawalERC20 mocks base method
 func (m *MockBanking) LockWithdrawalERC20(arg0 context.Context, arg1, arg2, arg3 string, arg4 uint64, arg5 *proto.Erc20WithdrawExt) error {
 	m.ctrl.T.Helper()

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -161,4 +161,5 @@ type Banking interface {
 	DepositERC20(context.Context, *types.ERC20Deposit, string, uint64, uint64) error
 	LockWithdrawalERC20(context.Context, string, string, string, uint64, *types.Erc20WithdrawExt) error
 	WithdrawalERC20(*types.ERC20Withdrawal, uint64, uint64) error
+	HasBalance(string) bool
 }


### PR DESCRIPTION
Maintains a list of pubkeys that have deposited collateral, and rejects TXs from any that have no balance. This is an extra spam protection that we want for [:hedgehog: the First Public testnet](https://github.com/orgs/vegaprotocol/projects/16).

close #2590 