### PR TITLE
Use bond account to topup margin in collateral

### DIFF
--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -66,6 +66,7 @@ func TestRemoveDistressed(t *testing.T) {
 
 func TestMarginUpdateOnOrder(t *testing.T) {
 	t.Run("Successfully update margin on new order if general account balance is OK", testMarginUpdateOnOrderOK)
+	t.Run("Successfully update margin on new order if general account balance is OK no shortfall with bond accound", testMarginUpdateOnOrderOKNotShortFallWithBondAccount)
 	t.Run("Successfully update margin on new order if general account balance is OK will use bond account if exists", testMarginUpdateOnOrderOKUseBondAccount)
 	t.Run("Successfully update margin on new order if general account balance is OK will use bond&general accounts if exists", testMarginUpdateOnOrderOKUseBondAndGeneralAccounts)
 	t.Run("Successfully update margin on new order then rollback", testMarginUpdateOnOrderOKThenRollback)
@@ -1676,17 +1677,17 @@ func testMarginUpdateOnOrderOK(t *testing.T) {
 	assert.NotNil(t, resp)
 }
 
-func testMarginUpdateOnOrderOKUseBondAccount(t *testing.T) {
+func testMarginUpdateOnOrderOKNotShortFallWithBondAccount(t *testing.T) {
 	eng := getTestEngine(t, testMarketID, 0)
 	defer eng.Finish()
 	trader := "oktrader"
 
 	// create traders
 	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
-	genaccID, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), genaccID, 500)
-	bondAccID, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), bondAccID, 500)
+	acc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), acc, 500)
+	bondacc, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), bondacc, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
 
@@ -1717,10 +1718,55 @@ func testMarginUpdateOnOrderOKUseBondAccount(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, closed)
 	assert.NotNil(t, resp)
+}
+
+func testMarginUpdateOnOrderOKUseBondAccount(t *testing.T) {
+	eng := getTestEngine(t, testMarketID, 0)
+	defer eng.Finish()
+	trader := "oktrader"
+
+	// create traders
+	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
+	genaccID, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), genaccID, 0)
+	bondAccID, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), bondAccID, 500)
+	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
+	assert.Nil(t, err)
+
+	evt := riskFake{
+		asset:  testMarketAsset,
+		amount: 100,
+		transfer: &types.Transfer{
+			Owner: trader,
+			Amount: &types.FinancialAmount{
+				Amount: 100,
+				Asset:  testMarketAsset,
+			},
+			MinAmount: 100,
+			Type:      types.TransferType_TRANSFER_TYPE_MARGIN_LOW,
+		},
+	}
+
+	eng.broker.EXPECT().SendBatch(gomock.Any()).AnyTimes()
+	eng.broker.EXPECT().Send(gomock.Any()).AnyTimes().Do(func(evt events.Event) {
+		ae, ok := evt.(accEvt)
+		assert.True(t, ok)
+		acc := ae.Account()
+		if acc.Owner == trader && acc.Type == types.AccountType_ACCOUNT_TYPE_MARGIN {
+			assert.Equal(t, acc.Balance, uint64(100))
+		}
+	})
+	resp, closed, err := eng.Engine.MarginUpdateOnOrder(context.Background(), testMarketID, evt)
+	assert.Nil(t, err)
+	assert.NotNil(t, closed)
+	assert.NotNil(t, resp)
+
+	assert.Equal(t, int(closed.MarginShortFall()), 100)
 
 	gacc, err := eng.Engine.GetAccountByID(genaccID)
 	assert.NoError(t, err)
-	assert.Equal(t, 500, int(gacc.Balance))
+	assert.Equal(t, 0, int(gacc.Balance))
 	bondAcc, err := eng.Engine.GetAccountByID(bondAccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, int(bondAcc.Balance))
@@ -1734,9 +1780,9 @@ func testMarginUpdateOnOrderOKUseBondAndGeneralAccounts(t *testing.T) {
 	// create traders
 	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
 	genaccID, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), genaccID, 500)
+	eng.Engine.IncrementBalance(context.Background(), genaccID, 70)
 	bondAccID, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), bondAccID, 70)
+	eng.Engine.IncrementBalance(context.Background(), bondAccID, 500)
 	marginAccID, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
 
@@ -1768,18 +1814,21 @@ func testMarginUpdateOnOrderOKUseBondAndGeneralAccounts(t *testing.T) {
 
 	resp, closed, err := eng.Engine.MarginUpdateOnOrder(context.Background(), testMarketID, evt)
 	assert.Nil(t, err)
-	assert.Nil(t, closed)
+	assert.NotNil(t, closed)
 	assert.NotNil(t, resp)
 
 	// we toped up only 70 in the bond account
 	// but requied 100 so we should pick 30 in the general account as well.
 
+	// check shortfall
+	assert.Equal(t, int(closed.MarginShortFall()), 30)
+
 	gacc, err := eng.Engine.GetAccountByID(genaccID)
 	assert.NoError(t, err)
-	assert.Equal(t, 470, int(gacc.Balance))
+	assert.Equal(t, 0, int(gacc.Balance))
 	bondAcc, err := eng.Engine.GetAccountByID(bondAccID)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, int(bondAcc.Balance))
+	assert.Equal(t, 470, int(bondAcc.Balance))
 	marginAcc, err := eng.Engine.GetAccountByID(marginAccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 100, int(marginAcc.Balance))
@@ -1915,7 +1964,7 @@ func TestMarginUpdates(t *testing.T) {
 		},
 	}
 
-	resp, margin, err := eng.Engine.MarginUpdate(context.Background(), testMarketID, list)
+	resp, margin, _, err := eng.Engine.MarginUpdate(context.Background(), testMarketID, list)
 	assert.Nil(t, err)
 	assert.Equal(t, len(margin), 0)
 	assert.Equal(t, len(resp), 1)
@@ -2274,6 +2323,7 @@ type riskFake struct {
 	amount          int64
 	transfer        *types.Transfer
 	asset           string
+	marginShortFall uint64
 }
 
 func (m riskFake) Party() string                     { return m.party }
@@ -2291,6 +2341,7 @@ func (m riskFake) Asset() string                     { return m.asset }
 func (m riskFake) MarketID() string                  { return "" }
 func (m riskFake) MarginBalance() uint64             { return 0 }
 func (m riskFake) GeneralBalance() uint64            { return 0 }
+func (m riskFake) MarginShortFall() uint64           { return m.marginShortFall }
 
 type transferFees struct {
 	tfs []*types.Transfer

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -1683,10 +1683,10 @@ func testMarginUpdateOnOrderOKUseBondAccount(t *testing.T) {
 
 	// create traders
 	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
-	genaccId, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), genaccId, 500)
-	bondAccId, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), bondAccId, 500)
+	genaccID, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), genaccID, 500)
+	bondAccID, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), bondAccID, 500)
 	_, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
 
@@ -1718,10 +1718,10 @@ func testMarginUpdateOnOrderOKUseBondAccount(t *testing.T) {
 	assert.Nil(t, closed)
 	assert.NotNil(t, resp)
 
-	gacc, err := eng.Engine.GetAccountByID(genaccId)
+	gacc, err := eng.Engine.GetAccountByID(genaccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 500, int(gacc.Balance))
-	bondAcc, err := eng.Engine.GetAccountByID(bondAccId)
+	bondAcc, err := eng.Engine.GetAccountByID(bondAccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, int(bondAcc.Balance))
 }
@@ -1733,11 +1733,11 @@ func testMarginUpdateOnOrderOKUseBondAndGeneralAccounts(t *testing.T) {
 
 	// create traders
 	eng.broker.EXPECT().Send(gomock.Any()).Times(6)
-	genaccId, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), genaccId, 500)
-	bondAccId, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
-	eng.Engine.IncrementBalance(context.Background(), bondAccId, 70)
-	marginAccId, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
+	genaccID, _ := eng.Engine.CreatePartyGeneralAccount(context.Background(), trader, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), genaccID, 500)
+	bondAccID, _ := eng.Engine.CreatePartyBondAccount(context.Background(), trader, testMarketID, testMarketAsset)
+	eng.Engine.IncrementBalance(context.Background(), bondAccID, 70)
+	marginAccID, err := eng.Engine.CreatePartyMarginAccount(context.Background(), trader, testMarketID, testMarketAsset)
 	assert.Nil(t, err)
 
 	evt := riskFake{
@@ -1774,13 +1774,13 @@ func testMarginUpdateOnOrderOKUseBondAndGeneralAccounts(t *testing.T) {
 	// we toped up only 70 in the bond account
 	// but requied 100 so we should pick 30 in the general account as well.
 
-	gacc, err := eng.Engine.GetAccountByID(genaccId)
+	gacc, err := eng.Engine.GetAccountByID(genaccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 470, int(gacc.Balance))
-	bondAcc, err := eng.Engine.GetAccountByID(bondAccId)
+	bondAcc, err := eng.Engine.GetAccountByID(bondAccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, int(bondAcc.Balance))
-	marginAcc, err := eng.Engine.GetAccountByID(marginAccId)
+	marginAcc, err := eng.Engine.GetAccountByID(marginAccID)
 	assert.NoError(t, err)
 	assert.Equal(t, 100, int(marginAcc.Balance))
 }

--- a/collateral/margins.go
+++ b/collateral/margins.go
@@ -8,12 +8,13 @@ import (
 
 type marginUpdate struct {
 	events.MarketPosition
-	margin   *types.Account
-	general  *types.Account
-	lock     *types.Account
-	bond     *types.Account
-	asset    string
-	marketID string
+	margin          *types.Account
+	general         *types.Account
+	lock            *types.Account
+	bond            *types.Account
+	asset           string
+	marketID        string
+	marginShortFall uint64
 }
 
 func (n marginUpdate) Transfer() *types.Transfer {
@@ -50,4 +51,8 @@ func (n marginUpdate) GeneralBalance() uint64 {
 		bond = n.bond.Balance
 	}
 	return bond + gen
+}
+
+func (n marginUpdate) MarginShortFall() uint64 {
+	return n.marginShortFall
 }

--- a/collateral/margins.go
+++ b/collateral/margins.go
@@ -11,6 +11,7 @@ type marginUpdate struct {
 	margin   *types.Account
 	general  *types.Account
 	lock     *types.Account
+	bond     *types.Account
 	asset    string
 	marketID string
 }
@@ -34,9 +35,19 @@ func (n marginUpdate) MarginBalance() uint64 {
 	return uint64(n.margin.Balance)
 }
 
+// GeneralBalance here we cumulate both the general
+// account and bon account so other package do not have
+// to worry about how much funds are available in both
+// if a bond account exists
+// TODO(): maybe rename this method into AvailableBalance
+// at some point if it makes senses overall the codebase
 func (n marginUpdate) GeneralBalance() uint64 {
-	if n.general == nil {
-		return 0
+	var gen, bond uint64
+	if n.general != nil {
+		gen = n.general.Balance
 	}
-	return uint64(n.general.Balance)
+	if n.bond != nil {
+		bond = n.bond.Balance
+	}
+	return bond + gen
 }

--- a/events/events.go
+++ b/events/events.go
@@ -63,6 +63,7 @@ type Margin interface {
 	MarginBalance() uint64
 	GeneralBalance() uint64
 	MarketID() string
+	MarginShortFall() uint64
 }
 
 // Risk is an event that summarizes everything and an eventual update to margin account.

--- a/risk/engine_test.go
+++ b/risk/engine_test.go
@@ -33,18 +33,19 @@ type testEngine struct {
 
 // implements the events.Margin interface
 type testMargin struct {
-	party    string
-	size     int64
-	buy      int64
-	sell     int64
-	price    uint64
-	transfer *types.Transfer
-	asset    string
-	margin   uint64
-	general  uint64
-	market   string
-	vwBuy    uint64
-	vwSell   uint64
+	party           string
+	size            int64
+	buy             int64
+	sell            int64
+	price           uint64
+	transfer        *types.Transfer
+	asset           string
+	margin          uint64
+	general         uint64
+	market          string
+	vwBuy           uint64
+	vwSell          uint64
+	marginShortFall uint64
 }
 
 var (
@@ -536,4 +537,8 @@ func (m testMargin) ClearPotentials() {}
 
 func (m testMargin) Transfer() *types.Transfer {
 	return m.transfer
+}
+
+func (m testMargin) MarginShortFall() uint64 {
+	return m.marginShortFall
 }

--- a/settlement/engine_test.go
+++ b/settlement/engine_test.go
@@ -34,8 +34,8 @@ type posValue struct {
 
 type marginVal struct {
 	events.MarketPosition
-	asset, marketID string
-	margin, general uint64
+	asset, marketID                  string
+	margin, general, marginShortFall uint64
 }
 
 func TestMarketExpiry(t *testing.T) {
@@ -600,6 +600,10 @@ func (m marginVal) MarginBalance() uint64 {
 
 func (m marginVal) GeneralBalance() uint64 {
 	return m.general
+}
+
+func (m marginVal) MarginShortFall() uint64 {
+	return m.marginShortFall
 }
 
 //  vim: set ts=4 sw=4 tw=0 foldlevel=1 foldmethod=marker noet :


### PR DESCRIPTION
We now use the bond account to topup the margin account if it exists.

close #2417