### PR TITLE
Save reference prices after leaving auction (#2951)

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -823,6 +823,12 @@ func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
 
 	// We are moving to continuous trading so we have to unpark any pegged orders
 	m.repriceAllPeggedOrders(ctx, PriceMoveAll)
+
+	// Store the lastest prices so we can see if anything moves
+	m.lastMidBuyPrice, _ = m.getStaticMidPrice(types.Side_SIDE_BUY)
+	m.lastMidSellPrice, _ = m.getStaticMidPrice(types.Side_SIDE_SELL)
+	m.lastBestBidPrice, _ = m.getBestStaticBidPrice()
+	m.lastBestAskPrice, _ = m.getBestStaticAskPrice()
 }
 
 func (m *Market) validatePeggedOrder(ctx context.Context, order *types.Order) types.OrderError {


### PR DESCRIPTION
When leaving an auction and repricing any pegged orders, we do not store the last reference prices (BestBid, BestAsk, Mid) so we can't check if they move and we need to reprice again. This results in the first time we reprice after an auction we might not catch price moves. By adding code to save the reference prices after leaving auction we prevent this problem.