### PR TITLE
Park LP based orders when reprice fail

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -3012,6 +3012,10 @@ func (m *Market) createAndUpdateOrders(ctx context.Context, newOrders []*types.O
 	}()
 
 	for _, order := range newOrders {
+		if order.Price == 0 {
+			order.Status = types.Order_STATUS_PARKED
+		}
+
 		if _, err := m.submitOrder(ctx, order, false); err != nil {
 			return err
 		}

--- a/execution/market.go
+++ b/execution/market.go
@@ -1057,14 +1057,7 @@ func (m *Market) submitOrder(ctx context.Context, order *types.Order, setID bool
 		m.idgen.SetID(order)
 	}
 	order.Version = InitialOrderVersion
-
-	// If price is 0 it means that a reference price could not be found and it
-	// should be parked.
-	if order.Price != 0 {
-		order.Status = types.Order_STATUS_ACTIVE
-	} else {
-		order.Status = types.Order_STATUS_PARKED
-	}
+	order.Status = types.Order_STATUS_ACTIVE
 
 	if err := m.validateOrder(ctx, order); err != nil {
 		return nil, err

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -397,16 +397,17 @@ func (e *Engine) createOrUpdateForParty(markPrice uint64, party string, repriceF
 			Reference: buy.LiquidityOrder.Reference,
 			Offset:    buy.LiquidityOrder.Offset,
 		}
-		price, err := repriceFn(pegged)
-		if err != nil {
-			continue
+		order := &supplied.LiquidityOrder{
+			OrderID:    buy.OrderId,
+			Proportion: uint64(buy.LiquidityOrder.Proportion),
+		}
+		if price, err := repriceFn(pegged); err != nil {
+			e.log.Debug("Building Buy Shape", logging.Error(err))
+		} else {
+			order.Price = price
 		}
 		oneOrMoreValidOrdersBuy = true
-		buysShape = append(buysShape, &supplied.LiquidityOrder{
-			OrderID:    buy.OrderId,
-			Price:      price,
-			Proportion: uint64(buy.LiquidityOrder.Proportion),
-		})
+		buysShape = append(buysShape, order)
 	}
 
 	for _, sell := range lp.Sells {
@@ -414,17 +415,18 @@ func (e *Engine) createOrUpdateForParty(markPrice uint64, party string, repriceF
 			Reference: sell.LiquidityOrder.Reference,
 			Offset:    sell.LiquidityOrder.Offset,
 		}
-		price, err := repriceFn(pegged)
-		if err != nil {
-			continue
+		order := &supplied.LiquidityOrder{
+			OrderID:    sell.OrderId,
+			Proportion: uint64(sell.LiquidityOrder.Proportion),
+		}
+		if price, err := repriceFn(pegged); err != nil {
+			e.log.Debug("Building Sell Shape", logging.Error(err))
+		} else {
+			order.Price = price
 		}
 		oneOrMoreValidOrdersSell = true
 
-		sellsShape = append(sellsShape, &supplied.LiquidityOrder{
-			OrderID:    sell.OrderId,
-			Price:      price,
-			Proportion: uint64(sell.LiquidityOrder.Proportion),
-		})
+		sellsShape = append(sellsShape, order)
 	}
 
 	if !(oneOrMoreValidOrdersBuy && oneOrMoreValidOrdersSell) {

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -2,7 +2,6 @@ package liquidity_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -211,17 +210,8 @@ func TestInitialDeplyFailsWorksLater(t *testing.T) {
 		markPrice = uint64(10)
 	)
 
-	fn := func(order *types.PeggedOrder) (uint64, error) {
-		return 0, errors.New("some error")
-	}
-
-	// Expecting no creates as repreiceFn returns an error
-	creates, _, err := tng.engine.CreateInitialOrders(markPrice, party, []*types.Order{}, fn)
-	require.NoError(t, err)
-	require.Len(t, creates, 0)
-
 	// Now repreiceFn works as expected, so initial orders should get created now
-	fn = func(order *types.PeggedOrder) (uint64, error) {
+	fn := func(order *types.PeggedOrder) (uint64, error) {
 		return markPrice + uint64(order.Offset), nil
 	}
 


### PR DESCRIPTION
When trying to create orders based on the shape, reprice might fail if
no previous order were in the book; a reference price won't be found.

This PR changes this behavior and park orders.

Closes #2920
Related to #2951