### PR TITLE
send a market data event when the market is created so graphql can retrieve it through subscription

### DIFF
--- a/execution/engine.go
+++ b/execution/engine.go
@@ -188,6 +188,8 @@ func (e *Engine) SubmitMarket(ctx context.Context, marketConfig *types.Market) e
 	e.markets[marketConfig.Id] = mkt
 	e.marketsCpy = append(e.marketsCpy, mkt)
 
+	// we send a market data event for this market when it's created so graphql does not fail
+	e.broker.Send(events.NewMarketDataEvent(ctx, mkt.GetMarketData()))
 	e.broker.Send(events.NewMarketEvent(ctx, *mkt.mkt))
 
 	// we ignore the reponse, this cannot fail as the asset


### PR DESCRIPTION
close #2633 