### PR TITLE
Unit test and helpers for amending commitment amount (#2918)

### DIFF
--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -54,3 +54,17 @@ func (m *Market) State() types.Market_State {
 func (m *Market) GetLPSCount() int {
 	return len(m.equityShares.lps)
 }
+
+// Get the commitment of a LP provider given their partyID
+func (m *Market) GetLPCommitment(partyID string) int {
+	lps := m.equityShares.lps[partyID]
+	if lps != nil {
+		return int(lps.stake)
+	}
+	return 0
+}
+
+// Get the LP Provision object for the given partyID
+func (m *Market) GetLPProvision(partyID string) *types.LiquidityProvision {
+	return m.liquidity.LiquidityProvisionByPartyID(partyID)
+}

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -68,3 +68,8 @@ func (m *Market) GetLPCommitment(partyID string) int {
 func (m *Market) GetLPProvision(partyID string) *types.LiquidityProvision {
 	return m.liquidity.LiquidityProvisionByPartyID(partyID)
 }
+
+// Are we currently in an auction
+func (m *Market) InAuction() bool {
+	return m.as.InAuction()
+}


### PR DESCRIPTION
If a client creates a liquidity position during the opening auction, they should be able to amend it (by sending in the same LP submission but with a different commitment value).