### PR TITLE
Prevent zero pegged price after reprice

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -539,7 +539,7 @@ func (m *Market) getNewPeggedPrice(ctx context.Context, order *types.Order) (uin
 	// At this stage offset is negative so we change it's sign to cast it to an
 	// unsigned type
 	offset := uint64(-order.PeggedOrder.Offset)
-	if price < offset {
+	if price <= offset {
 		return 0, ErrUnableToReprice
 	}
 


### PR DESCRIPTION
We mistakenly allowed a price of zero after reprice when the minimum value should be 1.
The code is updated to prevent this happening.