### PR TITLE
stop setting the market opening auction to nil when leave opening auction

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -779,11 +779,6 @@ func (m *Market) EnterAuction(ctx context.Context) {
 
 // LeaveAuction : Return the orderbook and market to continuous trading
 func (m *Market) LeaveAuction(ctx context.Context, now time.Time) {
-	// If we were an opening auction, clear it
-	if m.as.IsOpeningAuction() {
-		m.mkt.OpeningAuction = nil
-	}
-
 	// Change market type to continuous trading
 	uncrossedOrders, ordersToCancel, err := m.matching.LeaveAuction(m.currentTime)
 	if err != nil {


### PR DESCRIPTION
As of now we were setting the m.mkt.OpeningAuction field in the market to nil for some reason when leaving auction.
This is done for no apparent reason as the actual state of the auction / opening auction is handled in the AuctionState type.

By doing so, when the m.mkt field is send via a market event, the nill field is sent as well, this is breaking graphql as it expect a non-null field at any time.

close #2972 