### PR TITLE
Minor liquidity engine changes

### DIFF
--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -102,7 +102,7 @@ func (e *Engine) SubmitLiquidityProvision(ctx context.Context, lps *types.Liquid
 		now                           = e.currentTime.UnixNano()
 	)
 
-	if len(lps.Buys) == 0 && len(lps.Sells) == 0 {
+	if len(lps.Buys) == 0 || len(lps.Sells) == 0 {
 		return ErrEmptyShape
 	}
 

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -224,17 +224,6 @@ func (e *Engine) Update(markPrice uint64, repriceFn RepricePeggedOrder, orders [
 		// update our internal orders
 		e.updatePartyOrders(party, orders)
 
-		// Create a slice shaped copy of the orders
-		buyOrders := make([]*types.Order, 0, len(e.orders[party])/2)
-		sellOrders := make([]*types.Order, 0, len(e.orders[party])/2)
-		for _, order := range e.orders[party] {
-			if order.Side == types.Side_SIDE_BUY {
-				buyOrders = append(buyOrders, order)
-			} else {
-				sellOrders = append(sellOrders, order)
-			}
-		}
-
 		obligation := float64(lp.CommitmentAmount) * e.suppliedFactor
 		var (
 			buysShape  = make([]*supplied.LiquidityOrder, len(lp.Buys))
@@ -273,10 +262,15 @@ func (e *Engine) Update(markPrice uint64, repriceFn RepricePeggedOrder, orders [
 			}
 		}
 
+		orders := make([]*types.Order, 0, len(e.orders[party]))
+		for _, o := range e.orders[party] {
+			orders = append(orders, o)
+		}
+
 		if err := e.suppliedEngine.CalculateLiquidityImpliedVolumes(
 			float64(markPrice),
 			obligation,
-			buyOrders, sellOrders,
+			orders,
 			buysShape, sellsShape,
 		); err != nil {
 			return nil, nil, err

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -51,8 +51,8 @@ type Engine struct {
 	idGen          IDGen
 	suppliedEngine *supplied.Engine
 
-	currentTime    time.Time
-	suppliedFactor float64
+	currentTime             time.Time
+	stakeToObligationFactor float64
 
 	// state
 	provisions map[string]*types.LiquidityProvision
@@ -75,14 +75,14 @@ func NewEngine(
 	priceMonitor PriceMonitor,
 ) *Engine {
 	return &Engine{
-		log:             log,
-		broker:          broker,
-		idGen:           idGen,
-		suppliedEngine:  supplied.NewEngine(riskModel, priceMonitor),
-		suppliedFactor:  1,
-		provisions:      map[string]*types.LiquidityProvision{},
-		orders:          map[string]map[string]*types.Order{},
-		liquidityOrders: map[string]map[string]*types.Order{},
+		log:                     log,
+		broker:                  broker,
+		idGen:                   idGen,
+		suppliedEngine:          supplied.NewEngine(riskModel, priceMonitor),
+		stakeToObligationFactor: 1,
+		provisions:              map[string]*types.LiquidityProvision{},
+		orders:                  map[string]map[string]*types.Order{},
+		liquidityOrders:         map[string]map[string]*types.Order{},
 	}
 }
 
@@ -224,7 +224,7 @@ func (e *Engine) Update(markPrice uint64, repriceFn RepricePeggedOrder, orders [
 		// update our internal orders
 		e.updatePartyOrders(party, orders)
 
-		obligation := float64(lp.CommitmentAmount) * e.suppliedFactor
+		obligation := float64(lp.CommitmentAmount) * e.stakeToObligationFactor
 		var (
 			buysShape  = make([]*supplied.LiquidityOrder, len(lp.Buys))
 			sellsShape = make([]*supplied.LiquidityOrder, len(lp.Sells))

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -66,6 +66,64 @@ func TestSubmissions(t *testing.T) {
 	t.Run("CreateUpdateDelete", testSubmissionCRUD)
 	t.Run("CancelNonExisting", testCancelNonExistingSubmission)
 	t.Run("FailWhenNoShape", testSubmissionFailWhenNoShape)
+	t.Run("FailWhenShapeForOneSideOnly", testSubmissionFailWhenOneShapeSepcified)
+}
+
+func testSubmissionFailWhenOneShapeSepcified(t *testing.T) {
+	var (
+		party = "party-1"
+		ctx   = context.Background()
+		now   = time.Now()
+		tng   = newTestEngine(t, now)
+	)
+	defer tng.ctrl.Finish()
+
+	require.Nil(t, tng.engine.LiquidityProvisionByPartyID("some-party"))
+
+	buyShape := []*types.LiquidityOrder{
+		{
+			Reference:  types.PeggedReference_PEGGED_REFERENCE_MID,
+			Offset:     -1,
+			Proportion: 1,
+		},
+	}
+	sellShape := []*types.LiquidityOrder{
+		{
+			Reference:  types.PeggedReference_PEGGED_REFERENCE_MID,
+			Offset:     1,
+			Proportion: 1,
+		},
+	}
+
+	lps1 := &types.LiquidityProvisionSubmission{
+		MarketID: "test", CommitmentAmount: 100, Fee: "0.5",
+		Buys: nil, Sells: sellShape,
+	}
+
+	lps2 := &types.LiquidityProvisionSubmission{
+		MarketID: "test", CommitmentAmount: 100, Fee: "0.5",
+		Buys: buyShape, Sells: nil,
+	}
+
+	lps3 := &types.LiquidityProvisionSubmission{
+		MarketID: "test", CommitmentAmount: 100, Fee: "0.5",
+		Buys: buyShape, Sells: sellShape,
+	}
+
+	// Create a submission should fire an event
+	tng.broker.EXPECT().Send(gomock.Any()).Times(1)
+
+	require.Error(t,
+		tng.engine.SubmitLiquidityProvision(ctx, lps1, party, "some-id-1"),
+	)
+
+	require.Error(t,
+		tng.engine.SubmitLiquidityProvision(ctx, lps2, party, "some-id-2"),
+	)
+
+	require.NoError(t,
+		tng.engine.SubmitLiquidityProvision(ctx, lps3, party, "some-id-3"),
+	)
 }
 
 func testSubmissionCRUD(t *testing.T) {
@@ -188,14 +246,7 @@ func testCancelNonExistingSubmission(t *testing.T) {
 			},
 		},
 	}
-	expected := events.NewLiquidityProvisionEvent(ctx, &types.LiquidityProvision{
-		Id:        "some-id",
-		PartyID:   party,
-		CreatedAt: now.UnixNano(),
-		Status:    types.LiquidityProvision_LIQUIDITY_PROVISION_STATUS_REJECTED,
-	})
 
-	tng.broker.EXPECT().Send(eq(t, expected)).Times(1)
 	err := tng.engine.SubmitLiquidityProvision(ctx,
 		lps, party, "some-id")
 	require.Error(t, err)
@@ -291,3 +342,6 @@ func TestUpdate(t *testing.T) {
 	require.Len(t, creates, 0)
 	require.Len(t, updates, 0)
 }
+
+// TODO (WG): Write a test where new limit orders should reduce the liquidity deployed with shapes.
+// TODO (WG): Cover the case when pegs outside valid range.

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -326,6 +326,24 @@ func TestUpdate(t *testing.T) {
 	require.Len(t, creates, 3)
 	require.Len(t, updates, 0)
 
+	initialSizes := make([]uint64, 0, len(creates))
+	for _, c := range creates {
+		initialSizes = append(initialSizes, c.Size)
+	}
+
+	// Manual orders provide more liquidity, LiqOrders should decrease
+	orders[0].Remaining, orders[0].Size = 10, 10
+	orders[1].Remaining, orders[1].Size = 10, 10
+
+	creates, updates, err = tng.engine.Update(markPrice, fn, orders)
+	require.NoError(t, err)
+	require.Len(t, creates, 0)
+	require.Len(t, updates, 3)
+	for i, order := range updates {
+		assert.Greater(t, order.Size, uint64(0))
+		require.Less(t, order.Size, initialSizes[i])
+	}
+
 	// Manual order satisfies the commitment, LiqOrders should be removed
 	orders[0].Remaining, orders[0].Size = 1000, 1000
 	orders[1].Remaining, orders[1].Size = 1000, 1000

--- a/liquidity/supplied/engine.go
+++ b/liquidity/supplied/engine.go
@@ -72,16 +72,12 @@ func (e *Engine) CalculateSuppliedLiquidity(markPrice float64, orders []*types.O
 }
 
 // CalculateLiquidityImpliedVolumes updates the LiquidityImpliedSize fields in LiquidityOrderReference so that the liquidity commitment is met.
-// Current markt price, liquidity obligation, and orders must be specified.
+// Current markt price, liquidity obligation, and existing (non LP) orders must be specified.
 // Note that due to integer order size the actual liquidity provided will be more than or equal to the commitment amount.
-func (e *Engine) CalculateLiquidityImpliedVolumes(markPrice, liquidityObligation float64, buyLimitOrders, sellLimitOrders []*types.Order, buyShapes []*LiquidityOrder, sellShapes []*LiquidityOrder) error {
+func (e *Engine) CalculateLiquidityImpliedVolumes(markPrice, liquidityObligation float64, orders []*types.Order, buyShapes []*LiquidityOrder, sellShapes []*LiquidityOrder) error {
 	minPrice, maxPrice := e.pm.GetValidPriceRange()
 
-	limitOrders := make([]*types.Order, 0, len(buyLimitOrders)+len(sellLimitOrders))
-	limitOrders = append(limitOrders, buyLimitOrders...)
-	limitOrders = append(limitOrders, sellLimitOrders...)
-
-	buySupplied, sellSupplied, err := e.calculateBuySellLiquidityWithMinMax(markPrice, limitOrders, minPrice, maxPrice)
+	buySupplied, sellSupplied, err := e.calculateBuySellLiquidityWithMinMax(markPrice, orders, minPrice, maxPrice)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some minor changes and additional test cases for the liquidity engine.

DRAFT for now, will extend once https://github.com/vegaprotocol/vega/pull/2622 is merged.