### PR TITLE
do not cache transaction before they are rate/balance limited

### DIFF
--- a/blockchain/abci/abci.go
+++ b/blockchain/abci/abci.go
@@ -87,11 +87,11 @@ func (app *App) DeliverTx(req types.RequestDeliverTx) (resp types.ResponseDelive
 	if err != nil {
 		return NewResponseDeliverTx(code, err.Error())
 	}
+	app.removeTxFromCache(req.GetTx())
 
 	if err := app.replayProtector.DeliverTx(tx); err != nil {
 		return NewResponseDeliverTx(AbciTxnValidationFailure, err.Error())
 	}
-	app.removeTxFromCache(req.GetTx())
 
 	// It's been validated by CheckTx so we can skip the validation here
 	ctx := app.ctx

--- a/blockchain/abci/app.go
+++ b/blockchain/abci/app.go
@@ -112,6 +112,5 @@ func (app *App) getTx(bytes []byte) (Tx, uint32, error) {
 		return nil, code, err
 	}
 
-	app.cacheTx(bytes, tx)
 	return tx, 0, nil
 }


### PR DESCRIPTION
It appears that the transaction cache might be caching transaction before we rate / balance limit them.
Which in the end cache the transaction forever as never removed during the DeliverTx.

This PR should at least prevent the transaction to be added into the cache when it's actually wrong.

A follow up PR will want to use an LRU cache or something similar with TTL on transaction so they are kept in memory for a maximum duration, after which it would be assumed that the transaction would have been rejected by the other nodes, hence by the network so it would be acceptable to remove it from the cache (it still might comes up later, but that would be fine).