### PR TITLE
fix expiry field in the erc20withdrawalApproval gql query

### DIFF
--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -443,7 +443,7 @@ func (r *myQueryResolver) Erc20WithdrawalApproval(ctx context.Context, wid strin
 	return &Erc20WithdrawalApproval{
 		AssetSource: res.AssetSource,
 		Amount:      res.Amount,
-		Expiry:      vegatime.Format(vegatime.UnixNano(res.Expiry)),
+		Expiry:      strconv.FormatInt(res.Expiry, 10),
 		Nonce:       res.Nonce,
 		Signatures:  res.Signatures,
 	}, nil


### PR DESCRIPTION
Do not format the expiry into a RFC3339 but keep it as integer.
This erc20WithdrawalApproval has been created to return the exact information to be sent to the bridge, and the expiry have to be a timestamp

Issue to be closed to be added later on if created.