### PR TITLE
Bugfix/2697 fix fee monitoring auction

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1152,13 +1152,6 @@ func (m *Market) applyFees(ctx context.Context, order *types.Order, trades []*ty
 	} else if m.as.IsMonitorAuction() {
 		// we are in auction mode
 		fees, err = m.fee.CalculateForAuctionMode(trades)
-		fmt.Printf("AUCTION MODE FEES: %v#\n", fees)
-		for _, v := range fees.Transfers() {
-			fmt.Printf("transfer: %v# | amount: %v\n", v, v.Amount.Amount)
-		}
-		for _, v := range trades {
-			fmt.Printf("trade: %v\n", v)
-		}
 	} else if m.as.IsFBA() {
 		fees, err = m.fee.CalculateForFrequentBatchesAuctionMode(trades)
 	}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -1031,9 +1031,9 @@ func baseMarket(row *gherkin.TableRow) types.Market {
 		DecimalPlaces: 2,
 		Fees: &types.Fees{
 			Factors: &types.FeeFactors{
-				LiquidityFee:      val(row, 17),
+				LiquidityFee:      val(row, 19),
 				InfrastructureFee: val(row, 18),
-				MakerFee:          val(row, 19),
+				MakerFee:          val(row, 17),
 			},
 		},
 		TradableInstrument: &types.TradableInstrument{

--- a/integration/features/price-monitoring-for-system-test.feature
+++ b/integration/features/price-monitoring-for-system-test.feature
@@ -25,12 +25,12 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_OPENING_AUCTION"
 
     # T + 5s
-    Then the time is updated to "2020-10-16T00:00:05Z" 
+    Then the time is updated to "2020-10-16T00:00:05Z"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_OPENING_AUCTION"
 
     # T + 1s
-    Then the time is updated to "2020-10-16T00:00:06Z" 
+    Then the time is updated to "2020-10-16T00:00:06Z"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
 
@@ -38,7 +38,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     Then traders place following orders with references:
       | trader  | id        | type | volume |    price  | resulting trades | type       | tif     | reference      |
       | trader1 | ETH/DEC20 | sell |      1 |    99844  |                0 | TYPE_LIMIT  | TIF_GTC | trader1_sell_1 |
- 
+
     Then traders place following orders:
       | trader  | id        | type | volume |    price | resulting trades | type       | tif     |
       | trader2 | ETH/DEC20 | buy  |      1 |    99844 |                0 | TYPE_LIMIT | TIF_FOK |
@@ -52,7 +52,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | trader1  |  trader1_sell_1 |
 
     # T + 4s
-    Then the time is updated to "2020-10-16T00:00:10Z" 
+    Then the time is updated to "2020-10-16T00:00:10Z"
 
     # 2nd trigger breached with persistent order -> auction extended by 8s (total auction time no 14s).
     Then traders place following orders:
@@ -61,18 +61,20 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | trader2 | ETH/DEC20 | buy  |      1 |   100291  |                0 | TYPE_LIMIT | TIF_GTC |
 
     # T + 10s (last second of the auciton)
-    Then the time is updated to "2020-10-16T00:00:20Z" 
+    Then the time is updated to "2020-10-16T00:00:20Z"
 
     And the mark price for the market "ETH/DEC20" is "100000"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
     # T + 1s (auction ended)
-    Then the time is updated to "2020-10-16T00:00:21Z" 
+    Then the time is updated to "2020-10-16T00:00:21Z"
 
     And the mark price for the market "ETH/DEC20" is "100291"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
+
+    And dump transfers
 
     # 100291 is the new reference price, we get the following valid price ranges for the 2 triggers: [100135, 100447] & [100001, 100582]
     Then traders place following orders:
@@ -84,9 +86,9 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
 
-    # Now we should be after update and the bounds should change 
+    # Now we should be after update and the bounds should change
     # T + 5s
-    Then the time is updated to "2020-10-16T00:00:26Z" 
+    Then the time is updated to "2020-10-16T00:00:26Z"
 
     Then traders place following orders:
       | trader  | id        | type | volume |    price  | resulting trades | type       | tif     |
@@ -96,7 +98,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     And the mark price for the market "ETH/DEC20" is "100448"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
- 
+
     # Now, we have the following valid price ranges for the 2 triggers: [100213, 100525] & [100079, 100660]
     Then traders place following orders:
       | trader  | id        | type | volume |    price  | resulting trades | type       | tif     |
@@ -108,8 +110,8 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
 
 
-    # T + 2s 
-    Then the time is updated to "2020-10-16T00:00:28Z" 
+    # T + 2s
+    Then the time is updated to "2020-10-16T00:00:28Z"
 
     # Both triggers breached with market order -> 14s auction
     Then traders place following orders:
@@ -121,15 +123,15 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
-    # T + 7s 
-    Then the time is updated to "2020-10-16T00:00:35Z" 
+    # T + 7s
+    Then the time is updated to "2020-10-16T00:00:35Z"
 
     And the mark price for the market "ETH/DEC20" is "100448"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
-    # T + 8s 
-    Then the time is updated to "2020-10-16T00:00:43Z" 
+    # T + 8s
+    Then the time is updated to "2020-10-16T00:00:43Z"
 
     And the mark price for the market "ETH/DEC20" is "100448"
 
@@ -148,8 +150,8 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
 
 
-    # T + 2s 
-    Then the time is updated to "2020-10-16T00:00:45Z" 
+    # T + 2s
+    Then the time is updated to "2020-10-16T00:00:45Z"
 
      # 1st trigger breached with persistent order -> auction with initial duration of 6s starts
     Then traders place following orders:
@@ -162,16 +164,16 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
-    # T + 6s 
-    Then the time is updated to "2020-10-16T00:00:51Z" 
+    # T + 6s
+    Then the time is updated to "2020-10-16T00:00:51Z"
 
     And the mark price for the market "ETH/DEC20" is "100292"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
 
-    # T + 1s 
-    Then the time is updated to "2020-10-16T00:00:52Z" 
+    # T + 1s
+    Then the time is updated to "2020-10-16T00:00:52Z"
 
     And the mark price for the market "ETH/DEC20" is "100213"
 


### PR DESCRIPTION
Send the trades to the event bus when fees have been applied when LeaveAuction is called.
Until that the right amount of fees was not sent through the event bus.

close #2697 