### PR TITLE
Better naming on Fee Distribution

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -480,12 +480,12 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 		return false
 	}
 
-	// distribute fees each `m.lpFeeDistributionTimeStep`
+	// distribute liquidity fees each `m.lpFeeDistributionTimeStep`
 	if t.Sub(m.lastEquityShareDistributed) > m.lpFeeDistributionTimeStep {
 		m.lastEquityShareDistributed = t
 
-		if err := m.distributeShares(ctx); err != nil {
-			m.log.Panic("Distributing Shares", logging.Error(err))
+		if err := m.distributeLiquidityFees(ctx); err != nil {
+			m.log.Panic("Distributing Liquidity Fees", logging.Error(err))
 		}
 	}
 
@@ -3164,7 +3164,7 @@ func lpsToLiquidityProviderFeeShare(lps map[string]*lp) []*types.LiquidityProvid
 	return out
 }
 
-func (m *Market) distributeShares(ctx context.Context) error {
+func (m *Market) distributeLiquidityFees(ctx context.Context) error {
 	asset, err := m.mkt.GetAsset()
 	if err != nil {
 		return err
@@ -3185,7 +3185,7 @@ func (m *Market) distributeShares(ctx context.Context) error {
 		return nil
 	}
 
-	feeTransfer := m.fee.DistributeLiquidityFees(shares, acc)
+	feeTransfer := m.fee.BuildLiquidityFeeDistributionTransfer(shares, acc)
 	if feeTransfer == nil {
 		return nil
 	}

--- a/fee/engine.go
+++ b/fee/engine.go
@@ -392,7 +392,12 @@ func (e *Engine) CalculateFeeForPositionResolution(
 	}, partiesFees, nil
 }
 
-func (e *Engine) DistributeLiquidityFees(shares map[string]float64, acc *types.Account) events.FeesTransfer {
+// BuildLiquidityFeeDistributionTransfer returns the set of transfers that will
+// be used by the collateral engine to distribute the fees.  As shares are
+// represented in float64 and fees are uint64, shares are floored and the
+// remainder is assigned to the last party on the share map. Note that the map
+// is sorted lexicographically to keep determinism.
+func (e *Engine) BuildLiquidityFeeDistributionTransfer(shares map[string]float64, acc *types.Account) events.FeesTransfer {
 	if len(shares) == 0 {
 		return nil
 	}


### PR DESCRIPTION
`m.distributeShares` renamed to `m.distributeLiquidityFees`
and since `DistributeLiquidityFees` is not distributing but only
calculating the amounts it's been renamed to `CalculateLiquidityFees`