### PR TITLE
add missing order error mapping + add test for 2747

### DIFF
--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -19,11 +19,11 @@ import (
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/risk"
 	"code.vegaprotocol.io/vega/settlement"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const MAXMOVEUP = 10

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -123,6 +123,18 @@ func (err OrderError) Error() string {
 		return "OrderError: cannot amend pegged details on a non pegged order"
 	case OrderError_ORDER_ERROR_INVALID_TIME_IN_FORCE:
 		return "OrderError: invalid time in force"
+	case OrderError_ORDER_ERROR_BUY_CANNOT_REFERENCE_BEST_ASK_PRICE:
+		return "OrderError: buy cannot reference best ask price"
+	case OrderError_ORDER_ERROR_OFFSET_MUST_BE_LESS_OR_EQUAL_TO_ZERO:
+		return "OrderError: offset must be <= 0"
+	case OrderError_ORDER_ERROR_OFFSET_MUST_BE_LESS_THAN_ZERO:
+		return "OrderError: offset must be < 0"
+	case OrderError_ORDER_ERROR_OFFSET_MUST_BE_GREATER_OR_EQUAL_TO_ZERO:
+		return "OrderError: offset must be >= 0"
+	case OrderError_ORDER_ERROR_SELL_CANNOT_REFERENCE_BEST_BID_PRICE:
+		return "OrderError: sell cannot reference best bid price"
+	case OrderError_ORDER_ERROR_OFFSET_MUST_BE_GREATER_THAN_ZERO:
+		return "OrderError: offset must be greater than zero"
 	default:
 		return "invalid OrderError"
 	}


### PR DESCRIPTION
@3jtechtest This appear not to be an issue. The original issue seems to try to change an order:
from:
BUY, Pegged MID
to:
BUY, Pegged BestAsk

Which is not permitted.

Althought the error was not mapped so you would get: invalid OrderError

close #2747 
now the error should be more explicit: OrderError: buy cannot reference best ask price
