### PR TITLE
Fix vega verify

### DIFF
--- a/cmd/vega/verify/genesis.go
+++ b/cmd/vega/verify/genesis.go
@@ -7,6 +7,8 @@ import (
 	"code.vegaprotocol.io/vega/broker"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/netparams"
+
+	types "code.vegaprotocol.io/vega/proto"
 )
 
 type GenesisCmd struct{}
@@ -24,9 +26,7 @@ func verifyGenesis(r *reporter, bs []byte) string {
 			NetworkParameters map[string]string `json:"network_parameters"`
 			Validators        map[string]string `json:"validators"`
 			Assets            *struct {
-				ERC20 map[string]struct {
-					ContractAddress string `json:"contractAddress"`
-				} `json:"ERC20"`
+				ERC20 map[string]types.ERC20 `json:"ERC20"`
 			} `json:"assets"`
 		} `json:"app_state"`
 	}{}

--- a/cmd/vega/verify/genesis.go
+++ b/cmd/vega/verify/genesis.go
@@ -37,6 +37,11 @@ func verifyGenesis(r *reporter, bs []byte) string {
 		return ""
 	}
 
+	if g.AppState == nil {
+		r.Err("app_state is missing")
+		return ""
+	}
+
 	if g.AppState.Network == nil {
 		r.Err("app_state.network is missing")
 	} else if g.AppState.Network.ReplayAttackThreshold == nil {


### PR DESCRIPTION
Uses the proto type to unmarshal the erc20 assets in the genesis.

The struct used to unmarshal the genesis file needs to be dynamically build because:
- we want pointer to identify missing fields, or full parts of the genesis app state
- the genesis state is built dynamically initially, there's no type for it.

This ensure the erc20 are unmarshal as expected.
Also fix panic with empty json.

close #2904
close #2903