### PR TITLE
comment out the updating fees until it's all working

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1321,13 +1321,18 @@ func (m *Market) confirmMTM(ctx context.Context, order *types.Order) {
 func (m *Market) updateLiquidityFee(ctx context.Context) {
 	stake := m.getTargetStake()
 	fee := m.liquidity.ProvisionsPerParty().FeeForTarget(uint64(stake))
+	_ = fee
 
-	m.fee.SetLiquidityFee(fee)
-
-	m.mkt.Fees.Factors.LiquidityFee = fee
-	m.broker.Send(
-		events.NewMarketEvent(ctx, *m.mkt),
-	)
+	// TODO(jeremy): this need to be uncommented later
+	// we do not set the fee for now so system-test
+	// can keep running with the static fee setted up in the
+	// genesis block.
+	// m.fee.SetLiquidityFee(fee)
+	//
+	// m.mkt.Fees.Factors.LiquidityFee = fee
+	// m.broker.Send(
+	// 	events.NewMarketEvent(ctx, *m.mkt),
+	// )
 }
 
 // resolveClosedOutTraders - the traders with the given market position who haven't got sufficient collateral


### PR DESCRIPTION
This is just commenting us setting the fee dynamically with the Liquidity stuff.
Until this is fully build liquidity fee are not working at all, so we'll rely on the static fee defined in the genesis block, and all system test should work.

close #2744 