### PR TITLE
Added consistency check (#3136)

### DIFF
--- a/execution/event_generation_test.go
+++ b/execution/event_generation_test.go
@@ -2,6 +2,7 @@ package execution_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -51,31 +52,98 @@ func leaveAuction(tm *testMarket, ctx context.Context, now *time.Time) {
 	tm.market.LeaveAuction(ctx, *now)
 }
 
-func processEvents(t *testing.T, tm *testMarket, ctx context.Context) *subscribers.MarketDepthBuilder {
-	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
-
+func processEvents2(t *testing.T, tm *testMarket, mdb *subscribers.MarketDepthBuilder, i int) {
 	for _, event := range tm.orderEvents {
 		mdb.Push(event)
 	}
-	checkConsistency(t, tm, mdb)
-	return mdb
+	needToQuit := false
+	orders := mdb.GetAllOrders(tm.market.GetID())
+	for _, order := range orders {
+		if !tm.market.ValidateOrder(order) {
+			needToQuit = true
+		}
+	}
+
+	if !checkConsistency(t, tm, mdb) {
+		// We had an error, lets dump all the events
+		for i, event := range tm.orderEvents {
+			switch te := event.(type) {
+			case subscribers.OE:
+				fmt.Println("Event:", i, te.Order())
+			}
+		}
+		needToQuit = true
+	}
+
+	if needToQuit {
+		fmt.Println("About to exit after finding an issue on iteration", i)
+		require.Equal(t, true, false)
+	}
+}
+
+func processEvents(t *testing.T, tm *testMarket, mdb *subscribers.MarketDepthBuilder) {
+	processEvents2(t, tm, mdb, 0)
+}
+
+func clearEvents(tm *testMarket) {
+	// Reset the event counter
+	tm.eventCount = 0
+	tm.orderEventCount = 0
+	tm.events = nil
+	tm.orderEvents = nil
 }
 
 // Check that the orders in the matching engine are the same as the orders in the market depth
-func checkConsistency(t *testing.T, tm *testMarket, mdb *subscribers.MarketDepthBuilder) {
+func checkConsistency(t *testing.T, tm *testMarket, mdb *subscribers.MarketDepthBuilder) bool {
+	correct := true
 	// Do we have the same number of orders in each?
-	require.Equal(t, tm.market.GetOrdersOnBookCount(), mdb.GetOrderCount(tm.market.GetID()))
+	if !assert.Equal(t, tm.market.GetOrdersOnBookCount(), mdb.GetOrderCount(tm.market.GetID())) {
+		fmt.Println("Market Order On Book:", tm.market.GetOrdersOnBookCount())
+		fmt.Println("Market Depth Orders :", mdb.GetOrderCount(tm.market.GetID()))
+		correct = false
+	}
 	// Do we have the same volume in each?
-	require.Equal(t, tm.market.GetVolumeOnBook(), mdb.GetTotalVolume(tm.market.GetID()))
+	if !assert.Equal(t, tm.market.GetVolumeOnBook(), mdb.GetTotalVolume(tm.market.GetID())) {
+		fmt.Println("Market Volume On Book:", tm.market.GetVolumeOnBook())
+		fmt.Println("Market Depth Volume  :", mdb.GetTotalVolume(tm.market.GetID()))
+		correct = false
+	}
 	// Do we have the same best bid price?
-	require.Equal(t, tm.market.GetMarketData().BestBidPrice, mdb.GetBestBidPrice(tm.market.GetID()))
+	if !assert.Equal(t, tm.market.GetMarketData().BestBidPrice, mdb.GetBestBidPrice(tm.market.GetID())) {
+		fmt.Println("Market Best Bid:", tm.market.GetMarketData().BestBidPrice)
+		fmt.Println("Market Depth BB:", mdb.GetBestBidPrice(tm.market.GetID()))
+		correct = false
+	}
 	// Do we have the same best ask price?
-	require.Equal(t, tm.market.GetMarketData().BestOfferPrice, mdb.GetBestAskPrice(tm.market.GetID()))
+	if !assert.Equal(t, tm.market.GetMarketData().BestOfferPrice, mdb.GetBestAskPrice(tm.market.GetID())) {
+		fmt.Println("Market Best Ask:", tm.market.GetMarketData().BestOfferPrice)
+		fmt.Println("Market Depth BA:", mdb.GetBestAskPrice(tm.market.GetID()))
+		correct = false
+	}
+
+	// Check volume at each level is correct
+	bestBid := tm.market.GetMarketData().BestBidPrice
+	bestAsk := tm.market.GetMarketData().BestOfferPrice
+
+	if !assert.Equal(t, tm.market.GetMarketData().BestBidVolume, mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_BUY, bestBid)) {
+		fmt.Println("BestBidVolume in OB:", tm.market.GetMarketData().BestBidVolume)
+		fmt.Println("BestBidVolume in MD:", mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_BUY, bestBid))
+		correct = false
+	}
+
+	if !assert.Equal(t, tm.market.GetMarketData().BestOfferVolume, mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, bestAsk)) {
+		fmt.Println("BestAskVolume in OB:", tm.market.GetMarketData().BestOfferVolume)
+		fmt.Println("BestAskVolume in MD:", mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, bestAsk))
+		correct = false
+	}
+
+	return correct
 }
 
 func TestEvents_LeavingAuctionCancelsGFAOrders(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 
 	// Add a GFA order
@@ -90,13 +158,14 @@ func TestEvents_LeavingAuctionCancelsGFAOrders(t *testing.T) {
 	// Check we have 2 events
 	assert.Equal(t, uint64(2), tm.orderEventCount)
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(0), mdb.GetOrderCount(tm.market.GetID()))
 }
 
 func TestEvents_EnteringAuctionCancelsGFNOrders(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -130,13 +199,14 @@ func TestEvents_EnteringAuctionCancelsGFNOrders(t *testing.T) {
 	assert.Equal(t, uint64(6), tm.orderEventCount)
 	assert.Equal(t, int64(2), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(2), mdb.GetOrderCount(tm.market.GetID()))
 }
 
 func TestEvents_CloseOutTrader(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -172,7 +242,7 @@ func TestEvents_CloseOutTrader(t *testing.T) {
 	assert.Equal(t, uint64(12), tm.orderEventCount)
 	assert.Equal(t, int64(1), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(1), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
 	assert.Equal(t, uint64(69), mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
@@ -181,6 +251,7 @@ func TestEvents_CloseOutTrader(t *testing.T) {
 func TestEvents_CloseOutTraderWithPeggedOrder(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -207,10 +278,16 @@ func TestEvents_CloseOutTraderWithPeggedOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Place the pegged order
-	o5 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order05", types.Side_SIDE_BUY, "trader-A", 1, 10)
+	o5 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order05", types.Side_SIDE_BUY, "trader-A", 1, 0)
 	o5.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -1}
 	o5conf, err := tm.market.SubmitOrder(ctx, o5)
 	require.NotNil(t, o5conf)
+	require.NoError(t, err)
+
+	o7 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order07", types.Side_SIDE_BUY, "trader-A", 1, 0)
+	o7.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -110}
+	o7conf, err := tm.market.SubmitOrder(ctx, o7)
+	require.NotNil(t, o7conf)
 	require.NoError(t, err)
 
 	o3 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order03", types.Side_SIDE_SELL, "trader-C", 100, 100)
@@ -219,10 +296,10 @@ func TestEvents_CloseOutTraderWithPeggedOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check we have the right amount of events
-	assert.Equal(t, uint64(13), tm.orderEventCount)
+	assert.Equal(t, uint64(15), tm.orderEventCount)
 	assert.Equal(t, int64(2), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(2), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
 	assert.Equal(t, uint64(69), mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
@@ -233,6 +310,7 @@ func TestEvents_CloseOutTraderWithPeggedOrder(t *testing.T) {
 func TestEvents_EnteringAuctionParksAllPegs(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -270,7 +348,7 @@ func TestEvents_EnteringAuctionParksAllPegs(t *testing.T) {
 	assert.Equal(t, uint64(8), tm.orderEventCount)
 	assert.Equal(t, int64(3), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(3), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 3, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -278,6 +356,7 @@ func TestEvents_EnteringAuctionParksAllPegs(t *testing.T) {
 func TestEvents_SelfTrading(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -300,7 +379,7 @@ func TestEvents_SelfTrading(t *testing.T) {
 	assert.Equal(t, uint64(4), tm.orderEventCount)
 	assert.Equal(t, int64(1), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(1), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 1, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -308,6 +387,7 @@ func TestEvents_SelfTrading(t *testing.T) {
 func TestEvents_Amending(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -353,7 +433,7 @@ func TestEvents_Amending(t *testing.T) {
 	assert.Equal(t, uint64(6), tm.orderEventCount)
 	assert.Equal(t, int64(1), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(1), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 1, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -361,6 +441,7 @@ func TestEvents_Amending(t *testing.T) {
 func TestEvents_MovingPegsAround(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -405,7 +486,7 @@ func TestEvents_MovingPegsAround(t *testing.T) {
 	assert.Equal(t, uint64(10), tm.orderEventCount)
 	assert.Equal(t, int64(0), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(0), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 0, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -413,6 +494,7 @@ func TestEvents_MovingPegsAround(t *testing.T) {
 func TestEvents_MovingPegsAround2(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -447,7 +529,7 @@ func TestEvents_MovingPegsAround2(t *testing.T) {
 	assert.Equal(t, uint64(6), tm.orderEventCount)
 	assert.Equal(t, int64(0), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(0), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 0, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -455,6 +537,7 @@ func TestEvents_MovingPegsAround2(t *testing.T) {
 func TestEvents_AmendOrderToSelfTrade(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -488,7 +571,7 @@ func TestEvents_AmendOrderToSelfTrade(t *testing.T) {
 	assert.Equal(t, uint64(5), tm.orderEventCount)
 	assert.Equal(t, int64(1), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(1), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 1, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -496,6 +579,7 @@ func TestEvents_AmendOrderToSelfTrade(t *testing.T) {
 func TestEvents_AmendOrderToIncreaseSizeAndPartiallyFill(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -530,7 +614,7 @@ func TestEvents_AmendOrderToIncreaseSizeAndPartiallyFill(t *testing.T) {
 	assert.Equal(t, uint64(5), tm.orderEventCount)
 	assert.Equal(t, int64(2), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(2), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 2, mdb.GetPriceLevels(tm.market.GetID()))
 }
@@ -538,6 +622,7 @@ func TestEvents_AmendOrderToIncreaseSizeAndPartiallyFill(t *testing.T) {
 func TestEvents_CloseOutTraderWithNotEnoughLiquidity(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 
 	leaveAuction(tm, ctx, &now)
@@ -580,7 +665,7 @@ func TestEvents_CloseOutTraderWithNotEnoughLiquidity(t *testing.T) {
 	assert.Equal(t, uint64(10), tm.orderEventCount)
 	assert.Equal(t, int64(2), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(2), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
 	assert.Equal(t, uint64(9), mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
@@ -591,6 +676,7 @@ func TestEvents_CloseOutTraderWithNotEnoughLiquidity(t *testing.T) {
 func TestEvents_CloseOutTraderWithLPOrder(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	addAccountWithAmount(tm, "trader-Z", 4000)
 
@@ -648,7 +734,7 @@ func TestEvents_CloseOutTraderWithLPOrder(t *testing.T) {
 	assert.Equal(t, uint64(13), tm.orderEventCount)
 	assert.Equal(t, int64(3), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(3), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
 	assert.Equal(t, uint64(9), mdb.GetVolumeAtPrice(tm.market.GetID(), types.Side_SIDE_SELL, 100))
@@ -659,6 +745,7 @@ func TestEvents_CloseOutTraderWithLPOrder(t *testing.T) {
 func TestEvents_LPOrderRecalcDueToFill(t *testing.T) {
 	now := time.Unix(10, 0)
 	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
 	tm := startMarketInAuction(t, ctx, &now)
 	leaveAuction(tm, ctx, &now)
 
@@ -704,8 +791,133 @@ func TestEvents_LPOrderRecalcDueToFill(t *testing.T) {
 	assert.Equal(t, uint64(11), tm.orderEventCount)
 	assert.Equal(t, int64(4), tm.market.GetOrdersOnBookCount())
 
-	mdb := processEvents(t, tm, ctx)
+	processEvents(t, tm, mdb)
 	assert.Equal(t, int64(4), mdb.GetOrderCount(tm.market.GetID()))
 	assert.Equal(t, 2, tm.market.GetPeggedOrderCount())
 	assert.Equal(t, 0, tm.market.GetParkedOrderCount())
+}
+
+func TestEvents_PeggedOrders(t *testing.T) {
+	now := time.Unix(10, 0)
+	ctx := context.Background()
+	mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
+	tm := startMarketInAuction(t, ctx, &now)
+	leaveAuction(tm, ctx, &now)
+
+	o1 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GFN, "Order01", types.Side_SIDE_BUY, "trader-B", 2, 100)
+	o1conf, err := tm.market.SubmitOrder(ctx, o1)
+	require.NotNil(t, o1conf)
+	require.NoError(t, err)
+
+	o4 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order04", types.Side_SIDE_BUY, "trader-B", 2, 98)
+	o4conf, err := tm.market.SubmitOrder(ctx, o4)
+	require.NotNil(t, o4conf)
+	require.NoError(t, err)
+
+	o2 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order02", types.Side_SIDE_SELL, "trader-C", 2, 110)
+	o2conf, err := tm.market.SubmitOrder(ctx, o2)
+	require.NotNil(t, o2conf)
+	require.NoError(t, err)
+
+	o6 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order06", types.Side_SIDE_SELL, "trader-C", 2, 112)
+	o6conf, err := tm.market.SubmitOrder(ctx, o6)
+	require.NotNil(t, o6conf)
+	require.NoError(t, err)
+
+	// Place the pegged order
+	o5 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order05", types.Side_SIDE_BUY, "trader-A", 1, 0)
+	o5.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -1}
+	o5conf, err := tm.market.SubmitOrder(ctx, o5)
+	require.NotNil(t, o5conf)
+	require.NoError(t, err)
+
+	o7 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order07", types.Side_SIDE_BUY, "trader-A", 1, 0)
+	o7.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -99}
+	o7conf, err := tm.market.SubmitOrder(ctx, o7)
+	require.NotNil(t, o7conf)
+	require.NoError(t, err)
+
+	// Now cause the best bid to drop and cause a reprice
+	o3 := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, "Order03", types.Side_SIDE_SELL, "trader-C", 2, 100)
+	o3conf, err := tm.market.SubmitOrder(ctx, o3)
+	require.NotNil(t, o3conf)
+	require.NoError(t, err)
+
+	// Check we have the right amount of events
+	assert.Equal(t, uint64(10), tm.orderEventCount)
+	assert.Equal(t, int64(4), tm.market.GetOrdersOnBookCount())
+
+	processEvents(t, tm, mdb)
+	assert.Equal(t, 2, tm.market.GetPeggedOrderCount())
+	assert.Equal(t, 1, tm.market.GetParkedOrderCount())
+}
+
+func TestEvents_Fuzzing(t *testing.T) {
+	/*	now := time.Unix(10, 0)
+		ctx := context.Background()
+		mdb := subscribers.NewMarketDepthBuilder(ctx, nil, true)
+		tm := startMarketInAuction(t, ctx, &now)
+		leaveAuction(tm, ctx, &now)
+
+		r := rand.New(rand.NewSource(99))
+
+		var (
+			traderCount int = 10
+			side        types.Side
+			price       uint64
+			size        uint64
+		)
+
+		// Create the traders
+		for i := 0; i < traderCount; i++ {
+			traderName := fmt.Sprintf("Trader%02d", i)
+			addAccountWithAmount(tm, traderName, 1000000000)
+		}
+
+		for i := 1; i < 110000; i++ {
+			//		if i%1000 == 0 {
+			fmt.Println("Processing ", i)
+			//		}
+
+			if i == 101625 || i == 43056 {
+				fmt.Println("Interesting stuff happens here", i)
+			}
+
+			randomTrader := r.Intn(traderCount)
+			traderName := fmt.Sprintf("Trader%02d", randomTrader)
+			orderID := fmt.Sprintf("Order%8d", i)
+			action := r.Intn(10)
+
+			if r.Intn(2) == 0 {
+				side = types.Side_SIDE_BUY
+			} else {
+				side = types.Side_SIDE_SELL
+			}
+
+			size = uint64(r.Int63n(100) + 1)
+
+			if action <= 2 && i > 20 {
+				// Pegged order
+				po := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, orderID, side, traderName, size, 0)
+				if side == types.Side_SIDE_BUY {
+					po.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_BID, Offset: -1 - r.Int63n(10)}
+				} else {
+					po.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_BEST_ASK, Offset: r.Int63n(10) + 1}
+				}
+				_, _ = tm.market.SubmitOrder(ctx, po)
+				processEvents2(t, tm, mdb, i)
+				clearEvents(tm)
+			} else {
+				// Normal order
+				if side == types.Side_SIDE_BUY {
+					price = uint64(50 + r.Intn(60))
+				} else {
+					price = uint64(90 + r.Intn(60))
+				}
+				o := getMarketOrder(tm, now, types.Order_TYPE_LIMIT, types.Order_TIME_IN_FORCE_GTC, orderID, side, traderName, size, price)
+				_, _ = tm.market.SubmitOrder(ctx, o)
+				processEvents2(t, tm, mdb, i)
+				clearEvents(tm)
+			}
+		}*/
 }

--- a/execution/event_generation_test.go
+++ b/execution/event_generation_test.go
@@ -39,9 +39,7 @@ func startMarketInAuction(t *testing.T, ctx context.Context, now *time.Time) *te
 	tm.market.EnterAuction(ctx)
 
 	// Reset the event counter
-	tm.eventCount = 0
-	tm.orderEventCount = 0
-	tm.events = nil
+	clearEvents(tm)
 
 	return tm
 }

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"code.vegaprotocol.io/vega/events"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -140,4 +141,18 @@ func (m *Market) ValidateOrder(order *types.Order) bool {
 		return false
 	}
 	return true
+}
+
+func (m *Market) SendEvents(ctx context.Context, orderCount int) {
+	order := &types.Order{
+		Price:     1111,
+		Size:      2222,
+		Remaining: 3333,
+		Id:        "wiqoweqoiwopqiweuoiwe",
+	}
+
+	for i := 0; i < orderCount; i++ {
+		order.UpdatedAt = int64(i)
+		m.broker.Send(events.NewOrderEvent(ctx, order))
+	}
 }

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -33,6 +33,11 @@ func (m *Market) GetOrdersOnBookCount() int64 {
 	return m.matching.GetTotalNumberOfOrders()
 }
 
+// GetVolumeOnBook returns the volume of orders on one side of the book
+func (m *Market) GetVolumeOnBook() int64 {
+	return m.matching.GetTotalVolume()
+}
+
 // StartPriceAuction initialises the market to handle a price auction
 func (m *Market) StartPriceAuction(now time.Time) {
 	end := types.AuctionDuration{

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	types "code.vegaprotocol.io/vega/proto"
@@ -121,4 +122,22 @@ func (m *Market) GetTotalAccountBalance(ctx context.Context, partyID, marketID, 
 // Return the current liquidity fee value for a market
 func (m *Market) GetLiquidityFee() float64 {
 	return m.fee.GetLiquidityFee()
+}
+
+// Log out orders that don't match
+func (m *Market) ValidateOrder(order *types.Order) bool {
+	order2, err := m.matching.GetOrderByID(order.Id)
+	if err != nil {
+		return false
+	}
+	if order.Price != order2.Price ||
+		order.Size != order2.Size ||
+		order.Remaining != order2.Remaining ||
+		order.Status != order2.Status {
+		fmt.Println("Orders do not match")
+		fmt.Println("OrderBook  :", order2)
+		fmt.Println("MarketDepth:", order)
+		return false
+	}
+	return true
 }

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -2,10 +2,8 @@ package execution
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"code.vegaprotocol.io/vega/events"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -135,24 +133,7 @@ func (m *Market) ValidateOrder(order *types.Order) bool {
 		order.Size != order2.Size ||
 		order.Remaining != order2.Remaining ||
 		order.Status != order2.Status {
-		fmt.Println("Orders do not match")
-		fmt.Println("OrderBook  :", order2)
-		fmt.Println("MarketDepth:", order)
 		return false
 	}
 	return true
-}
-
-func (m *Market) SendEvents(ctx context.Context, orderCount int) {
-	order := &types.Order{
-		Price:     1111,
-		Size:      2222,
-		Remaining: 3333,
-		Id:        "wiqoweqoiwopqiweuoiwe",
-	}
-
-	for i := 0; i < orderCount; i++ {
-		order.UpdatedAt = int64(i)
-		m.broker.Send(events.NewOrderEvent(ctx, order))
-	}
 }

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -984,6 +984,12 @@ func (b *OrderBook) PrintState(types string) {
 	b.log.Debug("------------------------------------------------------------")
 }
 
+// GetTotalNumberOfOrders is a debug/testing function to return the total number of orders in the book
 func (b *OrderBook) GetTotalNumberOfOrders() int64 {
 	return b.buy.getOrderCount() + b.sell.getOrderCount()
+}
+
+// GetTotalVolume is a debug/testing function to return the total volume in the order book
+func (b *OrderBook) GetTotalVolume() int64 {
+	return b.buy.getTotalVolume() + b.sell.getTotalVolume()
 }

--- a/matching/side.go
+++ b/matching/side.go
@@ -569,3 +569,11 @@ func (s *OrderBookSide) getOrderCount() int64 {
 	}
 	return orderCount
 }
+
+func (s *OrderBookSide) getTotalVolume() int64 {
+	var volume int64
+	for _, level := range s.levels {
+		volume = volume + int64(level.volume)
+	}
+	return volume
+}

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -386,6 +386,14 @@ func (mdb *MarketDepthBuilder) GetMarketDepth(ctx context.Context, market string
 /*                 FUNCTIONS TO HELP WITH UNIT TESTING                       */
 /*****************************************************************************/
 
+func (mdb *MarketDepthBuilder) GetAllOrders(market string) map[string]*types.Order {
+	md := mdb.marketDepths[market]
+	if md != nil {
+		return md.liveOrders
+	}
+	return nil
+}
+
 // GetOrderCount returns the number of live orders for the given market
 func (mdb *MarketDepthBuilder) GetOrderCount(market string) int64 {
 	var liveOrders int64

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -253,8 +253,7 @@ func (mdb *MarketDepthBuilder) updateMarketDepth(order *types.Order) {
 	}
 
 	// Orders that where not valid are ignored
-	if order.Status == types.Order_STATUS_UNSPECIFIED ||
-		order.Status == types.Order_STATUS_REJECTED {
+	if order.Status == types.Order_STATUS_UNSPECIFIED {
 		return
 	}
 
@@ -282,6 +281,7 @@ func (mdb *MarketDepthBuilder) updateMarketDepth(order *types.Order) {
 			order.Status == types.Order_STATUS_STOPPED ||
 			order.Status == types.Order_STATUS_FILLED ||
 			order.Status == types.Order_STATUS_PARTIALLY_FILLED ||
+			order.Status == types.Order_STATUS_REJECTED ||
 			order.Status == types.Order_STATUS_PARKED {
 			md.removeOrder(originalOrder)
 		} else {
@@ -291,6 +291,11 @@ func (mdb *MarketDepthBuilder) updateMarketDepth(order *types.Order) {
 		if order.Remaining > 0 && order.Status == types.Order_STATUS_ACTIVE {
 			md.addOrder(order)
 		}
+	}
+
+	// If nothing changed we can stop here
+	if len(md.changes) == 0 {
+		return
 	}
 
 	buyPtr := []*types.PriceLevel{}

--- a/subscribers/market_depth_test.go
+++ b/subscribers/market_depth_test.go
@@ -51,7 +51,7 @@ func TestBuyPriceLevels(t *testing.T) {
 
 	assert.Equal(t, 4, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 4, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(4), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(7), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 102))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 102))
@@ -88,7 +88,7 @@ func TestSellPriceLevels(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 4, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 4, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(4), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(7), mdb.GetVolumeAtPrice("M", types.Side_SIDE_SELL, 102))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_SELL, 102))
@@ -113,7 +113,7 @@ func TestAddOrderToEmptyBook(t *testing.T) {
 
 	assert.Equal(t, 1, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 1, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(1), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(10), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -134,7 +134,7 @@ func TestCancelOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -155,7 +155,7 @@ func TestStoppedOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -176,7 +176,7 @@ func TestExpiredOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -202,7 +202,7 @@ func TestAmendOrderPrice(t *testing.T) {
 
 	assert.Equal(t, 2, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 2, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(2), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(10), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(10), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 90))
@@ -226,7 +226,7 @@ func TestAmendOrderVolumeUp(t *testing.T) {
 
 	assert.Equal(t, 1, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 1, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(1), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(20), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -248,7 +248,7 @@ func TestAmendOrderVolumeDown(t *testing.T) {
 
 	assert.Equal(t, 1, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 1, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(1), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(5), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -270,7 +270,7 @@ func TestAmendOrderVolumeDownToZero(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -291,7 +291,7 @@ func TestPartialFill(t *testing.T) {
 
 	assert.Equal(t, 1, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 1, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(1), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(5), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -309,7 +309,7 @@ func TestIOCPartialFill(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -331,7 +331,7 @@ func TestFullyFill(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -348,7 +348,7 @@ func TestMarketOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -366,7 +366,7 @@ func TestFOKOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -384,7 +384,7 @@ func TestIOCOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -402,7 +402,7 @@ func TestRejectedOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -420,7 +420,7 @@ func TestInvalidOrder(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -446,7 +446,7 @@ func TestPartialMatchOrders(t *testing.T) {
 
 	assert.Equal(t, 1, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 1, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(1), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(1), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(1), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -473,7 +473,7 @@ func TestFullyMatchOrders(t *testing.T) {
 
 	assert.Equal(t, 0, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 0, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(0), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 100))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 100))
@@ -500,7 +500,7 @@ func TestRemovingPriceLevels(t *testing.T) {
 
 	assert.Equal(t, 2, mdb.GetBuyPriceLevels("M"))
 	assert.Equal(t, 0, mdb.GetSellPriceLevels("M"))
-	assert.Equal(t, 2, mdb.GetOrderCount("M"))
+	assert.Equal(t, int64(2), mdb.GetOrderCount("M"))
 
 	assert.Equal(t, uint64(0), mdb.GetVolumeAtPrice("M", types.Side_SIDE_BUY, 101))
 	assert.Equal(t, uint64(0), mdb.GetOrderCountAtPrice("M", types.Side_SIDE_BUY, 101))


### PR DESCRIPTION
I added some code to send random orders to the market to attempt to reproduce an issue with reporting negative spread. The new code found an error with pegged orders that failed repricing due to a margin short full producing an event with status REJECTED. The market depth code throws away REJECTED orders as it assumed they were not on the book. Now it checks if the order is there before throwing the REJECT message away