### PR TITLE
ensure liquidity provisions are process in a deterministic way

### DIFF
--- a/liquidity/types.go
+++ b/liquidity/types.go
@@ -45,7 +45,7 @@ func (l LiquidityProvisions) sortByFee() LiquidityProvisions {
 	return LiquidityProvisions(byFee)
 }
 
-// Provisions is a map of partys to *types.LiquidityProvision
+// Provisions is a map of parties to *types.LiquidityProvision
 type ProvisionsPerParty map[string]*types.LiquidityProvision
 
 // slice returns the parties as a slice.
@@ -54,6 +54,8 @@ func (l ProvisionsPerParty) slice() LiquidityProvisions {
 	for _, p := range l {
 		slice = append(slice, p)
 	}
+	// sorting by partyId to ensure any processing in a deterministic manner later on
+	sort.Slice(slice, func(i, j int) bool { return slice[i].PartyId < slice[j].PartyId })
 	return slice
 }
 
@@ -74,11 +76,28 @@ func (l ProvisionsPerParty) TotalStake() uint64 {
 // Orders provides convenience functions to a slice of *veaga/proto.Orders.
 type Orders []*types.Order
 
+type PartyOrders struct {
+	Party  string
+	Orders []*types.Order
+}
+
 // ByParty returns the orders grouped by it's PartyID
-func (ords Orders) ByParty() map[string][]*types.Order {
+func (ords Orders) ByParty() []PartyOrders {
+	// first extract all orders, per party
 	parties := map[string][]*types.Order{}
 	for _, order := range ords {
 		parties[order.PartyId] = append(parties[order.PartyId], order)
 	}
-	return parties
+
+	// now, move stuff from the map, into the PartyOrders type, and sort it
+	partyOrders := make([]PartyOrders, 0, len(parties))
+	for k, v := range parties {
+		partyOrders = append(partyOrders, PartyOrders{k, v})
+	}
+
+	// now sort them to guaranty deterministic
+	sort.Slice(partyOrders, func(i, j int) bool {
+		return partyOrders[i].Party < partyOrders[j].Party
+	})
+	return partyOrders
 }


### PR DESCRIPTION
This ensure that iterations done in the liquidity engine are always deterministic.

may close the issue for the devnet crash: #3112