### PR TITLE
Fixing order reference (#2718)

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1904,7 +1904,7 @@ func (m *Market) parkOrder(ctx context.Context, order *types.Order) {
 	order.Price = 0
 	m.broker.Send(events.NewOrderEvent(ctx, order))
 	if _, err := m.position.UnregisterOrder(order); err != nil {
-		m.log.Fatal("Failure unregistering order in positions engine (parking)",
+		m.log.Fatal("Failure un-registering order in positions engine (parking)",
 			logging.Order(*order),
 			logging.Error(err))
 	}
@@ -2390,7 +2390,10 @@ func (m *Market) orderCancelReplace(ctx context.Context, existingOrder, newOrder
 			return nil, err
 		}
 
-		conf, err = m.matching.SubmitOrder(newOrder) //lint:ignore SA4006 this value might be overwriter, careful!
+		// Because other collections might be pointing at the original order
+		// use it's memory when inserting the new version
+		*existingOrder = *newOrder
+		conf, err = m.matching.SubmitOrder(existingOrder) //lint:ignore SA4006 this value might be overwriter, careful!
 		// replace the trades in the confirmation to have
 		// the ones with the fees embedded
 		conf.Trades = trades


### PR DESCRIPTION
When performing amends on pegged orders, the pegged order list was referencing the order before it was amended while the order book was referencing the new amended order.
The code is now updated to reuse the original memory area so anything pointing at it will automatically get the updated order details.