### PR TITLE
Fix remove order created at bug

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -2392,7 +2392,7 @@ func (m *Market) orderCancelReplace(ctx context.Context, existingOrder, newOrder
 
 		conf, err = m.matching.SubmitOrder(newOrder) //lint:ignore SA4006 this value might be overwriter, careful!
 		// replace the trades in the confirmation to have
-		// the ones with the fees embbeded
+		// the ones with the fees embedded
 		conf.Trades = trades
 	}
 

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -1482,39 +1482,52 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	addAccount(tm, "D")
 	addAccount(tm, "E")
 	addAccount(tm, "F")
+	addAccount(tm, "G")
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
 
 	o1 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GFN, "Order01", types.Side_SIDE_BUY, "A", 5, 11500)
 	o1conf, err := tm.market.SubmitOrder(ctx, o1)
 	require.NotNil(t, o1conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
-	o2 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GFN, "Order02", types.Side_SIDE_SELL, "B", 20, 11000)
+	o2 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GFN, "Order02", types.Side_SIDE_SELL, "B", 25, 11000)
 	o2conf, err := tm.market.SubmitOrder(ctx, o2)
 	require.NotNil(t, o2conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	o3 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GFN, "Order03", types.Side_SIDE_BUY, "A", 10, 10500)
 	o3conf, err := tm.market.SubmitOrder(ctx, o3)
 	require.NotNil(t, o3conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	o4 := getMarketOrder(tm, now, types.Order_TYPE_MARKET, types.Order_TIF_IOC, "Order04", types.Side_SIDE_SELL, "C", 5, 0)
 	o4conf, err := tm.market.SubmitOrder(ctx, o4)
 	require.NotNil(t, o4conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	o5 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order05", types.Side_SIDE_BUY, "C", 35, 0)
 	o5.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Offset: -500}
 	o5conf, err := tm.market.SubmitOrder(ctx, o5)
 	require.NotNil(t, o5conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	o6 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order06", types.Side_SIDE_BUY, "D", 16, 0)
 	o6.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -2000}
 	o6conf, err := tm.market.SubmitOrder(ctx, o6)
 	require.NotNil(t, o6conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	o7 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTT, "Order07", types.Side_SIDE_SELL, "E", 19, 0)
 	o7.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Offset: +3000}
@@ -1522,17 +1535,37 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	o7conf, err := tm.market.SubmitOrder(ctx, o7)
 	require.NotNil(t, o7conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	o8 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order08", types.Side_SIDE_BUY, "F", 25, 10000)
 	o8conf, err := tm.market.SubmitOrder(ctx, o8)
 	require.NotNil(t, o8conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 
 	// This one should crash
 	o9 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order09", types.Side_SIDE_SELL, "F", 25, 10250)
 	o9conf, err := tm.market.SubmitOrder(ctx, o9)
 	require.NotNil(t, o9conf)
 	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
+
+	o10 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order10", types.Side_SIDE_BUY, "G", 45, 14000)
+	o10conf, err := tm.market.SubmitOrder(ctx, o10)
+	require.NotNil(t, o10conf)
+	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
+
+	o11 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order11", types.Side_SIDE_SELL, "G", 45, 8500)
+	o11conf, err := tm.market.SubmitOrder(ctx, o11)
+	require.NotNil(t, o11conf)
+	require.NoError(t, err)
+	now = now.Add(time.Second * 1)
+	tm.market.OnChainTimeUpdate(context.Background(), now)
 }
 
 func TestTriggerAfterOpeningAuction(t *testing.T) {

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -1601,7 +1601,7 @@ func testPeggedOrderCanDeleteAfterLostPriority(t *testing.T) {
 	amendOrder(t, tm, "party1", buyOrder1, 0, 100, types.Order_TIF_UNSPECIFIED, 0, true)
 
 	// Try to delete the pegged order
-	cancelconf, err := tm.market.CancelOrder(context.TODO(), "party1", order.Id)
+	cancelconf, _ := tm.market.CancelOrder(context.TODO(), "party1", order.Id)
 	assert.NotNil(t, cancelconf)
 	assert.Equal(t, types.Order_STATUS_CANCELLED, cancelconf.Order.Status)
 }

--- a/matching/side.go
+++ b/matching/side.go
@@ -249,24 +249,14 @@ func (s *OrderBookSide) RemoveOrder(o *types.Order) (*types.Order, error) {
 		return nil, types.ErrOrderNotFound
 	}
 
-	// orders are order by timestamp (CreatedAt)
-	oidx := sort.Search(len(s.levels[i].orders), func(j int) bool {
-		return s.levels[i].orders[j].CreatedAt >= o.CreatedAt
-	})
-	// we did not find the order
-	if oidx >= len(s.levels[i].orders) {
-		return nil, types.ErrOrderNotFound
-	}
-
 	// now we may have a few orders with the same timestamp
 	// lets iterate over them in order to find the right one
 	finaloidx := -1
-	for oidx < len(s.levels[i].orders) && s.levels[i].orders[oidx].CreatedAt == o.CreatedAt {
-		if s.levels[i].orders[oidx].Id == o.Id {
-			finaloidx = oidx
+	for index, order := range s.levels[i].orders {
+		if order.Id == o.Id {
+			finaloidx = index
 			break
 		}
-		oidx++
 	}
 
 	var order *types.Order
@@ -580,4 +570,16 @@ func (s *OrderBookSide) getOrderCount() int64 {
 		orderCount = orderCount + int64(len(level.orders))
 	}
 	return orderCount
+}
+
+func (s *OrderBookSide) logSide() {
+	s.log.Error("OrderBookSide", logging.String("Side:", s.side.String()))
+
+	for _, level := range s.levels {
+		s.log.Error("PriceLevel", logging.Uint64("Price", level.price))
+		for _, order := range level.orders {
+			s.log.Error("Orders", logging.Order(*order))
+		}
+	}
+
 }

--- a/matching/side.go
+++ b/matching/side.go
@@ -571,15 +571,3 @@ func (s *OrderBookSide) getOrderCount() int64 {
 	}
 	return orderCount
 }
-
-func (s *OrderBookSide) logSide() {
-	s.log.Error("OrderBookSide", logging.String("Side:", s.side.String()))
-
-	for _, level := range s.levels {
-		s.log.Error("PriceLevel", logging.Uint64("Price", level.price))
-		for _, order := range level.orders {
-			s.log.Error("Orders", logging.Order(*order))
-		}
-	}
-
-}


### PR DESCRIPTION
We found an error where orders that had lost their time priority could not be deleted from the order book because the code expected the orders on a price level to be sorted by createdAt. This sorting can be broken by amends and pegged orders so this code was failing to remove orders.

We now iterate through all the orders on a price level ignoring the createdAt field.