### PR TITLE
Reject LP order submission if not enough collateral (#2932)

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1129,6 +1129,11 @@ func (e *Engine) getBondTransferRequest(t *types.Transfer, market string) (*type
 		return nil, err
 	}
 
+	// do we have enough in the general account to make the transfer?
+	if general.Balance < uint64(t.Amount.Amount) {
+		return nil, errors.New("not enough collateral in general account")
+	}
+
 	// we'll need this account for all transfer types anyway (settlements, margin-risk updates)
 	insurancePool, err := e.GetAccountByID(e.accountID(market, systemOwner, t.Amount.Asset, types.AccountType_ACCOUNT_TYPE_INSURANCE))
 	if err != nil {

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1130,7 +1130,7 @@ func (e *Engine) getBondTransferRequest(t *types.Transfer, market string) (*type
 	}
 
 	// do we have enough in the general account to make the transfer?
-	if general.Balance < uint64(t.Amount.Amount) {
+	if t.Amount.Amount > 0 && general.Balance < uint64(t.Amount.Amount) {
 		return nil, errors.New("not enough collateral in general account")
 	}
 

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1129,11 +1129,6 @@ func (e *Engine) getBondTransferRequest(t *types.Transfer, market string) (*type
 		return nil, err
 	}
 
-	// do we have enough in the general account to make the transfer?
-	if t.Amount.Amount > 0 && general.Balance < uint64(t.Amount.Amount) {
-		return nil, errors.New("not enough collateral in general account")
-	}
-
 	// we'll need this account for all transfer types anyway (settlements, margin-risk updates)
 	insurancePool, err := e.GetAccountByID(e.accountID(market, systemOwner, t.Amount.Asset, types.AccountType_ACCOUNT_TYPE_INSURANCE))
 	if err != nil {
@@ -1155,6 +1150,10 @@ func (e *Engine) getBondTransferRequest(t *types.Transfer, market string) (*type
 
 	switch t.Type {
 	case types.TransferType_TRANSFER_TYPE_BOND_LOW:
+		// do we have enough in the general account to make the transfer?
+		if t.Amount.Amount > 0 && general.Balance < uint64(t.Amount.Amount) {
+			return nil, errors.New("not enough collateral in general account")
+		}
 		treq.FromAccount = []*types.Account{general}
 		treq.ToAccount = []*types.Account{bond}
 		return treq, nil

--- a/execution/market.go
+++ b/execution/market.go
@@ -2946,9 +2946,9 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		}
 		if transfer.Type == types.TransferType_TRANSFER_TYPE_BOND_HIGH {
 			transfer.Type = types.TransferType_TRANSFER_TYPE_BOND_LOW
+		} else {
+			transfer.Type = types.TransferType_TRANSFER_TYPE_BOND_HIGH
 		}
-		transfer.Amount.Amount = -transfer.Amount.Amount
-		transfer.MinAmount = -transfer.MinAmount
 
 		tresp, newerr := m.collateral.BondUpdate(ctx, m.GetID(), party, transfer)
 		if newerr != nil {

--- a/execution/market.go
+++ b/execution/market.go
@@ -2921,6 +2921,7 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 	ty := types.TransferType_TRANSFER_TYPE_BOND_LOW
 	if amount < 0 {
 		ty = types.TransferType_TRANSFER_TYPE_BOND_HIGH
+		amount = -amount
 	}
 	transfer := &types.Transfer{
 		Owner: party,

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -2841,3 +2841,35 @@ func TestOrderBook_ParkPeggedOrderWhenMovingToAuction(t *testing.T) {
 	require.Equal(t, 1, tm.market.GetParkedOrderCount())
 	assert.Equal(t, int64(0), tm.market.GetOrdersOnBookCount())
 }
+
+func TestMarket_LeaveAuctionRepricePeggedOrdersShouldFailIfNoMargin(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(1000000000, 0)
+	tm := getTestMarket(t, now, closingAt, nil, nil)
+	ctx := context.Background()
+
+	// Create a new trader account with very little funding
+	addAccountWithAmount(tm, "trader-C", 1)
+	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	// Start the opening auction
+	tm.mas.StartOpeningAuction(now, &types.AuctionDuration{Duration: 10})
+	tm.mas.AuctionStarted(ctx)
+	tm.market.EnterAuction(ctx)
+
+	buys := []*types.LiquidityOrder{&types.LiquidityOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -10, Proportion: 50},
+		&types.LiquidityOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -20, Proportion: 50}}
+	sells := []*types.LiquidityOrder{&types.LiquidityOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Offset: 10, Proportion: 50},
+		&types.LiquidityOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Offset: 20, Proportion: 50}}
+
+	lps := &types.LiquidityProvisionSubmission{
+		Fee:              "0.01",
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 1000000000,
+		Buys:             buys,
+		Sells:            sells}
+
+	// Because we do not have enough funds to support our commitment level, we should reject this call
+	err := tm.market.SubmitLiquidityProvision(ctx, lps, "trader-C", "LPOrder01")
+	require.Error(t, err)
+}

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -61,7 +61,7 @@ type Engine struct {
 	// state
 	provisions ProvisionsPerParty
 
-	// orders stores all the market orders (except the liquidity orders) explicitly submited by a given party.
+	// orders stores all the market orders (except the liquidity orders) explicitly submitted by a given party.
 	// indexed as: map of PartyID -> OrderId -> order to easy access
 	orders map[string]map[string]*types.Order
 
@@ -100,10 +100,12 @@ func (e *Engine) OnChainTimeUpdate(ctx context.Context, now time.Time) {
 	e.currentTime = now
 }
 
+// OnSuppliedStakeToObligationFactorUpdate updates the stake factor
 func (e *Engine) OnSuppliedStakeToObligationFactorUpdate(v float64) {
 	e.stakeToObligationFactor = v
 }
 
+// CancelLiquidityProvision removes a parties commitment of liquidity
 func (e *Engine) CancelLiquidityProvision(ctx context.Context, party string) error {
 	lp := e.provisions[party]
 	if lp == nil {
@@ -119,7 +121,7 @@ func (e *Engine) CancelLiquidityProvision(ctx context.Context, party string) err
 	return nil
 }
 
-// ProvisionsPerParty returns the resgistered a map of party-id -> LiquidityProvision.
+// ProvisionsPerParty returns the registered a map of party-id -> LiquidityProvision.
 func (e *Engine) ProvisionsPerParty() ProvisionsPerParty {
 	return e.provisions
 }
@@ -127,7 +129,7 @@ func (e *Engine) ProvisionsPerParty() ProvisionsPerParty {
 func (e *Engine) validateLiquidityProvisionSubmission(lp *types.LiquidityProvisionSubmission) (err error) {
 
 	// we check if the commitment is 0 which would mean this is a cancel
-	// a cancel don't need validations
+	// a cancel does not need validations
 	if lp.CommitmentAmount == 0 {
 		return nil
 	}
@@ -173,7 +175,7 @@ func (e *Engine) rejectLiquidityProvisionSubmission(ctx context.Context, lps *ty
 
 // SubmitLiquidityProvision handles a new liquidity provision submission.
 // It's used to create, update or delete a LiquidityProvision.
-// The LiquidityProvision is created if submited for the first time, updated if a
+// The LiquidityProvision is created if submitted for the first time, updated if a
 // previous one was created for the same PartyId or deleted (if exists) when
 // the CommitmentAmount is set to 0.
 func (e *Engine) SubmitLiquidityProvision(ctx context.Context, lps *types.LiquidityProvisionSubmission, party, id string) error {
@@ -187,7 +189,7 @@ func (e *Engine) SubmitLiquidityProvision(ctx context.Context, lps *types.Liquid
 		now                           = e.currentTime.UnixNano()
 	)
 
-	// regardless of the final operaion (create,update or delete) we finish
+	// regardless of the final operation (create,update or delete) we finish
 	// sending an event.
 	defer func() {
 		evt := events.NewLiquidityProvisionEvent(ctx, lp)
@@ -291,8 +293,8 @@ func (e *Engine) IsLiquidityOrder(party, order string) bool {
 	return ok
 }
 
-// CreateInitialOrders returns two slices of orders, one are the one to be
-// created and the other the one to be updates.
+// CreateInitialOrders returns two slices of orders, one for orders to be
+// created and the other for orders to be updated.
 func (e *Engine) CreateInitialOrders(markPrice uint64, party string, orders []*types.Order, repriceFn RepricePeggedOrder) ([]*types.Order, []*types.OrderAmendment, error) {
 	// update our internal orders
 	e.updatePartyOrders(party, orders)
@@ -558,7 +560,6 @@ func validateShape(sh []*types.LiquidityOrder, side types.Side) error {
 				}
 			}
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
Traders should not be able to become liquidity providers if they do not have enough collateral in their general account to cover the initial amount of commitment required in their LP submission.
Attempting to do so will now result in the LP submission being rejected.