### PR TITLE
Various steps cleanups

### DIFF
--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -342,18 +342,6 @@ func theFollowingTransfersHappened(arg1 *gherkin.DataTable) error {
 	return nil
 }
 
-func theInsurancePoolBalanceIsForTheMarket(amountstr, market string) error {
-	amount, _ := strconv.ParseUint(amountstr, 10, 0)
-	acc, err := execsetup.broker.GetMarketInsurancePoolAccount(market)
-	if err != nil {
-		return err
-	}
-	if amount != acc.Balance {
-		return fmt.Errorf("invalid balance for market insurance pool, expected %v, got %v", amount, acc.Balance)
-	}
-	return nil
-}
-
 func theTimeIsUpdatedTo(newTime string) error {
 	t, err := time.Parse("2006-01-02T15:04:05Z", newTime)
 	if err != nil {

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -103,52 +103,6 @@ func missingTradersPlaceFollowingOrdersWithReferences(orders *gherkin.DataTable)
 	return nil
 }
 
-func tradersPlaceFollowingOrdersWithReferences(orders *gherkin.DataTable) error {
-	for _, row := range orders.Rows {
-		if val(row, 0) == "trader" {
-			continue
-		}
-
-		oty, err := ordertypeval(row, 6)
-		if err != nil {
-			return err
-		}
-		tif, err := tifval(row, 7)
-		if err != nil {
-			return err
-		}
-
-		var expiresAt int64
-		if oty != types.Order_TYPE_MARKET {
-			expiresAt = time.Now().Add(24 * time.Hour).UnixNano()
-		}
-
-		order := types.Order{
-			Status:      types.Order_STATUS_ACTIVE,
-			Id:          uuid.NewV4().String(),
-			MarketId:    val(row, 1),
-			PartyId:     val(row, 0),
-			Side:        sideval(row, 2),
-			Price:       u64val(row, 4),
-			Size:        u64val(row, 3),
-			Remaining:   u64val(row, 3),
-			ExpiresAt:   expiresAt,
-			Type:        oty,
-			TimeInForce: tif,
-			CreatedAt:   time.Now().UnixNano(),
-			Reference:   val(row, 8),
-		}
-		result, err := execsetup.engine.SubmitOrder(context.Background(), &order)
-		if err != nil {
-			return fmt.Errorf("err(%v), trader(%v), ref(%v)", err, order.PartyId, order.Reference)
-		}
-		if int64(len(result.Trades)) != i64val(row, 5) {
-			return fmt.Errorf("expected %d trades, instead saw %d (%#v)", i64val(row, 5), len(result.Trades), *result)
-		}
-	}
-	return nil
-}
-
 func missingTradersCancelsTheFollowingOrdersReference(refs *gherkin.DataTable) error {
 	for _, row := range refs.Rows {
 		if val(row, 0) == "trader" {

--- a/integration/execution_layer_test.go
+++ b/integration/execution_layer_test.go
@@ -539,24 +539,6 @@ func positionAPIProduceTheFollowing(table *gherkin.DataTable) error {
 	return nil
 }
 
-func theMarkPriceForTheMarketIs(market, markPriceStr string) error {
-	markPrice, err := strconv.ParseUint(markPriceStr, 10, 0)
-	if err != nil {
-		return fmt.Errorf("markPrice is not a integer: markPrice(%v), err(%v)", markPriceStr, err)
-	}
-
-	mktdata, err := execsetup.engine.GetMarketData(market)
-	if err != nil {
-		return fmt.Errorf("unable to get mark price for market(%v), err(%v)", markPriceStr, err)
-	}
-
-	if mktdata.MarkPrice != markPrice {
-		return fmt.Errorf("mark price if wrong for market(%v), expected(%v) got(%v)", market, markPrice, mktdata.MarkPrice)
-	}
-
-	return nil
-}
-
 func theMarketTradingModeIs(market, marketTradingModeStr string) error {
 	ms, ok := types.Market_TradingMode_value[marketTradingModeStr]
 	if !ok {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -101,7 +101,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the margins levels for the traders are:$`, theMarginsLevelsForTheTradersAre)
 	s.Step(`^traders place following failing orders:$`, tradersPlaceFollowingFailingOrders)
 	s.Step(`^the following orders are rejected:$`, theFollowingOrdersAreRejected)
-	s.Step(`^traders place following orders with references:$`, tradersPlaceFollowingOrdersWithReferences)
+	s.Step(`^traders place following orders with references:$`, func(table *gherkin.DataTable) error {
+		return steps.TradersPlaceFollowingOrdersWithReferences(execsetup.engine, table)
+	})
 	s.Step(`^missing traders place following orders with references:$`, missingTradersPlaceFollowingOrdersWithReferences)
 	s.Step(`^traders cancels the following orders reference:$`, tradersCancelsTheFollowingOrdersReference)
 	s.Step(`^traders cancels the following filled orders reference:$`, func(table *gherkin.DataTable) error {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -92,7 +92,9 @@ func FeatureContext(s *godog.Suite) {
 		return steps.SettlementAccountBalanceIsForMarket(execsetup.broker, amountStr, market)
 	})
 	s.Step(`^the insurance pool initial balance for the markets is "([^"]*)":$`, theInsurancePoolInitialBalanceForTheMarketsIs)
-	s.Step(`^the insurance pool balance is "([^"]*)" for the market "([^"]*)"$`, theInsurancePoolBalanceIsForTheMarket)
+	s.Step(`^the insurance pool balance is "([^"]*)" for the market "([^"]*)"$`, func(amountStr, market string) error {
+		return steps.TheInsurancePoolBalanceIsForTheMarket(execsetup.broker, amountStr, market)
+	})
 	s.Step(`^the markets starts on "([^"]*)" and expires on "([^"]*)"$`, theMarketsStartsOnAndExpiresOn)
 	s.Step(`^the time is updated to "([^"]*)"$`, theTimeIsUpdatedTo)
 	s.Step(`^traders cannot place the following orders anymore:$`, tradersCannotPlaceTheFollowingOrdersAnymore)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -108,7 +108,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^missing traders cancels the following orders reference:$`, missingTradersCancelsTheFollowingOrdersReference)
 	s.Step(`^position API produce the following:$`, positionAPIProduceTheFollowing)
 	s.Step(`^dump transfers$`, dumpTransfers)
-	s.Step(`^the mark price for the market "([^"]*)" is "([^"]*)"$`, theMarkPriceForTheMarketIs)
+	s.Step(`^the mark price for the market "([^"]*)" is "([^"]*)"$`, func(market, markPriceStr string) error {
+		return steps.TheMarkPriceForTheMarketIs(execsetup.engine, market, markPriceStr)
+	})
 	s.Step(`^the market trading mode for the market "([^"]*)" is "([^"]*)"$`, theMarketTradingModeIs)
 	s.Step(`^the following network trades happened:$`, theFollowingNetworkTradesHappened)
 	s.Step(`^traders amends the following orders reference:$`, tradersAmendsTheFollowingOrdersReference)

--- a/integration/steps/the_insurance_balance_is_for_the_market.go
+++ b/integration/steps/the_insurance_balance_is_for_the_market.go
@@ -1,0 +1,30 @@
+package steps
+
+import (
+	"fmt"
+	"strconv"
+
+	types "code.vegaprotocol.io/vega/proto"
+)
+
+func TheInsurancePoolBalanceIsForTheMarket(
+	broker interface {
+		GetMarketInsurancePoolAccount(string) (types.Account, error)
+	},
+	amountstr, market string,
+) error {
+
+	amount, err := strconv.ParseUint(amountstr, 10, 0)
+	panicW(err)
+	acc, err := broker.GetMarketInsurancePoolAccount(market)
+	if err != nil {
+		return err
+	}
+	if amount != acc.Balance {
+		return fmt.Errorf(
+			"invalid balance for market insurance pool, expected %v, got %v",
+			amount, acc.Balance,
+		)
+	}
+	return nil
+}

--- a/integration/steps/the_mark_price_for_the_market_is.go
+++ b/integration/steps/the_mark_price_for_the_market_is.go
@@ -1,0 +1,29 @@
+package steps
+
+import (
+	"fmt"
+	"strconv"
+
+	"code.vegaprotocol.io/vega/execution"
+)
+
+func TheMarkPriceForTheMarketIs(
+	exec *execution.Engine,
+	market, markPriceStr string,
+) error {
+	markPrice, err := strconv.ParseUint(markPriceStr, 10, 0)
+	if err != nil {
+		return fmt.Errorf("markPrice is not a integer: markPrice(%v), err(%v)", markPriceStr, err)
+	}
+
+	mktdata, err := exec.GetMarketData(market)
+	if err != nil {
+		return fmt.Errorf("unable to get mark price for market(%v), err(%v)", markPriceStr, err)
+	}
+
+	if mktdata.MarkPrice != markPrice {
+		return fmt.Errorf("mark price if wrong for market(%v), expected(%v) got(%v)", market, markPrice, mktdata.MarkPrice)
+	}
+
+	return nil
+}

--- a/integration/steps/traders_place_following_orders_with_references.go
+++ b/integration/steps/traders_place_following_orders_with_references.go
@@ -1,0 +1,65 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"code.vegaprotocol.io/vega/execution"
+	types "code.vegaprotocol.io/vega/proto"
+	"github.com/cucumber/godog/gherkin"
+	uuid "github.com/satori/go.uuid"
+)
+
+func TradersPlaceFollowingOrdersWithReferences(
+	exec *execution.Engine,
+	table *gherkin.DataTable,
+) error {
+	for _, row := range TableWrapper(*table).Parse() {
+		oty, err := row.OrderType("type")
+		panicW(err)
+		tif, err := row.TIF("tif")
+		panicW(err)
+		side, err := row.Side("side")
+		panicW(err)
+		price, err := row.U64("price")
+		panicW(err)
+		volume, err := row.U64("volume")
+		panicW(err)
+
+		var expiresAt int64
+		if oty != types.Order_TYPE_MARKET {
+			expiresAt = time.Now().Add(24 * time.Hour).UnixNano()
+		}
+
+		order := types.Order{
+			Status:      types.Order_STATUS_ACTIVE,
+			Id:          uuid.NewV4().String(),
+			MarketId:    row.Str("market id"),
+			PartyId:     row.Str("trader"),
+			Side:        side,
+			Price:       price,
+			Size:        volume,
+			Remaining:   volume,
+			ExpiresAt:   expiresAt,
+			Type:        oty,
+			TimeInForce: tif,
+			CreatedAt:   time.Now().UnixNano(),
+			Reference:   row.Str("reference"),
+		}
+		result, err := exec.SubmitOrder(context.Background(), &order)
+		if err != nil {
+			return fmt.Errorf("err(%v), trader(%v), ref(%v)",
+				err, order.PartyId, order.Reference)
+		}
+		resultingTrades, err := row.U64("resulting trades")
+		panicW(err)
+		if len(result.Trades) != int(resultingTrades) {
+			return fmt.Errorf(
+				"expected %d trades, instead saw %d (%#v)",
+				resultingTrades, len(result.Trades), *result,
+			)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This cleans the following steps:

- ^the mark price for the market "([^"]*)" is "([^"]*)"$
- ^the insurance pool balance is "([^"]*)" for the market "([^"]*)"$
- ^traders place following orders with references:$