### PR TITLE
redo amend liquidity provision, with a cancel and replace approach

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1557,6 +1557,28 @@ func (e *Engine) ClearMarket(ctx context.Context, mktID, asset string, parties [
 	return resps, nil
 }
 
+func (e *Engine) CanCoverBond(market, party, asset string, amount uint64) bool {
+	bondID := e.accountID(
+		market, party, asset, types.AccountType_ACCOUNT_TYPE_BOND,
+	)
+	genID := e.accountID(
+		noMarket, party, asset, types.AccountType_ACCOUNT_TYPE_GENERAL,
+	)
+
+	var availableBalance uint64
+
+	bondAcc, ok := e.accs[bondID]
+	if ok {
+		availableBalance += bondAcc.Balance
+	}
+	genAcc, ok := e.accs[genID]
+	if ok {
+		availableBalance += genAcc.Balance
+	}
+
+	return availableBalance >= amount
+}
+
 // GetOrCreatePartyBondAccount returns a bond account given a set of parameters.
 // crates it if not exists
 func (e *Engine) GetOrCreatePartyBondAccount(ctx context.Context, partyID, marketID, asset string) (*types.Account, error) {

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1679,6 +1679,13 @@ func (e *Engine) GetPartyGeneralAccount(partyID, asset string) (*types.Account, 
 	return e.GetAccountByID(generalID)
 }
 
+// GetPartyBondAccount returns a general account given the partyID.
+func (e *Engine) GetPartyBondAccount(market, partyID, asset string) (*types.Account, error) {
+	id := e.accountID(
+		market, partyID, asset, types.AccountType_ACCOUNT_TYPE_BOND)
+	return e.GetAccountByID(id)
+}
+
 // CreatePartyGeneralAccount create the general account for a trader
 func (e *Engine) CreatePartyGeneralAccount(ctx context.Context, partyID, asset string) (string, error) {
 	if !e.AssetExists(asset) {

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -2,7 +2,6 @@ package execution_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -340,15 +339,4 @@ func TestAmendDeployedCommitmment(t *testing.T) {
 			ctx, lpCancelCommitment, lpparty, "liquidity-submission-6"),
 		"commitment submission rejected, not enouth stake",
 	)
-}
-
-func (tm *testMarket) dumpMarketData() {
-	fmt.Printf("\nMarketData:\n%#v\n", tm.market.GetMarketData())
-}
-
-func (tm *testMarket) dumpPeggedOrders() {
-	fmt.Printf("\nPeggedOrdersCount: %v\n", tm.market.GetPeggedOrderCount())
-	fmt.Printf("ParkedOrdersOrdersCount: %v\n", tm.market.GetParkedOrderCount())
-	fmt.Printf("LPSCount: %v\n", tm.market.GetLPSCount())
-	fmt.Printf("OrdersOnBookCount: %v\n", tm.market.GetOrdersOnBookCount())
 }

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -1,0 +1,354 @@
+package execution_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/events"
+	types "code.vegaprotocol.io/vega/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAmendDeployedCommitmment(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(1000000000, 0)
+	ctx := context.Background()
+
+	auctionEnd := now.Add(10001 * time.Second)
+	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
+		Duration: 10000,
+	})
+	mktCfg.Fees = &types.Fees{
+		Factors: &types.FeeFactors{
+			LiquidityFee:      "0.001",
+			InfrastructureFee: "0.0005",
+			MakerFee:          "0.00025",
+		},
+	}
+	mktCfg.TradableInstrument.RiskModel = &types.TradableInstrument_LogNormalRiskModel{
+		LogNormalRiskModel: &types.LogNormalRiskModel{
+			RiskAversionParameter: 0.001,
+			Tau:                   0.00011407711613050422,
+			Params: &types.LogNormalModelParams{
+				Mu:    0,
+				R:     0.016,
+				Sigma: 20,
+			},
+		},
+	}
+
+	lpparty := "lp-party-1"
+
+	tm := newTestMarket(t, now).Run(ctx, mktCfg)
+	tm.StartOpeningAuction().
+		// the liquidity provider
+		WithAccountAndAmount(lpparty, 500000000000)
+
+	tm.market.OnSuppliedStakeToObligationFactorUpdate(1.0)
+	tm.market.OnChainTimeUpdate(ctx, now)
+
+	// Add a LPSubmission
+	// this is a log of stake, enough to cover all
+	// the required stake for the market
+	lpSubmission := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 70000,
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-1",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	// submit our lp
+	require.NoError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+	)
+
+	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
+		acc, err := tm.collateraEngine.GetPartyBondAccount(tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 70000, int(acc.Balance))
+	})
+
+	tm.EndOpeningAuction(t, auctionEnd, false)
+
+	// now we will reduce our commitmment
+	// we will still be higher than the required stake
+	lpSmallerCommitment := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 60000,
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-2",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	tm.events = nil
+	// submit our lp
+	require.NoError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpSmallerCommitment, lpparty, "liquidity-submission-2"),
+	)
+
+	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
+		acc, err := tm.collateraEngine.GetPartyBondAccount(tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 60000, int(acc.Balance))
+	})
+
+	t.Run("expect commitment statuses", func(t *testing.T) {
+		// First collect all the orders events
+		found := map[string]types.LiquidityProvision{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.LiquidityProvision:
+				lp := evt.LiquidityProvision()
+				found[lp.Id] = lp
+			}
+		}
+
+		expectedStatus := map[string]types.LiquidityProvision_Status{
+			"liquidity-submission-1": types.LiquidityProvision_STATUS_CANCELLED,
+			"liquidity-submission-2": types.LiquidityProvision_STATUS_ACTIVE,
+		}
+
+		require.Len(t, found, len(expectedStatus))
+
+		for k, v := range expectedStatus {
+			assert.Equal(t, v.String(), found[k].Status.String())
+		}
+	})
+
+	t.Run("previous LP orders to be cancelled", func(t *testing.T) {
+		// First collect all the orders events
+		found := []*types.Order{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.Order:
+				found = append(found, evt.Order())
+			}
+		}
+
+		require.Len(t, found, 8)
+
+		// reference -> status
+		expectedStatus := map[string]types.Order_Status{
+			"ref-lp-submission-1": types.Order_STATUS_CANCELLED,
+			"ref-lp-submission-2": types.Order_STATUS_ACTIVE,
+		}
+
+		totalCancelled := 0
+		totalActive := 0
+
+		for _, o := range found {
+			assert.Equal(t,
+				expectedStatus[o.Reference].String(),
+				o.Status.String(),
+			)
+			if o.Status == types.Order_STATUS_CANCELLED {
+				totalCancelled += 1
+			}
+			if o.Status == types.Order_STATUS_ACTIVE {
+				totalActive += 1
+			}
+		}
+
+		assert.Equal(t, totalCancelled, 4)
+		assert.Equal(t, totalActive, 4)
+
+	})
+
+	// now we will reduce our commitmment
+	// we will still be higher than the required stake
+	lpHigherCommitment := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 80000,
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-3",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	tm.events = nil
+	// submit our lp
+	require.NoError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpHigherCommitment, lpparty, "liquidity-submission-3"),
+	)
+
+	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
+		acc, err := tm.collateraEngine.GetPartyBondAccount(tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 80000, int(acc.Balance))
+	})
+
+	t.Run("expect commitment statuses", func(t *testing.T) {
+		// First collect all the orders events
+		found := map[string]types.LiquidityProvision{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.LiquidityProvision:
+				lp := evt.LiquidityProvision()
+				found[lp.Id] = lp
+			}
+		}
+
+		expectedStatus := map[string]types.LiquidityProvision_Status{
+			"liquidity-submission-2": types.LiquidityProvision_STATUS_CANCELLED,
+			"liquidity-submission-3": types.LiquidityProvision_STATUS_ACTIVE,
+		}
+
+		require.Len(t, found, len(expectedStatus))
+
+		for k, v := range expectedStatus {
+			assert.Equal(t, v.String(), found[k].Status.String())
+		}
+	})
+
+	t.Run("previous LP orders to be cancelled", func(t *testing.T) {
+		// First collect all the orders events
+		found := []*types.Order{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.Order:
+				found = append(found, evt.Order())
+			}
+		}
+
+		require.Len(t, found, 8)
+
+		// reference -> status
+		expectedStatus := map[string]types.Order_Status{
+			"ref-lp-submission-2": types.Order_STATUS_CANCELLED,
+			"ref-lp-submission-3": types.Order_STATUS_ACTIVE,
+		}
+
+		totalCancelled := 0
+		totalActive := 0
+
+		for _, o := range found {
+			assert.Equal(t,
+				expectedStatus[o.Reference].String(),
+				o.Status.String(),
+			)
+			if o.Status == types.Order_STATUS_CANCELLED {
+				totalCancelled += 1
+			}
+			if o.Status == types.Order_STATUS_ACTIVE {
+				totalActive += 1
+			}
+		}
+
+		assert.Equal(t, totalCancelled, 4)
+		assert.Equal(t, totalActive, 4)
+
+	})
+
+	// now we will reduce the commitment too much so it gets under
+	// the expected stake.
+	// this should result into an error, and the commitment staying
+	// untouched
+	lpTooSmallCommitment := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 30000, // required commitment is 50000
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-4",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	tm.events = nil
+	// submit our lp
+	require.EqualError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpTooSmallCommitment, lpparty, "liquidity-submission-4"),
+		"commitment submission rejected, not enouth stake",
+	)
+
+	// now we will increase the commitment too much so it gets
+	// at a point where we cannot fill the bond requirement
+	// this should result into an error, and the commitment staying
+	// untouched
+	lpTooHighCommitment := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 600000000000, // required commitment is 50000
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-5",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	tm.events = nil
+	// submit our lp
+	require.EqualError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpTooHighCommitment, lpparty, "liquidity-submission-5"),
+		"commitment submission not allowed",
+	)
+
+	// now we will try to cancel the LP
+	// at a point where we cannot fill the bond requirement
+	// this should result into an error, and the commitment staying
+	// untouched
+	lpCancelCommitment := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 0, // required commitment is 50000
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-6",
+		Buys:             []*types.LiquidityOrder{},
+		Sells:            []*types.LiquidityOrder{},
+	}
+
+	tm.events = nil
+	// submit our lp
+	require.EqualError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpCancelCommitment, lpparty, "liquidity-submission-6"),
+		"commitment submission rejected, not enouth stake",
+	)
+}
+
+func (tm *testMarket) dumpMarketData() {
+	fmt.Printf("\nMarketData:\n%#v\n", tm.market.GetMarketData())
+}
+
+func (tm *testMarket) dumpPeggedOrders() {
+	fmt.Printf("\nPeggedOrdersCount: %v\n", tm.market.GetPeggedOrderCount())
+	fmt.Printf("ParkedOrdersOrdersCount: %v\n", tm.market.GetParkedOrderCount())
+	fmt.Printf("LPSCount: %v\n", tm.market.GetLPSCount())
+	fmt.Printf("OrdersOnBookCount: %v\n", tm.market.GetOrdersOnBookCount())
+}

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -173,6 +173,11 @@ func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketC
 	if e.log.IsDebug() {
 		e.log.Debug("submit market with liquidity provision",
 			logging.Market(*marketConfig),
+			// FIXME(JEREMY): this would crash in some cases at the moment.
+			// as the lp can be nil as it's optional for now in order
+			// to ease the transitions for the tests to use LP commitment
+			// submission with every new market.
+			// uncomment when this is not needed anymore
 			// logging.LiquidityProvisionSubmission(*lp),
 			logging.PartyID(party),
 			logging.LiquidityID(lpID),

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -34,6 +34,7 @@ type TimeService interface {
 	NotifyOnTick(f func(context.Context, time.Time))
 }
 
+// Broker ...
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/event_broker_mock.go -package mocks code.vegaprotocol.io/vega/execution Broker
 type Broker interface {
 	Send(event events.Event)
@@ -175,7 +176,6 @@ func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketC
 			logging.LiquidityProvisionSubmission(*lp),
 			logging.PartyID(party),
 			logging.LiquidityID(lpID),
-
 		)
 	}
 

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -173,7 +173,7 @@ func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketC
 	if e.log.IsDebug() {
 		e.log.Debug("submit market with liquidity provision",
 			logging.Market(*marketConfig),
-			logging.LiquidityProvisionSubmission(*lp),
+			// logging.LiquidityProvisionSubmission(*lp),
 			logging.PartyID(party),
 			logging.LiquidityID(lpID),
 		)

--- a/execution/market.go
+++ b/execution/market.go
@@ -115,6 +115,7 @@ type TargetStakeCalculator interface {
 	UpdateTimeWindow(tWindow time.Duration)
 }
 
+// AuctionState ...
 // We can't use the interface yet. AuctionState is passed to the engines, which access different methods
 // keep the interface for documentation purposes
 type AuctionState interface {
@@ -2615,7 +2616,7 @@ func (m *Market) orderCancelReplace(ctx context.Context, existingOrder, newOrder
 		// Because other collections might be pointing at the original order
 		// use it's memory when inserting the new version
 		*existingOrder = *newOrder
-		conf, err = m.matching.SubmitOrder(existingOrder) //lint:ignore SA4006 this value might be overwriter, careful!
+		conf, err = m.matching.SubmitOrder(existingOrder)
 		if err != nil {
 			m.log.Panic("unable to submit order", logging.Error(err))
 		}
@@ -3034,7 +3035,7 @@ func (m *Market) amendLiquidityProvision(
 
 	lp := m.liquidity.LiquidityProvisionByPartyID(party)
 	if lp == nil {
-		m.log.Panic("trying to amend a liquidity provision from a party which is not a liquidity provider")
+		return fmt.Errorf("cannot edit liquidity provision from a non liquidity provider party (%v)", party)
 	}
 
 	// Increasing the commitment should always be allowed, but decreasing is

--- a/proto/vega_ext.go
+++ b/proto/vega_ext.go
@@ -9,6 +9,27 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+func (l *LiquidityProvision) IntoSubmission() *LiquidityProvisionSubmission {
+	sells := make([]*LiquidityOrder, 0, len(l.Sells))
+	for _, v := range l.Sells {
+		sells = append(sells, v.LiquidityOrder)
+	}
+
+	buys := make([]*LiquidityOrder, 0, len(l.Buys))
+	for _, v := range l.Buys {
+		buys = append(buys, v.LiquidityOrder)
+	}
+
+	return &LiquidityProvisionSubmission{
+		MarketId:         l.MarketId,
+		CommitmentAmount: l.CommitmentAmount,
+		Fee:              l.Fee,
+		Sells:            sells,
+		Buys:             buys,
+		Reference:        l.Reference,
+	}
+}
+
 // Float64Fee tries to parse the Fee (string) into a float64.
 // If parsing fails 0 is returned.
 func (l *LiquidityProvision) Float64Fee() float64 {


### PR DESCRIPTION
This update the lp amendment to use an cancel and replace approach.
This is not ready for merging, I'll be adding a bunch of tests to cover amending of submissions.

close #3065 
close #3064 