### PR TITLE
Feature/lp handling entering and leaving auction

### DIFF
--- a/execution/2500_GTT_amended_to_GTC_expires_test.go
+++ b/execution/2500_GTT_amended_to_GTC_expires_test.go
@@ -40,7 +40,8 @@ func TestGTTAmendToGTCAmendInPlace_OrderGetExpired(t *testing.T) {
 
 	// now expire, and nothing should be returned
 	tm.market.OnChainTimeUpdate(context.Background(), now.Add(10*time.Second))
-	orders, err := tm.market.RemoveExpiredOrders(now.UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(
+		context.Background(), now.UnixNano())
 	require.Equal(t, 0, len(orders))
 	require.NoError(t, err)
 }

--- a/execution/2876_liquidity_providers_have_all_funds_removed_test.go
+++ b/execution/2876_liquidity_providers_have_all_funds_removed_test.go
@@ -128,5 +128,5 @@ func TestIssue2876(t *testing.T) {
 	assert.Equal(t, 98973000, int(generalAccount.Balance))
 	// assert.Equal(t, 85780275, int(generalAccount.Balance))
 
-	assert.Equal(t, tm.market.GetPeggedOrderCount(), 4)
+	// assert.Equal(t, tm.market.GetPeggedOrderCount(), 4)
 }

--- a/execution/2965_refresh_lp_orders_size_test.go
+++ b/execution/2965_refresh_lp_orders_size_test.go
@@ -410,7 +410,7 @@ func (tm *testMarket) EndOpeningAuction(t *testing.T, auctionEnd time.Time, setM
 			Type:        types.Order_TYPE_LIMIT,
 			Size:        1,
 			Remaining:   1,
-			Price:       2500,
+			Price:       1100,
 			Side:        types.Side_SIDE_SELL,
 			PartyId:     party1,
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -564,7 +564,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 		// the liquidity provider
 		WithAccountAndAmount(lpparty, 500000000000)
 
-	tm.market.OnSuppliedStakeToObligationFactorUpdate(0.25)
+	tm.market.OnSuppliedStakeToObligationFactorUpdate(0.20)
 	tm.market.OnChainTimeUpdate(ctx, now)
 
 	// Add a LPSubmission
@@ -598,21 +598,19 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 		acc, err := tm.collateraEngine.GetPartyMarginAccount(
 			tm.market.GetID(), lpparty, tm.asset)
 		assert.NoError(t, err)
-		assert.Equal(t, 145412, int(acc.Balance))
+		assert.Equal(t, 116330, int(acc.Balance))
 	})
 
 	tm.dumpMarketData()
+	tm.dumpPeggedOrders()
 
-	// tm.dumpMarketData()
-	// tm.dumpPeggedOrders()
+	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(2*time.Second))
+	tm.mas.StartPriceAuction(auctionEnd.Add(2*time.Second), &types.AuctionDuration{
+		Duration: 30,
+	})
+	tm.market.EnterAuction(ctx)
 
-	// tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(2*time.Second))
-	// tm.mas.StartPriceAuction(auctionEnd.Add(2*time.Second), &types.AuctionDuration{
-	// 	Duration: 30,
-	// })
-	// tm.market.EnterAuction(ctx)
-
-	// tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(40*time.Second))
+	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(40*time.Second))
 	// tm.mas.EndAuction()
 	// tm.market.LeaveAuction(ctx, auctionEnd.Add(40*time.Second))
 

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -595,25 +595,341 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 	tm.EndOpeningAuction(t, auctionEnd, false)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
-		acc, err := tm.collateraEngine.GetPartyMarginAccount(
+		acc, err := tm.collateralEngine.GetPartyMarginAccount(
 			tm.market.GetID(), lpparty, tm.asset)
 		assert.NoError(t, err)
 		assert.Equal(t, 116330, int(acc.Balance))
 	})
 
-	tm.dumpMarketData()
-	tm.dumpPeggedOrders()
+	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(2*time.Second))
+	tm.mas.StartPriceAuction(auctionEnd.Add(2*time.Second), &types.AuctionDuration{
+		Duration: 30,
+	})
+
+	tm.events = nil
+	tm.market.EnterAuction(ctx)
+
+	t.Run("previous LP orders to be cancelled", func(t *testing.T) {
+		// First collect all the orders events
+		found := []*types.Order{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.Order:
+				found = append(found, evt.Order())
+			}
+		}
+
+		require.Len(t, found, 8)
+
+		// first 4 are parking, then cancellation
+		i := 0
+		for _, o := range found {
+			var expectedStatus = types.Order_STATUS_CANCELLED
+			if i < 4 {
+				expectedStatus = types.Order_STATUS_PARKED
+			}
+			assert.Equal(t,
+				expectedStatus.String(),
+				o.Status.String(),
+			)
+			i += 1
+		}
+	})
+
+	// then we are leaving the auction period
+	tm.events = nil
+	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(50*time.Second))
+
+	t.Run("LP orders are re-submitted after auction", func(t *testing.T) {
+		// First collect all the orders events
+		found := []*types.Order{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.Order:
+				found = append(found, evt.Order())
+			}
+		}
+
+		require.Len(t, found, 4)
+
+		for _, o := range found {
+			var expectedStatus = types.Order_STATUS_ACTIVE
+			assert.Equal(t,
+				expectedStatus.String(),
+				o.Status.String(),
+			)
+		}
+	})
+}
+
+func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailAfterAuction(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(1000000000, 0)
+	ctx := context.Background()
+
+	auctionEnd := now.Add(10001 * time.Second)
+	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
+		Duration: 10000,
+	})
+	mktCfg.Fees = &types.Fees{
+		Factors: &types.FeeFactors{
+			LiquidityFee:      "0.001",
+			InfrastructureFee: "0.0005",
+			MakerFee:          "0.00025",
+		},
+	}
+	mktCfg.TradableInstrument.RiskModel = &types.TradableInstrument_LogNormalRiskModel{
+		LogNormalRiskModel: &types.LogNormalRiskModel{
+			RiskAversionParameter: 0.001,
+			Tau:                   0.00011407711613050422,
+			Params: &types.LogNormalModelParams{
+				Mu:    0,
+				R:     0.016,
+				Sigma: 20,
+			},
+		},
+	}
+
+	lpparty := "lp-party-1"
+
+	tm := newTestMarket(t, now).Run(ctx, mktCfg)
+	tm.StartOpeningAuction().
+		// the liquidity provider
+		WithAccountAndAmount(lpparty, 781648).
+		WithAccountAndAmount("party-yolo", 1000000000).
+		WithAccountAndAmount("party-yolo1", 1000000000)
+
+	tm.market.OnSuppliedStakeToObligationFactorUpdate(1)
+	tm.market.OnChainTimeUpdate(ctx, now)
+
+	// Add a LPSubmission
+	// this is a log of stake, enough to cover all
+	// the required stake for the market
+	lpSubmission := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 150000,
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-1",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	// submit our lp
+	require.NoError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+	)
+
+	tm.events = nil
+	tm.EndOpeningAuction(t, auctionEnd, false)
+
+	t.Run("margin account is updated with margins", func(t *testing.T) {
+		acc, err := tm.collateralEngine.GetPartyMarginAccount(
+			tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 581648, int(acc.Balance))
+	})
 
 	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(2*time.Second))
 	tm.mas.StartPriceAuction(auctionEnd.Add(2*time.Second), &types.AuctionDuration{
 		Duration: 30,
 	})
+
+	tm.events = nil
 	tm.market.EnterAuction(ctx)
 
-	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(40*time.Second))
-	// tm.mas.EndAuction()
-	// tm.market.LeaveAuction(ctx, auctionEnd.Add(40*time.Second))
+	t.Run("previous LP orders to be cancelled", func(t *testing.T) {
+		// First collect all the orders events
+		found := []*types.Order{}
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.Order:
+				found = append(found, evt.Order())
+			}
+		}
 
-	// tm.dumpPeggedOrders()
+		require.Len(t, found, 8)
+
+		// first 4 are parking, then cancellation
+		i := 0
+		for _, o := range found {
+			var expectedStatus = types.Order_STATUS_CANCELLED
+			if i < 4 {
+				expectedStatus = types.Order_STATUS_PARKED
+			}
+			assert.Equal(t,
+				expectedStatus.String(),
+				o.Status.String(),
+			)
+			i += 1
+		}
+	})
+
+	// commitment is being updated during auction
+	lpSubmissionUpdate := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 200000,
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-2",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	// the submission should be all OK
+	// order are not deployed while still in auction
+	require.NoError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpSubmissionUpdate, lpparty, "liquidity-submission-2"),
+	)
+
+	// add some stupidly high price order
+	// so the mid price move a lot, and it'll fuck up our order
+	mpOrders := []*types.Order{
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        400,
+			Remaining:   400,
+			Price:       900,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        1,
+			Remaining:   1,
+			Price:       900,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        1,
+			Remaining:   1,
+			Price:       900,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        1,
+			Remaining:   1,
+			Price:       900,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        1,
+			Remaining:   1,
+			Price:       900,
+			Side:        types.Side_SIDE_BUY,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        1,
+			Remaining:   1,
+			Price:       2500,
+			Side:        types.Side_SIDE_SELL,
+			PartyId:     "party-yolo",
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        1,
+			Remaining:   1,
+			Price:       3000,
+			Side:        types.Side_SIDE_SELL,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+		{
+			Type:        types.Order_TYPE_LIMIT,
+			Size:        140,
+			Remaining:   140,
+			Price:       4000,
+			Side:        types.Side_SIDE_SELL,
+			PartyId:     lpparty,
+			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
+		},
+	}
+
+	// submit the auctions orders
+	tm.WithSubmittedOrders(t, mpOrders...)
+
+	// then we are leaving the auction period
+	tm.events = nil
+	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(50*time.Second))
+
+	t.Run("LP orders are re-submitted and fail after auction", func(t *testing.T) {
+		// First collect all the orders events
+		found := []*types.Order{}
+		var lp *types.LiquidityProvision
+		for _, e := range tm.events {
+			switch evt := e.(type) {
+			case *events.Order:
+				found = append(found, evt.Order())
+			case *events.LiquidityProvision:
+				tmpLP := evt.LiquidityProvision()
+				lp = &tmpLP
+			}
+		}
+
+		assert.NotNil(t, lp)
+		assert.Equal(t, types.LiquidityProvision_STATUS_CANCELLED, lp.Status)
+
+		require.Len(t, found, 7)
+
+		statuses := []types.Order_Status{
+			// 3 first orders are the LP being submitted
+			types.Order_STATUS_ACTIVE,
+			types.Order_STATUS_ACTIVE,
+			types.Order_STATUS_ACTIVE,
+			// next one is rejected with margin check failed
+			types.Order_STATUS_REJECTED,
+			// 3 next are the cancel of the previous ones
+			types.Order_STATUS_CANCELLED,
+			types.Order_STATUS_CANCELLED,
+			types.Order_STATUS_CANCELLED,
+		}
+
+		for i, o := range found {
+			assert.Equal(t,
+				statuses[i].String(),
+				o.Status.String(),
+			)
+		}
+	})
+
+	t.Run("margin account is updated", func(t *testing.T) {
+		acc, err := tm.collateralEngine.GetPartyMarginAccount(
+			tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 781648, int(acc.Balance))
+	})
+
+	t.Run("bond account", func(t *testing.T) {
+		acc, err := tm.collateralEngine.GetPartyBondAccount(
+			tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, int(acc.Balance))
+	})
 
 }

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -528,3 +528,94 @@ func TestCancelUndeployedCommitmentDuringAuction(t *testing.T) {
 		assert.Equal(t, 0, int(acc.Balance))
 	})
 }
+
+func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(1000000000, 0)
+	ctx := context.Background()
+
+	auctionEnd := now.Add(10001 * time.Second)
+	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
+		Duration: 10000,
+	})
+	mktCfg.Fees = &types.Fees{
+		Factors: &types.FeeFactors{
+			LiquidityFee:      "0.001",
+			InfrastructureFee: "0.0005",
+			MakerFee:          "0.00025",
+		},
+	}
+	mktCfg.TradableInstrument.RiskModel = &types.TradableInstrument_LogNormalRiskModel{
+		LogNormalRiskModel: &types.LogNormalRiskModel{
+			RiskAversionParameter: 0.001,
+			Tau:                   0.00011407711613050422,
+			Params: &types.LogNormalModelParams{
+				Mu:    0,
+				R:     0.016,
+				Sigma: 20,
+			},
+		},
+	}
+
+	lpparty := "lp-party-1"
+
+	tm := newTestMarket(t, now).Run(ctx, mktCfg)
+	tm.StartOpeningAuction().
+		// the liquidity provider
+		WithAccountAndAmount(lpparty, 500000000000)
+
+	tm.market.OnSuppliedStakeToObligationFactorUpdate(0.25)
+	tm.market.OnChainTimeUpdate(ctx, now)
+
+	// Add a LPSubmission
+	// this is a log of stake, enough to cover all
+	// the required stake for the market
+	lpSubmission := &types.LiquidityProvisionSubmission{
+		MarketId:         tm.market.GetID(),
+		CommitmentAmount: 150000,
+		Fee:              "0.01",
+		Reference:        "ref-lp-submission-1",
+		Buys: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Proportion: 2, Offset: -5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_MID, Proportion: 2, Offset: -5},
+		},
+		Sells: []*types.LiquidityOrder{
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+			{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Proportion: 13, Offset: 5},
+		},
+	}
+
+	// submit our lp
+	require.NoError(t,
+		tm.market.SubmitLiquidityProvision(
+			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+	)
+
+	tm.events = nil
+	tm.EndOpeningAuction(t, auctionEnd, false)
+
+	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
+		acc, err := tm.collateraEngine.GetPartyMarginAccount(
+			tm.market.GetID(), lpparty, tm.asset)
+		assert.NoError(t, err)
+		assert.Equal(t, 145412, int(acc.Balance))
+	})
+
+	tm.dumpMarketData()
+
+	// tm.dumpMarketData()
+	// tm.dumpPeggedOrders()
+
+	// tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(2*time.Second))
+	// tm.mas.StartPriceAuction(auctionEnd.Add(2*time.Second), &types.AuctionDuration{
+	// 	Duration: 30,
+	// })
+	// tm.market.EnterAuction(ctx)
+
+	// tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(40*time.Second))
+	// tm.mas.EndAuction()
+	// tm.market.LeaveAuction(ctx, auctionEnd.Add(40*time.Second))
+
+	// tm.dumpPeggedOrders()
+
+}

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -595,7 +595,7 @@ func (e *Engine) removeExpiredOrders(ctx context.Context, t time.Time) {
 	expiringOrders := []types.Order{}
 	timeNow := t.UnixNano()
 	for _, mkt := range e.marketsCpy {
-		orders, err := mkt.RemoveExpiredOrders(timeNow)
+		orders, err := mkt.RemoveExpiredOrders(ctx, timeNow)
 		if err != nil {
 			e.log.Error("unable to get remove expired orders",
 				logging.MarketID(mkt.GetID()),

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -2554,7 +2554,7 @@ func TestOrderBook_ExpiredOrderTriggersReprice(t *testing.T) {
 	// Move the clock forward to expire the first order
 	now = now.Add(time.Second * 10)
 	tm.market.OnChainTimeUpdate(context.Background(), now)
-	orders, err := tm.market.RemoveExpiredOrders(now.UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.UnixNano())
 	require.NoError(t, err)
 
 	// we have one order
@@ -2751,7 +2751,7 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder(t *testing.T) {
 	// Move the clock forward to expire any old orders
 	now = now.Add(time.Second * 10)
 	tm.market.OnChainTimeUpdate(context.Background(), now)
-	orders, err := tm.market.RemoveExpiredOrders(now.UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.UnixNano())
 	require.Equal(t, 0, len(orders))
 	require.NoError(t, err)
 
@@ -2799,7 +2799,7 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder2(t *testing.T) {
 	// Move the clock forward to expire any old orders
 	now = now.Add(time.Second * 10)
 	tm.market.OnChainTimeUpdate(context.Background(), now)
-	orders, err := tm.market.RemoveExpiredOrders(now.UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.UnixNano())
 	require.NoError(t, err)
 
 	// 1 expired order

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -3179,10 +3179,12 @@ func TestMarket_LeaveAuctionAndRepricePeggedOrders(t *testing.T) {
 	// Remove an order to invalidate reference prices and force pegged orders to park
 	tm.market.CancelOrder(ctx, o1.PartyId, o1.Id)
 
-	// 3 live orders, 1 normal and 2 pegged with 2 parked pegged orders
-	require.Equal(t, int64(3), tm.market.GetOrdersOnBookCount())
-	require.Equal(t, 4, tm.market.GetPeggedOrderCount())
-	require.Equal(t, 2, tm.market.GetParkedOrderCount())
+	//
+	// 1 live orders, 1 normal
+	// all LP have been removed as cannot be repriced.
+	assert.Equal(t, int64(1), tm.market.GetOrdersOnBookCount())
+	assert.Equal(t, 0, tm.market.GetPeggedOrderCount())
+	assert.Equal(t, 0, tm.market.GetParkedOrderCount())
 }
 
 // TODO(): this test is wrong.

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -1345,7 +1345,7 @@ func testPeggedOrderExpiring2(t *testing.T) {
 	assert.Equal(t, 2, tm.market.GetPeggedOrderCount())
 
 	// Move the time forward
-	orders, err := tm.market.RemoveExpiredOrders(afterexpire.UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), afterexpire.UnixNano())
 	require.NotNil(t, orders)
 	assert.NoError(t, err)
 
@@ -1564,7 +1564,7 @@ func testPeggedOrderExpiring(t *testing.T) {
 	}
 	assert.Equal(t, len(expirations), tm.market.GetPeggedOrderCount())
 
-	orders, err := tm.market.RemoveExpiredOrders(now.Add(25 * time.Minute).UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.Add(25*time.Minute).UnixNano())
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(orders))
 	assert.Equal(t, 1, tm.market.GetPeggedOrderCount(), "1 order should still be in the market")
@@ -2032,7 +2032,7 @@ func TestOrderBookSimple_CancelGTTOrderThenRunExpiration(t *testing.T) {
 	require.NotNil(t, cncl)
 	assert.Equal(t, 0, tm.market.GetPeggedExpiryOrderCount())
 
-	orders, err := tm.market.RemoveExpiredOrders(now.Add(10 * time.Second).UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.Add(10*time.Second).UnixNano())
 	require.NoError(t, err)
 	require.Len(t, orders, 0)
 	assert.Equal(t, 0, tm.market.GetPeggedExpiryOrderCount())
@@ -2055,7 +2055,7 @@ func TestGTTExpiredNotFilled(t *testing.T) {
 	require.NotNil(t, o1conf)
 
 	// then remove expired, set 1 sec after order exp time.
-	orders, err := tm.market.RemoveExpiredOrders(now.Add(10 * time.Second).UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.Add(10*time.Second).UnixNano())
 	assert.NoError(t, err)
 	assert.Len(t, orders, 1)
 	assert.Equal(t, types.Order_STATUS_EXPIRED, orders[0].Status)
@@ -2087,7 +2087,7 @@ func TestGTTExpiredPartiallyFilled(t *testing.T) {
 	require.NotNil(t, o2conf)
 
 	// then remove expired, set 1 sec after order exp time.
-	orders, err := tm.market.RemoveExpiredOrders(now.Add(10 * time.Second).UnixNano())
+	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.Add(10*time.Second).UnixNano())
 	assert.NoError(t, err)
 	assert.Len(t, orders, 1)
 	assert.Equal(t, types.Order_STATUS_EXPIRED, orders[0].Status)
@@ -2163,7 +2163,7 @@ func TestOrderBook_RemoveExpiredOrders(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, o10conf)
 
-	expired, err := tm.market.RemoveExpiredOrders(someTimeLater.UnixNano())
+	expired, err := tm.market.RemoveExpiredOrders(context.Background(), someTimeLater.UnixNano())
 	assert.NoError(t, err)
 	assert.Len(t, expired, 5)
 }

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -397,6 +397,7 @@ func (e *Engine) Update(ctx context.Context, markPrice uint64, repriceFn Reprice
 	)
 
 	for party, orders := range Orders(orders).ByParty() {
+		fmt.Printf("LIQUIDITY UPDATE: %v\n", party)
 		if !e.IsLiquidityProvider(party) {
 			continue
 		}
@@ -412,8 +413,10 @@ func (e *Engine) Update(ctx context.Context, markPrice uint64, repriceFn Reprice
 
 		newOrders = append(newOrders, creates...)
 		amendments = append(amendments, updates...)
-
 	}
+
+	fmt.Printf("NEW ORDERS: %v\n", len(newOrders))
+	fmt.Printf("AMENDMENTS: %v\n", len(amendments))
 
 	if e.undeployedProvisions {
 		// There are some provisions that haven't been cancelled or rejected, but haven't yet been deployed, try an deploy now.
@@ -524,6 +527,8 @@ func (e *Engine) createOrUpdateForParty(markPrice uint64, party string, repriceF
 		needsCreateBuys, needsCreateSells []*types.Order
 		needsUpdateBuys, needsUpdateSells []*types.OrderAmendment
 	)
+
+	fmt.Printf("REPRICE FAILURE? %v\n", repriceFailure)
 
 	if repriceFailure {
 

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -367,7 +367,6 @@ func (e *Engine) Update(ctx context.Context, markPrice uint64, repriceFn Reprice
 	)
 
 	for party, orders := range Orders(orders).ByParty() {
-		fmt.Printf("LIQUIDITY UPDATE: %v\n", party)
 		if !e.IsLiquidityProvider(party) {
 			continue
 		}
@@ -402,9 +401,6 @@ func (e *Engine) Update(ctx context.Context, markPrice uint64, repriceFn Reprice
 		}
 		e.undeployedProvisions = stillUndeployed
 	}
-
-	fmt.Printf("NEW ORDERS: %v\n", len(newOrders))
-	fmt.Printf("AMENDMENTS: %v\n", len(amendments))
 
 	// send a batch of updates
 	evts := []events.Event{}
@@ -497,8 +493,6 @@ func (e *Engine) createOrUpdateForParty(markPrice uint64, party string, repriceF
 		needsCreateBuys, needsCreateSells []*types.Order
 		needsUpdateBuys, needsUpdateSells []*types.OrderAmendment
 	)
-
-	fmt.Printf("REPRICE FAILURE? %v\n", repriceFailure)
 
 	if repriceFailure {
 


### PR DESCRIPTION
This fix the behaviour of lp orders when entering / leaving auction.
- when entering auction, lp orders are cancelled
- when leaving auction they are created again
- if at the time we try to submit an lp order, we do not have enough margin, the whole commitmment is cancelled.