### PR TITLE
disable all subscribers for validators

### DIFF
--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -115,6 +115,7 @@ func (l *NodeCommand) persistentPre(args []string) (err error) {
 	if err := l.setupStorages(); err != nil {
 		return err
 	}
+
 	l.setupSubscibers()
 
 	if !l.conf.StoresEnabled {
@@ -166,6 +167,9 @@ func (l *NodeCommand) loadMarketsConfig() error {
 }
 
 func (l *NodeCommand) setupSubscibers() {
+	if !l.conf.StoresEnabled {
+		return
+	}
 	l.transferSub = subscribers.NewTransferResponse(l.ctx, l.transferResponseStore, true)
 	l.marketEventSub = subscribers.NewMarketEvent(l.ctx, l.conf.Subscribers, l.Log, false)
 	l.orderSub = subscribers.NewOrderEvent(l.ctx, l.conf.Subscribers, l.Log, l.orderStore, true)
@@ -438,13 +442,15 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 	l.genesisHandler.OnGenesisTimeLoaded(l.timeService.SetTimeNow)
 
 	l.broker = broker.New(l.ctx)
-	l.broker.SubscribeBatch(
-		l.marketEventSub, l.transferSub, l.orderSub, l.accountSub,
-		l.partySub, l.tradeSub, l.marginLevelSub, l.governanceSub,
-		l.voteSub, l.marketDataSub, l.notaryPlugin, l.settlePlugin,
-		l.newMarketSub, l.assetPlugin, l.candleSub, l.withdrawalPlugin,
-		l.depositPlugin, l.marketDepthSub, l.riskFactorSub, l.netParamsService,
-		l.liquidityService)
+	if l.conf.StoresEnabled {
+		l.broker.SubscribeBatch(
+			l.marketEventSub, l.transferSub, l.orderSub, l.accountSub,
+			l.partySub, l.tradeSub, l.marginLevelSub, l.governanceSub,
+			l.voteSub, l.marketDataSub, l.notaryPlugin, l.settlePlugin,
+			l.newMarketSub, l.assetPlugin, l.candleSub, l.withdrawalPlugin,
+			l.depositPlugin, l.marketDepthSub, l.riskFactorSub, l.netParamsService,
+			l.liquidityService)
+	}
 
 	now, _ := l.timeService.GetTimeNow()
 


### PR DESCRIPTION
This update the disable storage to work with the broker and storages now.
If stores-enabled=false, then no subscribers is instanciated, and set to subscribe to events in the broker

close #2619