### PR TITLE
Check for nil values

### DIFF
--- a/collateral/margins.go
+++ b/collateral/margins.go
@@ -27,9 +27,15 @@ func (n marginUpdate) MarketID() string {
 }
 
 func (n marginUpdate) MarginBalance() uint64 {
+	if n.margin == nil {
+		return 0
+	}
 	return uint64(n.margin.Balance)
 }
 
 func (n marginUpdate) GeneralBalance() uint64 {
+	if n.general == nil {
+		return 0
+	}
 	return uint64(n.general.Balance)
 }

--- a/execution/market.go
+++ b/execution/market.go
@@ -1637,6 +1637,11 @@ func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketP
 		if ip := m.matching.GetIndicativePrice(); ip != 0 {
 			price = ip
 		}
+		// in opening auctions, there might not be price data at all, in which case we should default to
+		// the order price to base our margin requirements on
+		if m.as.IsOpeningAuction() && price < order.Price {
+			price = order.Price
+		}
 	}
 	riskUpdate, err := m.collateralAndRiskForOrder(ctx, e, price, pos)
 	if err != nil {


### PR DESCRIPTION
This is just to prevent the worst that could happen: runtime panic on nil pointer deref.

The underlying reason for this bug is that we're MTM'ing all traders when we uncross the book at the end of the auction period. That's fine, but we're doing so before fully uncrossing the book, which results in traders being distressed, accounts being removed etc.. before we actually generate their trades.