### PR TITLE
Added rounding to MID price for pegged orders

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -168,7 +168,8 @@ type Market struct {
 	// Store the previous price values so we can see what has changed
 	lastBestBidPrice uint64
 	lastBestAskPrice uint64
-	lastMidPrice     uint64
+	lastMidBuyPrice  uint64
+	lastMidSellPrice uint64
 
 	marketValueWindowLength time.Duration
 	feeSplitter             *FeeSplitter
@@ -609,7 +610,7 @@ func (m *Market) getNewPeggedPrice(ctx context.Context, order *types.Order) (uin
 
 	switch order.PeggedOrder.Reference {
 	case types.PeggedReference_PEGGED_REFERENCE_MID:
-		price, err = m.getStaticMidPrice()
+		price, err = m.getStaticMidPrice(order.Side)
 	case types.PeggedReference_PEGGED_REFERENCE_BEST_BID:
 		price, err = m.getBestStaticBidPrice()
 	case types.PeggedReference_PEGGED_REFERENCE_BEST_ASK:
@@ -2650,7 +2651,7 @@ func (m *Market) getBestStaticBidPriceAndVolume() (uint64, uint64, error) {
 	return m.matching.GetBestStaticBidPriceAndVolume()
 }
 
-func (m *Market) getStaticMidPrice() (uint64, error) {
+func (m *Market) getStaticMidPrice(side types.Side) (uint64, error) {
 	bid, err := m.matching.GetBestStaticBidPrice()
 	if err != nil {
 		return 0, err
@@ -2659,7 +2660,14 @@ func (m *Market) getStaticMidPrice() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return (bid + ask) / 2, nil
+	var mid uint64
+	if side == types.Side_SIDE_BUY {
+		mid = (bid + ask + 1) / 2
+	} else {
+		mid = (bid + ask) / 2
+	}
+
+	return mid, nil
 }
 
 // checkForReferenceMoves looks to see if the reference prices have moved since the
@@ -2673,11 +2681,13 @@ func (m *Market) checkForReferenceMoves(ctx context.Context) {
 		// Get the current reference values and compare them to the last saved set
 		newBestBid, _ := m.getBestStaticBidPrice()
 		newBestAsk, _ := m.getBestStaticAskPrice()
-		newMid, _ := m.getStaticMidPrice()
+		newMidBuy, _ := m.getStaticMidPrice(types.Side_SIDE_BUY)
+		newMidSell, _ := m.getStaticMidPrice(types.Side_SIDE_SELL)
 
 		// Look for a move
 		var changes uint8
-		if newMid != m.lastMidPrice {
+		if newMidBuy != m.lastMidBuyPrice ||
+			newMidSell != m.lastMidSellPrice {
 			changes |= PriceMoveMid
 		}
 		if newBestBid != m.lastBestBidPrice {
@@ -2695,7 +2705,8 @@ func (m *Market) checkForReferenceMoves(ctx context.Context) {
 		}
 
 		// Update the last price values
-		m.lastMidPrice = newMid
+		m.lastMidBuyPrice = newMidBuy
+		m.lastMidSellPrice = newMidSell
 		m.lastBestBidPrice = newBestBid
 		m.lastBestAskPrice = newBestAsk
 

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -1568,6 +1568,7 @@ func TestPeggedOrdersAmends(t *testing.T) {
 	t.Run("pegged orders amend multiple fields at once", testPeggedOrderAmendMultiple)
 	t.Run("pegged orders amend multiple fields at once in an auction", testPeggedOrderAmendMultipleInAuction)
 	t.Run("pegged orders delete an order that has lost time priority", testPeggedOrderCanDeleteAfterLostPriority)
+	t.Run("pegged orders validate mid price values", testPeggedOrderMidPriceCalc)
 }
 
 // We had a case where things crashed when the orders on the same price level were not sorted
@@ -1903,4 +1904,42 @@ func testPeggedOrderAmendMultiple(t *testing.T) {
 	assert.Equal(t, 1, tm.market.GetPeggedOrderCount())
 	assert.Equal(t, types.PeggedReference_PEGGED_REFERENCE_MID, amended.Order.PeggedOrder.Reference)
 	assert.Equal(t, types.Order_TIF_GTT, amended.Order.TimeInForce)
+}
+
+func testPeggedOrderMidPriceCalc(t *testing.T) {
+	now := time.Unix(10, 0)
+	closeSec := int64(10000000000)
+	closingAt := time.Unix(closeSec, 0)
+	tm := getTestMarket(t, now, closingAt, nil, nil)
+
+	addAccount(tm, "party1")
+
+	// Place 2 trades so we have a valid BEST_BID+MID+BEST_ASK price
+	buyOrder := sendOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, 0, types.Side_SIDE_BUY, "party1", 1, 90)
+	require.NotNil(t, buyOrder)
+	sellOrder := sendOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, 0, types.Side_SIDE_SELL, "party1", 1, 110)
+	require.NotNil(t, sellOrder)
+
+	// Place the pegged orders
+	order1 := getOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, 0, types.Side_SIDE_BUY, "party1", 10, 10)
+	order1.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Offset: -20}
+	confirmation1, err := tm.market.SubmitOrder(context.Background(), &order1)
+	require.NotNil(t, confirmation1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(80), confirmation1.Order.Price)
+
+	order2 := getOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, 0, types.Side_SIDE_SELL, "party1", 10, 10)
+	order2.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Offset: +20}
+	confirmation2, err := tm.market.SubmitOrder(context.Background(), &order2)
+	require.NotNil(t, confirmation2)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(120), confirmation2.Order.Price)
+
+	// Make the mid price wonky (needs rounding)
+	buyOrder2 := sendOrder(t, tm, &now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, 0, types.Side_SIDE_BUY, "party1", 1, 91)
+	require.NotNil(t, buyOrder2)
+
+	// Check the pegged orders have reprices properly
+	assert.Equal(t, uint64(81), confirmation1.Order.Price)  // Buy price gets rounded up
+	assert.Equal(t, uint64(120), confirmation2.Order.Price) // Sell price gets rounded down
 }

--- a/integration/features/market-depth-1.feature
+++ b/integration/features/market-depth-1.feature
@@ -7,7 +7,7 @@ Feature: Test market depth events for pegged orders
       | name      | baseName | quoteName | asset | markprice | risk model | lamd/long | tau/short | mu |     r | sigma | release factor | initial factor | search factor | settlementPrice | openAuction | trading mode | makerFee | infrastructureFee | liquidityFee | p. m. update freq. | p. m. horizons | p. m. probs | p. m. durations | Prob of trading |
       | ETH/DEC19 | ETH      | BTC       | BTC   |       100 | simple     |          0 |        0 |  0 | 0.016 |   2.0 |            1.4 |            1.2 |           1.1 |              42 | 0           | continuous   |        0 |                 0 |            0 |                 0  |                |             |                 | 0.1             |
 
-  Scenario: Ensure the expect order events for pegged orders are produced when mid price changes
+  Scenario: Ensure the expected order events for pegged orders are produced when mid price changes
 # setup accounts
     Given the following traders:
       | name             |    amount |


### PR DESCRIPTION
When a MID price falls on a non integer value we round it up if the pegged order is a buy and round it down if the pegged order is a sell.