### PR TITLE
make empty validators blocks a warning not an error

### DIFF
--- a/cmd/vega/verify/genesis.go
+++ b/cmd/vega/verify/genesis.go
@@ -79,8 +79,8 @@ func verifyGenesis(r *reporter, bs []byte) string {
 		}
 	}
 
-	if g.AppState.Validators == nil {
-		r.Err("app_state.validators is missing")
+	if g.AppState.Validators == nil || len(g.AppState.Validators) <= 0 {
+		r.Warn("app_state.validators is missing or empty")
 	} else {
 		for k, v := range g.AppState.Validators {
 			if len(k) <= 0 {


### PR DESCRIPTION
Makes missing / empty validators block in genesis a vega verify warning not an error.