### PR TITLE
PM integration test: increase wait time and triggering price

### DIFF
--- a/integration/features/price-monitoring-for-system-test.feature
+++ b/integration/features/price-monitoring-for-system-test.feature
@@ -152,11 +152,11 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     # T + 12s
     Then the time is updated to "2020-10-16T00:00:55Z"
 
-     # 1st trigger breached with persistent order -> auction with initial duration of 6s starts
+     # Both triggers breached with persistent order -> auction with duration of 10s starts
     Then traders place following orders:
       | trader  | id        | type | volume |    price  | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC20 | sell |      1 |   100450  |                0 | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC20 | buy  |      1 |   100450  |                0 | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC20 | sell |      1 |   100650  |                0 | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC20 | buy  |      1 |   100650  |                0 | TYPE_LIMIT | TIF_GTC |
 
 
     And the mark price for the market "ETH/DEC20" is "100292"
@@ -170,10 +170,16 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
-
     # T + 1s
     Then the time is updated to "2020-10-16T00:01:02Z"
 
-    And the mark price for the market "ETH/DEC20" is "100450"
+    And the mark price for the market "ETH/DEC20" is "100292"
+
+    And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
+
+    # T + 8s
+    Then the time is updated to "2020-10-16T00:01:10Z"
+
+    And the mark price for the market "ETH/DEC20" is "100650"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"

--- a/integration/features/price-monitoring-for-system-test.feature
+++ b/integration/features/price-monitoring-for-system-test.feature
@@ -149,14 +149,14 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"
 
 
-    # T + 2s
-    Then the time is updated to "2020-10-16T00:00:45Z"
+    # T + 12s
+    Then the time is updated to "2020-10-16T00:00:55Z"
 
      # 1st trigger breached with persistent order -> auction with initial duration of 6s starts
     Then traders place following orders:
       | trader  | id        | type | volume |    price  | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC20 | sell |      1 |   100370  |                0 | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC20 | buy  |      1 |   100370  |                0 | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC20 | sell |      1 |   100450  |                0 | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC20 | buy  |      1 |   100450  |                0 | TYPE_LIMIT | TIF_GTC |
 
 
     And the mark price for the market "ETH/DEC20" is "100292"
@@ -164,7 +164,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_MONITORING_AUCTION"
 
     # T + 6s
-    Then the time is updated to "2020-10-16T00:00:51Z"
+    Then the time is updated to "2020-10-16T00:01:01Z"
 
     And the mark price for the market "ETH/DEC20" is "100292"
 
@@ -172,8 +172,8 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
 
     # T + 1s
-    Then the time is updated to "2020-10-16T00:00:52Z"
+    Then the time is updated to "2020-10-16T00:01:02Z"
 
-    And the mark price for the market "ETH/DEC20" is "100370"
+    And the mark price for the market "ETH/DEC20" is "100450"
 
     And the market state for the market "ETH/DEC20" is "MARKET_STATE_CONTINUOUS"


### PR DESCRIPTION
Some system-tests steps take at least a few seconds to execute, hence a 2s wait was not enough and test (on the system-tests side) was non deterministic with the old value.
Now using a longer wait and a value in between-ish the 2 triggers to aid that.

This way the system test can use the same reference values as the integration test which might be helpful for debugging in the future. 