### PR TITLE
2671 auction integration test when uncrossing the book

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -698,7 +698,6 @@ func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
 
 	// Process each confirmation & apply fee calculations to each trade
 	evts := make([]events.Event, 0, len(uncrossedOrders))
-	tradeEvts := []events.Event{}
 	for _, uncrossedOrder := range uncrossedOrders {
 		m.handleConfirmation(ctx, uncrossedOrder.Order, uncrossedOrder)
 
@@ -710,13 +709,9 @@ func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
 			// @TODO this ought to be an event
 			m.log.Error("Unable to apply fees to order", logging.String("OrderID", uncrossedOrder.Order.Id))
 		}
-		for _, t := range uncrossedOrder.Trades {
-			tradeEvts = append(tradeEvts, events.NewTradeEvent(ctx, *t))
-		}
 	}
 	// send order events in a single batch, it's more efficient
 	m.broker.SendBatch(evts)
-	m.broker.SendBatch(tradeEvts)
 
 	// Process each order we have to cancel
 	for _, order := range ordersToCancel {

--- a/execution/market.go
+++ b/execution/market.go
@@ -696,8 +696,9 @@ func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
 		m.log.Error("Error leaving auction", logging.Error(err))
 	}
 
-	// Process each confirmation
+	// Process each confirmation & apply fee calculations to each trade
 	evts := make([]events.Event, 0, len(uncrossedOrders))
+	tradeEvts := []events.Event{}
 	for _, uncrossedOrder := range uncrossedOrders {
 		m.handleConfirmation(ctx, uncrossedOrder.Order, uncrossedOrder)
 
@@ -705,9 +706,17 @@ func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
 			uncrossedOrder.Order.Status = types.Order_STATUS_FILLED
 		}
 		evts = append(evts, events.NewOrderEvent(ctx, uncrossedOrder.Order))
+		if err := m.applyFees(ctx, uncrossedOrder.Order, uncrossedOrder.Trades); err != nil {
+			// @TODO this ought to be an event
+			m.log.Error("Unable to apply fees to order", logging.String("OrderID", uncrossedOrder.Order.Id))
+		}
+		for _, t := range uncrossedOrder.Trades {
+			tradeEvts = append(tradeEvts, events.NewTradeEvent(ctx, *t))
+		}
 	}
 	// send order events in a single batch, it's more efficient
 	m.broker.SendBatch(evts)
+	m.broker.SendBatch(tradeEvts)
 
 	// Process each order we have to cancel
 	for _, order := range ordersToCancel {
@@ -717,18 +726,6 @@ func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
 		}
 	}
 
-	// Apply fee calculations to each trade
-	tradeEvts := []events.Event{}
-	for _, uo := range uncrossedOrders {
-		err := m.applyFees(ctx, uo.Order, uo.Trades)
-		if err != nil {
-			// @TODO this ought to be an event
-			m.log.Error("Unable to apply fees to order", logging.String("OrderID", uo.Order.Id))
-		}
-		for _, t := range uo.Trades {
-			tradeEvts = append(tradeEvts, events.NewTradeEvent(ctx, *t))
-		}
-	}
 	// now that we're left the auction, we can mark all positions
 	// in case any trader is distressed (Which shouldn't be possible)
 	// we'll fall back to the a network order at the new mark price (mid-price)

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -1353,11 +1353,10 @@ func tradersWithdrawBalance(in *gherkin.DataTable) error {
 		if trader == "trader" {
 			continue
 		}
-		asset := val(row, 1)
-		if _, err := execsetup.collateral.GetOrCreatePartyLockWithdrawAccount(context.Background(), trader, asset); err != nil {
+		asset, amount := val(row, 1), u64val(row, 2)
+		if _, err := execsetup.collateral.LockFundsForWithdraw(context.Background(), trader, asset, amount); err != nil {
 			return err
 		}
-		amount := u64val(row, 2)
 		if _, err := execsetup.collateral.Withdraw(context.Background(), trader, asset, amount); err != nil {
 			return err
 		}

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -1154,6 +1154,15 @@ func dumpOrders() error {
 	return nil
 }
 
+func dumpTrades() error {
+	fmt.Println("DUMPING TRADES")
+	data := execsetup.broker.getTrades()
+	for _, t := range data {
+		fmt.Printf("trade %s, %#v\n", t.Id, t)
+	}
+	return nil
+}
+
 func tradersPlacePeggedOrders(orders *gherkin.DataTable) error {
 	for i, row := range orders.Rows {
 		trader := val(row, 0)

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -535,11 +535,12 @@ func allBalancesCumulatedAreWorth(amountstr string) error {
 
 func theFollowingTransfersHappend(arg1 *gherkin.DataTable) error {
 	for _, row := range arg1.Rows {
-		if val(row, 0) == "from" {
+		from := val(row, 0)
+		if from == "from" {
 			continue
 		}
 
-		fromAccountID := accountID(val(row, 4), val(row, 0), val(row, 6), types.AccountType_value[val(row, 2)])
+		fromAccountID := accountID(val(row, 4), from, val(row, 6), types.AccountType_value[val(row, 2)])
 		toAccountID := accountID(val(row, 4), val(row, 1), val(row, 6), types.AccountType_value[val(row, 3)])
 
 		var ledgerEntry *types.LedgerEntry
@@ -922,11 +923,12 @@ func tradersAmendsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 
 func verifyTheStatusOfTheOrderReference(refs *gherkin.DataTable) error {
 	for _, row := range refs.Rows {
-		if val(row, 0) == "trader" {
+		trader := val(row, 0)
+		if trader == "trader" {
 			continue
 		}
 
-		o, err := execsetup.broker.getByReference(val(row, 0), val(row, 1))
+		o, err := execsetup.broker.getByReference(trader, val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -944,6 +946,7 @@ func verifyTheStatusOfTheOrderReference(refs *gherkin.DataTable) error {
 }
 
 func dumpTransfers() error {
+	fmt.Println("DUMPING TRANSFERS")
 	transferEvents := execsetup.broker.GetTransferResponses()
 	for _, e := range transferEvents {
 		for _, t := range e.TransferResponses() {
@@ -1142,6 +1145,7 @@ func executedTrades(trades *gherkin.DataTable) error {
 }
 
 func dumpOrders() error {
+	fmt.Println("DUMPING ORDERS")
 	data := execsetup.broker.GetOrderEvents()
 	for _, v := range data {
 		o := *v.Order()

--- a/integration/features/opening-auction-uncross.feature
+++ b/integration/features/opening-auction-uncross.feature
@@ -54,6 +54,7 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | trader1 | 10000 | 3    | trader2 |
       | trader1 | 10000 | 2    | trader2 |
       | trader1 | 10000 | 3    | trader2 |
+    And the mark price for the market "ETH/DEC19" is "10000"
     ## Network for distressed trader1 -> cancelled, nothing on the book is remaining
     Then verify the status of the order reference:
       | trader  | reference | status           |
@@ -69,3 +70,7 @@ Feature: Set up a market, with an opening auction, then uncross the book
     And the following transfers happened:
       | from    | to      | from account type   | to account type      | market ID | amount | asset |
       | trader2 | trader2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 3479   | BTC   |
+    Then I expect the trader to have a margin:
+      | trader  | asset | id        | margin | general  |
+      | trader2 | BTC   | ETH/DEC19 | 9600   | 3479     |
+      | trader1 | BTC   | ETH/DEC19 | 13440  | 0        |

--- a/integration/features/opening-auction-uncross.feature
+++ b/integration/features/opening-auction-uncross.feature
@@ -1,0 +1,46 @@
+Feature: Set up a market, with an opening auction, then uncross the book
+
+
+  Background:
+    Given the insurance pool initial balance for the markets is "0":
+    And the executon engine have these markets:
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee | p. m. update freq. | p. m. horizons | p. m. probs | p. m. durations |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 1           | continuous   |        0 |                 0 |            0 |                 0  |                |             |                 |
+
+  Scenario: set up 2 traders with balance
+    # setup accounts
+    Given the following traders:
+      | name    | amount    |
+      | trader1 | 100000000 |
+      | trader2 | 100000000 |
+    Then I Expect the traders to have new general account:
+      | name    | asset |
+      | trader1 | BTC   |
+      | trader2 | BTC   |
+
+    # place orders and generate trades
+    Then traders place following orders with references:
+      | trader  | id        | type | volume | price  | resulting trades | type        | tif     | reference |
+      | trader1 | ETH/DEC19 | buy  | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-1    |
+      | trader2 | ETH/DEC19 | sell | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t2_s-1    |
+      | trader1 | ETH/DEC19 | buy  | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-1    |
+      | trader2 | ETH/DEC19 | sell | 5      | 10001  | 0                | TYPE_LIMIT  | TIF_GFA | t2-s-2    |
+      | trader1 | ETH/DEC19 | buy  | 4      | 3000   | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-3    |
+      | trader2 | ETH/DEC19 | sell | 3      | 3000   | 0                | TYPE_LIMIT  | TIF_GFA | t2-s-3    |
+    And dump orders
+    Then the margins levels for the traders are:
+      | trader  | id        | maintenance | search | initial | release |
+      | trader1 | ETH/DEC19 |       11200 |  12320 |   13440 |   27679 |
+      | trader2 | ETH/DEC19 |       10899 |  11989 |   13079 |   27258 |
+    Then traders withdraw balance:
+      | trader  | asset | amount   |
+      | trader1 | BTC   | 99986560 |
+      | trader2 | BTC   | 99986921 |
+    Then I expect the trader to have a margin:
+      | trader  | asset | id        | margin | general  |
+#     | trader1 | BTC   | ETH/DEC19 |  11200 | 99988800 |
+#     | trader2 | BTC   | ETH/DEC19 |  10899 | 99989101 |
+      | trader1 | BTC   | ETH/DEC19 |  13440 | 99986560 |
+      | trader2 | BTC   | ETH/DEC19 |  13079 | 99986921 |
+    Then the opening auction period for market "ETH/DEC19" ends
+    And dump orders

--- a/integration/features/opening-auction-uncross.feature
+++ b/integration/features/opening-auction-uncross.feature
@@ -48,6 +48,12 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | trader2 | BTC   | ETH/DEC19 |  13079 | 0        |
 #   And dump transfers
     Then the opening auction period for market "ETH/DEC19" ends
+    ## We're seeing these events twice for some reason
+    And executed trades:
+      | buyer   | price | size | seller  |
+      | trader1 | 10000 | 3    | trader2 |
+      | trader1 | 10000 | 2    | trader2 |
+      | trader1 | 10000 | 3    | trader2 |
     ## Network for distressed trader1 -> cancelled, nothing on the book is remaining
     Then verify the status of the order reference:
       | trader  | reference | status           |
@@ -58,6 +64,7 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | trader1 | t1-b-3    | STATUS_CANCELLED |
       | trader2 | t2-s-3    | STATUS_FILLED    |
       | network | LS-       | STATUS_STOPPED   |
+#   And dump trades
 #   And dump transfers
     And the following transfers happened:
       | from    | to      | from account type   | to account type      | market ID | amount | asset |

--- a/integration/features/opening-auction-uncross.feature
+++ b/integration/features/opening-auction-uncross.feature
@@ -22,12 +22,12 @@ Feature: Set up a market, with an opening auction, then uncross the book
     Then traders place following orders with references:
       | trader  | id        | type | volume | price  | resulting trades | type        | tif     | reference |
       | trader1 | ETH/DEC19 | buy  | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-1    |
-      | trader2 | ETH/DEC19 | sell | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t2_s-1    |
-      | trader1 | ETH/DEC19 | buy  | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-1    |
+      | trader2 | ETH/DEC19 | sell | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t2-s-1    |
+      | trader1 | ETH/DEC19 | buy  | 5      | 10000  | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-2    |
       | trader2 | ETH/DEC19 | sell | 5      | 10001  | 0                | TYPE_LIMIT  | TIF_GFA | t2-s-2    |
       | trader1 | ETH/DEC19 | buy  | 4      | 3000   | 0                | TYPE_LIMIT  | TIF_GFA | t1-b-3    |
       | trader2 | ETH/DEC19 | sell | 3      | 3000   | 0                | TYPE_LIMIT  | TIF_GFA | t2-s-3    |
-    And dump orders
+#   And dump orders
     Then the margins levels for the traders are:
       | trader  | id        | maintenance | search | initial | release |
       | trader1 | ETH/DEC19 |       11200 |  12320 |   13440 |   27679 |
@@ -46,5 +46,19 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | trader  | asset | id        | margin | general  |
       | trader1 | BTC   | ETH/DEC19 |  13440 | 0        |
       | trader2 | BTC   | ETH/DEC19 |  13079 | 0        |
+#   And dump transfers
     Then the opening auction period for market "ETH/DEC19" ends
-    And dump orders
+    ## Network for distressed trader1 -> cancelled, nothing on the book is remaining
+    Then verify the status of the order reference:
+      | trader  | reference | status           |
+      | trader1 | t1-b-1    | STATUS_FILLED    |
+      | trader2 | t2-s-1    | STATUS_FILLED    |
+      | trader1 | t1-b-2    | STATUS_CANCELLED |
+      | trader2 | t2-s-2    | STATUS_CANCELLED |
+      | trader1 | t1-b-3    | STATUS_CANCELLED |
+      | trader2 | t2-s-3    | STATUS_FILLED    |
+      | network | LS-       | STATUS_STOPPED   |
+#   And dump transfers
+    And the following transfers happened:
+      | from    | to      | from account type   | to account type      | market ID | amount | asset |
+      | trader2 | trader2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 3479   | BTC   |

--- a/integration/features/opening-auction-uncross.feature
+++ b/integration/features/opening-auction-uncross.feature
@@ -4,8 +4,8 @@ Feature: Set up a market, with an opening auction, then uncross the book
   Background:
     Given the insurance pool initial balance for the markets is "0":
     And the executon engine have these markets:
-      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee | p. m. update freq. | p. m. horizons | p. m. probs | p. m. durations |
-      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 1           | continuous   |        0 |                 0 |            0 |                 0  |                |             |                 |
+      | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu | r  | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee | p. m. update freq. | p. m. horizons | p. m. probs | p. m. durations | Prob of trading |
+      | ETH/DEC19 | ETH      | BTC       | BTC   | 100       | simple     | 0.1       | 0.1       | -1 | -1 | -1    | 1.4            | 1.2            | 1.1           | 100             | 1           | continuous   |        0 |                 0 |            0 |                 0  |                |             |                 | 0.1             |
 
   Scenario: set up 2 traders with balance
     # setup accounts
@@ -32,15 +32,19 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | trader  | id        | maintenance | search | initial | release |
       | trader1 | ETH/DEC19 |       11200 |  12320 |   13440 |   27679 |
       | trader2 | ETH/DEC19 |       10899 |  11989 |   13079 |   27258 |
-    Then traders withdraw balance:
-      | trader  | asset | amount   |
-      | trader1 | BTC   | 99986560 |
-      | trader2 | BTC   | 99986921 |
     Then I expect the trader to have a margin:
       | trader  | asset | id        | margin | general  |
 #     | trader1 | BTC   | ETH/DEC19 |  11200 | 99988800 |
 #     | trader2 | BTC   | ETH/DEC19 |  10899 | 99989101 |
       | trader1 | BTC   | ETH/DEC19 |  13440 | 99986560 |
       | trader2 | BTC   | ETH/DEC19 |  13079 | 99986921 |
+    And traders withdraw balance:
+      | trader  | asset | amount   |
+      | trader1 | BTC   | 99986560 |
+      | trader2 | BTC   | 99986921 |
+    Then I expect the trader to have a margin:
+      | trader  | asset | id        | margin | general  |
+      | trader1 | BTC   | ETH/DEC19 |  13440 | 0        |
+      | trader2 | BTC   | ETH/DEC19 |  13079 | 0        |
     Then the opening auction period for market "ETH/DEC19" ends
     And dump orders

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -108,4 +108,6 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^traders cancel pegged orders and clear:$`, tradersCancelPeggedOrdersAndClear)
 	s.Step(`^the trader submits LP:$`, submitLP)
 	s.Step(`^I see the LP events:$`, seeLPEvents)
+	s.Step(`^the opening auction period for market "([^"]+)" ends$`, theOpeningAuctionPeriodEnds)
+	s.Step(`^traders withdraw balance:$`, tradersWithdrawBalance)
 }

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -110,4 +110,5 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I see the LP events:$`, seeLPEvents)
 	s.Step(`^the opening auction period for market "([^"]+)" ends$`, theOpeningAuctionPeriodEnds)
 	s.Step(`^traders withdraw balance:$`, tradersWithdrawBalance)
+	s.Step(`^dump trades$`, dumpTrades)
 }


### PR DESCRIPTION
Recreate the scenario from system tests that uncovered the runtime panic: 2 traders place orders during the opening auction, and then withdraw their general account balance. The opening auction ends. The book should be uncrossed, parties ought to be marked to market, and market should start trading normally.

The scenario is currently passing, but trader1 still ends up distressed. This is likely due to the margin being calculated based on the the order price, which differs too much from the mid price. The trader is placing orders for a long position, and the margin allocated is insufficient given the eventual mid price.

The uncrossing appears to be correct (both traders have matching orders of equal size, and both are filled. Trader 2 uncrosses an order of size 3 with an order of size 5 placed by trader1, this order is then cancelled after being partially filled). Trader2 does get some margin released. Currently the MTM settlements aren't showing up, and we're not verifying the mark price yet. Would like to get some eyes on the scenario itself, though