### PR TITLE
use exponential backoff for retries in ext_res_checker

### DIFF
--- a/assets/erc20/erc20.go
+++ b/assets/erc20/erc20.go
@@ -432,11 +432,11 @@ func (b *ERC20) String() string {
 func getMaybeHTTPStatus(err error) string {
 	errstr := err.Error()
 	if len(errstr) < 3 {
-		return "unknown"
+		return "tooshort"
 	}
 	i, err := strconv.Atoi(errstr[:3])
 	if err != nil {
-		return "unknown"
+		return "nan"
 	}
 	if http.StatusText(i) == "" {
 		return "unknown"

--- a/assets/erc20/erc20.go
+++ b/assets/erc20/erc20.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net/http"
+	"strconv"
 
 	"code.vegaprotocol.io/vega/assets/common"
 	"code.vegaprotocol.io/vega/assets/erc20/bridge"
+	"code.vegaprotocol.io/vega/metrics"
 	"code.vegaprotocol.io/vega/nodewallet"
 	types "code.vegaprotocol.io/vega/proto"
 
@@ -194,6 +197,11 @@ func (b *ERC20) ValidateWhitelist(w *types.ERC20AssetList, blockNumber, txIndex 
 		return "", err
 	}
 
+	var resp string = "ok"
+	defer func() {
+		metrics.EthCallInc("validate_allowlist", b.asset.ID, resp)
+	}()
+
 	iter, err := bf.FilterAssetWhitelisted(
 		&bind.FilterOpts{
 			Start: blockNumber - 1,
@@ -204,6 +212,7 @@ func (b *ERC20) ValidateWhitelist(w *types.ERC20AssetList, blockNumber, txIndex 
 	)
 
 	if err != nil {
+		resp = getMaybeHTTPStatus(err)
 		return "", err
 	}
 
@@ -324,6 +333,11 @@ func (b *ERC20) ValidateWithdrawal(w *types.ERC20Withdrawal, blockNumber, txInde
 		return nil, "", err
 	}
 
+	var resp string = "ok"
+	defer func() {
+		metrics.EthCallInc("validate_withdrawal", b.asset.ID, resp)
+	}()
+
 	iter, err := bf.FilterAssetWithdrawn(
 		&bind.FilterOpts{
 			Start: blockNumber - 1,
@@ -335,6 +349,7 @@ func (b *ERC20) ValidateWithdrawal(w *types.ERC20Withdrawal, blockNumber, txInde
 		[]*big.Int{})
 
 	if err != nil {
+		resp = getMaybeHTTPStatus(err)
 		return nil, "", err
 	}
 
@@ -368,6 +383,11 @@ func (b *ERC20) ValidateDeposit(d *types.ERC20Deposit, blockNumber, txIndex uint
 		return "", "", "", 0, err
 	}
 
+	var resp string = "ok"
+	defer func() {
+		metrics.EthCallInc("validate_deposit", b.asset.ID, resp)
+	}()
+
 	iter, err := bf.FilterAssetDeposited(
 		&bind.FilterOpts{
 			Start: blockNumber - 1,
@@ -379,6 +399,7 @@ func (b *ERC20) ValidateDeposit(d *types.ERC20Deposit, blockNumber, txIndex uint
 		[]*big.Int{})
 
 	if err != nil {
+		resp = getMaybeHTTPStatus(err)
 		return "", "", "", 0, err
 	}
 
@@ -406,4 +427,20 @@ func (b *ERC20) String() string {
 	return fmt.Sprintf("id(%v) name(%v) symbol(%v) totalSupply(%v) decimals(%v)",
 		b.asset.ID, b.asset.Name, b.asset.Symbol, b.asset.TotalSupply,
 		b.asset.Decimals)
+}
+
+func getMaybeHTTPStatus(err error) string {
+	errstr := err.Error()
+	if len(errstr) < 3 {
+		return "unknown"
+	}
+	i, err := strconv.Atoi(errstr[:3])
+	if err != nil {
+		return "unknown"
+	}
+	if http.StatusText(i) == "" {
+		return "unknown"
+	}
+
+	return errstr[:3]
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -33,6 +33,7 @@ var (
 	unconfirmedTxGauge prometheus.Gauge
 	engineTime         *prometheus.CounterVec
 	orderCounter       *prometheus.CounterVec
+	ethCallCounter     *prometheus.CounterVec
 	orderGauge         *prometheus.GaugeVec
 	// Call counters for each request type per API
 	apiRequestCallCounter *prometheus.CounterVec
@@ -350,6 +351,22 @@ func setupMetrics() error {
 	}
 	orderCounter = ot
 
+	h, err = AddInstrument(
+		Counter,
+		"eth_calls_total",
+		Namespace("vega"),
+		Vectors("func", "asset", "respcode"),
+		Help("Number of call made to the ethereum node"),
+	)
+	if err != nil {
+		return err
+	}
+	ethCalls, err := h.CounterVec()
+	if err != nil {
+		return err
+	}
+	ethCallCounter = ethCalls
+
 	// now add the orders gauge
 	h, err = AddInstrument(
 		Gauge,
@@ -432,6 +449,14 @@ func OrderCounterInc(labelValues ...string) {
 		return
 	}
 	orderCounter.WithLabelValues(labelValues...).Inc()
+}
+
+// EthCallInc increments the order counter
+func EthCallInc(labelValues ...string) {
+	if ethCallCounter == nil {
+		return
+	}
+	ethCallCounter.WithLabelValues(labelValues...).Inc()
 }
 
 // OrderGaugeAdd incement the order gauge

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -451,7 +451,7 @@ func OrderCounterInc(labelValues ...string) {
 	orderCounter.WithLabelValues(labelValues...).Inc()
 }
 
-// EthCallInc increments the order counter
+// EthCallInc increments the eth call counter
 func EthCallInc(labelValues ...string) {
 	if ethCallCounter == nil {
 		return

--- a/validators/ext_res_checker.go
+++ b/validators/ext_res_checker.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"math/rand"
 	"sync/atomic"
 	"time"
 
 	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/txn"
+	"github.com/cenkalti/backoff"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -56,6 +58,12 @@ const (
 	maxValidationPeriod = 48 * 3600 // 2 days
 	nodeApproval        = 1         // float for percentage
 )
+
+func init() {
+	// we seed the random generator just in case
+	// as the backoff library use random internally
+	rand.Seed(time.Now().UnixNano())
+}
 
 type res struct {
 	res Resource
@@ -160,7 +168,7 @@ func (e *ExtResChecker) StartCheck(
 		return err
 	}
 
-	ctx, cfunc := context.WithCancel(context.Background())
+	ctx, cfunc := context.WithDeadline(context.Background(), checkUntil)
 	rs := &res{
 		res:        r,
 		checkUntil: checkUntil,
@@ -188,6 +196,38 @@ func (e *ExtResChecker) validateCheckUntil(checkUntil time.Time) error {
 	}
 	return nil
 
+}
+
+func newBackoff(ctx context.Context, maxElapsedTime time.Duration) backoff.BackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = maxElapsedTime
+	bo.InitialInterval = 1 * time.Second
+	return backoff.WithContext(bo, ctx)
+}
+
+func (e ExtResChecker) start2(ctx context.Context, r *res) {
+	backff := newBackoff(ctx, r.checkUntil.Sub(e.now))
+	f := func() error {
+		e.log.Debug("Checking the resource",
+			logging.String("asset-source", r.res.GetID()),
+		)
+		err := r.res.Check()
+		if err != nil {
+			e.log.Warn("error checking resource", logging.Error(err))
+			// dump error
+			return err
+		}
+		return nil
+	}
+
+	err := backoff.Retry(f, backff)
+	if err != nil {
+
+		return
+	}
+
+	// check succeeded
+	atomic.StoreUint32(&r.state, validated)
 }
 
 func (e ExtResChecker) start(ctx context.Context, r *res) {


### PR DESCRIPTION
This adds a exponential backoff instead of a linear 500ms retry for ext_rest_checker.

Also adds a new counter for the request made to ethereum.

close #2663 