### PR TITLE
Removing LPS when commitment set to 0 (#2935)

### DIFF
--- a/execution/equity_shares.go
+++ b/execution/equity_shares.go
@@ -38,7 +38,17 @@ func (es *EquityShares) SetPartyStake(id string, newStake float64) {
 	v, found := es.lps[id]
 	// first time we set the newStake and mvp as avg.
 	if !found {
-		es.lps[id] = &lp{stake: newStake, avg: es.mvp}
+		if newStake > 0 {
+			es.lps[id] = &lp{stake: newStake, avg: es.mvp}
+			return
+		}
+		// If we didn't previously have stake and are trying to set it to zero, just return
+		return
+	}
+
+	if newStake <= 0 {
+		// We are removing an existing stake
+		delete(es.lps, id)
 		return
 	}
 

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -49,3 +49,8 @@ func (m *Market) TSCalc() TargetStakeCalculator {
 func (m *Market) State() types.Market_State {
 	return m.mkt.State
 }
+
+// Return the number if liquidity provisions in the market
+func (m *Market) GetLPSCount() int {
+	return len(m.equityShares.lps)
+}


### PR DESCRIPTION
When a traders commitment is reduced to zero we must remove their LP Submission from the system