### PR TITLE
Remove staticcheck ignore directive

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -2602,15 +2602,14 @@ func (m *Market) orderCancelReplace(ctx context.Context, existingOrder, newOrder
 		}
 
 		// try to apply fees on the trade
-		err = m.applyFees(ctx, newOrder, trades)
-		if err != nil {
+		if err := m.applyFees(ctx, newOrder, trades); err != nil {
 			return nil, err
 		}
 
 		// Because other collections might be pointing at the original order
 		// use it's memory when inserting the new version
 		*existingOrder = *newOrder
-		conf, err = m.matching.SubmitOrder(existingOrder) //lint:ignore SA4006 this value might be overwriter, careful!
+		conf, err = m.matching.SubmitOrder(existingOrder)
 		if err != nil {
 			m.log.Panic("unable to submit order", logging.Error(err))
 		}


### PR DESCRIPTION
This PR removes an old `staticcheck` check (`SA4006`) that was quietly ignored in version `2020.1.4`, but causes a failure (exit code 1) in version `2020.2.2`.

See #3070 for background.