### PR TITLE
use oasis/ed25519 instead of the std go one.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/jinzhu/copier v0.2.8
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/mwitkow/go-proto-validators v0.2.0
+	github.com/oasisprotocol/ed25519 v0.0.0-20210201150809-58be049e4f78
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/common v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/oasisprotocol/ed25519 v0.0.0-20210201150809-58be049e4f78 h1:a0H8rCXz6T620IHUV0wYdqALYUaUVhTzD/o7rjW99yA=
+github.com/oasisprotocol/ed25519 v0.0.0-20210201150809-58be049e4f78/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -664,6 +666,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190909091759-094676da4a83/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200406173513-056763e48d71/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/wallet/crypto/ed25519.go
+++ b/wallet/crypto/ed25519.go
@@ -6,7 +6,7 @@ import (
 
 	vcrypto "code.vegaprotocol.io/vega/crypto"
 
-	"golang.org/x/crypto/ed25519"
+	"github.com/oasisprotocol/ed25519"
 )
 
 var (


### PR DESCRIPTION
No need to be merged now, but I mentionned this library on slack, and wanted to see how difficult would it be to use it.
It appears to be actually a drop in replacement from the std lib, so it was just about changing the imports.

Just for info, here's again the benchmark, where old is the std lib, new is this library:
```
BenchmarkKeyGeneration-8     105543        34049         -67.74%
BenchmarkSigning-8           106769        35981         -66.30%
BenchmarkVerification-8      299258        140538        -53.04%
```

Also, it's good to note that this library is not audited at all, but also used in another "crypto" stuff.

here's the repo of the lib btw: https://github.com/oasisprotocol/ed25519.