### PR TITLE
add endpoint to sign abitrary data

### DIFF
--- a/wallet/handler.go
+++ b/wallet/handler.go
@@ -195,6 +195,54 @@ func (h *Handler) ListPublicKeys(token string) ([]Keypair, error) {
 	return out, nil
 }
 
+func (h *Handler) SignAny(token, inputData, pubkey string) ([]byte, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	// first the transaction would be in base64, let's decode
+	rawInputData, err := base64.StdEncoding.DecodeString(inputData)
+	if err != nil {
+		return nil, err
+	}
+
+	// then get the wallet name out of the token
+	wname, err := h.auth.VerifyToken(token)
+	if err != nil {
+		return nil, err
+	}
+
+	w, ok := h.store[wname]
+	if !ok {
+		// this should never happen as we cannot have a valid session
+		// without the actual wallet being loaded in memory but...
+		return nil, ErrWalletDoesNotExists
+	}
+
+	// let's retrieve the private key from the public key
+	var kp *Keypair
+	for i := range w.Keypairs {
+		if w.Keypairs[i].Pub == pubkey {
+			kp = &w.Keypairs[i]
+			break
+		}
+	}
+	// we did not find this pub key
+	if kp == nil {
+		return nil, ErrPubKeyDoesNotExist
+	}
+
+	if kp.Tainted {
+		return nil, ErrPubKeyIsTainted
+	}
+
+	// then lets sign the stuff and return it
+	signature, err := kp.Algorithm.Sign(kp.privBytes, rawInputData)
+	if err != nil {
+		return nil, err
+	}
+	return signature, nil
+}
+
 func (h *Handler) SignTx(token, tx, pubkey string) (SignedBundle, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/wallet/handler_test.go
+++ b/wallet/handler_test.go
@@ -55,6 +55,7 @@ func TestHandler(t *testing.T) {
 	t.Run("get public key failure - wallet not found", testGetPubWalletNotFound)
 	t.Run("get public key failure - invalid token", testGetPubInvalidToken)
 	t.Run("get public key failure - key not found", testGetPubKeyNotFound)
+	t.Run("sign any - success", testSignAnySuccess)
 	t.Run("sign tx - success", testSignTxSuccess)
 	t.Run("sign tx - failure key tainted", testSignTxFailure)
 	t.Run("taint key - success", testTaintKeySuccess)
@@ -377,6 +378,45 @@ func testSignTxSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	v, err := alg.Verify(keyBytes, signedBundle.Tx, signedBundle.Sig.Sig)
+	assert.NoError(t, err)
+	assert.True(t, v)
+
+	assert.NoError(t, os.RemoveAll(h.rootDir))
+}
+
+func testSignAnySuccess(t *testing.T) {
+	h := getTestHandler(t)
+	defer h.ctrl.Finish()
+
+	// then start the test
+	h.auth.EXPECT().VerifyToken(gomock.Any()).AnyTimes().
+		Return("jeremy", nil)
+
+	// first create the wallet
+	h.auth.EXPECT().NewSession(gomock.Any()).Times(1).
+		Return("some fake token", nil)
+
+	tok, err := h.CreateWallet("jeremy", "Th1isisasecurep@ssphraseinnit")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tok)
+
+	key, err := h.GenerateKeypair(tok, "Th1isisasecurep@ssphraseinnit")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, key)
+
+	message := "@myTwitterHandle"
+
+	keyBytes, _ := hex.DecodeString(key)
+
+	signature, err := h.SignAny(
+		tok, base64.StdEncoding.EncodeToString([]byte(message)), key)
+	assert.NoError(t, err)
+
+	// verify signature then
+	alg, err := crypto.NewSignatureAlgorithm(crypto.Ed25519)
+	assert.NoError(t, err)
+
+	v, err := alg.Verify(keyBytes, []byte(message), signature)
 	assert.NoError(t, err)
 	assert.True(t, v)
 

--- a/wallet/mocks/wallet_handler_mock.go
+++ b/wallet/mocks/wallet_handler_mock.go
@@ -137,6 +137,21 @@ func (mr *MockWalletHandlerMockRecorder) RevokeToken(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockWalletHandler)(nil).RevokeToken), arg0)
 }
 
+// SignAny mocks base method
+func (m *MockWalletHandler) SignAny(arg0, arg1, arg2 string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignAny", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignAny indicates an expected call of SignAny
+func (mr *MockWalletHandlerMockRecorder) SignAny(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignAny", reflect.TypeOf((*MockWalletHandler)(nil).SignAny), arg0, arg1, arg2)
+}
+
 // SignTx mocks base method
 func (m *MockWalletHandler) SignTx(arg0, arg1, arg2 string) (wallet.SignedBundle, error) {
 	m.ctrl.T.Helper()

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -56,6 +56,12 @@ type SignTxRequest struct {
 	Propagate bool   `json:"propagate"`
 }
 
+// SignAnyRequest describes the request for SignAny.
+type SignAnyRequest struct {
+	InputData string `json:"inputData"`
+	PubKey    string `json:"pubKey"`
+}
+
 // KeyResponse describes the response to a request that returns a single key.
 type KeyResponse struct {
 	Key Keypair `json:"key"`
@@ -71,6 +77,12 @@ type SignTxResponse struct {
 	SignedTx     SignedBundle `json:"signedTx"`
 	HexBundle    string       `json:"hexBundle"`
 	Base64Bundle string       `json:"base64Bundle"`
+}
+
+// SignAnyResponse describes the response for SignAny.
+type SignAnyResponse struct {
+	HexSignature    string `json:"hexSignature"`
+	Base64Signature string `json:"base64Signature"`
 }
 
 // SuccessResponse describes the response to a request that returns a simple true/false answer.
@@ -94,6 +106,7 @@ type WalletHandler interface {
 	GetWalletName(token string) (string, error)
 	ListPublicKeys(token string) ([]Keypair, error)
 	SignTx(token, tx, pubkey string) (SignedBundle, error)
+	SignAny(token, inputData, pubkey string) ([]byte, error)
 	TaintKey(token, pubkey, passphrase string) error
 	UpdateMeta(token, pubkey, passphrase string, meta []Meta) error
 	WalletPath(token string) (string, error)
@@ -134,6 +147,7 @@ func NewServiceWith(log *logging.Logger, cfg *Config, rootPath string, h WalletH
 	s.GET("/api/v1/keys/:keyid", ExtractToken(s.GetPublicKey))
 	s.PUT("/api/v1/keys/:keyid/taint", ExtractToken(s.TaintKey))
 	s.PUT("/api/v1/keys/:keyid/metadata", ExtractToken(s.UpdateMeta))
+	s.POST("/api/v1/sign", ExtractToken(s.SignAny))
 	s.POST("/api/v1/messages", ExtractToken(s.SignTx))
 	s.POST("/api/v1/messages/sync", ExtractToken(s.SignTxSync))
 	s.POST("/api/v1/messages/commit", ExtractToken(s.SignTxCommit))
@@ -416,6 +430,35 @@ func (s *Service) signTx(t string, w http.ResponseWriter, r *http.Request, _ htt
 		SignedTx:     sb,
 		HexBundle:    hexBundle,
 		Base64Bundle: base64Bundle,
+	}
+
+	writeSuccess(w, res, http.StatusOK)
+}
+
+func (s *Service) SignAny(t string, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	req := SignAnyRequest{}
+	if err := unmarshalBody(r, &req); err != nil {
+		writeError(w, newError(err.Error()), http.StatusBadRequest)
+		return
+	}
+	if len(req.InputData) <= 0 {
+		writeError(w, newError("missing inputData field"), http.StatusBadRequest)
+		return
+	}
+	if len(req.PubKey) <= 0 {
+		writeError(w, newError("missing pubKey field"), http.StatusBadRequest)
+		return
+	}
+
+	signature, err := s.handler.SignAny(t, req.InputData, req.PubKey)
+	if err != nil {
+		writeError(w, newError(err.Error()), http.StatusForbidden)
+		return
+	}
+
+	res := SignAnyResponse{
+		HexSignature:    hex.EncodeToString(signature),
+		Base64Signature: base64.StdEncoding.EncodeToString(signature),
 	}
 
 	writeSuccess(w, res, http.StatusOK)

--- a/wallet/service_test.go
+++ b/wallet/service_test.go
@@ -71,6 +71,7 @@ func TestService(t *testing.T) {
 	t.Run("get keypair fail key not found", testServiceGetPublicKeyFailKeyNotFound)
 	t.Run("get keypair fail misc error", testServiceGetPublicKeyFailMiscError)
 	t.Run("sign ok", testServiceSignOK)
+	t.Run("sign any", testServiceSignAnyOK)
 	t.Run("sign fail invalid request", testServiceSignFailInvalidRequest)
 	t.Run("taint ok", testServiceTaintOK)
 	t.Run("taint fail invalid request", testServiceTaintFailInvalidRequest)
@@ -494,6 +495,24 @@ func testServiceSignOK(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	wallet.ExtractToken(s.SignTx)(w, r, nil)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func testServiceSignAnyOK(t *testing.T) {
+	s := getTestService(t)
+	defer s.ctrl.Finish()
+
+	s.handler.EXPECT().SignAny(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1).Return([]byte("some sig"), nil)
+	payload := `{"inputData": "some data", "pubKey": "asdasasdasd"}`
+	r := httptest.NewRequest("POST", "scheme://host/path", bytes.NewBufferString(payload))
+	r.Header.Set("Authorization", "Bearer eyXXzA")
+
+	w := httptest.NewRecorder()
+
+	wallet.ExtractToken(s.SignAny)(w, r, nil)
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
This add an endpoint to the vega wallet to sign not just a transaction but any payload.