### PR TITLE
Update CI

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -306,9 +306,7 @@ steps:
       api_key:
         from_secret: GITHUB_API_TOKEN
       files:
-        - cmd/dummyriskmodel/dummyriskmodel-*
         - cmd/vega/vega-*
-        - cmd/vegaccount/vegaccount-*
         - cmd/vegastream/vegastream-*
     when:
       event: tag

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,7 @@
-FROM ubuntu:20.04
+FROM docker.pkg.github.com/vegaprotocol/devops-infra/geth:1.9.25 AS geth
 
+FROM ubuntu:20.04
 ENTRYPOINT ["/bin/bash"]
 EXPOSE 3002/tcp 3003/tcp 3004/tcp 26658/tcp
-
-ENV GETH_VERSION="1.9.13-cbc4ac26" GETH_MD5="40afcb489123d43a91e89811b06fc611"
-RUN \
-	apt update && \
-	apt install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-	&& \
-	wget -q "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-$GETH_VERSION.tar.gz" && \
-	md5sum "geth-linux-amd64-$GETH_VERSION.tar.gz" | grep -q "^$GETH_MD5\\s" && \
-	tar zxf "geth-linux-amd64-$GETH_VERSION.tar.gz" && \
-	mv "/geth-linux-amd64-$GETH_VERSION/geth" /usr/local/bin/ && \
-	rm -rf "/geth-linux-amd64-"* /var/lib/apt/lists/* /var/log/dpkg.log
-
+COPY --from=geth /usr/local/bin/geth /usr/local/bin/
 ADD bin/* /usr/local/bin/


### PR DESCRIPTION
This PR:
* removes old binaries (`dummyriskmodel` and `vegaccount` ) from CI
* updates `Dockerfile` to use a pre-built `geth` image