### PR TITLE
Change order how we process auction order changes

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -729,14 +729,14 @@ func (m *Market) EnterAuction(ctx context.Context) {
 		m.log.Error("Error entering auction: ", logging.Error(err))
 	}
 
-	// Cancel all the orders that were invalid
-	for _, order := range ordersToCancel {
-		m.cancelOrder(ctx, order.PartyID, order.Id)
-	}
-
 	// Send out events for all orders we park
 	for _, order := range ordersToPark {
 		m.parkOrder(ctx, order)
+	}
+
+	// Cancel all the orders that were invalid
+	for _, order := range ordersToCancel {
+		m.cancelOrder(ctx, order.PartyID, order.Id)
 	}
 
 	// Send an event bus update


### PR DESCRIPTION
This is a fix for testnet.

When moving into an auction we retrieve a set of orders to cancel and a set of orders to park. When processing the cancels it causes pegged order to reprice and might invalidate the list of orders we want to park.

By handling the parked orders first this problems goes away.