### PR TITLE
Tidy buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -8,16 +8,14 @@ build:
 lint:
   use:
     - DEFAULT
-    - FILE_LOWER_SNAKE_CASE
   except:
     - PACKAGE_DIRECTORY_MATCH
     - PACKAGE_VERSION_SUFFIX
-  ignore:
-    - tm
-  enum_zero_value_suffix: _UNSPECIFIED
-  rpc_allow_same_request_response: false
-  rpc_allow_google_protobuf_empty_requests: false
-  rpc_allow_google_protobuf_empty_responses: false
+  ignore_only:
+    ENUM_VALUE_PREFIX:
+      - tm/replay.proto
+    ENUM_ZERO_VALUE_SUFFIX:
+      - tm/replay.proto
 breaking:
   use:
     - WIRE_JSON


### PR DESCRIPTION
This PR copies the ~auto-generated~ PR https://github.com/vegaprotocol/api-clients/pull/133 which was created by https://github.com/bufdev now that the api-clients repo is public.

Justification (from the api-clients PR):

- Deletes `FILE_LOWER_SNAKE_CASE` from `lint.use`, as this is already in the `DEFAULT` [category](https://docs.buf.build/lint-rules#default), so this is duplicative.
- Deletes a few options that were set to the default value.
- Updates `lint.ignore` to `lint.ignore_only` via the output of `buf lint --error-format=config-ignore-yaml`. This will mean that future lint violations within `proto/tm/replay.proto` will still be caught for other violation types.