### PR TITLE
add a transaction submit type to graphql

### DIFF
--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -366,7 +366,7 @@ type ComplexityRoot struct {
 		PrepareProposal           func(childComplexity int, partyID string, reference *string, proposalTerms ProposalTermsInput) int
 		PrepareVote               func(childComplexity int, value VoteValue, partyID string, propopsalID string) int
 		PrepareWithdrawal         func(childComplexity int, partyID string, amount string, asset string, erc20details *Erc20WithdrawalDetailsInput) int
-		SubmitTransaction         func(childComplexity int, data string, sig SignatureInput) int
+		SubmitTransaction         func(childComplexity int, data string, sig SignatureInput, typeArg *SubmitTransactionType) int
 	}
 
 	NetworkParameter struct {
@@ -849,7 +849,7 @@ type MutationResolver interface {
 	PrepareProposal(ctx context.Context, partyID string, reference *string, proposalTerms ProposalTermsInput) (*PreparedProposal, error)
 	PrepareVote(ctx context.Context, value VoteValue, partyID string, propopsalID string) (*PreparedVote, error)
 	PrepareWithdrawal(ctx context.Context, partyID string, amount string, asset string, erc20details *Erc20WithdrawalDetailsInput) (*PreparedWithdrawal, error)
-	SubmitTransaction(ctx context.Context, data string, sig SignatureInput) (*TransactionSubmitted, error)
+	SubmitTransaction(ctx context.Context, data string, sig SignatureInput, typeArg *SubmitTransactionType) (*TransactionSubmitted, error)
 	PrepareLiquidityProvision(ctx context.Context, marketID string, commitmentAmount int, fee string, sells []*LiquidityOrderInput, buys []*LiquidityOrderInput) (*PreparedLiquidityProvision, error)
 }
 type NewAssetResolver interface {
@@ -2350,7 +2350,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SubmitTransaction(childComplexity, args["data"].(string), args["sig"].(SignatureInput)), true
+		return e.complexity.Mutation.SubmitTransaction(childComplexity, args["data"].(string), args["sig"].(SignatureInput), args["type"].(*SubmitTransactionType)), true
 
 	case "NetworkParameter.key":
 		if e.complexity.NetworkParameter.Key == nil {
@@ -4261,7 +4261,9 @@ type Mutation {
     data: String!
     "The signature"
     sig: SignatureInput!
-  ): TransactionSubmitted!
+    "The way to send the transaction"
+    type: SubmitTransactionType
+): TransactionSubmitted!
 
   "Prepare a Liquidity provision order so it can be signed and submitted"
   prepareLiquidityProvision(
@@ -4276,6 +4278,16 @@ type Mutation {
     "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
     buys:  [LiquidityOrderInput!]!
   ): PreparedLiquidityProvision!
+}
+
+"The way the transaction is sent to the blockchain"
+enum SubmitTransactionType {
+  "The call will return as soon as submitted"
+  Async
+  "The call will return once the mempool has run CheckTx on the transaction"
+  Sync
+  "The call will return once the transaction has been processed by the core"
+  Commit
 }
 
 "Create an order linked to an index rather than a price"
@@ -5805,7 +5817,7 @@ enum OrderRejectionReason {
 
   "Cannot change pegged order fields on a non pegged order"
   CannotAmendPeggedOrderDetailsOnNonPeggedOrder
-  
+
   "Unable to reprice a pegged order"
   UnableToRepricePeggedOrder
 }
@@ -7021,6 +7033,14 @@ func (ec *executionContext) field_Mutation_submitTransaction_args(ctx context.Co
 		}
 	}
 	args["sig"] = arg1
+	var arg2 *SubmitTransactionType
+	if tmp, ok := rawArgs["type"]; ok {
+		arg2, err = ec.unmarshalOSubmitTransactionType2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐSubmitTransactionType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["type"] = arg2
 	return args, nil
 }
 
@@ -13874,7 +13894,7 @@ func (ec *executionContext) _Mutation_submitTransaction(ctx context.Context, fie
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().SubmitTransaction(rctx, args["data"].(string), args["sig"].(SignatureInput))
+		return ec.resolvers.Mutation().SubmitTransaction(rctx, args["data"].(string), args["sig"].(SignatureInput), args["type"].(*SubmitTransactionType))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32014,6 +32034,30 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return ec.marshalOString2string(ctx, sel, *v)
+}
+
+func (ec *executionContext) unmarshalOSubmitTransactionType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐSubmitTransactionType(ctx context.Context, v interface{}) (SubmitTransactionType, error) {
+	var res SubmitTransactionType
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalOSubmitTransactionType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐSubmitTransactionType(ctx context.Context, sel ast.SelectionSet, v SubmitTransactionType) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalOSubmitTransactionType2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐSubmitTransactionType(ctx context.Context, v interface{}) (*SubmitTransactionType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOSubmitTransactionType2codeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐSubmitTransactionType(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOSubmitTransactionType2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋgatewayᚋgraphqlᚐSubmitTransactionType(ctx context.Context, sel ast.SelectionSet, v *SubmitTransactionType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOTrade2codeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐTrade(ctx context.Context, sel ast.SelectionSet, v proto.Trade) graphql.Marshaler {

--- a/gateway/graphql/models.go
+++ b/gateway/graphql/models.go
@@ -1800,6 +1800,53 @@ func (e Side) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+// The way the transaction is sent to the blockchain
+type SubmitTransactionType string
+
+const (
+	// The call will return as soon as submitted
+	SubmitTransactionTypeAsync SubmitTransactionType = "Async"
+	// The call will return once the mempool has run CheckTx on the transaction
+	SubmitTransactionTypeSync SubmitTransactionType = "Sync"
+	// The call will return once the transaction has been processed by the core
+	SubmitTransactionTypeCommit SubmitTransactionType = "Commit"
+)
+
+var AllSubmitTransactionType = []SubmitTransactionType{
+	SubmitTransactionTypeAsync,
+	SubmitTransactionTypeSync,
+	SubmitTransactionTypeCommit,
+}
+
+func (e SubmitTransactionType) IsValid() bool {
+	switch e {
+	case SubmitTransactionTypeAsync, SubmitTransactionTypeSync, SubmitTransactionTypeCommit:
+		return true
+	}
+	return false
+}
+
+func (e SubmitTransactionType) String() string {
+	return string(e)
+}
+
+func (e *SubmitTransactionType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SubmitTransactionType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SubmitTransactionType", str)
+	}
+	return nil
+}
+
+func (e SubmitTransactionType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // Valid trade types
 type TradeType string
 

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -15,7 +15,6 @@ import (
 	"code.vegaprotocol.io/vega/gateway"
 	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
-	"code.vegaprotocol.io/vega/proto/api"
 	protoapi "code.vegaprotocol.io/vega/proto/api"
 	"code.vegaprotocol.io/vega/vegatime"
 
@@ -1651,13 +1650,13 @@ func (r *myMutationResolver) PrepareWithdrawal(
 
 func (r *myMutationResolver) SubmitTransaction(ctx context.Context, data string, sig SignatureInput, ty *SubmitTransactionType) (*TransactionSubmitted, error) {
 
-	pty := api.SubmitTransactionRequest_TYPE_ASYNC
+	pty := protoapi.SubmitTransactionRequest_TYPE_ASYNC
 	if ty != nil {
 		switch *ty {
 		case SubmitTransactionTypeSync:
-			pty = api.SubmitTransactionRequest_TYPE_SYNC
+			pty = protoapi.SubmitTransactionRequest_TYPE_SYNC
 		case SubmitTransactionTypeCommit:
-			pty = api.SubmitTransactionRequest_TYPE_COMMIT
+			pty = protoapi.SubmitTransactionRequest_TYPE_COMMIT
 		}
 	}
 

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -129,7 +129,9 @@ type Mutation {
     data: String!
     "The signature"
     sig: SignatureInput!
-  ): TransactionSubmitted!
+    "The way to send the transaction"
+    type: SubmitTransactionType
+): TransactionSubmitted!
 
   "Prepare a Liquidity provision order so it can be signed and submitted"
   prepareLiquidityProvision(
@@ -144,6 +146,16 @@ type Mutation {
     "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
     buys:  [LiquidityOrderInput!]!
   ): PreparedLiquidityProvision!
+}
+
+"The way the transaction is sent to the blockchain"
+enum SubmitTransactionType {
+  "The call will return as soon as submitted"
+  Async
+  "The call will return once the mempool has run CheckTx on the transaction"
+  Sync
+  "The call will return once the transaction has been processed by the core"
+  Commit
 }
 
 "Create an order linked to an index rather than a price"
@@ -1673,7 +1685,7 @@ enum OrderRejectionReason {
 
   "Cannot change pegged order fields on a non pegged order"
   CannotAmendPeggedOrderDetailsOnNonPeggedOrder
-  
+
   "Unable to reprice a pegged order"
   UnableToRepricePeggedOrder
 }


### PR DESCRIPTION
This adds a transaction submission type to the graphql schema.
Default to old implementation -> Async submit.