### PR TITLE
Expose supplied stake

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -378,9 +378,7 @@ func (m *Market) GetMarketData() types.MarketData {
 		MarketState:           m.as.Mode(),
 		Trigger:               m.as.Trigger(),
 		TargetStake:           fmt.Sprintf("%.f", m.getTargetStake()),
-		// FIXME(WITOLD): uncomment set real values here
-		// TargetStake: getTargetStake(),
-		// SuppliedStake: getSuppliedStake(),
+		SuppliedStake:         fmt.Sprintf("%.f", m.getSuppliedStake()),
 		PriceMonitoringBounds: m.pMonitor.GetCurrentBounds(),
 	}
 }
@@ -2846,6 +2844,10 @@ func (m *Market) getTargetStake() float64 {
 		return 0
 	}
 	return m.tsCalc.GetTargetStake(*rf, m.currentTime)
+}
+
+func (m *Market) getSuppliedStake() float64 {
+	return m.liquidity.CalculateSuppliedLiquidity(m.markPrice)
 }
 
 func (m *Market) OnMarginScalingFactorsUpdate(ctx context.Context, sf *types.ScalingFactors) error {

--- a/execution/market.go
+++ b/execution/market.go
@@ -2847,7 +2847,7 @@ func (m *Market) getTargetStake() float64 {
 }
 
 func (m *Market) getSuppliedStake() float64 {
-	return m.liquidity.CalculateSuppliedLiquidity(m.markPrice)
+	return m.liquidity.CalculateSuppliedStake(m.markPrice)
 }
 
 func (m *Market) OnMarginScalingFactorsUpdate(ctx context.Context, sf *types.ScalingFactors) error {

--- a/execution/market.go
+++ b/execution/market.go
@@ -379,7 +379,7 @@ func (m *Market) GetMarketData() types.MarketData {
 		MarketState:           m.as.Mode(),
 		Trigger:               m.as.Trigger(),
 		TargetStake:           fmt.Sprintf("%.f", m.getTargetStake()),
-		SuppliedStake:         strconv.FormatFloat(m.getSuppliedStake(), 'f', -1, 64),
+		SuppliedStake:         strconv.FormatUint(m.getSuppliedStake(), 10),
 		PriceMonitoringBounds: m.pMonitor.GetCurrentBounds(),
 	}
 }
@@ -2847,8 +2847,8 @@ func (m *Market) getTargetStake() float64 {
 	return m.tsCalc.GetTargetStake(*rf, m.currentTime)
 }
 
-func (m *Market) getSuppliedStake() float64 {
-	return m.liquidity.CalculateSuppliedStake(m.markPrice)
+func (m *Market) getSuppliedStake() uint64 {
+	return m.liquidity.CalculateSuppliedStake()
 }
 
 func (m *Market) OnMarginScalingFactorsUpdate(ctx context.Context, sf *types.ScalingFactors) error {

--- a/execution/market.go
+++ b/execution/market.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strconv"
 	"sync"
 	"time"
 
@@ -378,7 +379,7 @@ func (m *Market) GetMarketData() types.MarketData {
 		MarketState:           m.as.Mode(),
 		Trigger:               m.as.Trigger(),
 		TargetStake:           fmt.Sprintf("%.f", m.getTargetStake()),
-		SuppliedStake:         fmt.Sprintf("%.f", m.getSuppliedStake()),
+		SuppliedStake:         strconv.FormatFloat(m.getSuppliedStake(), 'f', -1, 64),
 		PriceMonitoringBounds: m.pMonitor.GetCurrentBounds(),
 	}
 }
@@ -2972,7 +2973,8 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		m.broker.Send(events.NewTransferResponse(ctx, []*types.TransferResponse{tresp}))
 	}()
 
-	newOrders, amendments, err := m.liquidity.CreateInitialOrders(m.markPrice, party, m.repriceFuncW)
+	existingOrders := m.matching.GetOrdersPerParty(party)
+	newOrders, amendments, err := m.liquidity.CreateInitialOrders(m.markPrice, party, existingOrders, m.repriceFuncW)
 	if err != nil {
 		return err
 	}

--- a/execution/market.go
+++ b/execution/market.go
@@ -2973,8 +2973,7 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		m.broker.Send(events.NewTransferResponse(ctx, []*types.TransferResponse{tresp}))
 	}()
 
-	existingOrders := m.matching.GetOrdersPerParty(party)
-	newOrders, amendments, err := m.liquidity.CreateInitialOrders(m.markPrice, party, existingOrders, m.repriceFuncW)
+	newOrders, amendments, err := m.liquidity.CreateInitialOrders(m.markPrice, party, m.repriceFuncW)
 	if err != nil {
 		return err
 	}

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -1378,6 +1378,7 @@ func TestSuppliedStakeReturnedAndCorrect(t *testing.T) {
 	addAccount(tm, party2)
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
 
+	//TODO (WG 07/01/21): Currently limit orders need to be present on order book for liquidity provision submission to work, remove once fixed.
 	orderSell1 := &types.Order{
 		Type:        types.Order_TYPE_LIMIT,
 		TimeInForce: types.Order_TIF_GTT,
@@ -1450,12 +1451,9 @@ func TestSuppliedStakeReturnedAndCorrect(t *testing.T) {
 
 	mktData := tm.market.GetMarketData()
 	require.NotNil(t, mktData)
-	rmParams := tm.mktCfg.TradableInstrument.GetSimpleRiskModel().Params
-	expectedSuppliedStake := math.Min(
-		float64(mktData.BestBidPrice*mktData.BestBidVolume)*rmParams.ProbabilityOfTrading,
-		float64(mktData.BestOfferPrice*mktData.BestOfferVolume)*rmParams.ProbabilityOfTrading)
+	expectedSuppliedStake := lp1.CommitmentAmount + lp2.CommitmentAmount
 
-	require.Equal(t, strconv.FormatFloat(expectedSuppliedStake, 'f', -1, 64), mktData.SuppliedStake)
+	require.Equal(t, strconv.FormatUint(expectedSuppliedStake, 10), mktData.SuppliedStake)
 }
 
 func getMarketOrder(tm *testMarket,

--- a/integration/features/liquidity_provision_simple.feature
+++ b/integration/features/liquidity_provision_simple.feature
@@ -30,14 +30,14 @@ Feature: Test LP orders
       | buySideProvider   | ETH/DEC19 | buy  |   1000 |           | 0      | 80    | STATUS_ACTIVE |
     And clear order events
     Then the trader submits LP:
-      | id  | party   | market    | commitment amount  | fee | order side | order reference | order proportion | order offset |
-      | lp1 | trader1 | ETH/DEC19 | 10000              | 0   | buy        | BID             | 500              | -10          |
-      | lp1 | trader1 | ETH/DEC19 | 10000              | 0   | sell       | ASK             | 500              | 10           |
+      | id  | party   | market    | commitment amount | fee | order side | order reference | order proportion | order offset |
+      | lp1 | trader1 | ETH/DEC19 | 1000              | 0   | buy        | BID             | 500              | -10          |
+      | lp1 | trader1 | ETH/DEC19 | 1000              | 0   | sell       | ASK             | 500              | 10           |
     Then I see the LP events:
       | id  | party   | market    | commitment amount |
-      | lp1 | trader1 | ETH/DEC19 | 10000              |
-    And dump orders
+      | lp1 | trader1 | ETH/DEC19 | 1000              |
+#   And dump orders
     Then I see the following order events:
       | trader  | id        | side | volume | reference | offset | price | status        |
-      | trader1 | ETH/DEC19 | buy  |    450 |           | 0      | 100   | STATUS_ACTIVE |
-      | trader1 | ETH/DEC19 | sell |    308 |           | 0      | 130   | STATUS_ACTIVE |
+      | trader1 | ETH/DEC19 | buy  |    100 |           | 0      | 100   | STATUS_ACTIVE |
+      | trader1 | ETH/DEC19 | sell |     77 |           | 0      | 130   | STATUS_ACTIVE |

--- a/integration/features/liquidity_provision_simple.feature
+++ b/integration/features/liquidity_provision_simple.feature
@@ -30,14 +30,14 @@ Feature: Test LP orders
       | buySideProvider   | ETH/DEC19 | buy  |   1000 |           | 0      | 80    | STATUS_ACTIVE |
     And clear order events
     Then the trader submits LP:
-      | id  | party   | market    | commitment amount | fee | order side | order reference | order proportion | order offset |
-      | lp1 | trader1 | ETH/DEC19 | 1000              | 0   | buy        | BID             | 500              | -10          |
-      | lp1 | trader1 | ETH/DEC19 | 1000              | 0   | sell       | ASK             | 500              | 10           |
+      | id  | party   | market    | commitment amount  | fee | order side | order reference | order proportion | order offset |
+      | lp1 | trader1 | ETH/DEC19 | 10000              | 0   | buy        | BID             | 500              | -10          |
+      | lp1 | trader1 | ETH/DEC19 | 10000              | 0   | sell       | ASK             | 500              | 10           |
     Then I see the LP events:
       | id  | party   | market    | commitment amount |
-      | lp1 | trader1 | ETH/DEC19 | 1000              |
-#   And dump orders
+      | lp1 | trader1 | ETH/DEC19 | 10000              |
+    And dump orders
     Then I see the following order events:
       | trader  | id        | side | volume | reference | offset | price | status        |
-      | trader1 | ETH/DEC19 | buy  |    100 |           | 0      | 100   | STATUS_ACTIVE |
-      | trader1 | ETH/DEC19 | sell |     77 |           | 0      | 130   | STATUS_ACTIVE |
+      | trader1 | ETH/DEC19 | buy  |    450 |           | 0      | 100   | STATUS_ACTIVE |
+      | trader1 | ETH/DEC19 | sell |    308 |           | 0      | 130   | STATUS_ACTIVE |

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -266,8 +266,8 @@ func (e *Engine) Update(markPrice uint64, repriceFn RepricePeggedOrder, orders [
 	return newOrders, amendments, nil
 }
 
-// CalculateSuppliedLiquidity return the total liquidity supplied by all liquidity providers (via standard and liquidity provision orders) given the mark price provided
-func (e *Engine) CalculateSuppliedLiquidity(markPrice uint64) float64 {
+// CalculateSuppliedStake return the total stake supplied by all liquidity providers (via standard and liquidity provision orders) given the mark price provided
+func (e *Engine) CalculateSuppliedStake(markPrice uint64) float64 {
 	orders := make([]*types.Order, 0, len(e.liquidityOrders)+len(e.orders))
 	for party, ordersMap := range e.orders {
 		for _, o := range e.liquidityOrders[party] {

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -237,9 +237,7 @@ func (e *Engine) IsLiquidityOrder(party, order string) bool {
 
 // CreateInitialOrders returns two slices of orders, one are the one to be
 // created and the other the one to be updates.
-func (e *Engine) CreateInitialOrders(markPrice uint64, party string, orders []*types.Order, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {
-	// update our internal orders
-	e.updatePartyOrders(party, orders)
+func (e *Engine) CreateInitialOrders(markPrice uint64, party string, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {
 	creates, amendments, err := e.createOrUpdateForParty(markPrice, party, repriceFn)
 	return creates, amendments, err
 }

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -268,18 +268,13 @@ func (e *Engine) Update(markPrice uint64, repriceFn RepricePeggedOrder, orders [
 	return newOrders, amendments, nil
 }
 
-// CalculateSuppliedStake return the total stake supplied by all liquidity providers (via standard and liquidity provision orders) given the mark price provided
-func (e *Engine) CalculateSuppliedStake(markPrice uint64) float64 {
-	orders := make([]*types.Order, 0, len(e.liquidityOrders)+len(e.orders))
-	for party, ordersMap := range e.orders {
-		for _, o := range e.liquidityOrders[party] {
-			orders = append(orders, o)
-		}
-		for _, o := range ordersMap {
-			orders = append(orders, o)
-		}
+// CalculateSuppliedStake returns the sum of commitment amounts from all the liquidity providers
+func (e *Engine) CalculateSuppliedStake() uint64 {
+	var ss uint64 = 0
+	for _, v := range e.provisions {
+		ss += v.CommitmentAmount
 	}
-	return e.suppliedEngine.CalculateSuppliedLiquidity(float64(markPrice), orders)
+	return ss
 }
 
 func (e *Engine) createOrUpdateForParty(markPrice uint64, party string, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -237,7 +237,9 @@ func (e *Engine) IsLiquidityOrder(party, order string) bool {
 
 // CreateInitialOrders returns two slices of orders, one are the one to be
 // created and the other the one to be updates.
-func (e *Engine) CreateInitialOrders(markPrice uint64, party string, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {
+func (e *Engine) CreateInitialOrders(markPrice uint64, party string, orders []*types.Order, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {
+	// update our internal orders
+	e.updatePartyOrders(party, orders)
 	creates, amendments, err := e.createOrUpdateForParty(markPrice, party, repriceFn)
 	return creates, amendments, err
 }

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -266,6 +266,20 @@ func (e *Engine) Update(markPrice uint64, repriceFn RepricePeggedOrder, orders [
 	return newOrders, amendments, nil
 }
 
+// CalculateSuppliedLiquidity return the total liquidity supplied by all liquidity providers (via standard and liquidity provision orders) given the mark price provided
+func (e *Engine) CalculateSuppliedLiquidity(markPrice uint64) float64 {
+	orders := make([]*types.Order, 0, len(e.liquidityOrders)+len(e.orders))
+	for party, ordersMap := range e.orders {
+		for _, o := range e.liquidityOrders[party] {
+			orders = append(orders, o)
+		}
+		for _, o := range ordersMap {
+			orders = append(orders, o)
+		}
+	}
+	return e.suppliedEngine.CalculateSuppliedLiquidity(float64(markPrice), orders)
+}
+
 func (e *Engine) createOrUpdateForParty(markPrice uint64, party string, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {
 	lp := e.LiquidityProvisionByPartyID(party)
 	if lp == nil {

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -280,7 +280,7 @@ func TestUpdate(t *testing.T) {
 		{Id: "2", PartyID: party, Price: 11, Size: 1, Side: types.Side_SIDE_SELL, Status: types.Order_STATUS_ACTIVE},
 	}
 
-	creates, _, err := tng.engine.CreateInitialOrders(markPrice, party, fn)
+	creates, _, err := tng.engine.CreateInitialOrders(markPrice, party, orders, fn)
 	require.NoError(t, err)
 	require.Len(t, creates, 3)
 
@@ -350,7 +350,7 @@ func TestCalculateSuppliedStake(t *testing.T) {
 		tng.engine.SubmitLiquidityProvision(ctx, lp1, party1, "some-id"),
 	)
 
-	createslp1, _, err := tng.engine.CreateInitialOrders(markPrice, party1, fn)
+	createslp1, _, err := tng.engine.CreateInitialOrders(markPrice, party1, nil, fn)
 	require.NoError(t, err)
 	require.Len(t, createslp1, len(lp1.Buys)+len(lp1.Sells))
 
@@ -371,7 +371,7 @@ func TestCalculateSuppliedStake(t *testing.T) {
 		tng.engine.SubmitLiquidityProvision(ctx, lp2, party2, "some-id"),
 	)
 
-	createsLp2, _, err := tng.engine.CreateInitialOrders(markPrice, party2, fn)
+	createsLp2, _, err := tng.engine.CreateInitialOrders(markPrice, party2, nil, fn)
 	require.NoError(t, err)
 	require.Len(t, createsLp2, len(lp2.Buys)+len(lp2.Sells))
 
@@ -394,7 +394,7 @@ func TestCalculateSuppliedStake(t *testing.T) {
 		tng.engine.SubmitLiquidityProvision(ctx, lp3, party3, "some-id"),
 	)
 
-	createsLp3, _, err := tng.engine.CreateInitialOrders(markPrice, party3, fn)
+	createsLp3, _, err := tng.engine.CreateInitialOrders(markPrice, party3, nil, fn)
 	require.NoError(t, err)
 	require.Len(t, createsLp3, len(lp3.Buys)+len(lp3.Sells))
 

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -280,7 +280,7 @@ func TestUpdate(t *testing.T) {
 		{Id: "2", PartyID: party, Price: 11, Size: 1, Side: types.Side_SIDE_SELL, Status: types.Order_STATUS_ACTIVE},
 	}
 
-	creates, _, err := tng.engine.CreateInitialOrders(markPrice, party, orders, fn)
+	creates, _, err := tng.engine.CreateInitialOrders(markPrice, party, fn)
 	require.NoError(t, err)
 	require.Len(t, creates, 3)
 

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -316,24 +316,6 @@ func TestCalculateSuppliedStake(t *testing.T) {
 	// We don't care about the following calls
 	tng.broker.EXPECT().Send(gomock.Any()).AnyTimes()
 
-	var (
-		markPrice = uint64(10)
-	)
-
-	fn := func(order *types.PeggedOrder) (uint64, error) {
-		return markPrice + uint64(order.Offset), nil
-	}
-
-	// Expectations
-	tng.priceMonitor.EXPECT().GetValidPriceRange().Return(0.0, 100.0).AnyTimes()
-	any := gomock.Any()
-	tng.riskModel.EXPECT().ProbabilityOfTrading(
-		any, any, any, any, any, any, any,
-	).AnyTimes().Return(0.5)
-	tng.idGen.EXPECT().SetID(gomock.Any()).Do(func(order *types.Order) {
-		order.Id = uuid.NewV4().String()
-	}).AnyTimes()
-
 	// Send a submission to create the shape
 	lp1 := &types.LiquidityProvisionSubmission{
 		MarketID: tng.marketID, CommitmentAmount: 100, Fee: "0.5",
@@ -347,15 +329,10 @@ func TestCalculateSuppliedStake(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tng.engine.SubmitLiquidityProvision(ctx, lp1, party1, "some-id"),
+		tng.engine.SubmitLiquidityProvision(ctx, lp1, party1, "some-id1"),
 	)
-
-	createslp1, _, err := tng.engine.CreateInitialOrders(markPrice, party1, nil, fn)
-	require.NoError(t, err)
-	require.Len(t, createslp1, len(lp1.Buys)+len(lp1.Sells))
-
-	suppliedLiquidity1 := tng.engine.CalculateSuppliedStake(markPrice)
-	require.Greater(t, suppliedLiquidity1, 0.0)
+	suppliedStake := tng.engine.CalculateSuppliedStake()
+	require.Equal(t, lp1.CommitmentAmount, suppliedStake)
 
 	lp2 := &types.LiquidityProvisionSubmission{
 		MarketID: tng.marketID, CommitmentAmount: 500, Fee: "0.5",
@@ -368,16 +345,10 @@ func TestCalculateSuppliedStake(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tng.engine.SubmitLiquidityProvision(ctx, lp2, party2, "some-id"),
+		tng.engine.SubmitLiquidityProvision(ctx, lp2, party2, "some-id2"),
 	)
-
-	createsLp2, _, err := tng.engine.CreateInitialOrders(markPrice, party2, nil, fn)
-	require.NoError(t, err)
-	require.Len(t, createsLp2, len(lp2.Buys)+len(lp2.Sells))
-
-	suppliedLiquidityLp2 := tng.engine.CalculateSuppliedStake(markPrice)
-	require.Greater(t, suppliedLiquidityLp2, 0.0)
-	require.Greater(t, suppliedLiquidityLp2, suppliedLiquidity1)
+	suppliedStake = tng.engine.CalculateSuppliedStake()
+	require.Equal(t, lp1.CommitmentAmount+lp2.CommitmentAmount, suppliedStake)
 
 	lp3 := &types.LiquidityProvisionSubmission{
 		MarketID: tng.marketID, CommitmentAmount: 962, Fee: "0.5",
@@ -391,28 +362,15 @@ func TestCalculateSuppliedStake(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tng.engine.SubmitLiquidityProvision(ctx, lp3, party3, "some-id"),
+		tng.engine.SubmitLiquidityProvision(ctx, lp3, party3, "some-id3"),
 	)
+	suppliedStake = tng.engine.CalculateSuppliedStake()
+	require.Equal(t, lp1.CommitmentAmount+lp2.CommitmentAmount+lp3.CommitmentAmount, suppliedStake)
 
-	createsLp3, _, err := tng.engine.CreateInitialOrders(markPrice, party3, nil, fn)
-	require.NoError(t, err)
-	require.Len(t, createsLp3, len(lp3.Buys)+len(lp3.Sells))
-
-	suppliedLiquidity3 := tng.engine.CalculateSuppliedStake(markPrice)
-	require.Greater(t, suppliedLiquidity3, 0.0)
-	require.Greater(t, suppliedLiquidity3, suppliedLiquidityLp2)
-
-	// Manual orders
-	orders := []*types.Order{
-		{Id: "1", PartyID: party2, Price: markPrice - 2, Size: 20, Remaining: 20, Side: types.Side_SIDE_BUY, Status: types.Order_STATUS_ACTIVE},
-		{Id: "2", PartyID: party2, Price: markPrice + 2, Size: 20, Remaining: 20, Side: types.Side_SIDE_SELL, Status: types.Order_STATUS_ACTIVE},
-	}
-	newOrders, amendments, err := tng.engine.Update(markPrice, fn, orders)
-	require.NoError(t, err)
-	require.Len(t, newOrders, 0)
-	require.Len(t, amendments, len(lp2.Buys)+len(lp2.Sells))
-
-	// Amendments haven't been applied so supplied liquidity should increase.
-	suppliedLiquidityLp2afterUpdate := tng.engine.CalculateSuppliedStake(markPrice)
-	require.Greater(t, suppliedLiquidityLp2afterUpdate, suppliedLiquidity3)
+	lp1.CommitmentAmount -= 100
+	require.NoError(t,
+		tng.engine.SubmitLiquidityProvision(ctx, lp1, party1, "some-id1"),
+	)
+	suppliedStake = tng.engine.CalculateSuppliedStake()
+	require.Equal(t, lp1.CommitmentAmount+lp2.CommitmentAmount+lp3.CommitmentAmount, suppliedStake)
 }

--- a/liquidity/supplied/engine.go
+++ b/liquidity/supplied/engine.go
@@ -62,13 +62,10 @@ func NewEngine(riskModel RiskModel, priceMonitor PriceMonitor) *Engine {
 }
 
 // CalculateSuppliedLiquidity returns the current supplied liquidity per specified current mark price and order set
-func (e *Engine) CalculateSuppliedLiquidity(markPrice float64, orders []*types.Order) (float64, error) {
+func (e *Engine) CalculateSuppliedLiquidity(markPrice float64, orders []*types.Order) float64 {
 	minPrice, maxPrice := e.pm.GetValidPriceRange()
-	bLiq, sLiq, err := e.calculateBuySellLiquidityWithMinMax(markPrice, orders, minPrice, maxPrice)
-	if err != nil {
-		return 0, err
-	}
-	return math.Min(bLiq, sLiq), nil
+	bLiq, sLiq := e.calculateBuySellLiquidityWithMinMax(markPrice, orders, minPrice, maxPrice)
+	return math.Min(bLiq, sLiq)
 }
 
 // CalculateLiquidityImpliedVolumes updates the LiquidityImpliedSize fields in LiquidityOrderReference so that the liquidity commitment is met.
@@ -81,10 +78,7 @@ func (e *Engine) CalculateLiquidityImpliedVolumes(markPrice, liquidityObligation
 	limitOrders = append(limitOrders, buyLimitOrders...)
 	limitOrders = append(limitOrders, sellLimitOrders...)
 
-	buySupplied, sellSupplied, err := e.calculateBuySellLiquidityWithMinMax(markPrice, limitOrders, minPrice, maxPrice)
-	if err != nil {
-		return err
-	}
+	buySupplied, sellSupplied := e.calculateBuySellLiquidityWithMinMax(markPrice, limitOrders, minPrice, maxPrice)
 
 	buyRemaining := liquidityObligation - buySupplied
 	if err := e.updateSizes(buyRemaining, markPrice, buyShapes, true, minPrice, maxPrice); err != nil {
@@ -100,7 +94,7 @@ func (e *Engine) CalculateLiquidityImpliedVolumes(markPrice, liquidityObligation
 }
 
 // CalculateSuppliedLiquidity returns the current supplied liquidity per market specified in the constructor
-func (e *Engine) calculateBuySellLiquidityWithMinMax(currentPrice float64, orders []*types.Order, minPrice, maxPrice float64) (float64, float64, error) {
+func (e *Engine) calculateBuySellLiquidityWithMinMax(currentPrice float64, orders []*types.Order, minPrice, maxPrice float64) (float64, float64) {
 	bLiq := 0.0
 	sLiq := 0.0
 	for _, o := range orders {
@@ -111,7 +105,7 @@ func (e *Engine) calculateBuySellLiquidityWithMinMax(currentPrice float64, order
 			sLiq += float64(o.Price) * float64(o.Remaining) * e.getProbabilityOfTrading(currentPrice, o.Price, false, minPrice, maxPrice)
 		}
 	}
-	return bLiq, sLiq, nil
+	return bLiq, sLiq
 }
 
 func (e *Engine) updateSizes(liquidityObligation, currentPrice float64, orders []*LiquidityOrder, isBid bool, minPrice, maxPrice float64) error {

--- a/liquidity/supplied/engine_test.go
+++ b/liquidity/supplied/engine_test.go
@@ -33,8 +33,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
-	liquidity, err := engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{})
-	require.NoError(t, err)
+	liquidity := engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{})
 	require.Equal(t, 0.0, liquidity)
 
 	// 1 buy, no sells
@@ -49,8 +48,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(buyOrder1.Price), true, true, minPrice, maxPrice).Return(buyOrder1Prob).Times(1)
 
-	liquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{buyOrder1})
-	require.NoError(t, err)
+	liquidity = engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{buyOrder1})
 	require.Equal(t, 0.0, liquidity)
 
 	// 1 buy, 2 sells
@@ -77,8 +75,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(sellOrder1.Price), false, true, minPrice, maxPrice).Return(sellOrder1Prob).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(sellOrder2.Price), false, true, minPrice, maxPrice).Return(sellOrder2Prob).Times(1)
 
-	liquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{buyOrder1, sellOrder1, sellOrder2})
-	require.NoError(t, err)
+	liquidity = engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{buyOrder1, sellOrder1, sellOrder2})
 	require.Equal(t, expectedLiquidity, liquidity)
 
 	// 2 buys, 2 sells
@@ -94,8 +91,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice)
 
-	liquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{buyOrder1, sellOrder1, sellOrder2, buyOrder2})
-	require.NoError(t, err)
+	liquidity = engine.CalculateSuppliedLiquidity(MarkPrice, []*types.Order{buyOrder1, sellOrder1, sellOrder2, buyOrder2})
 	require.Equal(t, expectedLiquidity, liquidity)
 }
 
@@ -150,8 +146,7 @@ func Test_InteralConsistency(t *testing.T) {
 
 	// 	Verify engine is internally consistent
 	allOrders := collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err := engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity := engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 }
 
@@ -234,8 +229,7 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 
 	// 	Verify engine is internally consistent
 	allOrders := collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err := engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity := engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 
 	// 0 liquidity obligation -> 0 sizes on all orders
@@ -252,8 +246,7 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 
 	// Verify engine is internally consistent
 	allOrders = collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 
 	// Positive liquidity obligation -> positive sizes on orders -> suplied liquidity >= liquidity obligation
@@ -277,8 +270,7 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 
 	// Verify engine is internally consistent
 	allOrders = collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 	require.True(t, totalSuppliedLiquidity < 2*liquidityObligation)
 
@@ -371,11 +363,10 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(buyLimitOrders[1].Price), true, true, minPrice, maxPrice).Return(0.312).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(sellLimitOrders[0].Price), false, true, minPrice, maxPrice).Return(0.5).Times(1)
 
-	limitOrdersSuppliedLiquidity, err := engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
-	require.NoError(t, err)
+	limitOrdersSuppliedLiquidity := engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
 	require.True(t, limitOrdersSuppliedLiquidity < liquidityObligation)
 
-	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
+	err := engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
 	require.NoError(t, err)
 
 	var zero uint64 = 0
@@ -388,8 +379,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 
 	// 	Verify engine is internally consistent
 	allOrders := collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err := engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity := engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 	require.True(t, totalSuppliedLiquidity < 2*liquidityObligation)
 
@@ -417,8 +407,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 		},
 	}
 
-	limitOrdersSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
-	require.NoError(t, err)
+	limitOrdersSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
 	require.True(t, limitOrdersSuppliedLiquidity < liquidityObligation)
 
 	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
@@ -433,8 +422,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 
 	// 	Verify engine is internally consistent
 	allOrders = collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 	require.True(t, totalSuppliedLiquidity < 2*liquidityObligation)
 
@@ -462,8 +450,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 		},
 	}
 
-	limitOrdersSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
-	require.NoError(t, err)
+	limitOrdersSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
 	require.True(t, limitOrdersSuppliedLiquidity < liquidityObligation)
 
 	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
@@ -478,8 +465,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 
 	// 	Verify engine is internally consistent
 	allOrders = collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 	require.True(t, totalSuppliedLiquidity < 2*liquidityObligation)
 
@@ -507,8 +493,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 		},
 	}
 
-	limitOrdersSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
-	require.NoError(t, err)
+	limitOrdersSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, collateOrders(buyLimitOrders, sellLimitOrders, nil, nil))
 	require.True(t, limitOrdersSuppliedLiquidity > liquidityObligation)
 
 	err = engine.CalculateLiquidityImpliedVolumes(MarkPrice, liquidityObligation, buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
@@ -523,8 +508,7 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 
 	// 	Verify engine is internally consistent
 	allOrders = collateOrders(buyLimitOrders, sellLimitOrders, buyShapes, sellShapes)
-	totalSuppliedLiquidity, err = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
-	require.NoError(t, err)
+	totalSuppliedLiquidity = engine.CalculateSuppliedLiquidity(MarkPrice, allOrders)
 	require.True(t, totalSuppliedLiquidity >= liquidityObligation)
 }
 
@@ -610,8 +594,7 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
 
-	liquidity1, err := engine.CalculateSuppliedLiquidity(MarkPrice, orders)
-	require.NoError(t, err)
+	liquidity1 := engine.CalculateSuppliedLiquidity(MarkPrice, orders)
 	require.Less(t, 0.0, liquidity1)
 
 	// Change minPrice, maxPrice and verify that probability of trading is called with new values
@@ -621,8 +604,7 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(order1.Price), true, true, minPrice, maxPrice).Return(0.123).Times(1)
 	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, Horizon, float64(order2.Price), false, true, minPrice, maxPrice).Return(0.234).Times(1)
 
-	liquidity2, err := engine.CalculateSuppliedLiquidity(MarkPrice, orders)
-	require.NoError(t, err)
+	liquidity2 := engine.CalculateSuppliedLiquidity(MarkPrice, orders)
 	require.Less(t, 0.0, liquidity2)
 	require.Equal(t, liquidity1, liquidity2)
 


### PR DESCRIPTION
Expose supplied stake in market data API.

Also includes refactoring within the supplied/engine which removes the redundant error for the signature (nil was always returned). 

Closes #2543 