### PR TITLE
use an lru-cache for check-tx

### DIFF
--- a/blockchain/abci/app.go
+++ b/blockchain/abci/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"code.vegaprotocol.io/vega/txn"
+	lru "github.com/hashicorp/golang-lru"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -33,19 +34,20 @@ type App struct {
 
 	// checkedTxs holds a map of valid transactions (validated by CheckTx)
 	// They are consumed by DeliverTx to avoid double validation.
-	checkedTxs map[string]Tx
+	checkedTxs *lru.Cache // map[string]Tx
 
 	// the current block context
 	ctx context.Context
 }
 
 func New(codec Codec) *App {
+	lruCache, _ := lru.New(1024)
 	return &App{
 		codec:           codec,
 		replayProtector: &replayProtectorNoop{},
 		checkTxs:        map[txn.Command]TxHandler{},
 		deliverTxs:      map[txn.Command]TxHandler{},
-		checkedTxs:      map[string]Tx{},
+		checkedTxs:      lruCache,
 		ctx:             context.Background(),
 	}
 }
@@ -79,22 +81,22 @@ func (app *App) decodeAndValidateTx(bytes []byte) (Tx, uint32, error) {
 
 // cacheTx adds a Tx to the cache.
 func (app *App) cacheTx(in []byte, tx Tx) {
-	app.checkedTxs[string(in)] = tx
+	app.checkedTxs.Add(string(in), tx)
 }
 
 // txFromCache retrieves (and remove if found) a Tx from the cache,
 // it returns the Tx or nil if not found.
 func (app *App) txFromCache(in []byte) Tx {
-	tx, ok := app.checkedTxs[string(in)]
+	tx, ok := app.checkedTxs.Get(string(in))
 	if !ok {
 		return nil
 	}
 
-	return tx
+	return tx.(Tx)
 }
 
 func (app *App) removeTxFromCache(in []byte) {
-	delete(app.checkedTxs, string(in))
+	app.checkedTxs.Remove(string(in))
 }
 
 // getTx returns an internal Tx given a []byte.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/protobuf v3.7.0+incompatible // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/grpc-gateway v1.9.5
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/mwitkow/go-proto-validators v0.2.0


### PR DESCRIPTION
This introduce the hashicorp lru-cache instead of the map to keep track of all check tx.

This bring 2 benefit:
- will remove naturaly all transaction which got checked OK, but then rejected by other nodees, which would never reach DeliverTx and so never be removed from the map.
- it prevent from panic with map access conccurently betwen DeliverTx and CheckTx