### PR TITLE
Various LP fixes

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -494,7 +494,7 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 		m.lastEquityShareDistributed = t
 
 		if err := m.distributeLiquidityFees(ctx); err != nil {
-			m.log.Panic("Distributing Liquidity Fees", logging.Error(err))
+			m.log.Panic("liquidity fee distribution error", logging.Error(err))
 		}
 	}
 

--- a/execution/market.go
+++ b/execution/market.go
@@ -477,6 +477,7 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 	m.liquidity.OnChainTimeUpdate(ctx, t)
 	m.risk.OnTimeUpdate(t)
 	m.settlement.OnTick(t)
+	m.feeSplitter.SetCurrentTime(t)
 
 	// TODO(): This also assume that the market is not
 	// being closed before the market is leaving
@@ -537,13 +538,26 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 	// TODO(): handle market start time
 
 	m.risk.CalculateFactors(ctx, t)
-
 	timer.EngineTimeCounterAdd()
+
+	if mvwl := m.marketValueWindowLength; m.feeSplitter.Elapsed() > mvwl {
+		ts := m.liquidity.ProvisionsPerParty().TotalStake()
+		m.lastMarketValueProxy = m.feeSplitter.MarketValueProxy(mvwl, float64(ts))
+		m.equityShares.WithMVP(m.lastMarketValueProxy)
+
+		m.feeSplitter.TimeWindowStart(t)
+	}
 
 	if !closed {
 		m.broker.Send(events.NewMarketTick(ctx, m.mkt.Id, t))
-		return
+	} else {
+		m.closeMarket(ctx, t)
 	}
+
+	return
+}
+
+func (m *Market) closeMarket(ctx context.Context, t time.Time) {
 	// market is closed, final settlement
 	// call settlement and stuff
 	positions, err := m.settlement.Settle(t, m.markPrice)
@@ -584,15 +598,6 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 		}
 	}
 
-	if mvwl := m.marketValueWindowLength; m.feeSplitter.Elapsed() > mvwl {
-		ts := m.liquidity.ProvisionsPerParty().TotalStake()
-		m.lastMarketValueProxy = m.feeSplitter.MarketValueProxy(mvwl, float64(ts))
-		m.equityShares.WithMVP(m.lastMarketValueProxy)
-
-		m.feeSplitter.TimeWindowStart(t)
-	}
-
-	return
 }
 
 func (m *Market) unregisterAndReject(ctx context.Context, order *types.Order, err error) error {
@@ -1721,7 +1726,15 @@ func (m *Market) resolveClosedOutTraders(ctx context.Context, distressedMarginEv
 	// Any of the closed out traders could be liquidity providers,
 	// we should cancel their LP submission
 	for _, trader := range closedMPs {
-		m.liquidity.CancelLiquidityProvision(ctx, trader.Party())
+		party := trader.Party()
+		if m.liquidity.IsLiquidityProvider(party) {
+			if err := m.cancelLiquidityProvision(ctx, party, true); err != nil {
+				m.log.Debug("could not cancel liquidity provision",
+					logging.String("market-id", m.GetID()),
+					logging.String("party-id", party),
+					logging.Error(err))
+			}
+		}
 	}
 	return err
 }
@@ -2897,7 +2910,8 @@ func (m *Market) repriceFuncW(po *types.PeggedOrder) (uint64, error) {
 	)
 }
 
-func (m *Market) cancelLiquidityProvision(ctx context.Context, party string) error {
+func (m *Market) cancelLiquidityProvision(
+	ctx context.Context, party string, isDistressed bool) error {
 	// cancel the liquidity provision
 	cancelOrders, err := m.liquidity.CancelLiquidityProvision(ctx, party)
 	if err != nil {
@@ -2909,16 +2923,21 @@ func (m *Market) cancelLiquidityProvision(ctx context.Context, party string) err
 		return err
 	}
 
-	// now we cancel all existing orders
-	for _, order := range cancelOrders {
-		if _, err := m.cancelOrder(ctx, party, order.Id); err != nil {
-			// nothing much we can do here, I suppose
-			// somethign wrong might have happen...
-			// does this need a panic? need to think about it...
-			m.log.Debug("unable cancel liquidity order",
-				logging.String("party", party),
-				logging.String("order-id", order.Id),
-				logging.Error(err))
+	// is our party distressed?
+	// if yes, the orders have been cancelled by the resolve
+	// distresed traders flow.
+	if !isDistressed {
+		// now we cancel all existing orders
+		for _, order := range cancelOrders {
+			if _, err := m.cancelOrder(ctx, party, order.Id); err != nil {
+				// nothing much we can do here, I suppose
+				// somethign wrong might have happen...
+				// does this need a panic? need to think about it...
+				m.log.Debug("unable cancel liquidity order",
+					logging.String("party", party),
+					logging.String("order-id", order.Id),
+					logging.Error(err))
+			}
 		}
 	}
 
@@ -2928,27 +2947,37 @@ func (m *Market) cancelLiquidityProvision(ctx context.Context, party string) err
 	bondAcc, err := m.collateral.GetOrCreatePartyBondAccount(
 		ctx, party, m.GetID(), asset)
 	if err != nil {
-		return err
+		m.log.Debug("could not get the party bond accound",
+			logging.String("party-id", party),
+			logging.Error(err))
 	}
 
-	transfer := &types.Transfer{
-		Owner: party,
-		Amount: &types.FinancialAmount{
-			Amount: int64(bondAcc.Balance),
-			Asset:  asset,
-		},
-		Type:      types.TransferType_TRANSFER_TYPE_BOND_HIGH,
-		MinAmount: int64(bondAcc.Balance),
+	// now if our bondAccount is nil
+	// it just mean that the trader my have gone the distressed path
+	// also if the balance is already 0, let's not bother created a
+	// transfer request
+	if err != nil && bondAcc.Balance > 0 {
+		transfer := &types.Transfer{
+			Owner: party,
+			Amount: &types.FinancialAmount{
+				Amount: int64(bondAcc.Balance),
+				Asset:  asset,
+			},
+			Type:      types.TransferType_TRANSFER_TYPE_BOND_HIGH,
+			MinAmount: int64(bondAcc.Balance),
+		}
+
+		tresp, err := m.collateral.BondUpdate(ctx, m.GetID(), party, transfer)
+		if err != nil {
+			m.log.Debug("bond update error", logging.Error(err))
+			return err
+		}
+		m.broker.Send(events.NewTransferResponse(ctx, []*types.TransferResponse{tresp}))
 	}
 
-	tresp, err := m.collateral.BondUpdate(ctx, m.GetID(), party, transfer)
-	if err != nil {
-		m.log.Debug("bond update error", logging.Error(err))
-		return err
-	}
-	m.broker.Send(events.NewTransferResponse(ctx, []*types.TransferResponse{tresp}))
-
+	// now let's update the fee selection
 	m.updateLiquidityFee(ctx)
+	// and remove the party from the equitey share like calculation
 	m.equityShares.SetPartyStake(party, float64(0))
 	return nil
 }
@@ -2994,7 +3023,7 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		// if this amendment is to reduce the stake to 0, then we'll want to
 		// cancel this lp submission
 		if sub.CommitmentAmount == 0 {
-			return m.cancelLiquidityProvision(ctx, party)
+			return m.cancelLiquidityProvision(ctx, party, false)
 		}
 	}
 

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -3914,7 +3914,6 @@ func Test3008CancelLiquidityProvision(t *testing.T) {
 	})
 
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))
-	fmt.Printf("\n\n%#v\n\n", tm.market.GetMarketData())
 
 	// now we do a cancellation
 	lpCancel := &types.LiquidityProvisionSubmission{
@@ -3988,5 +3987,191 @@ func Test3008CancelLiquidityProvision(t *testing.T) {
 	assert.True(t, len(cnf.Trades) > 0)
 
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))
-	fmt.Printf("\n\n%#v\n\n", tm.market.GetMarketData())
+}
+
+func Test2963EnsureMarketValueProxyAndEquitityShareAreInMarketData(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(1000000000, 0)
+	ctx := context.Background()
+
+	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
+		Duration: 10000,
+	})
+	mktCfg.Fees = &types.Fees{
+		Factors: &types.FeeFactors{
+			LiquidityFee:      "0.001",
+			InfrastructureFee: "0.0005",
+			MakerFee:          "0.00025",
+		},
+	}
+	mktCfg.TradableInstrument.RiskModel = &types.TradableInstrument_LogNormalRiskModel{
+		LogNormalRiskModel: &types.LogNormalRiskModel{
+			RiskAversionParameter: 0.001,
+			Tau:                   0.00011407711613050422,
+			Params: &types.LogNormalModelParams{
+				Mu:    0,
+				R:     0.016,
+				Sigma: 20,
+			},
+		},
+	}
+
+	tm := newTestMarket(t, now).Run(ctx, mktCfg)
+	tm.StartOpeningAuction().
+		WithAccountAndAmount("trader-0", 1000000).
+		WithAccountAndAmount("trader-1", 1000000).
+		WithAccountAndAmount("trader-2", 10000000000).
+		// provide stake as well but will cancel
+		WithAccountAndAmount("trader-2-bis", 10000000000).
+		WithAccountAndAmount("trader-3", 1000000).
+		WithAccountAndAmount("trader-4", 1000000)
+
+	tm.market.OnSuppliedStakeToObligationFactorUpdate(1.0)
+	tm.market.OnChainTimeUpdate(ctx, now)
+
+	orderParams := []struct {
+		id        string
+		size      uint64
+		side      types.Side
+		tif       types.Order_TimeInForce
+		pegRef    types.PeggedReference
+		pegOffset int64
+	}{
+		{"trader-4", 1, types.Side_SIDE_BUY, types.Order_TIME_IN_FORCE_GTC, types.PeggedReference_PEGGED_REFERENCE_BEST_BID, -2000},
+		{"trader-3", 1, types.Side_SIDE_SELL, types.Order_TIME_IN_FORCE_GTC, types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, 1000},
+	}
+	traderA, traderB := orderParams[0], orderParams[1]
+
+	tpl := OrderTemplate{
+		Type: types.Order_TYPE_LIMIT,
+	}
+	var orders = []*types.Order{
+		// Limit Orders
+		tpl.New(types.Order{
+			Size:        20,
+			Remaining:   20,
+			Price:       uint64(5500 + traderA.pegOffset), // 3500
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     "trader-0",
+			TimeInForce: types.Order_TIME_IN_FORCE_GFA,
+		}),
+		tpl.New(types.Order{
+			Size:        20,
+			Remaining:   20,
+			Price:       uint64(5000 - traderB.pegOffset), // 4000
+			Side:        types.Side_SIDE_SELL,
+			PartyId:     "trader-1",
+			TimeInForce: types.Order_TIME_IN_FORCE_GFA,
+		}),
+		tpl.New(types.Order{
+			Size:        10,
+			Remaining:   10,
+			Price:       5500,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     "trader-2",
+			TimeInForce: types.Order_TIME_IN_FORCE_GFA,
+		}),
+		tpl.New(types.Order{
+			Size:        100,
+			Remaining:   100,
+			Price:       5000,
+			Side:        types.Side_SIDE_SELL,
+			PartyId:     "trader-2",
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		}),
+		tpl.New(types.Order{
+			Size:        100,
+			Remaining:   100,
+			Price:       3500,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     "trader-0",
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		}),
+		tpl.New(types.Order{
+			Size:        20,
+			Remaining:   20,
+			Price:       8500,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     "trader-0",
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		}),
+
+		// Pegged Orders
+		tpl.New(types.Order{
+			PartyId:     traderA.id,
+			Side:        traderA.side,
+			Size:        traderA.size,
+			Remaining:   traderA.size,
+			TimeInForce: traderA.tif,
+			PeggedOrder: &types.PeggedOrder{
+				Reference: traderA.pegRef,
+				Offset:    traderA.pegOffset,
+			},
+		}),
+		tpl.New(types.Order{
+			PartyId:     traderB.id,
+			Side:        traderB.side,
+			Size:        traderB.size,
+			Remaining:   traderB.size,
+			TimeInForce: traderB.tif,
+			PeggedOrder: &types.PeggedOrder{
+				Reference: traderB.pegRef,
+				Offset:    traderB.pegOffset,
+			},
+		}),
+	}
+
+	tm.WithSubmittedOrders(t, orders...)
+
+	// Add a LPSubmission
+	// this is a log of stake, enough to cover all
+	// the required stake for the market
+	lp := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 2000000,
+		Fee:              "0.01",
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 10, Offset: 2},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 1},
+		},
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 10, Offset: -1},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 13, Offset: -15},
+		},
+	}
+
+	// Leave the auction
+	tm.market.OnChainTimeUpdate(ctx, now.Add(10001*time.Second))
+
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "trader-2", "id-lp"))
+	assert.Equal(t, 1, tm.market.GetLPSCount())
+
+	// this is our second stake provider
+	// small player
+	lp2 := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 1000,
+		Fee:              "0.01",
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 10, Offset: 2},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 1},
+		},
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 10, Offset: -1},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 13, Offset: -15},
+		},
+	}
+
+	// cleanup the events, we want to make sure our orders are created
+	tm.events = nil
+
+	require.NoError(t, tm.market.SubmitLiquidityProvision(
+		ctx, lp2, "trader-2-bis", "id-lp-2"))
+	assert.Equal(t, 2, tm.market.GetLPSCount())
+
+	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))
+
+	mktData := tm.market.GetMarketData()
+	assert.Equal(t, mktData.MarketValueProxy, "2001000")
+	assert.Len(t, mktData.LiquidityProviderFeeShare, 2)
 }

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -3913,6 +3913,9 @@ func Test3008CancelLiquidityProvision(t *testing.T) {
 		}
 	})
 
+	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))
+	fmt.Printf("\n\n%#v\n\n", tm.market.GetMarketData())
+
 	// now we do a cancellation
 	lpCancel := &types.LiquidityProvisionSubmission{
 		MarketId:         tm.market.GetID(),
@@ -3970,4 +3973,20 @@ func Test3008CancelLiquidityProvision(t *testing.T) {
 		}
 	})
 
+	newOrder := tpl.New(types.Order{
+		MarketId:    tm.market.GetID(),
+		Size:        20,
+		Remaining:   20,
+		Price:       5250,
+		Side:        types.Side_SIDE_BUY,
+		PartyId:     "trader-0",
+		TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+	})
+
+	cnf, err := tm.market.SubmitOrder(ctx, newOrder)
+	assert.NoError(t, err)
+	assert.True(t, len(cnf.Trades) > 0)
+
+	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))
+	fmt.Printf("\n\n%#v\n\n", tm.market.GetMarketData())
 }

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -129,6 +129,12 @@ func (e *Engine) stopLiquidityProvision(
 
 }
 
+// IsLiquidityProvider returns true if the party hold any liquidity commitmement
+func (e *Engine) IsLiquidityProvider(party string) bool {
+	_, ok := e.provisions[party]
+	return ok
+}
+
 // RejectLiquidityProvision removes a parties commitment of liquidity
 func (e *Engine) RejectLiquidityProvision(ctx context.Context, party string) error {
 	_, err := e.stopLiquidityProvision(


### PR DESCRIPTION
Various LPs fixes

properly cancel lp when party is distressed
update time when on chain time update for fee splitter
fix fee splitter being called when time update
move closeMarket procedure out of onChainTimeUpdate
fix marketValueProxy and equityShare in market data

close #2963 