### PR TITLE
Removing need to return orders to park (#2856)

### DIFF
--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -1,6 +1,10 @@
 package execution
 
-import types "code.vegaprotocol.io/vega/proto"
+import (
+	"time"
+
+	types "code.vegaprotocol.io/vega/proto"
+)
 
 // GetPeggedOrderCount returns the number of pegged orders in the market
 func (m *Market) GetPeggedOrderCount() int {
@@ -21,6 +25,20 @@ func (m *Market) GetParkedOrderCount() int {
 // GetPeggedExpiryOrderCount returns the number of pegged order that can expire
 func (m *Market) GetPeggedExpiryOrderCount() int {
 	return m.expiringOrders.GetExpiryingOrderCount()
+}
+
+// GetOrdersOnBookCount returns the number of orders on the live book
+func (m *Market) GetOrdersOnBookCount() int64 {
+	return m.matching.GetTotalNumberOfOrders()
+}
+
+// StartPriceAuction initialises the market to handle a price auction
+func (m *Market) StartPriceAuction(now time.Time) {
+	end := types.AuctionDuration{
+		Duration: 1000,
+	}
+	// setup auction
+	m.as.StartPriceAuction(now, &end)
 }
 
 // TSCalc returns the local tsCalc instance

--- a/matching/2385_panic_in_leave_opening_auction_test.go
+++ b/matching/2385_panic_in_leave_opening_auction_test.go
@@ -104,10 +104,9 @@ func TestPanicInLeaveAuction(t *testing.T) {
 	}
 
 	// enter auction, should return no error and no orders
-	cnlorders, parkedorders, err := book.EnterAuction()
+	cnlorders, err := book.EnterAuction()
 	assert.NoError(t, err)
 	assert.Len(t, cnlorders, 0)
-	assert.Len(t, parkedorders, 0)
 
 	for _, o := range orders {
 		o := o

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -161,16 +161,16 @@ func (b *OrderBook) GetCloseoutPrice(volume uint64, side types.Side) (uint64, er
 }
 
 // EnterAuction Moves the order book into an auction state
-func (b *OrderBook) EnterAuction() ([]*types.Order, []*types.Order, error) {
-	// Scan existing orders to see which ones can be kept, cancelled and parked
-	buyCancelledOrders, buyParkOrders, err := b.buy.getOrdersToCancelOrPark(true)
+func (b *OrderBook) EnterAuction() ([]*types.Order, error) {
+	// Scan existing orders to see which ones can be kept or cancelled
+	buyCancelledOrders, err := b.buy.getOrdersToCancel(true)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	sellCancelledOrders, sellParkOrder, err := b.sell.getOrdersToCancelOrPark(true)
+	sellCancelledOrders, err := b.sell.getOrdersToCancel(true)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Set the market state
@@ -179,9 +179,7 @@ func (b *OrderBook) EnterAuction() ([]*types.Order, []*types.Order, error) {
 	// Return all the orders that have been removed from the book and need to be cancelled
 	ordersToCancel := buyCancelledOrders
 	ordersToCancel = append(ordersToCancel, sellCancelledOrders...)
-	ordersToPark := buyParkOrders
-	ordersToPark = append(ordersToPark, sellParkOrder...)
-	return ordersToCancel, ordersToPark, nil
+	return ordersToCancel, nil
 }
 
 // LeaveAuction Moves the order book back into continuous trading state
@@ -208,12 +206,12 @@ func (b *OrderBook) LeaveAuction(at time.Time) ([]*types.OrderConfirmation, []*t
 	}
 
 	// Remove any orders that will not be valid in continuous trading
-	buyOrdersToCancel, _, err := b.buy.getOrdersToCancelOrPark(false)
+	buyOrdersToCancel, err := b.buy.getOrdersToCancel(false)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	sellOrdersToCancel, _, err := b.sell.getOrdersToCancelOrPark(false)
+	sellOrdersToCancel, err := b.sell.getOrdersToCancel(false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -2238,10 +2238,9 @@ func TestOrderBook_GFNOrdersCancelledInAuction(t *testing.T) {
 	assert.NotNil(t, orderConf)
 
 	// Switch to auction and makes sure the order is cancelled
-	orders, parked, err := book.EnterAuction()
+	orders, err := book.EnterAuction()
 	assert.NoError(t, err)
 	assert.Equal(t, len(orders), 1)
-	assert.Equal(t, len(parked), 0)
 	assert.Equal(t, book.GetTotalNumberOfOrders(), int64(1))
 }
 
@@ -2254,7 +2253,7 @@ func TestOrderBook_GFAOrdersCancelledInContinuous(t *testing.T) {
 	defer logger.Sync()
 
 	// Flip straight to auction mode
-	_, _, err := book.EnterAuction()
+	_, err := book.EnterAuction()
 	assert.NoError(t, err)
 	assert.True(t, book.InAuction())
 
@@ -2886,10 +2885,9 @@ func TestOrderBook_GetTradesInLineWithSubmitOrderDuringAuction(t *testing.T) {
 	market := "testOrderbook"
 	book := getTestOrderBook(t, market)
 
-	orders, parked, err := book.EnterAuction()
+	orders, err := book.EnterAuction()
 
 	assert.Equal(t, 0, len(orders))
-	assert.Equal(t, 0, len(parked))
 	assert.Nil(t, err)
 	order1Id := "1000000000000000000000" //Must be 22 characters
 	order2Id := "1000000000000000000001" //Must be 22 characters
@@ -3091,8 +3089,7 @@ func TestOrderBook_PeggedOrders(t *testing.T) {
 	book.SubmitOrder(bp1)
 
 	// Leave auction and uncross the book
-	cancels, parked, err := book.EnterAuction()
+	cancels, err := book.EnterAuction()
 	assert.Nil(t, err)
 	assert.Equal(t, len(cancels), 0)
-	assert.Equal(t, len(parked), 2)
 }

--- a/matching/side.go
+++ b/matching/side.go
@@ -41,9 +41,8 @@ func (s *OrderBookSide) Hash() []byte {
 }
 
 // When we leave an auction we need to remove any orders marked as GFA
-func (s *OrderBookSide) getOrdersToCancelOrPark(auction bool) ([]*types.Order, []*types.Order, error) {
+func (s *OrderBookSide) getOrdersToCancel(auction bool) ([]*types.Order, error) {
 	ordersToCancel := make([]*types.Order, 0)
-	ordersToPark := make([]*types.Order, 0)
 	for _, pricelevel := range s.levels {
 		for _, order := range pricelevel.orders {
 			// Find orders to cancel
@@ -52,13 +51,9 @@ func (s *OrderBookSide) getOrdersToCancelOrPark(auction bool) ([]*types.Order, [
 				// Save order to send back to client
 				ordersToCancel = append(ordersToCancel, order)
 			}
-
-			if auction && order.PeggedOrder != nil {
-				ordersToPark = append(ordersToPark, order)
-			}
 		}
 	}
-	return ordersToCancel, ordersToPark, nil
+	return ordersToCancel, nil
 }
 
 func (s *OrderBookSide) addOrder(o *types.Order) {


### PR DESCRIPTION
Fixing issue where going into a price monitoring auction can cause a crash when trying to park an order that has been parked due to a cancel.

When a price auction is triggered, we would query the order book to get all orders that should be cancelled (TIF=GFN) and all pegged orders that need to be parked. We then processed the list of orders which needed cancelling and then processed the list of orders that needed parking. The bug appeared when the cancelling of an order forced a reprice and parked a pegged order which was unable to reprice. Then when we attempted to process the orders to park we would be unable to park the order that was already parked.

We have changed the code in 2 ways to fix this. First we move the market into auction mode before we process the orders to prevent repricing from occurring. Second we do not ask the order book for a list of pegged orders to park, we rely on the pegged order list held by the market.

All processing of the orders is complete before we send out the auction event on the event bus to let the clients know we are in an auction.

Replaces #2857. Closes #2856.