### PR TITLE
prevent lock in service when unsubscribing

### DIFF
--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -1388,6 +1388,7 @@ func (t *tradingDataService) MarketDepthUpdatesSubscribe(
 			resp := &protoapi.MarketDepthUpdatesSubscribeResponse{
 				Update: depth,
 			}
+
 			if err := srv.Send(resp); err != nil {
 				if t.log.GetLevel() == logging.DebugLevel {
 					t.log.Debug("Depth updates subscriber - rpc stream error",

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -1233,21 +1233,6 @@ func (r *myMarketDataResolver) LiquidityProviderFeeShare(_ context.Context, m *t
 
 type myMarketDepthResolver VegaResolverRoot
 
-func (r *myMarketDepthResolver) Buy(ctx context.Context, obj *types.MarketDepth) ([]types.PriceLevel, error) {
-	valBuyLevels := make([]types.PriceLevel, 0)
-	for _, v := range obj.Buy {
-		valBuyLevels = append(valBuyLevels, *v)
-	}
-	return valBuyLevels, nil
-}
-func (r *myMarketDepthResolver) Sell(ctx context.Context, obj *types.MarketDepth) ([]types.PriceLevel, error) {
-	valBuyLevels := make([]types.PriceLevel, 0)
-	for _, v := range obj.Sell {
-		valBuyLevels = append(valBuyLevels, *v)
-	}
-	return valBuyLevels, nil
-}
-
 func (r *myMarketDepthResolver) LastTrade(ctx context.Context, md *types.MarketDepth) (*types.Trade, error) {
 	if md == nil {
 		return nil, errors.New("invalid market depth")
@@ -1275,21 +1260,6 @@ func (r *myMarketDepthResolver) Market(ctx context.Context, md *types.MarketDept
 // BEGIN: Market Depth Update Resolver
 
 type myMarketDepthUpdateResolver VegaResolverRoot
-
-func (r *myMarketDepthUpdateResolver) Buy(ctx context.Context, obj *types.MarketDepthUpdate) ([]types.PriceLevel, error) {
-	valBuyLevels := make([]types.PriceLevel, 0)
-	for _, v := range obj.Buy {
-		valBuyLevels = append(valBuyLevels, *v)
-	}
-	return valBuyLevels, nil
-}
-func (r *myMarketDepthUpdateResolver) Sell(ctx context.Context, obj *types.MarketDepthUpdate) ([]types.PriceLevel, error) {
-	valBuyLevels := make([]types.PriceLevel, 0)
-	for _, v := range obj.Sell {
-		valBuyLevels = append(valBuyLevels, *v)
-	}
-	return valBuyLevels, nil
-}
 
 func (r *myMarketDepthUpdateResolver) SequenceNumber(ctx context.Context, md *types.MarketDepthUpdate) (string, error) {
 	return strconv.FormatUint(md.SequenceNumber, 10), nil
@@ -1547,7 +1517,7 @@ func (r *myPriceLevelResolver) Volume(ctx context.Context, obj *types.PriceLevel
 }
 
 func (r *myPriceLevelResolver) NumberOfOrders(ctx context.Context, obj *types.PriceLevel) (string, error) {
-	return strconv.FormatUint(obj.Price, 10), nil
+	return strconv.FormatUint(obj.NumberOfOrders, 10), nil
 }
 
 // END: Price Level Resolver
@@ -2308,6 +2278,7 @@ func (r *mySubscriptionResolver) MarketDepthUpdate(ctx context.Context, market s
 				}
 				break
 			}
+
 			c <- md.Update
 		}
 	}()

--- a/markets/service.go
+++ b/markets/service.go
@@ -238,6 +238,16 @@ func (s *Svc) ObserveDepthUpdates(ctx context.Context, retries int, market strin
 					logging.Uint64("id", ref),
 					logging.String("ip-address", ip),
 				)
+
+				go func() {
+					// here we just discard all event coming in, until the
+					// channel is actually properly closed.
+					// this is kind of necessary as we wait first to unsusubscribe
+					// which is locking in the subscriber, while the subscriber
+					// may be still sending us some data
+					for range internal {
+					}
+				}()
 				if err := s.marketDepth.Unsubscribe(ref); err != nil {
 					if s.log.GetLevel() == logging.DebugLevel {
 						s.log.Debug(

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -463,5 +463,6 @@ func (mdb *MarketDepthBuilder) Unsubscribe(id uint64) error {
 		delete(mdb.subscribers, id)
 		return nil
 	}
+
 	return fmt.Errorf("subscriber to market depth updates does not exist with id: %d", id)
 }


### PR DESCRIPTION
Fix a lock happening in the market services MarketDepthUpdateSubscriber, here's how the bug was happening:
- The client is opening a subscription for the marketDepthUpdates.
- A channel is created in the markets/service.go an given to the subscribers/market_depth.go
- The channel is unbuffered.
- when new updated arrive, the subscriber is locking an internal mutex to update it's state, then sends update in the channel.
- then the service is reading the event from the channel.
- When the client cancel the subscription, the service stop reading from the channel.
- Then the service call Unsubscribe on the subscribers, which try to acquire the lock on the internal mutex.
- It happen that subscriber have already locked the mutex to update it's state and send updates in the channel.
- However the channel being unbuffered, it may already be full, and the subscriber is waiting for it to be emptied before being able to send, therefore, we are locked forever there as no one is reading anymore on the other side of the channel, and we are being locked waiting to unsubscribe.

This issue is being fixed now.

This also fix a small issue in the graphql resolver for the PriceLevel (numberOfOrder was binded to price).

Also remove a bunch of un-needed methods for the MarketDepth and MarketDepth resolver.


closes #2984 