### PR TITLE
refactor: create step to verify one margin account per market

### DIFF
--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -86,7 +86,7 @@ func iExpectTheTradersToHaveNewGeneralAccount(arg1 *gherkin.DataTable) error {
 			continue
 		}
 
-		_, err := execsetup.broker.getTraderGeneralAccount(val(row, 0), val(row, 1))
+		_, err := execsetup.broker.GetTraderGeneralAccount(val(row, 0), val(row, 1))
 		if err != nil {
 			return fmt.Errorf("missing general account for trader=%v asset=%v", val(row, 0), val(row, 1))
 		}
@@ -98,7 +98,7 @@ func generalAccountsBalanceIs(arg1, arg2 string) error {
 	balance, _ := strconv.ParseUint(arg2, 10, 0)
 	for _, mkt := range execsetup.mkts {
 		asset, _ := mkt.GetAsset()
-		acc, err := execsetup.broker.getTraderGeneralAccount(arg1, asset)
+		acc, err := execsetup.broker.GetTraderGeneralAccount(arg1, asset)
 		if err != nil {
 			return err
 		}
@@ -128,25 +128,6 @@ func haveOnlyOneAccountPerAsset(arg1 string) error {
 	return nil
 }
 
-func haveOnlyOnMarginAccountPerMarket(arg1 string) error {
-	assets := map[string]struct{}{}
-
-	accs := execsetup.broker.GetAccounts()
-	data := make([]types.Account, 0, len(accs))
-	for _, a := range accs {
-		data = append(data, a.Account())
-	}
-	for _, acc := range data {
-		if acc.Owner == arg1 && acc.Type == types.AccountType_ACCOUNT_TYPE_MARGIN {
-			if _, ok := assets[acc.MarketId]; ok {
-				return fmt.Errorf("trader=%v have multiple account for market=%v", arg1, acc.MarketId)
-			}
-			assets[acc.MarketId] = struct{}{}
-		}
-	}
-	return nil
-}
-
 func theMakesADepositOfIntoTheAccount(trader, amountstr, asset string) error {
 	amount, _ := strconv.ParseUint(amountstr, 10, 0)
 	// row.0 = traderID, row.1 = amount to topup
@@ -159,7 +140,7 @@ func theMakesADepositOfIntoTheAccount(trader, amountstr, asset string) error {
 
 func generalAccountForAssetBalanceIs(trader, asset, balancestr string) error {
 	balance, _ := strconv.ParseUint(balancestr, 10, 0)
-	acc, err := execsetup.broker.getTraderGeneralAccount(trader, asset)
+	acc, err := execsetup.broker.GetTraderGeneralAccount(trader, asset)
 	if err != nil {
 		return err
 	}
@@ -286,7 +267,7 @@ func tradersCancelsTheFollowingFilledOrdersReference(refs *gherkin.DataTable) er
 			continue
 		}
 
-		o, err := execsetup.broker.getByReference(val(row, 0), val(row, 1))
+		o, err := execsetup.broker.GetByReference(val(row, 0), val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -311,7 +292,7 @@ func missingTradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) e
 			continue
 		}
 
-		o, err := execsetup.broker.getByReference(val(row, 0), val(row, 1))
+		o, err := execsetup.broker.GetByReference(val(row, 0), val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -336,7 +317,7 @@ func tradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			continue
 		}
 
-		o, err := execsetup.broker.getFirstByReference(val(row, 0), val(row, 1))
+		o, err := execsetup.broker.GetFirstByReference(val(row, 0), val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -364,7 +345,7 @@ func tradersCancelPeggedOrdersAndClear(data *gherkin.DataTable) error {
 			continue
 		}
 		mkt := val(row, 1)
-		orders := execsetup.broker.getOrdersByPartyAndMarket(trader, mkt)
+		orders := execsetup.broker.GetOrdersByPartyAndMarket(trader, mkt)
 		if len(orders) == 0 {
 			return fmt.Errorf("no orders found for party %s on market %s", trader, mkt)
 		}
@@ -403,7 +384,7 @@ func iExpectTheTraderToHaveAMargin(arg1 *gherkin.DataTable) error {
 			continue
 		}
 
-		generalAccount, err := execsetup.broker.getTraderGeneralAccount(val(row, 0), val(row, 1))
+		generalAccount, err := execsetup.broker.GetTraderGeneralAccount(val(row, 0), val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -413,7 +394,7 @@ func iExpectTheTraderToHaveAMargin(arg1 *gherkin.DataTable) error {
 		if generalAccount.GetBalance() != u64val(row, 4) {
 			hasError = true
 		}
-		marginAccount, err := execsetup.broker.getTraderMarginAccount(val(row, 0), val(row, 2))
+		marginAccount, err := execsetup.broker.GetTraderMarginAccount(val(row, 0), val(row, 2))
 		if err != nil {
 			return err
 		}
@@ -500,7 +481,7 @@ func theFollowingTransfersHappened(arg1 *gherkin.DataTable) error {
 
 func theSettlementAccountBalanceIsForTheMarketBeforeMTM(amountstr, market string) error {
 	amount, _ := strconv.ParseUint(amountstr, 10, 0)
-	acc, err := execsetup.broker.getMarketSettlementAccount(market)
+	acc, err := execsetup.broker.GetMarketSettlementAccount(market)
 	if err != nil {
 		return err
 	}
@@ -512,7 +493,7 @@ func theSettlementAccountBalanceIsForTheMarketBeforeMTM(amountstr, market string
 
 func theInsurancePoolBalanceIsForTheMarket(amountstr, market string) error {
 	amount, _ := strconv.ParseUint(amountstr, 10, 0)
-	acc, err := execsetup.broker.getMarketInsurancePoolAccount(market)
+	acc, err := execsetup.broker.GetMarketInsurancePoolAccount(market)
 	if err != nil {
 		return err
 	}
@@ -569,7 +550,7 @@ func theMarginsLevelsForTheTradersAre(traders *gherkin.DataTable) error {
 		}
 
 		partyID, marketID := val(row, 0), val(row, 1)
-		ml, err := execsetup.broker.getMarginByPartyAndMarket(partyID, marketID)
+		ml, err := execsetup.broker.GetMarginByPartyAndMarket(partyID, marketID)
 		if err != nil {
 			return err
 		}
@@ -751,7 +732,7 @@ func theFollowingNetworkTradesHappened(trades *gherkin.DataTable) error {
 		}
 		ok := false
 		party, side, volume := val(row, 0), sideval(row, 1), u64val(row, 2)
-		data := execsetup.broker.getTrades()
+		data := execsetup.broker.GetTrades()
 		for _, v := range data {
 			if (v.Buyer == party || v.Seller == party) && v.Aggressor == side && v.Size == volume {
 				ok = true
@@ -775,7 +756,7 @@ func theFollowingTradesHappened(trades *gherkin.DataTable) error {
 			continue
 		}
 		buyer, seller, price, volume := val(row, 0), val(row, 1), u64val(row, 2), u64val(row, 3)
-		data := execsetup.broker.getTrades()
+		data := execsetup.broker.GetTrades()
 		for _, v := range data {
 			if v.Buyer == buyer && v.Seller == seller && v.Price == price && v.Size == volume {
 				return nil
@@ -794,7 +775,7 @@ func tradersAmendsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 			continue
 		}
 
-		o, err := execsetup.broker.getByReference(val(row, 0), val(row, 1))
+		o, err := execsetup.broker.GetByReference(val(row, 0), val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -845,7 +826,7 @@ func verifyTheStatusOfTheOrderReference(refs *gherkin.DataTable) error {
 			continue
 		}
 
-		o, err := execsetup.broker.getByReference(trader, val(row, 1))
+		o, err := execsetup.broker.GetByReference(trader, val(row, 1))
 		if err != nil {
 			return err
 		}
@@ -916,7 +897,7 @@ func executedTrades(trades *gherkin.DataTable) error {
 			size := u64val(row, 2)
 			counterparty := val(row, 3)
 			var found = false
-			data := execsetup.broker.getTrades()
+			data := execsetup.broker.GetTrades()
 			for _, v := range data {
 				if v.Buyer == trader && v.Seller == counterparty && v.Price == price && v.Size == size {
 					found = true
@@ -946,7 +927,7 @@ func dumpOrders() error {
 
 func dumpTrades() error {
 	fmt.Println("DUMPING TRADES")
-	data := execsetup.broker.getTrades()
+	data := execsetup.broker.GetTrades()
 	for _, t := range data {
 		fmt.Printf("trade %s, %#v\n", t.Id, t)
 	}
@@ -1040,12 +1021,12 @@ func seeTheFollowingOrderEvents(evts *gherkin.DataTable) error {
 }
 
 func clearTransferEvents() error {
-	execsetup.broker.clearTransferEvents()
+	execsetup.broker.ClearTransferEvents()
 	return nil
 }
 
 func clearOrderEvents() error {
-	execsetup.broker.clearOrderEvents()
+	execsetup.broker.ClearOrderEvents()
 	return nil
 }
 
@@ -1056,7 +1037,7 @@ func clearOrdersByRef(in *gherkin.DataTable) error {
 			continue
 		}
 		ref := val(row, 1)
-		if err := execsetup.broker.clearOrderByReference(trader, ref); err != nil {
+		if err := execsetup.broker.ClearOrderByReference(trader, ref); err != nil {
 			return err
 		}
 	}
@@ -1148,10 +1129,10 @@ func theOpeningAuctionPeriodEnds(mktName string) error {
 		return fmt.Errorf("market %s not found", mktName)
 	}
 	// double the time, so it's definitely past opening auction time
-	now := execsetup.timesvc.now.Add(time.Duration(mkt.OpeningAuction.Duration*2) * time.Second)
-	execsetup.timesvc.now = now
+	now := execsetup.timesvc.Now.Add(time.Duration(mkt.OpeningAuction.Duration*2) * time.Second)
+	execsetup.timesvc.Now = now
 	// notify markets
-	execsetup.timesvc.notify(context.Background(), now)
+	execsetup.timesvc.Notify(context.Background(), now)
 	return nil
 }
 

--- a/integration/features/building_trader_accounts.feature
+++ b/integration/features/building_trader_accounts.feature
@@ -20,7 +20,7 @@ Feature: Test trader accounts
       | trader1 | VUSD  |
     And "trader1" general accounts balance is "100"
     And "trader1" have only one account per asset
-    And "trader1" have only on margin account per market
+    And "trader1" have only one margin account per market
 
   Scenario: a trader deposit collateral onto Vega. The general account for this asset increase
     Given the following traders:

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -55,7 +55,9 @@ func FeatureContext(s *godog.Suite) {
 		}
 	})
 
-	s.Step(`^"([^"]*)" have only on margin account per market$`, haveOnlyOnMarginAccountPerMarket)
+	s.Step(`^"([^"]*)" have only one margin account per market$`, func(owner string) error {
+		return steps.HaveOnlyOneMarginAccountPerMarket(execsetup.broker, owner)
+	})
 	s.Step(`^The "([^"]*)" withdraw "([^"]*)" from the "([^"]*)" account$`, theWithdrawFromTheAccount)
 	s.Step(`^The "([^"]*)" makes a deposit of "([^"]*)" into the "([^"]*)" account$`, theMakesADepositOfIntoTheAccount)
 	s.Step(`^"([^"]*)" general account for asset "([^"]*)" balance is "([^"]*)"$`, generalAccountForAssetBalanceIs)

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -8,6 +8,7 @@ import (
 
 	"code.vegaprotocol.io/vega/collateral"
 	"code.vegaprotocol.io/vega/execution"
+	"code.vegaprotocol.io/vega/integration/stubs"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/oracles"
 	"code.vegaprotocol.io/vega/plugins"
@@ -49,13 +50,13 @@ type executionTestSetup struct {
 	cfg          execution.Config
 	log          *logging.Logger
 	ctrl         *gomock.Controller
-	timesvc      *timeStub
+	timesvc      *stubs.TimeStub
 	collateral   *collateral.Engine
 	oracleEngine *oracles.Engine
 
 	positionPlugin *plugins.Positions
 
-	broker *brokerStub
+	broker *stubs.BrokerStub
 
 	// save trader accounts state
 	accs map[string][]account
@@ -86,8 +87,8 @@ func getExecutionTestSetup(startTime time.Time, mkts []types.Market) *executionT
 	execsetup.log = logging.NewTestLogger()
 	execsetup.accs = map[string][]account{}
 	execsetup.mkts = mkts
-	execsetup.timesvc = &timeStub{now: startTime}
-	execsetup.broker = NewBrokerStub()
+	execsetup.timesvc = &stubs.TimeStub{Now: startTime}
+	execsetup.broker = stubs.NewBrokerStub()
 	currentTime := time.Now()
 	execsetup.collateral, _ = collateral.New(
 		execsetup.log, collateral.NewDefaultConfig(), execsetup.broker, currentTime,

--- a/integration/steps/have_only_on_margin_account_per_market.go
+++ b/integration/steps/have_only_on_margin_account_per_market.go
@@ -1,0 +1,27 @@
+package steps
+
+import (
+	"fmt"
+
+	"code.vegaprotocol.io/vega/integration/stubs"
+	types "code.vegaprotocol.io/vega/proto"
+)
+
+func HaveOnlyOneMarginAccountPerMarket(broker *stubs.BrokerStub, owner string) error {
+	assets := map[string]struct{}{}
+
+	accs := broker.GetAccounts()
+	data := make([]types.Account, 0, len(accs))
+	for _, a := range accs {
+		data = append(data, a.Account())
+	}
+	for _, acc := range data {
+		if acc.Owner == owner && acc.Type == types.AccountType_ACCOUNT_TYPE_MARGIN {
+			if _, ok := assets[acc.MarketId]; ok {
+				return fmt.Errorf("trader=%v have multiple account for market=%v", owner, acc.MarketId)
+			}
+			assets[acc.MarketId] = struct{}{}
+		}
+	}
+	return nil
+}

--- a/integration/stubs/broker_stub.go
+++ b/integration/stubs/broker_stub.go
@@ -1,11 +1,9 @@
 package stubs
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"code.vegaprotocol.io/vega/broker"
 	"code.vegaprotocol.io/vega/events"
@@ -103,7 +101,6 @@ func (b *BrokerStub) GetBatch(t events.Type) []events.Event {
 	return r
 }
 
-// utility func:
 func (b *BrokerStub) GetTransferResponses() []events.TransferResponse {
 	batch := b.GetBatch(events.TransferResponses)
 	if len(batch) == 0 {
@@ -286,7 +283,7 @@ func (b *BrokerStub) GetMarketSettlementAccount(market string) (types.Account, e
 	return types.Account{}, errors.New("account does not exist")
 }
 
-// returns the latest event WRT the trader's general account
+// GetTraderGeneralAccount returns the latest event WRT the trader's general account
 func (b *BrokerStub) GetTraderGeneralAccount(trader, asset string) (ga types.Account, err error) {
 	batch := b.GetAccounts()
 	err = errors.New("account does not exist")
@@ -347,7 +344,7 @@ func (b *BrokerStub) GetByReference(party, ref string) (types.Order, error) {
 			matched = true
 		}
 	}
-	if matched == true {
+	if matched {
 		return last, nil
 	}
 	return types.Order{}, fmt.Errorf("no order for party %v and referrence %v", party, ref)
@@ -367,59 +364,3 @@ func (b *BrokerStub) ResetType(t events.Type) {
 	b.data[t] = []events.Event{}
 	b.mu.Unlock()
 }
-
-func (b *BrokerStub) Reset() {
-	b.mu.Lock()
-	b.data = map[events.Type][]events.Event{}
-	b.mu.Unlock()
-}
-
-type TimeStub struct {
-	Now    time.Time
-	Notify func(context.Context, time.Time)
-}
-
-func (t *TimeStub) GetTimeNow() (time.Time, error) {
-	return t.Now, nil
-}
-
-func (t *TimeStub) SetTime(newNow time.Time) {
-	t.Now = newNow
-	t.Notify(context.Background(), t.Now)
-}
-
-func (t *TimeStub) NotifyOnTick(f func(context.Context, time.Time)) {
-	t.Notify = f
-}
-
-type ProposalStub struct {
-	data []types.Proposal
-}
-
-func NewProposalStub() *ProposalStub {
-	return &ProposalStub{
-		data: []types.Proposal{},
-	}
-}
-
-func (p *ProposalStub) Add(v types.Proposal) {
-	p.data = append(p.data, v)
-}
-
-func (p *ProposalStub) Flush() {}
-
-type VoteStub struct {
-	data []types.Vote
-}
-
-func NewVoteStub() *VoteStub {
-	return &VoteStub{
-		data: []types.Vote{},
-	}
-}
-
-func (v *VoteStub) Add(vote types.Vote) {
-	v.data = append(v.data, vote)
-}
-
-func (v *VoteStub) Flush() {}

--- a/integration/stubs/broker_stub_test.go
+++ b/integration/stubs/broker_stub_test.go
@@ -1,4 +1,4 @@
-package core_test
+package stubs
 
 import (
 	"context"
@@ -12,20 +12,20 @@ import (
 	types "code.vegaprotocol.io/vega/proto"
 )
 
-type brokerStub struct {
+type BrokerStub struct {
 	mu   sync.Mutex
 	data map[events.Type][]events.Event
 	subT map[events.Type][]broker.Subscriber
 }
 
-func NewBrokerStub() *brokerStub {
-	return &brokerStub{
+func NewBrokerStub() *BrokerStub {
+	return &BrokerStub{
 		data: map[events.Type][]events.Event{},
 		subT: map[events.Type][]broker.Subscriber{},
 	}
 }
 
-func (b *brokerStub) Subscribe(sub broker.Subscriber) {
+func (b *BrokerStub) Subscribe(sub broker.Subscriber) {
 	b.mu.Lock()
 	types := sub.Types()
 	for _, t := range types {
@@ -37,7 +37,7 @@ func (b *brokerStub) Subscribe(sub broker.Subscriber) {
 	b.mu.Unlock()
 }
 
-func (b *brokerStub) SendBatch(evts []events.Event) {
+func (b *BrokerStub) SendBatch(evts []events.Event) {
 	if len(evts) == 0 {
 		return
 	}
@@ -68,7 +68,7 @@ func (b *brokerStub) SendBatch(evts []events.Event) {
 	b.mu.Unlock()
 }
 
-func (b *brokerStub) Send(e events.Event) {
+func (b *BrokerStub) Send(e events.Event) {
 	b.mu.Lock()
 	t := e.Type()
 	if subs, ok := b.subT[t]; ok {
@@ -96,7 +96,7 @@ func (b *brokerStub) Send(e events.Event) {
 	b.mu.Unlock()
 }
 
-func (b *brokerStub) GetBatch(t events.Type) []events.Event {
+func (b *BrokerStub) GetBatch(t events.Type) []events.Event {
 	b.mu.Lock()
 	r := b.data[t]
 	b.mu.Unlock()
@@ -104,7 +104,7 @@ func (b *brokerStub) GetBatch(t events.Type) []events.Event {
 }
 
 // utility func:
-func (b *brokerStub) GetTransferResponses() []events.TransferResponse {
+func (b *BrokerStub) GetTransferResponses() []events.TransferResponse {
 	batch := b.GetBatch(events.TransferResponses)
 	if len(batch) == 0 {
 		return nil
@@ -123,7 +123,7 @@ func (b *brokerStub) GetTransferResponses() []events.TransferResponse {
 	return ret
 }
 
-func (b *brokerStub) clearTransferEvents() {
+func (b *BrokerStub) ClearTransferEvents() {
 	t := events.TransferResponses
 	b.mu.Lock()
 	r := b.data[t]
@@ -131,7 +131,7 @@ func (b *brokerStub) clearTransferEvents() {
 	b.mu.Unlock()
 }
 
-func (b *brokerStub) clearOrderEvents() {
+func (b *BrokerStub) ClearOrderEvents() {
 	t := events.OrderEvent
 	b.mu.Lock()
 	r := b.data[t]
@@ -140,7 +140,7 @@ func (b *brokerStub) clearOrderEvents() {
 	b.mu.Unlock()
 }
 
-func (b *brokerStub) getOrdersByPartyAndMarket(party, market string) []types.Order {
+func (b *BrokerStub) GetOrdersByPartyAndMarket(party, market string) []types.Order {
 	orders := b.GetOrderEvents()
 	ret := []types.Order{}
 	for _, oe := range orders {
@@ -151,7 +151,7 @@ func (b *brokerStub) getOrdersByPartyAndMarket(party, market string) []types.Ord
 	return ret
 }
 
-func (b *brokerStub) GetOrderEvents() []events.Order {
+func (b *BrokerStub) GetOrderEvents() []events.Order {
 	batch := b.GetBatch(events.OrderEvent)
 	if len(batch) == 0 {
 		return nil
@@ -168,7 +168,7 @@ func (b *brokerStub) GetOrderEvents() []events.Order {
 	return ret
 }
 
-func (b *brokerStub) GetLPEvents() []events.LiquidityProvision {
+func (b *BrokerStub) GetLPEvents() []events.LiquidityProvision {
 	batch := b.GetBatch(events.LiquidityProvisionEvent)
 	if len(batch) == 0 {
 		return nil
@@ -185,7 +185,7 @@ func (b *brokerStub) GetLPEvents() []events.LiquidityProvision {
 	return ret
 }
 
-func (b *brokerStub) GetTradeEvents() []events.Trade {
+func (b *BrokerStub) GetTradeEvents() []events.Trade {
 	batch := b.GetBatch(events.TradeEvent)
 	if len(batch) == 0 {
 		return nil
@@ -202,7 +202,7 @@ func (b *brokerStub) GetTradeEvents() []events.Trade {
 	return ret
 }
 
-func (b *brokerStub) GetAccounts() []events.Acc {
+func (b *BrokerStub) GetAccounts() []events.Acc {
 	batch := b.GetBatch(events.AccountEvent)
 	if len(batch) == 0 {
 		return nil
@@ -223,7 +223,7 @@ func (b *brokerStub) GetAccounts() []events.Acc {
 	return s
 }
 
-func (b *brokerStub) getMarginByPartyAndMarket(partyID, marketID string) (types.MarginLevels, error) {
+func (b *BrokerStub) GetMarginByPartyAndMarket(partyID, marketID string) (types.MarginLevels, error) {
 	batch := b.GetBatch(events.MarginLevelsEvent)
 	mapped := map[string]map[string]types.MarginLevels{}
 	for _, e := range batch {
@@ -253,7 +253,7 @@ func (b *brokerStub) getMarginByPartyAndMarket(partyID, marketID string) (types.
 	return ml, nil
 }
 
-func (b *brokerStub) getMarketInsurancePoolAccount(market string) (types.Account, error) {
+func (b *BrokerStub) GetMarketInsurancePoolAccount(market string) (types.Account, error) {
 	batch := b.GetAccounts()
 	for _, e := range batch {
 		v := e.Account()
@@ -264,7 +264,7 @@ func (b *brokerStub) getMarketInsurancePoolAccount(market string) (types.Account
 	return types.Account{}, errors.New("account does not exist")
 }
 
-func (b *brokerStub) getTraderMarginAccount(trader, market string) (types.Account, error) {
+func (b *BrokerStub) GetTraderMarginAccount(trader, market string) (types.Account, error) {
 	batch := b.GetAccounts()
 	for _, e := range batch {
 		v := e.Account()
@@ -275,7 +275,7 @@ func (b *brokerStub) getTraderMarginAccount(trader, market string) (types.Accoun
 	return types.Account{}, errors.New("account does not exist")
 }
 
-func (b *brokerStub) getMarketSettlementAccount(market string) (types.Account, error) {
+func (b *BrokerStub) GetMarketSettlementAccount(market string) (types.Account, error) {
 	batch := b.GetAccounts()
 	for _, e := range batch {
 		v := e.Account()
@@ -287,7 +287,7 @@ func (b *brokerStub) getMarketSettlementAccount(market string) (types.Account, e
 }
 
 // returns the latest event WRT the trader's general account
-func (b *brokerStub) getTraderGeneralAccount(trader, asset string) (ga types.Account, err error) {
+func (b *BrokerStub) GetTraderGeneralAccount(trader, asset string) (ga types.Account, err error) {
 	batch := b.GetAccounts()
 	err = errors.New("account does not exist")
 	for _, e := range batch {
@@ -301,7 +301,7 @@ func (b *brokerStub) getTraderGeneralAccount(trader, asset string) (ga types.Acc
 	return
 }
 
-func (b *brokerStub) clearOrderByReference(party, ref string) error {
+func (b *BrokerStub) ClearOrderByReference(party, ref string) error {
 	b.mu.Lock()
 	data := b.data[events.OrderEvent]
 	cleared := make([]events.Event, 0, cap(data))
@@ -324,7 +324,7 @@ func (b *brokerStub) clearOrderByReference(party, ref string) error {
 	return nil
 }
 
-func (b *brokerStub) getFirstByReference(party, ref string) (types.Order, error) {
+func (b *BrokerStub) GetFirstByReference(party, ref string) (types.Order, error) {
 	data := b.GetOrderEvents()
 	for _, o := range data {
 		v := o.Order()
@@ -335,7 +335,7 @@ func (b *brokerStub) getFirstByReference(party, ref string) (types.Order, error)
 	return types.Order{}, fmt.Errorf("no order for party %v and referrence %v", party, ref)
 }
 
-func (b *brokerStub) getByReference(party, ref string) (types.Order, error) {
+func (b *BrokerStub) GetByReference(party, ref string) (types.Order, error) {
 	data := b.GetOrderEvents()
 
 	var last types.Order // we need the most recent event, the order object is not updated (copy v pointer, issue 2353)
@@ -353,7 +353,7 @@ func (b *brokerStub) getByReference(party, ref string) (types.Order, error) {
 	return types.Order{}, fmt.Errorf("no order for party %v and referrence %v", party, ref)
 }
 
-func (b *brokerStub) getTrades() []types.Trade {
+func (b *BrokerStub) GetTrades() []types.Trade {
 	data := b.GetTradeEvents()
 	trades := make([]types.Trade, 0, len(data))
 	for _, t := range data {
@@ -362,34 +362,34 @@ func (b *brokerStub) getTrades() []types.Trade {
 	return trades
 }
 
-func (b *brokerStub) ResetType(t events.Type) {
+func (b *BrokerStub) ResetType(t events.Type) {
 	b.mu.Lock()
 	b.data[t] = []events.Event{}
 	b.mu.Unlock()
 }
 
-func (b *brokerStub) Reset() {
+func (b *BrokerStub) Reset() {
 	b.mu.Lock()
 	b.data = map[events.Type][]events.Event{}
 	b.mu.Unlock()
 }
 
-type timeStub struct {
-	now    time.Time
-	notify func(context.Context, time.Time)
+type TimeStub struct {
+	Now    time.Time
+	Notify func(context.Context, time.Time)
 }
 
-func (t *timeStub) GetTimeNow() (time.Time, error) {
-	return t.now, nil
+func (t *TimeStub) GetTimeNow() (time.Time, error) {
+	return t.Now, nil
 }
 
-func (t *timeStub) SetTime(newNow time.Time) {
-	t.now = newNow
-	t.notify(context.Background(), t.now)
+func (t *TimeStub) SetTime(newNow time.Time) {
+	t.Now = newNow
+	t.Notify(context.Background(), t.Now)
 }
 
-func (t *timeStub) NotifyOnTick(f func(context.Context, time.Time)) {
-	t.notify = f
+func (t *TimeStub) NotifyOnTick(f func(context.Context, time.Time)) {
+	t.Notify = f
 }
 
 type ProposalStub struct {

--- a/integration/stubs/proposal_stub.go
+++ b/integration/stubs/proposal_stub.go
@@ -1,0 +1,19 @@
+package stubs
+
+import types "code.vegaprotocol.io/vega/proto"
+
+type ProposalStub struct {
+	data []types.Proposal
+}
+
+func NewProposalStub() *ProposalStub {
+	return &ProposalStub{
+		data: []types.Proposal{},
+	}
+}
+
+func (p *ProposalStub) Add(v types.Proposal) {
+	p.data = append(p.data, v)
+}
+
+func (p *ProposalStub) Flush() {}

--- a/integration/stubs/time_stub.go
+++ b/integration/stubs/time_stub.go
@@ -1,0 +1,24 @@
+package stubs
+
+import (
+	"context"
+	"time"
+)
+
+type TimeStub struct {
+	Now    time.Time
+	Notify func(context.Context, time.Time)
+}
+
+func (t *TimeStub) GetTimeNow() (time.Time, error) {
+	return t.Now, nil
+}
+
+func (t *TimeStub) SetTime(newNow time.Time) {
+	t.Now = newNow
+	t.Notify(context.Background(), t.Now)
+}
+
+func (t *TimeStub) NotifyOnTick(f func(context.Context, time.Time)) {
+	t.Notify = f
+}

--- a/integration/stubs/vote_stub.go
+++ b/integration/stubs/vote_stub.go
@@ -1,0 +1,28 @@
+package stubs
+
+import (
+	"code.vegaprotocol.io/vega/events"
+	types "code.vegaprotocol.io/vega/proto"
+)
+
+func (b *BrokerStub) Reset() {
+	b.mu.Lock()
+	b.data = map[events.Type][]events.Event{}
+	b.mu.Unlock()
+}
+
+type VoteStub struct {
+	data []types.Vote
+}
+
+func NewVoteStub() *VoteStub {
+	return &VoteStub{
+		data: []types.Vote{},
+	}
+}
+
+func (v *VoteStub) Add(vote types.Vote) {
+	v.data = append(v.data, vote)
+}
+
+func (v *VoteStub) Flush() {}


### PR DESCRIPTION
Create step for ^"([^"]*)" have only on margin account per market$

This change moves the broker stub out to its own package to avoid a cyclic dependency. This may require further refactoring to tidy up.


Fixes #3132