### PR TITLE
avoid read node lagging behind if they have received all vote but haven't seen the ext resources

### DIFF
--- a/banking/asset_action.go
+++ b/banking/asset_action.go
@@ -7,7 +7,6 @@ import (
 	"code.vegaprotocol.io/vega/assets"
 	"code.vegaprotocol.io/vega/assets/common"
 	types "code.vegaprotocol.io/vega/proto"
-
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -20,10 +19,10 @@ type withdrawal struct {
 }
 
 type txRef struct {
-	asset    common.AssetClass
-	hash     string
-	index    uint64
-	logIndex uint
+	asset       common.AssetClass
+	blockNumber uint64
+	hash        string
+	logIndex    uint64
 }
 
 type assetAction struct {
@@ -38,6 +37,7 @@ type assetAction struct {
 	// erc20 specifics
 	blockNumber uint64
 	txIndex     uint64
+	hash        string
 
 	// all deposit related types
 	builtinD *types.BuiltinAssetDeposit
@@ -118,42 +118,44 @@ func (t *assetAction) Check() error {
 }
 
 func (t *assetAction) checkBuiltinAssetDeposit() error {
-	asset, _ := t.asset.BuiltinAsset()
-	// builtin deposits do not have hash, and we don't need one
-	// so let's just add some random id
-	t.ref = txRef{asset.GetAssetClass(), uuid.NewV4().String(), 0, 0}
 	return nil
 }
 
 func (t *assetAction) checkERC20Deposit() error {
 	asset, _ := t.asset.ERC20()
-	_, _, hash, _, logIndex, err := asset.ValidateDeposit(t.erc20D, t.blockNumber, t.txIndex)
-	if err != nil {
-		return err
-	}
-	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex, logIndex}
-	return nil
+	_, _, _, _, _, err := asset.ValidateDeposit(t.erc20D, t.blockNumber, t.txIndex)
+	return err
 }
 
 func (t *assetAction) checkERC20Withdrawal() error {
 	asset, _ := t.asset.ERC20()
-	nonce, hash, logIndex, err := asset.ValidateWithdrawal(t.erc20W, t.blockNumber, t.txIndex)
+	nonce, _, _, err := asset.ValidateWithdrawal(t.erc20W, t.blockNumber, t.txIndex)
 	if err != nil {
 		return err
 	}
 	t.withdrawal = &withdrawal{
 		nonce: nonce,
 	}
-	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex, logIndex}
 	return nil
 }
 
 func (t *assetAction) checkERC20AssetList() error {
 	asset, _ := t.asset.ERC20()
-	hash, logIndex, err := asset.ValidateAssetList(t.erc20AL, t.blockNumber, t.txIndex)
-	if err != nil {
-		return err
+	_, _, err := asset.ValidateAssetList(t.erc20AL, t.blockNumber, t.txIndex)
+	return err
+}
+
+func (t *assetAction) getRef() txRef {
+	switch {
+	case t.IsBuiltinAssetDeposit():
+		return txRef{common.Builtin, 0, uuid.NewV4().String(), 0}
+	case t.IsERC20Deposit():
+		return txRef{common.ERC20, t.blockNumber, t.hash, t.txIndex}
+	case t.IsERC20AssetList():
+		return txRef{common.ERC20, t.blockNumber, t.hash, t.txIndex}
+	case t.IsERC20Withdrawal():
+		return txRef{common.ERC20, t.blockNumber, t.hash, t.txIndex}
+	default:
+		return txRef{} // this is basically unreachable
 	}
-	t.ref = txRef{asset.GetAssetClass(), hash, t.txIndex, logIndex}
-	return nil
 }

--- a/banking/asset_action.go
+++ b/banking/asset_action.go
@@ -30,10 +30,6 @@ type assetAction struct {
 	state uint32
 	asset *assets.Asset
 
-	// hash of transaction used to ensure a transaction has not been
-	// processed twice
-	ref txRef
-
 	// erc20 specifics
 	blockNumber uint64
 	txIndex     uint64

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/fatih/color v1.7.0
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.4.0
 	github.com/google/btree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,9 @@ github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5Nq
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/uuid v1.2.0 h1:coDhrjgyJaglxSjxuJdqQSSdUpG3w6p1OwN2od6frBU=
+github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
+github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/processor/mocks/banking_mock.go
+++ b/processor/mocks/banking_mock.go
@@ -49,17 +49,17 @@ func (mr *MockBankingMockRecorder) DepositBuiltinAsset(arg0, arg1, arg2, arg3 in
 }
 
 // DepositERC20 mocks base method
-func (m *MockBanking) DepositERC20(arg0 context.Context, arg1 *proto.ERC20Deposit, arg2 string, arg3, arg4 uint64) error {
+func (m *MockBanking) DepositERC20(arg0 context.Context, arg1 *proto.ERC20Deposit, arg2 string, arg3, arg4 uint64, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DepositERC20", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "DepositERC20", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DepositERC20 indicates an expected call of DepositERC20
-func (mr *MockBankingMockRecorder) DepositERC20(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockBankingMockRecorder) DepositERC20(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DepositERC20", reflect.TypeOf((*MockBanking)(nil).DepositERC20), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DepositERC20", reflect.TypeOf((*MockBanking)(nil).DepositERC20), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // EnableBuiltinAsset mocks base method
@@ -77,17 +77,17 @@ func (mr *MockBankingMockRecorder) EnableBuiltinAsset(arg0, arg1 interface{}) *g
 }
 
 // EnableERC20 mocks base method
-func (m *MockBanking) EnableERC20(arg0 context.Context, arg1 *proto.ERC20AssetList, arg2, arg3 uint64) error {
+func (m *MockBanking) EnableERC20(arg0 context.Context, arg1 *proto.ERC20AssetList, arg2, arg3 uint64, arg4 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnableERC20", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "EnableERC20", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnableERC20 indicates an expected call of EnableERC20
-func (mr *MockBankingMockRecorder) EnableERC20(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBankingMockRecorder) EnableERC20(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableERC20", reflect.TypeOf((*MockBanking)(nil).EnableERC20), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableERC20", reflect.TypeOf((*MockBanking)(nil).EnableERC20), arg0, arg1, arg2, arg3, arg4)
 }
 
 // HasBalance mocks base method
@@ -133,15 +133,15 @@ func (mr *MockBankingMockRecorder) WithdrawalBuiltinAsset(arg0, arg1, arg2, arg3
 }
 
 // WithdrawalERC20 mocks base method
-func (m *MockBanking) WithdrawalERC20(arg0 *proto.ERC20Withdrawal, arg1, arg2 uint64) error {
+func (m *MockBanking) WithdrawalERC20(arg0 *proto.ERC20Withdrawal, arg1, arg2 uint64, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithdrawalERC20", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "WithdrawalERC20", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WithdrawalERC20 indicates an expected call of WithdrawalERC20
-func (mr *MockBankingMockRecorder) WithdrawalERC20(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBankingMockRecorder) WithdrawalERC20(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawalERC20", reflect.TypeOf((*MockBanking)(nil).WithdrawalERC20), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawalERC20", reflect.TypeOf((*MockBanking)(nil).WithdrawalERC20), arg0, arg1, arg2, arg3)
 }

--- a/processor/process_chain_event.go
+++ b/processor/process_chain_event.go
@@ -86,7 +86,7 @@ func (app *App) processChainEventERC20(ctx context.Context, ce *types.ChainEvent
 		if !ok {
 			return ErrChainEventAssetListERC20WithoutEnoughSignature
 		}
-		return app.banking.EnableERC20(ctx, act.AssetList, evt.Block, evt.Index)
+		return app.banking.EnableERC20(ctx, act.AssetList, evt.Block, evt.Index, ce.TxID)
 	case *types.ERC20Event_AssetDelist:
 		return errors.New("ERC20.AssetDelist not implemented")
 	case *types.ERC20Event_Deposit:
@@ -95,13 +95,13 @@ func (app *App) processChainEventERC20(ctx context.Context, ce *types.ChainEvent
 		if err := app.checkVegaAssetID(act.Deposit, "ERC20.AssetDeposit"); err != nil {
 			return err
 		}
-		return app.banking.DepositERC20(ctx, act.Deposit, id, evt.Block, evt.Index)
+		return app.banking.DepositERC20(ctx, act.Deposit, id, evt.Block, evt.Index, ce.TxID)
 	case *types.ERC20Event_Withdrawal:
 		act.Withdrawal.VegaAssetID = strings.TrimPrefix(act.Withdrawal.VegaAssetID, "0x")
 		if err := app.checkVegaAssetID(act.Withdrawal, "ERC20.AssetWithdrawal"); err != nil {
 			return err
 		}
-		return app.banking.WithdrawalERC20(act.Withdrawal, evt.Block, evt.Index)
+		return app.banking.WithdrawalERC20(act.Withdrawal, evt.Block, evt.Index, ce.TxID)
 	default:
 		return ErrUnsupportedEventAction
 	}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -157,10 +157,10 @@ type Banking interface {
 	EnableBuiltinAsset(context.Context, string) error
 	DepositBuiltinAsset(context.Context, *types.BuiltinAssetDeposit, string, uint64) error
 	WithdrawalBuiltinAsset(context.Context, string, string, string, uint64) error
-	EnableERC20(context.Context, *types.ERC20AssetList, uint64, uint64) error
-	DepositERC20(context.Context, *types.ERC20Deposit, string, uint64, uint64) error
+	EnableERC20(context.Context, *types.ERC20AssetList, uint64, uint64, string) error
+	DepositERC20(context.Context, *types.ERC20Deposit, string, uint64, uint64, string) error
 	LockWithdrawalERC20(context.Context, string, string, string, uint64, *types.Erc20WithdrawExt) error
-	WithdrawalERC20(*types.ERC20Withdrawal, uint64, uint64) error
+	WithdrawalERC20(*types.ERC20Withdrawal, uint64, uint64, string) error
 	HasBalance(string) bool
 }
 


### PR DESCRIPTION
Basically read-nodes get out of sync because validators does not wait for them to have confirmations of the blockchains to move one.
This would not show before, because we were not waiting for confirmation before applying the change, so basically all node where seeing the changes at the same time, and moving on.

Now we wait for 3confirmations, which are ~45 seconds.
Which means that the exponential backoff kicks off more, and more delay is put in between checks. so it happen that all validators check the resources while a read-node may not have had the time to see it.

Why it's not an issue for validators: they wait for all validators to have confirmed the transaction, while read-node are not accounted for.

Solution: send ALL information through the blockchain when straight from the beginning so read-node do not have to check the ethereum chain, but only to wait for confirmation from the validators.

This is also useful for replay etc, as it would not work  without it actually.