### PR TITLE
add liquidityProvisionMaxShapeSize network parameter

### DIFF
--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -619,6 +619,10 @@ func (l *NodeCommand) setupNetParameters() error {
 			Param:   netparams.MarketLiquidityProvidersFeeDistribitionTimeStep,
 			Watcher: l.executionEngine.OnMarketLiquidityProvidersFeeDistributionTimeStep,
 		},
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityProvisionShapesMaxSize,
+			Watcher: l.executionEngine.OnMarketLiquidityProvisionShapesMaxSizeUpdate,
+		},
 	)
 }
 

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -214,6 +214,6 @@ func TestLiquidity_TooManyShapeLevels(t *testing.T) {
 		Sells:            sells}
 
 	err := tm.market.SubmitLiquidityProvision(ctx, lps, "trader-A", "LPOrder01")
-	require.NoError(t, err)
-	assert.Equal(t, 1, tm.market.GetLPSCount())
+	require.EqualError(t, err, "SIDE_BUY shape size exceed max (100)")
+	assert.Equal(t, 0, tm.market.GetLPSCount())
 }

--- a/execution/market.go
+++ b/execution/market.go
@@ -2869,6 +2869,10 @@ func (m *Market) OnMarketTargetStakeScalingFactorUpdate(v float64) error {
 	return m.tsCalc.UpdateScalingFactor(v)
 }
 
+func (m *Market) OnMarketLiquidityProvisionShapesMaxSizeUpdate(v int64) error {
+	return m.liquidity.OnMarketLiquidityProvisionShapesMaxSizeUpdate(v)
+}
+
 // repriceFuncW is an adapter for getNewPeggedPrice.
 func (m *Market) repriceFuncW(po *types.PeggedOrder) (uint64, error) {
 	return m.getNewPeggedPrice(

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -110,12 +110,12 @@ func (e *Engine) OnSuppliedStakeToObligationFactorUpdate(v float64) {
 	e.stakeToObligationFactor = v
 }
 
-func (m *Engine) OnMarketLiquidityProvisionShapesMaxSizeUpdate(v int64) error {
+func (e *Engine) OnMarketLiquidityProvisionShapesMaxSizeUpdate(v int64) error {
 	if v < 0 {
 		return errors.New("shapes max size cannot be < 0")
 
 	}
-	m.maxShapesSize = v
+	e.maxShapesSize = v
 	return nil
 }
 

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -71,6 +71,10 @@ type Engine struct {
 
 	// undeployedProvisions flags that there are provisions within the engine that are not deployed
 	undeployedProvisions bool
+
+	// the maximum number of liquidity orders to be created on
+	// each shape
+	maxShapesSize int64
 }
 
 // NewEngine returns a new Liquidity Engine.
@@ -92,6 +96,7 @@ func NewEngine(
 		provisions:              map[string]*types.LiquidityProvision{},
 		orders:                  map[string]map[string]*types.Order{},
 		liquidityOrders:         map[string]map[string]*types.Order{},
+		maxShapesSize:           100, // set it to the same default than the netparams
 	}
 }
 
@@ -103,6 +108,15 @@ func (e *Engine) OnChainTimeUpdate(ctx context.Context, now time.Time) {
 // OnSuppliedStakeToObligationFactorUpdate updates the stake factor
 func (e *Engine) OnSuppliedStakeToObligationFactorUpdate(v float64) {
 	e.stakeToObligationFactor = v
+}
+
+func (m *Engine) OnMarketLiquidityProvisionShapesMaxSizeUpdate(v int64) error {
+	if v < 0 {
+		return errors.New("shapes max size cannot be < 0")
+
+	}
+	m.maxShapesSize = v
+	return nil
 }
 
 func (e *Engine) stopLiquidityProvision(
@@ -164,10 +178,11 @@ func (e *Engine) validateLiquidityProvisionSubmission(lp *types.LiquidityProvisi
 	if fee, err := strconv.ParseFloat(lp.Fee, 64); err != nil || fee <= 0 || len(lp.Fee) <= 0 || fee > 1.0 {
 		return errors.New("invalid liquidity provision fee")
 	}
-	if err := validateShape(lp.Buys, types.Side_SIDE_BUY); err != nil {
+
+	if err := validateShape(lp.Buys, types.Side_SIDE_BUY, e.maxShapesSize); err != nil {
 		return err
 	}
-	return validateShape(lp.Sells, types.Side_SIDE_SELL)
+	return validateShape(lp.Sells, types.Side_SIDE_SELL, e.maxShapesSize)
 }
 
 func (e *Engine) rejectLiquidityProvisionSubmission(ctx context.Context, lps *types.LiquidityProvisionSubmission, party, id string) {
@@ -562,9 +577,12 @@ func (e *Engine) createOrdersFromShape(party string, supplied []*supplied.Liquid
 	return newOrders, amendments
 }
 
-func validateShape(sh []*types.LiquidityOrder, side types.Side) error {
+func validateShape(sh []*types.LiquidityOrder, side types.Side, maxSize int64) error {
 	if len(sh) <= 0 {
 		return fmt.Errorf("empty %v shape", side)
+	}
+	if len(sh) > int(maxSize) {
+		return fmt.Errorf("%v shape size exceed max (%v)", side, maxSize)
 	}
 	for _, lo := range sh {
 		if lo.Reference == types.PeggedReference_PEGGED_REFERENCE_UNSPECIFIED {

--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -30,6 +30,7 @@ func defaultNetParams() map[string]value {
 		MarketValueWindowLength:                         NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate(week),
 		MarketPriceMonitoringDefaultParameters:          NewJSON(&proto.PriceMonitoringParameters{}, JSONProtoValidator()).Mutable(true).MustUpdate(`{"triggers": []}`),
 		MarketPriceMonitoringUpdateFrequency:            NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("1m0s"),
+		MarketLiquidityProvisionShapesMaxSize:           NewInt(IntGT(0)).Mutable(true).MustUpdate("100"),
 
 		// governance market proposal
 		GovernanceProposalMarketMinClose:              NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("48h0m0s"),

--- a/netparams/keys.go
+++ b/netparams/keys.go
@@ -18,6 +18,7 @@ const (
 	MarketValueWindowLength                         = "market.value.windowLength"
 	MarketPriceMonitoringDefaultParameters          = "market.monitor.price.defaultParameters"
 	MarketPriceMonitoringUpdateFrequency            = "market.monitor.price.updateFrequency"
+	MarketLiquidityProvisionShapesMaxSize           = "market.liquidityProvision.shapes.maxSize"
 
 	GovernanceVoteAsset = "governance.vote.asset"
 
@@ -115,4 +116,5 @@ var AllKeys = map[string]struct{}{
 	GovernanceProposalUpdateNetParamMinProposerBalance:    {},
 	GovernanceProposalUpdateNetParamMinVoterBalance:       {},
 	BlockchainsEthereumConfig:                             {},
+	MarketLiquidityProvisionShapesMaxSize:                 {},
 }


### PR DESCRIPTION
update execution engine to keep track of the netparams update so it can send them to new markets (this was a bug were market were not updated with the network parameter until the netparmas gets updated themselves)

close #3027 