### PR TITLE
Fix withdrawal gql resolver: expiry, createdAt, updatedAt are now RFC3339Nano

### DIFF
--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -803,7 +803,7 @@ type LiquidityOrderReferenceResolver interface {
 type LiquidityProvisionResolver interface {
 	Party(ctx context.Context, obj *proto.LiquidityProvision) (*proto.Party, error)
 	CreatedAt(ctx context.Context, obj *proto.LiquidityProvision) (string, error)
-	UpdatedAt(ctx context.Context, obj *proto.LiquidityProvision) (string, error)
+	UpdatedAt(ctx context.Context, obj *proto.LiquidityProvision) (*string, error)
 	Market(ctx context.Context, obj *proto.LiquidityProvision) (*proto.Market, error)
 	CommitmentAmount(ctx context.Context, obj *proto.LiquidityProvision) (int, error)
 
@@ -916,7 +916,7 @@ type OrderResolver interface {
 	Type(ctx context.Context, obj *proto.Order) (*OrderType, error)
 	RejectionReason(ctx context.Context, obj *proto.Order) (*OrderRejectionReason, error)
 	Version(ctx context.Context, obj *proto.Order) (string, error)
-	UpdatedAt(ctx context.Context, obj *proto.Order) (string, error)
+	UpdatedAt(ctx context.Context, obj *proto.Order) (*string, error)
 }
 type PartyResolver interface {
 	Orders(ctx context.Context, obj *proto.Party, skip *int, first *int, last *int) ([]*proto.Order, error)
@@ -942,7 +942,7 @@ type PositionResolver interface {
 	UnrealisedPnl(ctx context.Context, obj *proto.Position) (string, error)
 	AverageEntryPrice(ctx context.Context, obj *proto.Position) (string, error)
 	Margins(ctx context.Context, obj *proto.Position) ([]*proto.MarginLevels, error)
-	UpdatedAt(ctx context.Context, obj *proto.Position) (string, error)
+	UpdatedAt(ctx context.Context, obj *proto.Position) (*string, error)
 }
 type PriceLevelResolver interface {
 	Price(ctx context.Context, obj *proto.PriceLevel) (string, error)
@@ -5517,7 +5517,7 @@ type Position {
   margins: [MarginLevels!]
 
   "last time the position was updated (RFC3339Nano)"
-  updatedAt: String!
+  updatedAt: String
 }
 
 "An order in Vega, if active it will be on the OrderBook for the market"
@@ -5572,7 +5572,7 @@ type Order {
   version: String!
 
   "UpdatedAt is the last time the order was altered"
-  updatedAt: String!
+  updatedAt: String
 
   "PeggedOrder contains the details about a pegged order"
   peggedOrder: PeggedOrder
@@ -6769,7 +6769,7 @@ type LiquidityProvision {
   "When the liquidity provision was initially created (formatted RFC3339)"
   createdAt: String!
   "When the liquidity provision was updated (formatted RFC3339)"
-  updatedAt: String!
+  updatedAt: String
   "Market identifier for the order"
   market: Market!
   "Specified as a unitless number that represents the amount of settlement asset of the market."
@@ -11309,14 +11309,11 @@ func (ec *executionContext) _LiquidityProvision_updatedAt(ctx context.Context, f
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _LiquidityProvision_market(ctx context.Context, field graphql.CollectedField, obj *proto.LiquidityProvision) (ret graphql.Marshaler) {
@@ -15409,14 +15406,11 @@ func (ec *executionContext) _Order_updatedAt(ctx context.Context, field graphql.
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Order_peggedOrder(ctx context.Context, field graphql.CollectedField, obj *proto.Order) (ret graphql.Marshaler) {
@@ -16265,14 +16259,11 @@ func (ec *executionContext) _Position_updatedAt(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PositionResolution_marketID(ctx context.Context, field graphql.CollectedField, obj *PositionResolution) (ret graphql.Marshaler) {
@@ -25628,9 +25619,6 @@ func (ec *executionContext) _LiquidityProvision(ctx context.Context, sel ast.Sel
 					}
 				}()
 				res = ec._LiquidityProvision_updatedAt(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		case "market":
@@ -27252,9 +27240,6 @@ func (ec *executionContext) _Order(ctx context.Context, sel ast.SelectionSet, ob
 					}
 				}()
 				res = ec._Order_updatedAt(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		case "peggedOrder":
@@ -27609,9 +27594,6 @@ func (ec *executionContext) _Position(ctx context.Context, sel ast.SelectionSet,
 					}
 				}()
 				res = ec._Position_updatedAt(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		default:

--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -4284,14 +4284,13 @@ var sources = []*ast.Source{
 	&ast.Source{Name: "schema.graphql", Input: `## VEGA - GraphQL schema
 
 schema {
-    query: Query
-    subscription: Subscription
-    mutation: Mutation
+  query: Query
+  subscription: Subscription
+  mutation: Mutation
 }
 
 "Mutations are similar to GraphQL queries, however they allow a caller to change or mutate data."
 type Mutation {
-
   """
   Send a submit order request to be prepared, and returns a blob of the transaction to submit.
   The OrderSubmit data is validated. Price and expiration will be converted to uint64 internally.
@@ -4405,7 +4404,6 @@ type Mutation {
   """
   Submit a new, signed, transaction to the VEGA network. This transaction will not be executed immediately.
   It validates the signature, and sends the transaction out for consensus
-
   """
   submitTransaction(
     "The signed transaction"
@@ -4414,7 +4412,7 @@ type Mutation {
     sig: SignatureInput!
     "The way to send the transaction"
     type: SubmitTransactionType
-): TransactionSubmitted!
+  ): TransactionSubmitted!
 
   "Prepare a Liquidity provision order so it can be signed and submitted"
   prepareLiquidityProvision(
@@ -4427,7 +4425,7 @@ type Mutation {
     "a set of liquidity sell orders to meet the liquidity provision obligation, see MM orders spec."
     sells: [LiquidityOrderInput!]!
     "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
-    buys:  [LiquidityOrderInput!]!
+    buys: [LiquidityOrderInput!]!
   ): PreparedLiquidityProvision!
 }
 
@@ -4524,9 +4522,9 @@ type Subscription {
     "ID of the market from which we want accounts updates"
     marketId: String
     "ID of the party from which we want accounts updates"
-    partyId: String,
+    partyId: String
     "Asset code"
-    asset: String,
+    asset: String
     "Type of the account"
     type: AccountType
   ): Account!
@@ -4593,7 +4591,7 @@ type MarginLevels {
   """
   collateralReleaseLevel: String!
 
-  "time at which these margin level were relevant"
+  "RFC3339Nano time from at which this margin level was relevant"
   timestamp: String!
 }
 
@@ -4623,13 +4621,13 @@ type MarketData {
   midPrice: String!
   "the arithmetic average of the best static bid price and best static offer price"
   staticMidPrice: String!
-  "time at which this mark price was relevant"
+  "RFC3339Nano time at which this market price was releavant"
   timestamp: String!
   "the sum of the size of all positions greater than 0."
   openInterest: String!
-  "time at which the auction will stop (null if not in auction mode"
+  "RFC3339Nano time at which the auction will stop (null if not in auction mode)"
   auctionEnd: String
-  "time at which the next auction will start (null if none is scheduled)"
+  "RFC3339Nano time at which the next auction will start (null if none is scheduled)"
   auctionStart: String
   "indicative price if the auction ended now, 0 if not in auction mode"
   indicativePrice: String!
@@ -4659,16 +4657,16 @@ type LiquidityProviderFeeShare {
   party: Party!
   "The share own by this liquidity provider (float)"
   equityLikeShare: String!
- "the average entry valuation of the liqidity provider for the market"
+  "the average entry valuation of the liqidity provider for the market"
   averageEntryValuation: String!
- }
+}
 
 "The MM commitments for this market"
 type MarketDataCommitments {
   "a set of liquidity sell orders to meet the liquidity provision obligation, see MM orders spec."
   sells: [LiquidityOrderReference!]
   "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
-  buys:  [LiquidityOrderReference!]
+  buys: [LiquidityOrderReference!]
 }
 
 type PreparedWithdrawal {
@@ -4697,30 +4695,17 @@ type TransactionSubmitted {
 
 "Queries allow a caller to read data and filter data via GraphQL."
 type Query {
-
   "One or more instruments that are trading on the VEGA network"
-  markets(
-    "ID of the market"
-    id: String
-  ): [Market!]
+  markets("ID of the market" id: String): [Market!]
 
   "An instrument that is trading on the VEGA network"
-  market(
-    "Optional ID of a market"
-    id: String!
-  ): Market
+  market("Optional ID of a market" id: String!): Market
 
   "One or more entities that are trading on the VEGA network"
-  parties(
-    "Optional ID of a party"
-    id: String
-  ): [Party!]
+  parties("Optional ID of a party" id: String): [Party!]
 
   "An entity that is trading on the VEGA network"
-  party(
-    "ID of a party"
-    id: String!
-  ): Party
+  party("ID of a party" id: String!): Party
 
   "a bunch of statistics about the node"
   statistics: Statistics!
@@ -4744,13 +4729,11 @@ type Query {
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Order!]
+    last: Int
+  ): [Order!]
 
   "An order in the VEGA network found by referenceID"
-  orderByReference(
-    "ReferenceID for an order"
-    referenceID: String!
-  ): Order!
+  orderByReference("ReferenceID for an order" referenceID: String!): Order!
 
   "All governance proposals in the VEGA network"
   proposals(
@@ -4793,15 +4776,10 @@ type Query {
   ): [Proposal!]
 
   "Return a list of aggregated node signature for a given resource ID"
-  nodeSignatures(
-    resourceId: String!
-  ): [NodeSignature!]
+  nodeSignatures(resourceId: String!): [NodeSignature!]
 
   "An asset which is used in the vega network"
-  asset(
-   "Id of the asset"
-    assetId: String!
-  ): Asset
+  asset("Id of the asset" assetId: String!): Asset
 
   "The list of all assets in use in the vega network"
   assets: [Asset!]
@@ -4827,10 +4805,7 @@ type Query {
   ): OrderEstimate!
 
   "find a withdrawal using its id"
-  withdrawal(
-    "id of the withdrawal"
-    id: String!
-  ): Withdrawal
+  withdrawal("id of the withdrawal" id: String!): Withdrawal
 
   "find a erc20 withdrawal approval using it a withdrawal id"
   erc20WithdrawalApproval(
@@ -4839,10 +4814,7 @@ type Query {
   ): Erc20WithdrawalApproval
 
   "find a deposit using its id"
-  deposit(
-    "id of the Deposit"
-    id: String!
-  ): Deposit
+  deposit("id of the Deposit" id: String!): Deposit
 
   "return the full list of network parameters"
   networkParameters: [NetworkParameter!]
@@ -4934,16 +4906,16 @@ type Statistics {
   "Total number of peers on the vega network"
   totalPeers: Int!
 
-  "Genesis time of the chain"
+  "RFC3339Nano genesis time of the chain"
   genesisTime: String!
 
-  "Current time (real)"
+  "RFC3339Nano current time (real)"
   currentTime: String!
 
-  "Uptime of the node"
+  "RFC3339Nano uptime of the node"
   upTime: String!
 
-  "Current time of the chain (decided through consensus)"
+  "RFC3339Nano current time of the chain (decided through consensus)"
   vegaTime: String!
 
   "Status of the vega application connection with the chain"
@@ -5047,7 +5019,6 @@ type SimpleRiskModelParams {
   factorShort: Float!
 }
 
-
 "A type of risk model for futures trading"
 type LogNormalRiskModel {
   "Lambda parameter of the risk model"
@@ -5068,14 +5039,12 @@ union RiskModel = LogNormalRiskModel | SimpleRiskModel
 
 "A set of metadata to associate to an instruments"
 type InstrumentMetadata {
-
   "An arbitrary list of tags to associated to associate to the Instrument (string list)"
   tags: [String!]
 }
 
 "An Ethereum oracle"
 type EthereumEvent {
-
   "The ID of the ethereum contract to use (string)"
   contractId: String!
 
@@ -5087,8 +5056,7 @@ union Oracle = EthereumEvent
 
 "A Future product"
 type Future {
-
-  "The maturity date of the product (ISO8601/RFC3339 timestamp)"
+  "RFC3339Nano maturity date of the product"
   maturity: String!
 
   "The name of the asset (string)"
@@ -5105,7 +5073,6 @@ union Product = Future
 
 "Describe something that can be traded on Vega"
 type Instrument {
-
   "Uniquely identify an instrument accrods all instruments available on Vega (string)"
   id: String!
 
@@ -5182,7 +5149,6 @@ type AuctionDuration {
   volume: Int!
 }
 
-
 """
 PriceMonitoringParameters holds a list of triggers
 """
@@ -5206,7 +5172,6 @@ type PriceMonitoringTrigger {
   """
   auctionExtensionSecs: Int!
 }
-
 
 "Configuration of a market price monitorings auctions triggers"
 type PriceMonitoringSettings {
@@ -5239,7 +5204,6 @@ type TargetStakeParameters {
 
 "Represents a product & associated parameters that can be traded on Vega, has an associated OrderBook and Trade history"
 type Market {
-
   "Market ID"
   id: String!
 
@@ -5292,7 +5256,7 @@ type Market {
   state: MarketState!
 
   "Orders on a market"
-  orders (
+  orders(
     "Pagination skip"
     skip: Int
     "Pagination first element"
@@ -5308,21 +5272,23 @@ type Market {
   ): [Account!]
 
   "Trades on a market"
-  trades (
+  trades(
     "Pagination skip"
     skip: Int
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Trade!]
+    last: Int
+  ): [Trade!]
 
   "Current depth on the orderbook for this market"
   depth(
     "Maximum market order book depth (returns whole order book if omitted)"
-    maxDepth: Int): MarketDepth!
+    maxDepth: Int
+  ): MarketDepth!
 
   "Candles on a market, for the 'last' n candles, at 'interval' seconds as specified by params"
-  candles (
+  candles(
     "RFC3339Nano encoded time from when to get candles"
     since: String!
     "Interval of the candles"
@@ -5337,8 +5303,6 @@ type Market {
     "An optional party id"
     party: String
   ): [LiquidityProvision!]
-
-
 }
 
 """
@@ -5346,21 +5310,20 @@ Market Depth is a measure of the number of open buy and sell orders for a securi
 The depth of market measure provides an indication of the liquidity and depth for the instrument.
 """
 type MarketDepth {
+  "Market id"
+  market: Market!
 
-    "Market id"
-    market: Market!
+  "Buy side price levels (if available)"
+  buy: [PriceLevel!]
 
-    "Buy side price levels (if available)"
-    buy: [PriceLevel!]
+  "Sell side price levels (if available)"
+  sell: [PriceLevel!]
 
-    "Sell side price levels (if available)"
-    sell: [PriceLevel!]
+  "Last trade for the given market (if available)"
+  lastTrade: Trade
 
-    "Last trade for the given market (if available)"
-    lastTrade: Trade
-
-    "Sequence number for the current snapshot of the market depth"
-    sequenceNumber: String!
+  "Sequence number for the current snapshot of the market depth"
+  sequenceNumber: String!
 }
 
 """
@@ -5368,59 +5331,56 @@ Market Depth Update is a delta to the current market depth which can be used to 
 market depth structure to keep it correct
 """
 type MarketDepthUpdate {
+  "Market id"
+  market: Market!
 
-    "Market id"
-    market: Market!
+  "Buy side price levels (if available)"
+  buy: [PriceLevel!]
 
-    "Buy side price levels (if available)"
-    buy: [PriceLevel!]
+  "Sell side price levels (if available)"
+  sell: [PriceLevel!]
 
-    "Sell side price levels (if available)"
-    sell: [PriceLevel!]
-
-    "Sequence number for the current snapshot of the market depth"
-    sequenceNumber: String!
+  "Sequence number for the current snapshot of the market depth"
+  sequenceNumber: String!
 }
 
 "Represents a price on either the buy or sell side and all the orders at that price"
 type PriceLevel {
+  "The price of all the orders at this level (uint64)"
+  price: String!
 
-    "The price of all the orders at this level (uint64)"
-    price: String!
+  "The total remaining size of all orders at this level (uint64)"
+  volume: String!
 
-    "The total remaining size of all orders at this level (uint64)"
-    volume: String!
-
-    "The number of orders at this price level (uint64)"
-    numberOfOrders: String!
+  "The number of orders at this price level (uint64)"
+  numberOfOrders: String!
 }
 
 "Candle stick representation of trading"
 type Candle {
+  "Unix epoch+nanoseconds for when the candle occurred"
+  timestamp: String!
 
-    "Unix epoch+nanoseconds for when the candle occurred"
-    timestamp: String!
+  "RFC3339Nano formatted date and time for the candle"
+  datetime: String!
 
-    "ISO-8601 RFC3339+Nano formatted data and time for the candle"
-    datetime: String!
+  "High price (uint64)"
+  high: String!
 
-    "High price (uint64)"
-    high: String!
+  "Low price (uint64)"
+  low: String!
 
-    "Low price (uint64)"
-    low: String!
+  "Open price (uint64)"
+  open: String!
 
-    "Open price (uint64)"
-    open: String!
+  "Close price (uint64)"
+  close: String!
 
-    "Close price (uint64)"
-    close: String!
+  "Volume price (uint64)"
+  volume: String!
 
-    "Volume price (uint64)"
-    volume: String!
-
-    "Interval price (string)"
-    interval: Interval!
+  "Interval price (string)"
+  interval: Interval!
 }
 
 "Represents a party on Vega, could be an ethereum wallet address in the future"
@@ -5435,7 +5395,8 @@ type Party {
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Order!]
+    last: Int
+  ): [Order!]
 
   "Trades relating to a party (specifically where party is either buyer OR seller)"
   trades(
@@ -5446,14 +5407,15 @@ type Party {
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Trade!]
+    last: Int
+  ): [Trade!]
 
   "Collateral accounts relating to a party"
   accounts(
     "Market ID - specify what market accounts for the party to return"
     marketId: String
     "Asset (USD, EUR etc)"
-    asset: String,
+    asset: String
     "Filter accounts by type (General account, margin account, etc...)"
     type: AccountType
   ): [Account!]
@@ -5464,7 +5426,7 @@ type Party {
   "marginLevels"
   margins(
     "market id off the margin to get, nil if all markets"
-    marketId: String,
+    marketId: String
   ): [MarginLevels!]
 
   proposals(
@@ -5494,7 +5456,6 @@ single trade may end up "splitting" with some of its volume matched into closed 
 remaining as open volume. This is why we don't refer to positions being comprised of trades, rather of volume.
 """
 type Position {
-
   "Market relating to this position"
   market: Market!
 
@@ -5516,13 +5477,12 @@ type Position {
   "margins of the party for the given position"
   margins: [MarginLevels!]
 
-  "last time the position was updated (RFC3339Nano)"
+  "RFC3339Nano time the position was updated"
   updatedAt: String
 }
 
 "An order in Vega, if active it will be on the OrderBook for the market"
 type Order {
-
   "Hash of the order data"
   id: ID!
 
@@ -5547,7 +5507,7 @@ type Order {
   "The trader who place the order (probably stored internally as the trader's public key)"
   party: Party!
 
-  "ISO-8601 RFC3339+Nano formatted date and time for when the order was created (timestamp)"
+  "RFC3339Nano formatted date and time for when the order was created (timestamp)"
   createdAt: String!
 
   "Expiration time of this order (ISO-8601 RFC3339+Nano formatted date)"
@@ -5571,7 +5531,7 @@ type Order {
   "Version of this order, counts the number of amends"
   version: String!
 
-  "UpdatedAt is the last time the order was altered"
+  "RFC3339Nano time the order was altered"
   updatedAt: String
 
   "PeggedOrder contains the details about a pegged order"
@@ -5592,7 +5552,6 @@ type OrderEstimate {
 
 "A trade on Vega, the result of two orders being 'matched' in the market"
 type Trade {
-
   "The hash of the trade data"
   id: ID!
 
@@ -5620,7 +5579,7 @@ type Trade {
   "The number of contracts trades, will always be <= the remaining size of both orders immediately before the trade (uint64)"
   size: String!
 
-  "RFC3339Nano for when the trade occurred"
+  "RFC3339Nano time for when the trade occurred"
   createdAt: String!
 
   "The type of trade"
@@ -5651,10 +5610,8 @@ type TradeFee {
   liquidityFee: String!
 }
 
-
 "Valid trade types"
 enum TradeType {
-
   "Default trade type"
   Default
 
@@ -5683,7 +5640,7 @@ type Erc20WithdrawalApproval {
   assetSource: String!
   "The amount to be withdrawan"
   amount: String!
-  "The expiry of the approval (RFC3339Nano)"
+  "Timestamp in seconds for expiry of the approval"
   expiry: String!
   "The nonce to be used in the request"
   nonce: String!
@@ -5708,11 +5665,11 @@ type Withdrawal {
   status: WithdrawalStatus!
   "A reference the foreign chain can use to refere to when processing the withdrawal"
   ref: String!
-  "The time until when the withdrawal will be valid (RFC3339Nano)"
+  "RFC3339Nano time until the withdrawal will be invalid"
   expiry: String!
-  "Time at which the withdrawal was created (RFC3339Nano)"
+  "RFC3339Nano time at which the withdrawal was created"
   createdTimestamp: String!
-  "Time at which the withdrawal was finalized (RFC3339Nano)"
+  "RFC3339Nano time at which the withdrawal was finalized"
   withdrawnTimestamp: String
   "Hash of the transaction on the foreign chain"
   txHash: String
@@ -5750,9 +5707,9 @@ type Deposit {
   asset: Asset!
   "The current status of the deposit"
   status: DepositStatus!
-  "Time at which the deposit was created (RFC3339Nano)"
+  "RFC3339Nano time at which the deposit was created"
   createdTimestamp: String!
-  "Time at which the deposit was finalized (RFC3339Nano)"
+  "RFC3339Nano time at which the deposit was finalized"
   creditedTimestamp: String
   "Hash of the transaction on the foreign chain"
   txHash: String
@@ -5770,27 +5727,26 @@ enum DepositStatus {
 
 "Valid order types, these determine what happens when an order is added to the book"
 enum OrderTimeInForce {
+  "The order either trades completely (remainingSize == 0 after adding) or not at all, does not remain on the book if it doesn't trade"
+  FOK
 
-    "The order either trades completely (remainingSize == 0 after adding) or not at all, does not remain on the book if it doesn't trade"
-    FOK
+  "The order trades any amount and as much as possible but does not remain on the book (whether it trades or not)"
+  IOC
 
-    "The order trades any amount and as much as possible but does not remain on the book (whether it trades or not)"
-    IOC
+  "This order trades any amount and as much as possible and remains on the book until it either trades completely or is cancelled"
+  GTC
 
-    "This order trades any amount and as much as possible and remains on the book until it either trades completely or is cancelled"
-    GTC
+  """
+  This order type trades any amount and as much as possible and remains on the book until they either trade completely, are cancelled, or expires at a set time
+  NOTE: this may in future be multiple types or have sub types for orders that provide different ways of specifying expiry
+  """
+  GTT
 
-    """
-    This order type trades any amount and as much as possible and remains on the book until they either trade completely, are cancelled, or expires at a set time
-    NOTE: this may in future be multiple types or have sub types for orders that provide different ways of specifying expiry
-    """
-    GTT
+  "This order is only accepted during an auction period"
+  GFA
 
-    "This order is only accepted during an auction period"
-    GFA
-
-    "This order is only accepted during normal trading (that can be continuous trading or frequent batched auctions)"
-    GFN
+  "This order is only accepted during normal trading (that can be continuous trading or frequent batched auctions)"
+  GFN
 }
 
 "Valid references used for pegged orders."
@@ -5805,7 +5761,6 @@ enum PeggedReference {
 
 "Valid order statuses, these determine several states for an order that cannot be expressed with other fields in Order."
 enum OrderStatus {
-
   """
   The order is active and not cancelled or expired, it could be unfilled, partially filled or fully filled.
   Active does not necessarily mean it's still on the order book.
@@ -5890,7 +5845,6 @@ enum ProposalRejectionReason {
 
 "Reason for the order being rejected by the core node"
 enum OrderRejectionReason {
-
   "Market id is invalid"
   InvalidMarketId
 
@@ -6015,7 +5969,7 @@ enum OrderRejectionReason {
   PeggedOrderSellCannotReferenceBestBidPrice
 
   "Pegged order offset must be > zero"
-	PeggedOrderOffsetMustBeGreaterThanZero
+  PeggedOrderOffsetMustBeGreaterThanZero
 
   "Insufficient balance to submit the order (no deposit made)"
   InsufficientAssetBalance
@@ -6180,13 +6134,12 @@ input FutureProductInput {
 }
 
 type FutureProduct {
-  "Future product maturity (ISO8601/RFC3339 timestamp)"
+  "RFC3339Nano time when the future products matures"
   maturity: String!
   "Product asset ID"
   settlementAsset: Asset!
- "String representing the quote (e.g. BTCUSD -> USD is quote)"
+  "String representing the quote (e.g. BTCUSD -> USD is quote)"
   quoteName: String!
-
 }
 
 input InstrumentConfigurationInput {
@@ -6330,17 +6283,21 @@ input NetworkParameterInput {
   value: String!
 }
 
-union ProposalChange = NewMarket | UpdateMarket | UpdateNetworkParameter | NewAsset
+union ProposalChange =
+    NewMarket
+  | UpdateMarket
+  | UpdateNetworkParameter
+  | NewAsset
 # there are no unions for input types as of today, see: https://github.com/graphql/graphql-spec/issues/488
 
 type ProposalTerms {
   """
-  ISO-8601 time and date when voting closes for this proposal.
-  Constrained by "minCloseInSeconds" and "maxCloseInSeconds" network parameters.
+  RFC3339Nano time and date when voting closes for this proposal.
+  Constrained by "minClose" and "maxClose" network parameters.
   """
   closingDatetime: String!
   """
-  ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
+  RFC3339Nano time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
   Constrained by "minEnactInSeconds" and "maxEnactInSeconds" network parameters.
   """
   enactmentDatetime: String!
@@ -6353,16 +6310,15 @@ type ProposalTerms {
 "Proposal terms input. Only one kind of change is expected. Proposals with no changes or more than one will not be accepted."
 input ProposalTermsInput {
   """
-  ISO-8601 time and date when voting closes for this proposal.
+  RFC3339Nano/ISO-8601 time and date when voting closes for this proposal.
   Constrained by "minCloseInSeconds" and "maxCloseInSeconds" network parameters.
   """
   closingDatetime: String!
   """
-  ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
+  RFC3339Nano/ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
   Constrained by "minEnactInSeconds" and "maxEnactInSeconds" network parameters.
   """
   enactmentDatetime: String!
-
 
   """
   Field defining new market change - the proposal will create new market if passed and enacted.
@@ -6386,7 +6342,6 @@ input ProposalTermsInput {
 
   "a new Asset proposal, this will create a new asset to be used in the vega network"
   newAsset: NewAssetInput
-
 }
 
 "A new asset to be added into vega"
@@ -6455,7 +6410,7 @@ type Proposal {
   party: Party!
   "State of the proposal"
   state: ProposalState!
-  "ISO-8601 time and date when the proposal reached Vega network"
+  "RFC3339Nano time and date when the proposal reached Vega network"
   datetime: String!
   "Terms of the proposal"
   terms: ProposalTerms!
@@ -6490,7 +6445,7 @@ type Vote {
   "The party casting the vote"
   party: Party!
 
-  "ISO-8601 time and date when the vote reached Vega network"
+  "RFC3339Nano time and date when the vote reached Vega network"
   datetime: String!
 
   "The ID of the proposal this vote applies to"
@@ -6513,7 +6468,7 @@ type PreparedVote {
 }
 
 type TimeUpdate {
-  "timestamp - new block time"
+  "RFC3339Nano time of new block time"
   timestamp: String!
 }
 
@@ -6542,7 +6497,7 @@ type LedgerEntry {
   reference: String!
   "Type of ledger entry"
   type: String!
-  "The time at which the transfer was made"
+  "RFC3339Nano time at which the transfer was made"
   timestamp: String!
 }
 
@@ -6621,9 +6576,9 @@ type AuctionEvent {
   leave: Boolean!
   "event related to opening auction"
   openingAuction: Boolean!
-  "start time of auction"
+  "RFC3339Nano start time of auction"
   auctionStart: String!
-  "optional end time of auction"
+  "RFC3339Nano optional end time of auction"
   auctionEnd: String!
   "What triggered the auction"
   trigger: AuctionTrigger!
@@ -6696,7 +6651,30 @@ enum BusEventType {
 }
 
 "union type for wrapped events in stream PROPOSAL is mapped to governance data, something to keep in mind"
-union Event = TimeUpdate | MarketEvent | TransferResponses | PositionResolution | Order | Trade | Account | Party | MarginLevels | Proposal | Vote | MarketData | NodeSignature | LossSocialization | SettlePosition | Market | Asset | MarketTick | SettleDistressed | AuctionEvent | RiskFactor | Deposit | Withdrawal
+union Event =
+    TimeUpdate
+  | MarketEvent
+  | TransferResponses
+  | PositionResolution
+  | Order
+  | Trade
+  | Account
+  | Party
+  | MarginLevels
+  | Proposal
+  | Vote
+  | MarketData
+  | NodeSignature
+  | LossSocialization
+  | SettlePosition
+  | Market
+  | Asset
+  | MarketTick
+  | SettleDistressed
+  | AuctionEvent
+  | RiskFactor
+  | Deposit
+  | Withdrawal
 
 type BusEvent {
   "the id for this event"
@@ -6768,7 +6746,7 @@ type LiquidityProvision {
   party: Party!
   "When the liquidity provision was initially created (formatted RFC3339)"
   createdAt: String!
-  "When the liquidity provision was updated (formatted RFC3339)"
+  "RFC3339Nano time of when the liquidity provision was updated"
   updatedAt: String
   "Market identifier for the order"
   market: Market!
@@ -6779,7 +6757,7 @@ type LiquidityProvision {
   "a set of liquidity sell orders to meet the liquidity provision obligation, see MM orders spec."
   sells: [LiquidityOrderReference!]!
   "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
-  buys:  [LiquidityOrderReference!]!
+  buys: [LiquidityOrderReference!]!
   "The version of this LiquidityProvision"
   version: String!
   "The current status of this liquidity provision"

--- a/gateway/graphql/models.go
+++ b/gateway/graphql/models.go
@@ -65,9 +65,9 @@ type AuctionEvent struct {
 	Leave bool `json:"leave"`
 	// event related to opening auction
 	OpeningAuction bool `json:"openingAuction"`
-	// start time of auction
+	// RFC3339Nano start time of auction
 	AuctionStart string `json:"auctionStart"`
-	// optional end time of auction
+	// RFC3339Nano optional end time of auction
 	AuctionEnd string `json:"auctionEnd"`
 	// What triggered the auction
 	Trigger AuctionTrigger `json:"trigger"`
@@ -170,7 +170,7 @@ type Erc20WithdrawalApproval struct {
 	AssetSource string `json:"assetSource"`
 	// The amount to be withdrawan
 	Amount string `json:"amount"`
-	// The expiry of the approval (RFC3339Nano)
+	// Timestamp in seconds for expiry of the approval
 	Expiry string `json:"expiry"`
 	// The nonce to be used in the request
 	Nonce string `json:"nonce"`
@@ -255,7 +255,7 @@ type LedgerEntry struct {
 	Reference string `json:"reference"`
 	// Type of ledger entry
 	Type string `json:"type"`
-	// The time at which the transfer was made
+	// RFC3339Nano time at which the transfer was made
 	Timestamp string `json:"timestamp"`
 }
 
@@ -532,10 +532,10 @@ type PriceMonitoringTriggerInput struct {
 
 // Proposal terms input. Only one kind of change is expected. Proposals with no changes or more than one will not be accepted.
 type ProposalTermsInput struct {
-	// ISO-8601 time and date when voting closes for this proposal.
+	// RFC3339Nano/ISO-8601 time and date when voting closes for this proposal.
 	// Constrained by "minCloseInSeconds" and "maxCloseInSeconds" network parameters.
 	ClosingDatetime string `json:"closingDatetime"`
-	// ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
+	// RFC3339Nano/ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
 	// Constrained by "minEnactInSeconds" and "maxEnactInSeconds" network parameters.
 	EnactmentDatetime string `json:"enactmentDatetime"`
 	// Field defining new market change - the proposal will create new market if passed and enacted.
@@ -645,7 +645,7 @@ type TargetStakeParameters struct {
 }
 
 type TimeUpdate struct {
-	// timestamp - new block time
+	// RFC3339Nano time of new block time
 	Timestamp string `json:"timestamp"`
 }
 
@@ -707,7 +707,7 @@ type Vote struct {
 	Value VoteValue `json:"value"`
 	// The party casting the vote
 	Party *proto.Party `json:"party"`
-	// ISO-8601 time and date when the vote reached Vega network
+	// RFC3339Nano time and date when the vote reached Vega network
 	Datetime string `json:"datetime"`
 	// The ID of the proposal this vote applies to
 	ProposalID string `json:"proposalId"`

--- a/gateway/graphql/resolvers.go
+++ b/gateway/graphql/resolvers.go
@@ -345,8 +345,13 @@ func (r *myLiquidityProvisionResolver) Party(ctx context.Context, obj *types.Liq
 func (r *myLiquidityProvisionResolver) CreatedAt(ctx context.Context, obj *types.LiquidityProvision) (string, error) {
 	return vegatime.Format(vegatime.UnixNano(obj.CreatedAt)), nil
 }
-func (r *myLiquidityProvisionResolver) UpdatedAt(ctx context.Context, obj *types.LiquidityProvision) (string, error) {
-	return vegatime.Format(vegatime.UnixNano(obj.UpdatedAt)), nil
+func (r *myLiquidityProvisionResolver) UpdatedAt(ctx context.Context, obj *types.LiquidityProvision) (*string, error) {
+	var updatedAt *string
+	if obj.UpdatedAt > 0 {
+		t := vegatime.Format(vegatime.UnixNano(obj.UpdatedAt))
+		updatedAt = &t
+	}
+	return updatedAt, nil
 }
 func (r *myLiquidityProvisionResolver) Market(ctx context.Context, obj *types.LiquidityProvision) (*types.Market, error) {
 	return r.r.getMarketByID(ctx, obj.MarketId)
@@ -1301,11 +1306,13 @@ func (r *myOrderResolver) CreatedAt(ctx context.Context, obj *types.Order) (stri
 	return vegatime.Format(vegatime.UnixNano(obj.CreatedAt)), nil
 }
 
-func (r *myOrderResolver) UpdatedAt(ctx context.Context, obj *types.Order) (string, error) {
-	if obj.UpdatedAt <= 0 {
-		return "", nil
+func (r *myOrderResolver) UpdatedAt(ctx context.Context, obj *types.Order) (*string, error) {
+	var updatedAt *string
+	if obj.UpdatedAt > 0 {
+		t := vegatime.Format(vegatime.UnixNano(obj.UpdatedAt))
+		updatedAt = &t
 	}
-	return vegatime.Format(vegatime.UnixNano(obj.UpdatedAt)), nil
+	return updatedAt, nil
 }
 
 func (r *myOrderResolver) Version(ctx context.Context, obj *types.Order) (string, error) {
@@ -1520,8 +1527,13 @@ func (r *myPositionResolver) Market(ctx context.Context, obj *types.Position) (*
 	return r.r.getMarketByID(ctx, obj.MarketId)
 }
 
-func (r *myPositionResolver) UpdatedAt(ctx context.Context, obj *types.Position) (string, error) {
-	return vegatime.Format(vegatime.UnixNano(obj.UpdatedAt)), nil
+func (r *myPositionResolver) UpdatedAt(ctx context.Context, obj *types.Position) (*string, error) {
+	var updatedAt *string
+	if obj.UpdatedAt > 0 {
+		t := vegatime.Format(vegatime.UnixNano(obj.UpdatedAt))
+		updatedAt = &t
+	}
+	return updatedAt, nil
 }
 
 func (r *myPositionResolver) OpenVolume(ctx context.Context, obj *types.Position) (string, error) {

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -1194,8 +1194,8 @@ type Position {
   "margins of the party for the given position"
   margins: [MarginLevels!]
 
-  "RFC3339Nano time the position was updated, can be empty string"
-  updatedAt: String!
+  "RFC3339Nano time the position was updated"
+  updatedAt: String
 }
 
 "An order in Vega, if active it will be on the OrderBook for the market"
@@ -1248,8 +1248,8 @@ type Order {
   "Version of this order, counts the number of amends"
   version: String!
 
-  "RFC3339Nano time the order was altered, can be empty string"
-  updatedAt: String!
+  "RFC3339Nano time the order was altered"
+  updatedAt: String
 
   "PeggedOrder contains the details about a pegged order"
   peggedOrder: PeggedOrder
@@ -2463,8 +2463,8 @@ type LiquidityProvision {
   party: Party!
   "When the liquidity provision was initially created (formatted RFC3339)"
   createdAt: String!
-  "RFC3339Nano time of when the liquidity provision was updated, can be empty string"
-  updatedAt: String!
+  "RFC3339Nano time of when the liquidity provision was updated"
+  updatedAt: String
   "Market identifier for the order"
   market: Market!
   "Specified as a unitless number that represents the amount of settlement asset of the market."

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -1,14 +1,13 @@
 ## VEGA - GraphQL schema
 
 schema {
-    query: Query
-    subscription: Subscription
-    mutation: Mutation
+  query: Query
+  subscription: Subscription
+  mutation: Mutation
 }
 
 "Mutations are similar to GraphQL queries, however they allow a caller to change or mutate data."
 type Mutation {
-
   """
   Send a submit order request to be prepared, and returns a blob of the transaction to submit.
   The OrderSubmit data is validated. Price and expiration will be converted to uint64 internally.
@@ -122,7 +121,6 @@ type Mutation {
   """
   Submit a new, signed, transaction to the VEGA network. This transaction will not be executed immediately.
   It validates the signature, and sends the transaction out for consensus
-
   """
   submitTransaction(
     "The signed transaction"
@@ -131,7 +129,7 @@ type Mutation {
     sig: SignatureInput!
     "The way to send the transaction"
     type: SubmitTransactionType
-): TransactionSubmitted!
+  ): TransactionSubmitted!
 
   "Prepare a Liquidity provision order so it can be signed and submitted"
   prepareLiquidityProvision(
@@ -144,7 +142,7 @@ type Mutation {
     "a set of liquidity sell orders to meet the liquidity provision obligation, see MM orders spec."
     sells: [LiquidityOrderInput!]!
     "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
-    buys:  [LiquidityOrderInput!]!
+    buys: [LiquidityOrderInput!]!
   ): PreparedLiquidityProvision!
 }
 
@@ -241,9 +239,9 @@ type Subscription {
     "ID of the market from which we want accounts updates"
     marketId: String
     "ID of the party from which we want accounts updates"
-    partyId: String,
+    partyId: String
     "Asset code"
-    asset: String,
+    asset: String
     "Type of the account"
     type: AccountType
   ): Account!
@@ -310,7 +308,7 @@ type MarginLevels {
   """
   collateralReleaseLevel: String!
 
-  "time at which these margin level were relevant"
+  "RFC3339Nano time from at which this margin level was relevant"
   timestamp: String!
 }
 
@@ -340,13 +338,13 @@ type MarketData {
   midPrice: String!
   "the arithmetic average of the best static bid price and best static offer price"
   staticMidPrice: String!
-  "time at which this mark price was relevant"
+  "RFC3339Nano time at which this market price was releavant"
   timestamp: String!
   "the sum of the size of all positions greater than 0."
   openInterest: String!
-  "time at which the auction will stop (null if not in auction mode"
+  "RFC3339Nano time at which the auction will stop (null if not in auction mode)"
   auctionEnd: String
-  "time at which the next auction will start (null if none is scheduled)"
+  "RFC3339Nano time at which the next auction will start (null if none is scheduled)"
   auctionStart: String
   "indicative price if the auction ended now, 0 if not in auction mode"
   indicativePrice: String!
@@ -376,16 +374,16 @@ type LiquidityProviderFeeShare {
   party: Party!
   "The share own by this liquidity provider (float)"
   equityLikeShare: String!
- "the average entry valuation of the liqidity provider for the market"
+  "the average entry valuation of the liqidity provider for the market"
   averageEntryValuation: String!
- }
+}
 
 "The MM commitments for this market"
 type MarketDataCommitments {
   "a set of liquidity sell orders to meet the liquidity provision obligation, see MM orders spec."
   sells: [LiquidityOrderReference!]
   "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
-  buys:  [LiquidityOrderReference!]
+  buys: [LiquidityOrderReference!]
 }
 
 type PreparedWithdrawal {
@@ -414,30 +412,17 @@ type TransactionSubmitted {
 
 "Queries allow a caller to read data and filter data via GraphQL."
 type Query {
-
   "One or more instruments that are trading on the VEGA network"
-  markets(
-    "ID of the market"
-    id: String
-  ): [Market!]
+  markets("ID of the market" id: String): [Market!]
 
   "An instrument that is trading on the VEGA network"
-  market(
-    "Optional ID of a market"
-    id: String!
-  ): Market
+  market("Optional ID of a market" id: String!): Market
 
   "One or more entities that are trading on the VEGA network"
-  parties(
-    "Optional ID of a party"
-    id: String
-  ): [Party!]
+  parties("Optional ID of a party" id: String): [Party!]
 
   "An entity that is trading on the VEGA network"
-  party(
-    "ID of a party"
-    id: String!
-  ): Party
+  party("ID of a party" id: String!): Party
 
   "a bunch of statistics about the node"
   statistics: Statistics!
@@ -461,13 +446,11 @@ type Query {
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Order!]
+    last: Int
+  ): [Order!]
 
   "An order in the VEGA network found by referenceID"
-  orderByReference(
-    "ReferenceID for an order"
-    referenceID: String!
-  ): Order!
+  orderByReference("ReferenceID for an order" referenceID: String!): Order!
 
   "All governance proposals in the VEGA network"
   proposals(
@@ -510,15 +493,10 @@ type Query {
   ): [Proposal!]
 
   "Return a list of aggregated node signature for a given resource ID"
-  nodeSignatures(
-    resourceId: String!
-  ): [NodeSignature!]
+  nodeSignatures(resourceId: String!): [NodeSignature!]
 
   "An asset which is used in the vega network"
-  asset(
-   "Id of the asset"
-    assetId: String!
-  ): Asset
+  asset("Id of the asset" assetId: String!): Asset
 
   "The list of all assets in use in the vega network"
   assets: [Asset!]
@@ -544,10 +522,7 @@ type Query {
   ): OrderEstimate!
 
   "find a withdrawal using its id"
-  withdrawal(
-    "id of the withdrawal"
-    id: String!
-  ): Withdrawal
+  withdrawal("id of the withdrawal" id: String!): Withdrawal
 
   "find a erc20 withdrawal approval using it a withdrawal id"
   erc20WithdrawalApproval(
@@ -556,10 +531,7 @@ type Query {
   ): Erc20WithdrawalApproval
 
   "find a deposit using its id"
-  deposit(
-    "id of the Deposit"
-    id: String!
-  ): Deposit
+  deposit("id of the Deposit" id: String!): Deposit
 
   "return the full list of network parameters"
   networkParameters: [NetworkParameter!]
@@ -651,16 +623,16 @@ type Statistics {
   "Total number of peers on the vega network"
   totalPeers: Int!
 
-  "Genesis time of the chain"
+  "RFC3339Nano genesis time of the chain"
   genesisTime: String!
 
-  "Current time (real)"
+  "RFC3339Nano current time (real)"
   currentTime: String!
 
-  "Uptime of the node"
+  "RFC3339Nano uptime of the node"
   upTime: String!
 
-  "Current time of the chain (decided through consensus)"
+  "RFC3339Nano current time of the chain (decided through consensus)"
   vegaTime: String!
 
   "Status of the vega application connection with the chain"
@@ -764,7 +736,6 @@ type SimpleRiskModelParams {
   factorShort: Float!
 }
 
-
 "A type of risk model for futures trading"
 type LogNormalRiskModel {
   "Lambda parameter of the risk model"
@@ -785,14 +756,12 @@ union RiskModel = LogNormalRiskModel | SimpleRiskModel
 
 "A set of metadata to associate to an instruments"
 type InstrumentMetadata {
-
   "An arbitrary list of tags to associated to associate to the Instrument (string list)"
   tags: [String!]
 }
 
 "An Ethereum oracle"
 type EthereumEvent {
-
   "The ID of the ethereum contract to use (string)"
   contractId: String!
 
@@ -804,8 +773,7 @@ union Oracle = EthereumEvent
 
 "A Future product"
 type Future {
-
-  "The maturity date of the product (ISO8601/RFC3339 timestamp)"
+  "RFC3339Nano maturity date of the product"
   maturity: String!
 
   "The name of the asset (string)"
@@ -822,7 +790,6 @@ union Product = Future
 
 "Describe something that can be traded on Vega"
 type Instrument {
-
   "Uniquely identify an instrument accrods all instruments available on Vega (string)"
   id: String!
 
@@ -899,7 +866,6 @@ type AuctionDuration {
   volume: Int!
 }
 
-
 """
 PriceMonitoringParameters holds a list of triggers
 """
@@ -923,7 +889,6 @@ type PriceMonitoringTrigger {
   """
   auctionExtensionSecs: Int!
 }
-
 
 "Configuration of a market price monitorings auctions triggers"
 type PriceMonitoringSettings {
@@ -956,7 +921,6 @@ type TargetStakeParameters {
 
 "Represents a product & associated parameters that can be traded on Vega, has an associated OrderBook and Trade history"
 type Market {
-
   "Market ID"
   id: String!
 
@@ -1009,7 +973,7 @@ type Market {
   state: MarketState!
 
   "Orders on a market"
-  orders (
+  orders(
     "Pagination skip"
     skip: Int
     "Pagination first element"
@@ -1025,21 +989,23 @@ type Market {
   ): [Account!]
 
   "Trades on a market"
-  trades (
+  trades(
     "Pagination skip"
     skip: Int
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Trade!]
+    last: Int
+  ): [Trade!]
 
   "Current depth on the orderbook for this market"
   depth(
     "Maximum market order book depth (returns whole order book if omitted)"
-    maxDepth: Int): MarketDepth!
+    maxDepth: Int
+  ): MarketDepth!
 
   "Candles on a market, for the 'last' n candles, at 'interval' seconds as specified by params"
-  candles (
+  candles(
     "RFC3339Nano encoded time from when to get candles"
     since: String!
     "Interval of the candles"
@@ -1054,8 +1020,6 @@ type Market {
     "An optional party id"
     party: String
   ): [LiquidityProvision!]
-
-
 }
 
 """
@@ -1063,21 +1027,20 @@ Market Depth is a measure of the number of open buy and sell orders for a securi
 The depth of market measure provides an indication of the liquidity and depth for the instrument.
 """
 type MarketDepth {
+  "Market id"
+  market: Market!
 
-    "Market id"
-    market: Market!
+  "Buy side price levels (if available)"
+  buy: [PriceLevel!]
 
-    "Buy side price levels (if available)"
-    buy: [PriceLevel!]
+  "Sell side price levels (if available)"
+  sell: [PriceLevel!]
 
-    "Sell side price levels (if available)"
-    sell: [PriceLevel!]
+  "Last trade for the given market (if available)"
+  lastTrade: Trade
 
-    "Last trade for the given market (if available)"
-    lastTrade: Trade
-
-    "Sequence number for the current snapshot of the market depth"
-    sequenceNumber: String!
+  "Sequence number for the current snapshot of the market depth"
+  sequenceNumber: String!
 }
 
 """
@@ -1085,59 +1048,56 @@ Market Depth Update is a delta to the current market depth which can be used to 
 market depth structure to keep it correct
 """
 type MarketDepthUpdate {
+  "Market id"
+  market: Market!
 
-    "Market id"
-    market: Market!
+  "Buy side price levels (if available)"
+  buy: [PriceLevel!]
 
-    "Buy side price levels (if available)"
-    buy: [PriceLevel!]
+  "Sell side price levels (if available)"
+  sell: [PriceLevel!]
 
-    "Sell side price levels (if available)"
-    sell: [PriceLevel!]
-
-    "Sequence number for the current snapshot of the market depth"
-    sequenceNumber: String!
+  "Sequence number for the current snapshot of the market depth"
+  sequenceNumber: String!
 }
 
 "Represents a price on either the buy or sell side and all the orders at that price"
 type PriceLevel {
+  "The price of all the orders at this level (uint64)"
+  price: String!
 
-    "The price of all the orders at this level (uint64)"
-    price: String!
+  "The total remaining size of all orders at this level (uint64)"
+  volume: String!
 
-    "The total remaining size of all orders at this level (uint64)"
-    volume: String!
-
-    "The number of orders at this price level (uint64)"
-    numberOfOrders: String!
+  "The number of orders at this price level (uint64)"
+  numberOfOrders: String!
 }
 
 "Candle stick representation of trading"
 type Candle {
+  "Unix epoch+nanoseconds for when the candle occurred"
+  timestamp: String!
 
-    "Unix epoch+nanoseconds for when the candle occurred"
-    timestamp: String!
+  "RFC3339Nano formatted date and time for the candle"
+  datetime: String!
 
-    "ISO-8601 RFC3339+Nano formatted data and time for the candle"
-    datetime: String!
+  "High price (uint64)"
+  high: String!
 
-    "High price (uint64)"
-    high: String!
+  "Low price (uint64)"
+  low: String!
 
-    "Low price (uint64)"
-    low: String!
+  "Open price (uint64)"
+  open: String!
 
-    "Open price (uint64)"
-    open: String!
+  "Close price (uint64)"
+  close: String!
 
-    "Close price (uint64)"
-    close: String!
+  "Volume price (uint64)"
+  volume: String!
 
-    "Volume price (uint64)"
-    volume: String!
-
-    "Interval price (string)"
-    interval: Interval!
+  "Interval price (string)"
+  interval: Interval!
 }
 
 "Represents a party on Vega, could be an ethereum wallet address in the future"
@@ -1152,7 +1112,8 @@ type Party {
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Order!]
+    last: Int
+  ): [Order!]
 
   "Trades relating to a party (specifically where party is either buyer OR seller)"
   trades(
@@ -1163,14 +1124,15 @@ type Party {
     "Pagination first element"
     first: Int
     "Pagination last element"
-    last: Int): [Trade!]
+    last: Int
+  ): [Trade!]
 
   "Collateral accounts relating to a party"
   accounts(
     "Market ID - specify what market accounts for the party to return"
     marketId: String
     "Asset (USD, EUR etc)"
-    asset: String,
+    asset: String
     "Filter accounts by type (General account, margin account, etc...)"
     type: AccountType
   ): [Account!]
@@ -1181,7 +1143,7 @@ type Party {
   "marginLevels"
   margins(
     "market id off the margin to get, nil if all markets"
-    marketId: String,
+    marketId: String
   ): [MarginLevels!]
 
   proposals(
@@ -1211,7 +1173,6 @@ single trade may end up "splitting" with some of its volume matched into closed 
 remaining as open volume. This is why we don't refer to positions being comprised of trades, rather of volume.
 """
 type Position {
-
   "Market relating to this position"
   market: Market!
 
@@ -1233,13 +1194,12 @@ type Position {
   "margins of the party for the given position"
   margins: [MarginLevels!]
 
-  "last time the position was updated (RFC3339Nano)"
+  "RFC3339Nano time the position was updated, can be empty string"
   updatedAt: String!
 }
 
 "An order in Vega, if active it will be on the OrderBook for the market"
 type Order {
-
   "Hash of the order data"
   id: ID!
 
@@ -1264,7 +1224,7 @@ type Order {
   "The trader who place the order (probably stored internally as the trader's public key)"
   party: Party!
 
-  "ISO-8601 RFC3339+Nano formatted date and time for when the order was created (timestamp)"
+  "RFC3339Nano formatted date and time for when the order was created (timestamp)"
   createdAt: String!
 
   "Expiration time of this order (ISO-8601 RFC3339+Nano formatted date)"
@@ -1288,7 +1248,7 @@ type Order {
   "Version of this order, counts the number of amends"
   version: String!
 
-  "UpdatedAt is the last time the order was altered"
+  "RFC3339Nano time the order was altered, can be empty string"
   updatedAt: String!
 
   "PeggedOrder contains the details about a pegged order"
@@ -1309,7 +1269,6 @@ type OrderEstimate {
 
 "A trade on Vega, the result of two orders being 'matched' in the market"
 type Trade {
-
   "The hash of the trade data"
   id: ID!
 
@@ -1337,7 +1296,7 @@ type Trade {
   "The number of contracts trades, will always be <= the remaining size of both orders immediately before the trade (uint64)"
   size: String!
 
-  "RFC3339Nano for when the trade occurred"
+  "RFC3339Nano time for when the trade occurred"
   createdAt: String!
 
   "The type of trade"
@@ -1368,10 +1327,8 @@ type TradeFee {
   liquidityFee: String!
 }
 
-
 "Valid trade types"
 enum TradeType {
-
   "Default trade type"
   Default
 
@@ -1400,7 +1357,7 @@ type Erc20WithdrawalApproval {
   assetSource: String!
   "The amount to be withdrawan"
   amount: String!
-  "The expiry of the approval (RFC3339Nano)"
+  "Timestamp in seconds for expiry of the approval"
   expiry: String!
   "The nonce to be used in the request"
   nonce: String!
@@ -1425,11 +1382,11 @@ type Withdrawal {
   status: WithdrawalStatus!
   "A reference the foreign chain can use to refere to when processing the withdrawal"
   ref: String!
-  "The time until when the withdrawal will be valid (RFC3339Nano)"
+  "RFC3339Nano time until the withdrawal will be invalid"
   expiry: String!
-  "Time at which the withdrawal was created (RFC3339Nano)"
+  "RFC3339Nano time at which the withdrawal was created"
   createdTimestamp: String!
-  "Time at which the withdrawal was finalized (RFC3339Nano)"
+  "RFC3339Nano time at which the withdrawal was finalized"
   withdrawnTimestamp: String
   "Hash of the transaction on the foreign chain"
   txHash: String
@@ -1467,9 +1424,9 @@ type Deposit {
   asset: Asset!
   "The current status of the deposit"
   status: DepositStatus!
-  "Time at which the deposit was created (RFC3339Nano)"
+  "RFC3339Nano time at which the deposit was created"
   createdTimestamp: String!
-  "Time at which the deposit was finalized (RFC3339Nano)"
+  "RFC3339Nano time at which the deposit was finalized"
   creditedTimestamp: String
   "Hash of the transaction on the foreign chain"
   txHash: String
@@ -1487,27 +1444,26 @@ enum DepositStatus {
 
 "Valid order types, these determine what happens when an order is added to the book"
 enum OrderTimeInForce {
+  "The order either trades completely (remainingSize == 0 after adding) or not at all, does not remain on the book if it doesn't trade"
+  FOK
 
-    "The order either trades completely (remainingSize == 0 after adding) or not at all, does not remain on the book if it doesn't trade"
-    FOK
+  "The order trades any amount and as much as possible but does not remain on the book (whether it trades or not)"
+  IOC
 
-    "The order trades any amount and as much as possible but does not remain on the book (whether it trades or not)"
-    IOC
+  "This order trades any amount and as much as possible and remains on the book until it either trades completely or is cancelled"
+  GTC
 
-    "This order trades any amount and as much as possible and remains on the book until it either trades completely or is cancelled"
-    GTC
+  """
+  This order type trades any amount and as much as possible and remains on the book until they either trade completely, are cancelled, or expires at a set time
+  NOTE: this may in future be multiple types or have sub types for orders that provide different ways of specifying expiry
+  """
+  GTT
 
-    """
-    This order type trades any amount and as much as possible and remains on the book until they either trade completely, are cancelled, or expires at a set time
-    NOTE: this may in future be multiple types or have sub types for orders that provide different ways of specifying expiry
-    """
-    GTT
+  "This order is only accepted during an auction period"
+  GFA
 
-    "This order is only accepted during an auction period"
-    GFA
-
-    "This order is only accepted during normal trading (that can be continuous trading or frequent batched auctions)"
-    GFN
+  "This order is only accepted during normal trading (that can be continuous trading or frequent batched auctions)"
+  GFN
 }
 
 "Valid references used for pegged orders."
@@ -1522,7 +1478,6 @@ enum PeggedReference {
 
 "Valid order statuses, these determine several states for an order that cannot be expressed with other fields in Order."
 enum OrderStatus {
-
   """
   The order is active and not cancelled or expired, it could be unfilled, partially filled or fully filled.
   Active does not necessarily mean it's still on the order book.
@@ -1607,7 +1562,6 @@ enum ProposalRejectionReason {
 
 "Reason for the order being rejected by the core node"
 enum OrderRejectionReason {
-
   "Market id is invalid"
   InvalidMarketId
 
@@ -1732,7 +1686,7 @@ enum OrderRejectionReason {
   PeggedOrderSellCannotReferenceBestBidPrice
 
   "Pegged order offset must be > zero"
-	PeggedOrderOffsetMustBeGreaterThanZero
+  PeggedOrderOffsetMustBeGreaterThanZero
 
   "Insufficient balance to submit the order (no deposit made)"
   InsufficientAssetBalance
@@ -1897,13 +1851,12 @@ input FutureProductInput {
 }
 
 type FutureProduct {
-  "Future product maturity (ISO8601/RFC3339 timestamp)"
+  "RFC3339Nano time when the future products matures"
   maturity: String!
   "Product asset ID"
   settlementAsset: Asset!
- "String representing the quote (e.g. BTCUSD -> USD is quote)"
+  "String representing the quote (e.g. BTCUSD -> USD is quote)"
   quoteName: String!
-
 }
 
 input InstrumentConfigurationInput {
@@ -2047,17 +2000,21 @@ input NetworkParameterInput {
   value: String!
 }
 
-union ProposalChange = NewMarket | UpdateMarket | UpdateNetworkParameter | NewAsset
+union ProposalChange =
+    NewMarket
+  | UpdateMarket
+  | UpdateNetworkParameter
+  | NewAsset
 # there are no unions for input types as of today, see: https://github.com/graphql/graphql-spec/issues/488
 
 type ProposalTerms {
   """
-  ISO-8601 time and date when voting closes for this proposal.
-  Constrained by "minCloseInSeconds" and "maxCloseInSeconds" network parameters.
+  RFC3339Nano time and date when voting closes for this proposal.
+  Constrained by "minClose" and "maxClose" network parameters.
   """
   closingDatetime: String!
   """
-  ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
+  RFC3339Nano time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
   Constrained by "minEnactInSeconds" and "maxEnactInSeconds" network parameters.
   """
   enactmentDatetime: String!
@@ -2070,16 +2027,15 @@ type ProposalTerms {
 "Proposal terms input. Only one kind of change is expected. Proposals with no changes or more than one will not be accepted."
 input ProposalTermsInput {
   """
-  ISO-8601 time and date when voting closes for this proposal.
+  RFC3339Nano/ISO-8601 time and date when voting closes for this proposal.
   Constrained by "minCloseInSeconds" and "maxCloseInSeconds" network parameters.
   """
   closingDatetime: String!
   """
-  ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
+  RFC3339Nano/ISO-8601 time and date when this proposal is executed (if passed). Note that it has to be after closing date time.
   Constrained by "minEnactInSeconds" and "maxEnactInSeconds" network parameters.
   """
   enactmentDatetime: String!
-
 
   """
   Field defining new market change - the proposal will create new market if passed and enacted.
@@ -2103,7 +2059,6 @@ input ProposalTermsInput {
 
   "a new Asset proposal, this will create a new asset to be used in the vega network"
   newAsset: NewAssetInput
-
 }
 
 "A new asset to be added into vega"
@@ -2172,7 +2127,7 @@ type Proposal {
   party: Party!
   "State of the proposal"
   state: ProposalState!
-  "ISO-8601 time and date when the proposal reached Vega network"
+  "RFC3339Nano time and date when the proposal reached Vega network"
   datetime: String!
   "Terms of the proposal"
   terms: ProposalTerms!
@@ -2207,7 +2162,7 @@ type Vote {
   "The party casting the vote"
   party: Party!
 
-  "ISO-8601 time and date when the vote reached Vega network"
+  "RFC3339Nano time and date when the vote reached Vega network"
   datetime: String!
 
   "The ID of the proposal this vote applies to"
@@ -2230,7 +2185,7 @@ type PreparedVote {
 }
 
 type TimeUpdate {
-  "timestamp - new block time"
+  "RFC3339Nano time of new block time"
   timestamp: String!
 }
 
@@ -2259,7 +2214,7 @@ type LedgerEntry {
   reference: String!
   "Type of ledger entry"
   type: String!
-  "The time at which the transfer was made"
+  "RFC3339Nano time at which the transfer was made"
   timestamp: String!
 }
 
@@ -2338,9 +2293,9 @@ type AuctionEvent {
   leave: Boolean!
   "event related to opening auction"
   openingAuction: Boolean!
-  "start time of auction"
+  "RFC3339Nano start time of auction"
   auctionStart: String!
-  "optional end time of auction"
+  "RFC3339Nano optional end time of auction"
   auctionEnd: String!
   "What triggered the auction"
   trigger: AuctionTrigger!
@@ -2413,7 +2368,30 @@ enum BusEventType {
 }
 
 "union type for wrapped events in stream PROPOSAL is mapped to governance data, something to keep in mind"
-union Event = TimeUpdate | MarketEvent | TransferResponses | PositionResolution | Order | Trade | Account | Party | MarginLevels | Proposal | Vote | MarketData | NodeSignature | LossSocialization | SettlePosition | Market | Asset | MarketTick | SettleDistressed | AuctionEvent | RiskFactor | Deposit | Withdrawal
+union Event =
+    TimeUpdate
+  | MarketEvent
+  | TransferResponses
+  | PositionResolution
+  | Order
+  | Trade
+  | Account
+  | Party
+  | MarginLevels
+  | Proposal
+  | Vote
+  | MarketData
+  | NodeSignature
+  | LossSocialization
+  | SettlePosition
+  | Market
+  | Asset
+  | MarketTick
+  | SettleDistressed
+  | AuctionEvent
+  | RiskFactor
+  | Deposit
+  | Withdrawal
 
 type BusEvent {
   "the id for this event"
@@ -2485,7 +2463,7 @@ type LiquidityProvision {
   party: Party!
   "When the liquidity provision was initially created (formatted RFC3339)"
   createdAt: String!
-  "When the liquidity provision was updated (formatted RFC3339)"
+  "RFC3339Nano time of when the liquidity provision was updated, can be empty string"
   updatedAt: String!
   "Market identifier for the order"
   market: Market!
@@ -2496,7 +2474,7 @@ type LiquidityProvision {
   "a set of liquidity sell orders to meet the liquidity provision obligation, see MM orders spec."
   sells: [LiquidityOrderReference!]!
   "a set of liquidity buy orders to meet the liquidity provision obligation, see MM orders spec."
-  buys:  [LiquidityOrderReference!]!
+  buys: [LiquidityOrderReference!]!
   "The version of this LiquidityProvision"
   version: String!
   "The current status of this liquidity provision"

--- a/gateway/graphql/withdrawal_resolver.go
+++ b/gateway/graphql/withdrawal_resolver.go
@@ -3,8 +3,10 @@ package gql
 import (
 	"context"
 	"strconv"
+	"time"
 
 	types "code.vegaprotocol.io/vega/proto"
+	"code.vegaprotocol.io/vega/vegatime"
 )
 
 type myWithdrawalResolver VegaResolverRoot
@@ -26,7 +28,8 @@ func (r *myWithdrawalResolver) Status(ctx context.Context, obj *types.Withdrawal
 }
 
 func (r *myWithdrawalResolver) Expiry(ctx context.Context, obj *types.Withdrawal) (string, error) {
-	return strconv.FormatInt(obj.Expiry, 10), nil
+	// this is a unix time stamp / non-nano
+	return vegatime.Format(time.Unix(obj.Expiry, 0)), nil
 }
 
 func (r *myWithdrawalResolver) TxHash(ctx context.Context, obj *types.Withdrawal) (*string, error) {
@@ -38,13 +41,13 @@ func (r *myWithdrawalResolver) TxHash(ctx context.Context, obj *types.Withdrawal
 }
 
 func (r *myWithdrawalResolver) CreatedTimestamp(ctx context.Context, obj *types.Withdrawal) (string, error) {
-	return strconv.FormatInt(obj.CreatedTimestamp, 10), nil
+	return vegatime.Format(vegatime.UnixNano(obj.CreatedTimestamp)), nil
 }
 
 func (r *myWithdrawalResolver) WithdrawnTimestamp(ctx context.Context, obj *types.Withdrawal) (*string, error) {
 	var s *string
 	if obj.WithdrawnTimestamp > 0 {
-		ts := strconv.FormatInt(obj.WithdrawnTimestamp, 10)
+		ts := vegatime.Format(vegatime.UnixNano(obj.WithdrawnTimestamp))
 		s = &ts
 	}
 	return s, nil


### PR DESCRIPTION
The 3 following fields are no RFC3339Nano in the graphql API:
- withdrawal.expiry
- withdrawal.createdAt
- withdrawal.updatedAt

TODO:
- Make Order.updatedAt, LiquidityProvision.updatedAt and Position.updatedAt fields return null if not set because `new Date('')` will return `Invalid Date`. Also update the schema to make the fields nullable.
- Make build pass