### PR TITLE
Matching up wash trade status codes with the specs

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1030,8 +1030,7 @@ func (m *Market) submitValidatedOrder(ctx context.Context, order *types.Order) (
 		order.Status == types.Order_STATUS_STOPPED) &&
 		confirmation.Order.Remaining != 0) ||
 		// Also do it if specifically we went against a wash trade
-		(order.Status == types.Order_STATUS_REJECTED &&
-			order.Reason == types.OrderError_ORDER_ERROR_SELF_TRADING) {
+		order.Reason == types.OrderError_ORDER_ERROR_SELF_TRADING {
 		_, err := m.position.UnregisterOrder(order)
 		if err != nil {
 			m.log.Error("Unable to unregister potential trader positions",

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -472,7 +472,7 @@ func TestPartialFilledWashTrade(t *testing.T) {
 	confirmation, err = tm.market.SubmitOrder(context.Background(), orderBuy1)
 	assert.NotNil(t, confirmation)
 	assert.NoError(t, err)
-	assert.Equal(t, confirmation.Order.Status, types.Order_STATUS_REJECTED)
+	assert.Equal(t, confirmation.Order.Status, types.Order_STATUS_PARTIALLY_FILLED)
 	assert.Equal(t, confirmation.Order.Remaining, uint64(15))
 }
 

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -748,7 +748,7 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 	}
 
 	// if we did hit a wash trade, set the status to rejected
-	if err != nil && err == ErrWashTrade {
+	if err == ErrWashTrade {
 		if order.Size > order.Remaining {
 			order.Status = types.Order_STATUS_PARTIALLY_FILLED
 		} else {

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -749,7 +749,7 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 
 	// if we did hit a wash trade, set the status to rejected
 	if err != nil && err == ErrWashTrade {
-		if order.Remaining > 0 {
+		if order.Size > order.Remaining {
 			order.Status = types.Order_STATUS_PARTIALLY_FILLED
 		} else {
 			order.Status = types.Order_STATUS_STOPPED

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -749,7 +749,11 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 
 	// if we did hit a wash trade, set the status to rejected
 	if err != nil && err == ErrWashTrade {
-		order.Status = types.Order_STATUS_REJECTED
+		if order.Remaining > 0 {
+			order.Status = types.Order_STATUS_PARTIALLY_FILLED
+		} else {
+			order.Status = types.Order_STATUS_STOPPED
+		}
 		order.Reason = types.OrderError_ORDER_ERROR_SELF_TRADING
 	}
 

--- a/matching/simpleorders_test.go
+++ b/matching/simpleorders_test.go
@@ -546,7 +546,7 @@ func TestOrderBookSimple_simpleWashTrade(t *testing.T) {
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(confirm.Trades))
-	assert.Equal(t, order2.Status, types.Order_STATUS_REJECTED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_PARTIALLY_FILLED)
 }
 
 func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T) {
@@ -598,7 +598,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(len(confirm.Trades)))
-	assert.Equal(t, order2.Status, types.Order_STATUS_REJECTED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_PARTIALLY_FILLED)
 	assert.Equal(t, int(order2.Remaining), 1)
 }
 
@@ -651,7 +651,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStoppedDifferentPrice
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, int(len(confirm.Trades)))
-	assert.Equal(t, order2.Status, types.Order_STATUS_REJECTED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_PARTIALLY_FILLED)
 	assert.Equal(t, int(order2.Remaining), 1)
 }
 

--- a/matching/simpleorders_test.go
+++ b/matching/simpleorders_test.go
@@ -546,7 +546,7 @@ func TestOrderBookSimple_simpleWashTrade(t *testing.T) {
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(confirm.Trades))
-	assert.Equal(t, order2.Status, types.Order_STATUS_PARTIALLY_FILLED)
+	assert.Equal(t, order2.Status, types.Order_STATUS_STOPPED)
 }
 
 func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T) {


### PR DESCRIPTION
The code previously returned the rejected state after a wash trade. This has been updated to return either PARTIALLY_FILLED or STOPPED depending how much of the order was filled.