### PR TITLE
fix panic in remove expiring order

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -2361,6 +2361,9 @@ func (m *Market) RemoveExpiredOrders(timestamp int64) ([]types.Order, error) {
 			m.unregisterOrder(&order)
 		}
 		m.removePeggedOrder(&order)
+		if err != nil || originalOrder == nil {
+			continue
+		}
 		originalOrder.Status = types.Order_STATUS_EXPIRED
 		expiredPegs = append(expiredPegs, *originalOrder)
 	}


### PR DESCRIPTION
In Market.RemoveExpiringOrder, we do not check if there was an error retrieving the order from the book, which in case there was one (basically the order was not on the book), we will try to use the pointer and panic.