### PR TITLE
deposits.CreditedTimestamps fixes

### DIFF
--- a/banking/engine.go
+++ b/banking/engine.go
@@ -510,6 +510,7 @@ func (e *Engine) getWithdrawalFromRef(ref *big.Int) (*types.Withdrawal, error) {
 
 func (e *Engine) finalizeDeposit(ctx context.Context, d *types.Deposit, id string) error {
 	d.Status = types.Deposit_DEPOSIT_STATUS_FINALIZED
+	d.CreditedTimestamp = e.currentTime.UnixNano()
 	e.broker.Send(events.NewDepositEvent(ctx, *d))
 	// no error this have been done before when starting the deposit
 	amount, _ := strconv.ParseUint(d.Amount, 10, 64)

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -379,10 +379,10 @@ func (r *myDepositResolver) CreatedTimestamp(ctx context.Context, obj *types.Dep
 }
 
 func (r *myDepositResolver) CreditedTimestamp(ctx context.Context, obj *types.Deposit) (*string, error) {
-	if obj.CreatedTimestamp == 0 {
+	if obj.CreditedTimestamp == 0 {
 		return nil, nil
 	}
-	t := vegatime.Format(vegatime.UnixNano(obj.CreatedTimestamp))
+	t := vegatime.Format(vegatime.UnixNano(obj.CreditedTimestamp))
 	return &t, nil
 }
 


### PR DESCRIPTION
use creditedTimestamps in gql resolve (instead of createdTimestamp)
update creditedTimestamp when deposit is finalized in vega

fixes #2801 