### PR TITLE
Redoing how we reprice pegged orders

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -643,7 +643,9 @@ func (m *Market) repriceAllPeggedOrders(ctx context.Context, changes uint8) uint
 			if price, err := m.getNewPeggedPrice(ctx, order); err != nil {
 				// Failed to reprice, if we are parked we do nothing, if not parked we need to park
 				if order.Status != types.Order_STATUS_PARKED {
+					order.UpdatedAt = m.currentTime.UnixNano()
 					order.Status = types.Order_STATUS_PARKED
+					order.Price = 0
 					m.broker.Send(events.NewOrderEvent(ctx, order))
 				}
 			} else {

--- a/execution/market.go
+++ b/execution/market.go
@@ -1273,7 +1273,7 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 			order.UpdatedAt = m.currentTime.UnixNano()
 			m.broker.Send(events.NewOrderEvent(ctx, order))
 
-			// If the order is a pegged order and it complete we must remove it from the pegged lists
+			// If the order is a pegged order and is complete we must remove it from the pegged list
 			if order.PeggedOrder != nil {
 				if order.Remaining == 0 || order.Status != types.Order_STATUS_ACTIVE {
 					m.removePeggedOrder(order)
@@ -1549,6 +1549,13 @@ func (m *Market) resolveClosedOutTraders(ctx context.Context, distressedMarginEv
 		for _, order := range confirmation.PassiveOrdersAffected {
 			order.UpdatedAt = m.currentTime.UnixNano()
 			m.broker.Send(events.NewOrderEvent(ctx, order))
+
+			// If the order is a pegged order and is complete we must remove it from the pegged list
+			if order.PeggedOrder != nil {
+				if order.Remaining == 0 || order.Status != types.Order_STATUS_ACTIVE {
+					m.removePeggedOrder(order)
+				}
+			}
 
 			// remove expiring order
 			if order.IsExpireable() && order.IsFinished() {

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -9,7 +9,13 @@ func (m *Market) GetPeggedOrderCount() int {
 
 // GetParkedOrderCount returns hte number of parked orders in the market
 func (m *Market) GetParkedOrderCount() int {
-	return len(m.parkedOrders)
+	var count int
+	for _, order := range m.peggedOrders {
+		if order.Status == types.Order_STATUS_PARKED {
+			count++
+		}
+	}
+	return count
 }
 
 // GetPeggedExpiryOrderCount returns the number of pegged order that can expire

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -2460,3 +2460,38 @@ func TestOrderBook_AmendToCancelForceReprice(t *testing.T) {
 	assert.Equal(t, types.Order_STATUS_PARKED, o2.Status)
 	assert.Equal(t, types.Order_STATUS_CANCELLED, o1.Status)
 }
+
+func TestOrderBook_AmendExpPeristParkPeggedOrder(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(10000000000, 0)
+	tm := getTestMarket(t, now, closingAt, nil, nil)
+	ctx := context.Background()
+
+	addAccount(tm, "trader-A")
+	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	o1 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order01", types.Side_SIDE_SELL, "trader-A", 10, 4550)
+	o1conf, err := tm.market.SubmitOrder(ctx, o1)
+	assert.NotNil(t, o1conf)
+	assert.NoError(t, err)
+
+	o2 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order02", types.Side_SIDE_SELL, "trader-A", 105, 0)
+	o2.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Offset: 100}
+	o2conf, err := tm.market.SubmitOrder(ctx, o2)
+	assert.NotNil(t, o2conf)
+	assert.NoError(t, err)
+
+	// Try to amend the price
+	amendment := &types.OrderAmendment{
+		OrderID:   o1.Id,
+		PartyID:   "trader-A",
+		SizeDelta: -10,
+	}
+
+	amendConf, err := tm.market.AmendOrder(ctx, amendment)
+	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Order_STATUS_PARKED, o2.Status)
+	assert.Equal(t, int(o2.Price), 0)
+	assert.Equal(t, types.Order_STATUS_CANCELLED, o1.Status)
+}

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -2456,6 +2456,7 @@ func TestOrderBook_AmendToCancelForceReprice(t *testing.T) {
 
 	amendConf, err := tm.market.AmendOrder(ctx, amendment)
 	assert.NotNil(t, amendConf)
+	assert.NoError(t, err)
 	assert.Equal(t, types.Order_STATUS_PARKED, o2.Status)
 	assert.Equal(t, types.Order_STATUS_CANCELLED, o1.Status)
 }

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -2426,3 +2426,36 @@ func TestOrderBook_RejectAmendPriceOnPeggedOrder2658(t *testing.T) {
 	assert.Equal(t, types.Order_STATUS_PARKED, o1.Status)
 	assert.Equal(t, uint64(1), o1.Version)
 }
+
+func TestOrderBook_AmendToCancelForceReprice(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(10000000000, 0)
+	tm := getTestMarket(t, now, closingAt, nil, nil)
+	ctx := context.Background()
+
+	addAccount(tm, "trader-A")
+	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	o1 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order01", types.Side_SIDE_SELL, "trader-A", 1, 5000)
+	o1conf, err := tm.market.SubmitOrder(ctx, o1)
+	assert.NotNil(t, o1conf)
+	assert.NoError(t, err)
+
+	o2 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIF_GTC, "Order02", types.Side_SIDE_SELL, "trader-A", 1, 0)
+	o2.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Offset: 10}
+	o2conf, err := tm.market.SubmitOrder(ctx, o2)
+	assert.NotNil(t, o2conf)
+	assert.NoError(t, err)
+
+	// Try to amend the price
+	amendment := &types.OrderAmendment{
+		OrderID:   o1.Id,
+		PartyID:   "trader-A",
+		SizeDelta: -1,
+	}
+
+	amendConf, err := tm.market.AmendOrder(ctx, amendment)
+	assert.NotNil(t, amendConf)
+	assert.Equal(t, types.Order_STATUS_PARKED, o2.Status)
+	assert.Equal(t, types.Order_STATUS_CANCELLED, o1.Status)
+}


### PR DESCRIPTION
This change makes pegged orders reprice in a group instead of individually.
Also removed parkedOrder list to reduce complexity