### PR TITLE
Expire pegged orders correctly (#2577)

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -2368,7 +2368,8 @@ func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 		if err == nil && originalOrder.Status != types.Order_STATUS_PARKED {
 			m.unregisterOrder(&order)
 		}
-		expiredPegs = append(expiredPegs, order)
+		originalOrder.Status = types.Order_STATUS_EXPIRED
+		expiredPegs = append(expiredPegs, originalOrder)
 	}
 
 	orderList := m.matching.RemoveExpiredOrders(timestamp)

--- a/execution/market.go
+++ b/execution/market.go
@@ -343,7 +343,7 @@ func (m *Market) GetMarketData() types.MarketData {
 		BestStaticOfferPrice:  bestStaticOfferPrice,
 		BestStaticOfferVolume: bestStaticOfferVolume,
 		MidPrice:              midPrice,
-		StaticMidPrice:		   staticMidPrice,
+		StaticMidPrice:        staticMidPrice,
 		MarkPrice:             m.markPrice,
 		Timestamp:             m.currentTime.UnixNano(),
 		OpenInterest:          m.position.GetOpenInterest(),
@@ -2348,6 +2348,7 @@ func (m *Market) orderAmendWhenParked(originalOrder, amendOrder *types.Order) (*
 }
 
 // RemoveExpiredOrders remove all expired orders from the order book
+// and also any pegged orders that are parked
 func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 	timer := metrics.NewTimeCounter(m.mkt.Id, "market", "RemoveExpiredOrders")
 	defer timer.EngineTimeCounterAdd()
@@ -2356,10 +2357,18 @@ func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 		return nil, ErrMarketClosed
 	}
 
+	expiredPegs := []types.Order{}
 	for _, order := range m.expiringPeggedOrders.Expire(timestamp) {
 		order := order
 		m.removePeggedOrder(&order)
-		m.unregisterOrder(&order)
+
+		// The pegged expiry orders are copies and do not reflect the
+		// current state of the order, therefore we look it up
+		originalOrder, _, err := m.getOrderByID(order.Id)
+		if err == nil && originalOrder.Status != types.Order_STATUS_PARKED {
+			m.unregisterOrder(&order)
+		}
+		expiredPegs = append(expiredPegs, order)
 	}
 
 	orderList := m.matching.RemoveExpiredOrders(timestamp)
@@ -2368,6 +2377,8 @@ func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 		order := order
 		m.unregisterOrder(&order)
 	}
+
+	orderList = append(orderList, expiredPegs...)
 
 	return orderList, nil
 }

--- a/execution/market.go
+++ b/execution/market.go
@@ -2360,7 +2360,6 @@ func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 	expiredPegs := []types.Order{}
 	for _, order := range m.expiringPeggedOrders.Expire(timestamp) {
 		order := order
-		m.removePeggedOrder(&order)
 
 		// The pegged expiry orders are copies and do not reflect the
 		// current state of the order, therefore we look it up
@@ -2368,8 +2367,9 @@ func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 		if err == nil && originalOrder.Status != types.Order_STATUS_PARKED {
 			m.unregisterOrder(&order)
 		}
+		m.removePeggedOrder(&order)
 		originalOrder.Status = types.Order_STATUS_EXPIRED
-		expiredPegs = append(expiredPegs, originalOrder)
+		expiredPegs = append(expiredPegs, *originalOrder)
 	}
 
 	orderList := m.matching.RemoveExpiredOrders(timestamp)

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -636,6 +636,7 @@ func TestPeggedOrders(t *testing.T) {
 	t.Run("pegged order cancel a parked order", testPeggedOrderCancelParked)
 	t.Run("pegged order reprice when no limit orders", testPeggedOrderRepriceCrashWhenNoLimitOrders)
 	t.Run("pegged orders cancelall", testPeggedOrderParkCancelAll)
+	t.Run("pegged orders expiring 2", testPeggedOrderExpiring2)
 }
 
 func testPeggedOrderRepriceCrashWhenNoLimitOrders(t *testing.T) {
@@ -1314,6 +1315,52 @@ func testPeggedOrderParkCancelAll(t *testing.T) {
 	assert.Equal(t, 3, len(cancelConf))
 }
 
+func testPeggedOrderExpiring2(t *testing.T) {
+	now := time.Unix(10, 0)
+	expire := now.Add(time.Second * 100)
+	afterexpire := now.Add(time.Second * 200)
+	closeSec := int64(10000000000)
+	closingAt := time.Unix(closeSec, 0)
+	tm := getTestMarket(t, now, closingAt, nil)
+	ctx := context.Background()
+
+	addAccount(tm, "user")
+	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	// Send one normal expiring order
+	limitOrder := sendOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTT, expire.UnixNano(), types.Side_SIDE_BUY, "user", 10, 100)
+	require.NotEmpty(t, limitOrder)
+
+	// Amend the expiry time
+	amendOrder(t, tm, "user", limitOrder, 0, 0, types.Order_TIF_UNSPECIFIED, now.UnixNano(), true)
+
+	// Send one pegged order that will be parked
+	order := getOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTT, expire.UnixNano(), types.Side_SIDE_BUY, "user", 10, 0)
+	order.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Offset: -5}
+	confirmation, err := tm.market.SubmitOrder(ctx, &order)
+	require.NoError(t, err)
+	assert.NotNil(t, confirmation)
+
+	// Send one pegged order that will be live
+	order2 := getOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTT, expire.UnixNano(), types.Side_SIDE_BUY, "user", 10, 0)
+	order2.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -5}
+	confirmation, err = tm.market.SubmitOrder(ctx, &order2)
+	require.NoError(t, err)
+	assert.NotNil(t, confirmation)
+
+	assert.Equal(t, 1, tm.market.GetParkedOrderCount())
+	assert.Equal(t, 2, tm.market.GetPeggedOrderCount())
+
+	// Move the time forward
+	orders, err := tm.market.RemoveExpiredOrders(afterexpire.UnixNano())
+	require.NotNil(t, orders)
+	assert.NoError(t, err)
+
+	// Check that we have no pegged orders
+	assert.Equal(t, 0, tm.market.GetParkedOrderCount())
+	assert.Equal(t, 0, tm.market.GetPeggedOrderCount())
+}
+
 func testPeggedOrderRepricing(t *testing.T) {
 	// Create the market
 	now := time.Unix(10, 0)
@@ -1434,7 +1481,7 @@ func testPeggedOrderExpiring(t *testing.T) {
 
 	orders, err := tm.market.RemoveExpiredOrders(now.Add(25 * time.Minute).UnixNano())
 	require.NoError(t, err)
-	assert.Empty(t, orders, "expiring pegged orders shouldn't be in the books expiring list")
+	assert.Equal(t, 2, len(orders))
 	assert.Equal(t, 1, tm.market.GetPeggedOrderCount(), "1 order should still be in the market")
 }
 


### PR DESCRIPTION
Pegged orders were expired internally but they never generated the event to notify the outside world of the change.
This PR adds the code to collect the set of expired pegged orders and send them out as events.
