### PR TITLE
Remove a pegged order from the system if it is rejected when unparked

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -651,8 +651,7 @@ func (m *Market) unparkAllPeggedOrders(ctx context.Context) {
 		} else {
 			_, err := m.submitValidatedOrder(ctx, order)
 			if err != nil {
-				// Failed to place the order on the book
-				failedToUnpark = append(failedToUnpark, order)
+				m.removePeggedOrder(order)
 			}
 		}
 	}

--- a/execution/market.go
+++ b/execution/market.go
@@ -1064,7 +1064,8 @@ func (m *Market) submitValidatedOrder(ctx context.Context, order *types.Order) (
 	if !m.as.InAuction() {
 
 		// first we call the order book to evaluate auction triggers and get the list of trades
-		trades, err := m.checkPriceAndGetTrades(ctx, order)
+		var err error
+		trades, err = m.checkPriceAndGetTrades(ctx, order)
 		if err != nil {
 			return nil, m.unregisterAndReject(ctx, order, err)
 		}

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -147,7 +147,7 @@ func (e *Engine) ReloadConf(cfg Config) {
 // It returns the updated position.
 // The margins+risk engines need the updated position to determine whether the
 // order should be accepted.
-func (e *Engine) RegisterOrder(order *types.Order) (*MarketPosition, error) {
+func (e *Engine) RegisterOrder(order *types.Order) *MarketPosition {
 	timer := metrics.NewTimeCounter("-", "positions", "RegisterOrder")
 	pos, found := e.positions[order.PartyID]
 	if !found {
@@ -166,7 +166,7 @@ func (e *Engine) RegisterOrder(order *types.Order) (*MarketPosition, error) {
 		pos.sell += int64(order.Remaining)
 	}
 	timer.EngineTimeCounterAdd()
-	return pos, nil
+	return pos
 }
 
 // UnregisterOrder undoes the actions of RegisterOrder. It is used when an order

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -176,8 +176,7 @@ func testRegisterOrderSuccessful(t *testing.T) {
 		Size:      uint64(buysize),
 		Remaining: uint64(buysize),
 	}
-	pos, err := e.RegisterOrder(&orderBuy)
-	assert.NoError(t, err)
+	pos := e.RegisterOrder(&orderBuy)
 	assert.Equal(t, buysize, pos.Buy())
 	assert.Zero(t, pos.Sell())
 	assert.Zero(t, pos.Price())
@@ -192,8 +191,7 @@ func testRegisterOrderSuccessful(t *testing.T) {
 		Size:      uint64(sellsize),
 		Remaining: uint64(sellsize),
 	}
-	pos, err = e.RegisterOrder(&orderSell)
-	assert.NoError(t, err)
+	pos = e.RegisterOrder(&orderSell)
 	assert.Equal(t, buysize, pos.Buy())
 	assert.Equal(t, sellsize, pos.Sell())
 	assert.Zero(t, pos.Price())
@@ -216,11 +214,10 @@ func testUnregisterOrderSuccessful(t *testing.T) {
 		Size:      uint64(buysize),
 		Remaining: uint64(buysize),
 	}
-	pos, err := e.RegisterOrder(&orderBuy)
-	assert.NoError(t, err)
+	pos := e.RegisterOrder(&orderBuy)
 	assert.Equal(t, buysize, pos.Buy())
 
-	pos, err = e.UnregisterOrder(&orderBuy)
+	pos, err := e.UnregisterOrder(&orderBuy)
 	assert.NoError(t, err)
 	assert.Zero(t, pos.Buy())
 
@@ -230,8 +227,7 @@ func testUnregisterOrderSuccessful(t *testing.T) {
 		Size:      uint64(sellsize),
 		Remaining: uint64(sellsize),
 	}
-	pos, err = e.RegisterOrder(&orderSell)
-	assert.NoError(t, err)
+	pos = e.RegisterOrder(&orderSell)
 	assert.Zero(t, pos.Buy())
 	assert.Equal(t, sellsize, pos.Sell())
 
@@ -326,8 +322,7 @@ func TestHash(t *testing.T) {
 	}
 
 	for _, order := range orders {
-		_, err := e.RegisterOrder(&order)
-		require.NoError(t, err)
+		e.RegisterOrder(&order)
 	}
 
 	trade := proto.Trade{

--- a/positions/positions_acceptance_criteria_test.go
+++ b/positions/positions_acceptance_criteria_test.go
@@ -558,8 +558,7 @@ func testNewOrderAddedToTheBook(t *testing.T) {
 	assert.Empty(t, engine.Positions())
 
 	for _, c := range cases {
-		pos, err := engine.RegisterOrder(&c.order)
-		assert.NoError(t, err)
+		pos := engine.RegisterOrder(&c.order)
 		assert.Equal(t, c.expectedBuy, pos.Buy())
 		assert.Equal(t, c.expectedSell, pos.Sell())
 		assert.Equal(t, c.expectedSize, pos.Size())
@@ -614,8 +613,7 @@ func testNewTradePartialAmountOfExistingOrderTraded(t *testing.T) {
 	assert.Empty(t, engine.Positions())
 
 	for i, c := range cases.orders {
-		_, err := engine.RegisterOrder(&c)
-		assert.NoError(t, err)
+		engine.RegisterOrder(&c)
 		// ensure we have 1 position with 1 potential buy of size 10 for traderA
 		pos := engine.Positions()
 		assert.Len(t, pos, i+1)
@@ -708,8 +706,7 @@ func testTradeCauseTheFullAmountOfOrderToTrade(t *testing.T) {
 	assert.Empty(t, engine.Positions())
 
 	for i, c := range cases.orders {
-		_, err := engine.RegisterOrder(&c)
-		assert.NoError(t, err)
+		engine.RegisterOrder(&c)
 		// ensure we have 1 position with 1 potential buy of size 10 for traderA
 		pos := engine.Positions()
 		assert.Len(t, pos, i+1)
@@ -803,8 +800,7 @@ func testOrderCancelled(t *testing.T) {
 
 	// first add the orders
 	for i, c := range cases.orders {
-		_, err := engine.RegisterOrder(&c)
-		assert.NoError(t, err)
+		engine.RegisterOrder(&c)
 		// ensure we have 1 position with 1 potential buy of size 10 for traderA
 		pos := engine.Positions()
 		assert.Len(t, pos, i+1)


### PR DESCRIPTION
When we try to unpark a pegged order but the order is rejected when attempting to submit, we should remove the pegged order as it is no longer valid.