### PR TITLE
Do not log.Error on ratelimit failure

### DIFF
--- a/api/trading.go
+++ b/api/trading.go
@@ -150,14 +150,16 @@ func (s *tradingService) SubmitTransaction(ctx context.Context, req *protoapi.Su
 	}
 
 	if err := s.blockchain.SubmitTransaction(ctx, req.Tx, ty); err != nil {
-		s.log.Error("unable to submit transaction", logging.Error(err))
+		// This is Tendermint's specific error signature
 		if _, ok := err.(interface {
 			Code() uint32
 			Details() string
 			Error() string
 		}); ok {
+			s.log.Debug("unable to submit transaction", logging.Error(err))
 			return nil, apiError(codes.InvalidArgument, err)
 		}
+		s.log.Error("unable to submit transaction", logging.Error(err))
 		return nil, apiError(codes.Internal, err)
 	}
 

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	ErrPublicKeyExceededRateLimit                    = errors.New("public key excedeed the rate limit")
+	ErrPublicKeyExceededRateLimit                    = errors.New("public key exceeded the rate limit")
 	ErrPublicKeyCannotSubmitTransactionWithNoBalance = errors.New("public key cannot submit transaction with no balance")
 )
 
@@ -298,7 +298,7 @@ func (app *App) limitPubkey(pk []byte) (limit bool, isValidator bool) {
 
 	key := ratelimit.Key(pk).String()
 	if !app.rates.Allow(key) {
-		app.log.Error("Rate limit exceeded", logging.String("key", key))
+		app.log.Debug("Rate limit exceeded", logging.String("key", key))
 		return true, false
 	}
 


### PR DESCRIPTION
Ratelimit errors are very frequent in our setup.
In a 24hour log file +99% of the lines are related to Ratelimit.
```
 # Total lines
 ➜ wc j.log
   2351148  40039534 494623216 j.log

 # Lines containing "rate"
 ➜ grep -i "rate" j.log|wc
   2343233 39834826 490907381

 # Lines excluding "rate"
 ➜ logs grep -iv "rate" j.log|wc
   7915  204708 3715835
```
Also, we can see that for each rate limit error, two modules are logging
the error:
```
 ➜  grep -i "rate" j.log|head -n2
 ERROR        processor        processor/abci.go:301  Rate limit exceeded          {"key": "2ozoZr2vCx2ZQSfcfpic7WCjAyJh7naiM6eZISeoz4k="}
 ERROR        api.grpc         api/trading.go:153     unable to submit transaction {"error": "public key excedeed the rate limit"}
```
This PR turns those logs into debug, but also keeps log.Error-ing when a
different type of error happens.

Since this is certainly a major contributor to #3104, I'd keep it like this before turning every `Error` into `Debug`.