### PR TITLE
use log index to find transaction and dedup chain events

### DIFF
--- a/api/trading.go
+++ b/api/trading.go
@@ -295,13 +295,11 @@ func (s *tradingService) PropagateChainEvent(ctx context.Context, req *protoapi.
 
 	var ok = true
 	err = s.evtForwarder.Forward(ctx, req.Evt, req.PubKey)
-	if err != nil {
+	if err != nil && err != evtforward.ErrEvtAlreadyExist {
 		s.log.Error("unable to forward chain event",
 			logging.String("pubkey", req.PubKey),
 			logging.Error(err))
-		if err == evtforward.ErrEvtAlreadyExist {
-			return nil, apiError(codes.AlreadyExists, err)
-		} else if err == evtforward.ErrPubKeyNotAllowlisted {
+		if err == evtforward.ErrPubKeyNotAllowlisted {
 			return nil, apiError(codes.PermissionDenied, err)
 		} else {
 			return nil, apiError(codes.Internal, err)

--- a/assets/erc20/erc20.go
+++ b/assets/erc20/erc20.go
@@ -190,11 +190,11 @@ func (b *ERC20) SignBridgeListing() (msg []byte, sig []byte, err error) {
 	return msg, sig, nil
 }
 
-func (b *ERC20) ValidateList(w *types.ERC20AssetList, blockNumber, txIndex uint64) (hash string, err error) {
+func (b *ERC20) ValidateAssetList(w *types.ERC20AssetList, blockNumber, txIndex uint64) (hash string, logIndex uint, err error) {
 	bf, err := bridge.NewBridgeFilterer(
 		ethcmn.HexToAddress(b.wallet.BridgeAddress()), b.wallet.Client())
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	var resp string = "ok"
@@ -213,7 +213,7 @@ func (b *ERC20) ValidateList(w *types.ERC20AssetList, blockNumber, txIndex uint6
 
 	if err != nil {
 		resp = getMaybeHTTPStatus(err)
-		return "", err
+		return "", 0, err
 	}
 
 	defer iter.Close()
@@ -226,10 +226,10 @@ func (b *ERC20) ValidateList(w *types.ERC20AssetList, blockNumber, txIndex uint6
 	}
 
 	if event == nil {
-		return "", ErrUnableToFindERC20AssetList
+		return "", 0, ErrUnableToFindERC20AssetList
 	}
 
-	return event.Raw.TxHash.Hex(), nil
+	return event.Raw.TxHash.Hex(), event.Raw.Index, nil
 }
 
 func (b *ERC20) SignWithdrawal(
@@ -326,11 +326,11 @@ func (b *ERC20) SignWithdrawal(
 	return msg, sig, nil
 }
 
-func (b *ERC20) ValidateWithdrawal(w *types.ERC20Withdrawal, blockNumber, txIndex uint64) (*big.Int, string, error) {
+func (b *ERC20) ValidateWithdrawal(w *types.ERC20Withdrawal, blockNumber, txIndex uint64) (*big.Int, string, uint, error) {
 	bf, err := bridge.NewBridgeFilterer(
 		ethcmn.HexToAddress(b.wallet.BridgeAddress()), b.wallet.Client())
 	if err != nil {
-		return nil, "", err
+		return nil, "", 0, err
 	}
 
 	var resp string = "ok"
@@ -350,7 +350,7 @@ func (b *ERC20) ValidateWithdrawal(w *types.ERC20Withdrawal, blockNumber, txInde
 
 	if err != nil {
 		resp = getMaybeHTTPStatus(err)
-		return nil, "", err
+		return nil, "", 0, err
 	}
 
 	defer iter.Close()
@@ -363,24 +363,24 @@ func (b *ERC20) ValidateWithdrawal(w *types.ERC20Withdrawal, blockNumber, txInde
 		// we do the slice operation to remove it ([2:]
 		if nonce.Cmp(iter.Event.Nonce) == 0 &&
 			iter.Event.Raw.BlockNumber == blockNumber &&
-			uint64(iter.Event.Raw.TxIndex) == txIndex {
+			uint64(iter.Event.Raw.Index) == txIndex {
 			event = iter.Event
 			break
 		}
 	}
 
 	if event == nil {
-		return nil, "", ErrUnableToFindWithdrawal
+		return nil, "", 0, ErrUnableToFindWithdrawal
 	}
 
-	return nonce, event.Raw.TxHash.Hex(), nil
+	return nonce, event.Raw.TxHash.Hex(), event.Raw.Index, nil
 }
 
-func (b *ERC20) ValidateDeposit(d *types.ERC20Deposit, blockNumber, txIndex uint64) (partyID, assetID, hash string, amount uint64, err error) {
+func (b *ERC20) ValidateDeposit(d *types.ERC20Deposit, blockNumber, txIndex uint64) (partyID, assetID, hash string, amount uint64, logIndex uint, err error) {
 	bf, err := bridge.NewBridgeFilterer(
 		ethcmn.HexToAddress(b.wallet.BridgeAddress()), b.wallet.Client())
 	if err != nil {
-		return "", "", "", 0, err
+		return "", "", "", 0, 0, err
 	}
 
 	var resp string = "ok"
@@ -400,7 +400,7 @@ func (b *ERC20) ValidateDeposit(d *types.ERC20Deposit, blockNumber, txIndex uint
 
 	if err != nil {
 		resp = getMaybeHTTPStatus(err)
-		return "", "", "", 0, err
+		return "", "", "", 0, 0, err
 	}
 
 	defer iter.Close()
@@ -410,17 +410,17 @@ func (b *ERC20) ValidateDeposit(d *types.ERC20Deposit, blockNumber, txIndex uint
 		// we do the slice operation to remove it ([2:]
 		if hex.EncodeToString(iter.Event.VegaPublicKey[:]) == d.TargetPartyID[2:] &&
 			iter.Event.Raw.BlockNumber == blockNumber &&
-			uint64(iter.Event.Raw.TxIndex) == txIndex {
+			uint64(iter.Event.Raw.Index) == txIndex {
 			event = iter.Event
 			break
 		}
 	}
 
 	if event == nil {
-		return "", "", "", 0, ErrUnableToFindDeposit
+		return "", "", "", 0, 0, ErrUnableToFindDeposit
 	}
 
-	return d.TargetPartyID, d.VegaAssetID, event.Raw.TxHash.Hex(), iter.Event.Amount.Uint64(), nil
+	return d.TargetPartyID, d.VegaAssetID, event.Raw.TxHash.Hex(), iter.Event.Amount.Uint64(), event.Raw.Index, nil
 }
 
 func (b *ERC20) String() string {

--- a/banking/asset_action.go
+++ b/banking/asset_action.go
@@ -26,9 +26,10 @@ type withdrawal struct {
 }
 
 type txRef struct {
-	asset common.AssetClass
-	hash  string
-	index uint64
+	asset    common.AssetClass
+	hash     string
+	index    uint64
+	logIndex uint
 }
 
 type assetAction struct {
@@ -132,13 +133,13 @@ func (t *assetAction) checkBuiltinAssetDeposit() error {
 	asset, _ := t.asset.BuiltinAsset()
 	// builtin deposits do not have hash, and we don't need one
 	// so let's just add some random id
-	t.ref = txRef{asset.GetAssetClass(), uuid.NewV4().String(), 0}
+	t.ref = txRef{asset.GetAssetClass(), uuid.NewV4().String(), 0, 0}
 	return nil
 }
 
 func (t *assetAction) checkERC20Deposit() error {
 	asset, _ := t.asset.ERC20()
-	partyID, assetID, hash, amount, err := asset.ValidateDeposit(t.erc20D, t.blockNumber, t.txIndex)
+	partyID, assetID, hash, amount, logIndex, err := asset.ValidateDeposit(t.erc20D, t.blockNumber, t.txIndex)
 	if err != nil {
 		return err
 	}
@@ -147,29 +148,29 @@ func (t *assetAction) checkERC20Deposit() error {
 		partyID: partyID,
 		assetID: assetID,
 	}
-	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex}
+	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex, logIndex}
 	return nil
 }
 
 func (t *assetAction) checkERC20Withdrawal() error {
 	asset, _ := t.asset.ERC20()
-	nonce, hash, err := asset.ValidateWithdrawal(t.erc20W, t.blockNumber, t.txIndex)
+	nonce, hash, logIndex, err := asset.ValidateWithdrawal(t.erc20W, t.blockNumber, t.txIndex)
 	if err != nil {
 		return err
 	}
 	t.withdrawal = &withdrawal{
 		nonce: nonce,
 	}
-	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex}
+	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex, logIndex}
 	return nil
 }
 
 func (t *assetAction) checkERC20AssetList() error {
 	asset, _ := t.asset.ERC20()
-	hash, err := asset.ValidateList(t.erc20AL, t.blockNumber, t.txIndex)
+	hash, logIndex, err := asset.ValidateAssetList(t.erc20AL, t.blockNumber, t.txIndex)
 	if err != nil {
 		return err
 	}
-	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex}
+	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex, logIndex}
 	return nil
 }

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -412,6 +412,7 @@ func (e *Engine) OnTick(ctx context.Context, t time.Time) {
 		if state == pendingState {
 			continue
 		}
+
 		switch state {
 		case okState:
 			// check if this transaction have been seen before then

--- a/evtforward/evtforward.go
+++ b/evtforward/evtforward.go
@@ -139,6 +139,7 @@ func (e *EvtForwarder) Ack(evt *types.ChainEvent) bool {
 
 	e.evtsmu.Lock()
 	defer e.evtsmu.Unlock()
+
 	key := string(crypto.Hash([]byte(evt.String())))
 	_, ok, acked := e.getEvt(key)
 	if ok && acked {


### PR DESCRIPTION
Use the log index instead of the the transaction index in order to deduplicate transaction.
We used before the transaction index which would be the same for transaction with sub transaction.
We now use the log index which is unique for subtransaction inside the block.