### PR TITLE
remove liquidityFee from the netparams

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1488,18 +1488,20 @@ func (m *Market) confirmMTM(ctx context.Context, order *types.Order) {
 func (m *Market) updateLiquidityFee(ctx context.Context) {
 	stake := m.getTargetStake()
 	fee := m.liquidity.ProvisionsPerParty().FeeForTarget(uint64(stake))
-	_ = fee
+	if fee != m.getLiquidityFee() {
+		m.fee.SetLiquidityFee(fee)
+		m.setLiquidityFee(fee)
+		m.broker.Send(
+			events.NewMarketUpdatedEvent(ctx, *m.mkt),
+		)
+	}
+}
 
-	// TODO(jeremy): this need to be uncommented later
-	// we do not set the fee for now so system-test
-	// can keep running with the static fee setted up in the
-	// genesis block.
-	// m.fee.SetLiquidityFee(fee)
-	//
-	// m.mkt.Fees.Factors.LiquidityFee = fee
-	// m.broker.Send(
-	// 	events.NewMarketEvent(ctx, *m.mkt),
-	// )
+func (m *Market) setLiquidityFee(fee string) {
+	m.mkt.Fees.Factors.LiquidityFee = fee
+}
+func (m *Market) getLiquidityFee() string {
+	return m.mkt.Fees.Factors.LiquidityFee
 }
 
 // resolveClosedOutTraders - the traders with the given market position who haven't got sufficient collateral

--- a/execution/market.go
+++ b/execution/market.go
@@ -2109,7 +2109,9 @@ func (m *Market) cancelOrder(ctx context.Context, partyID, orderID string) (*typ
 
 	if foundOnBook {
 		if err := m.liquidityUpdate(ctx, []*types.Order{order}); err != nil {
-			return nil, err
+			// FIXME(): we do not return an error here as the issue is linked
+			// to liquidyt provision, most likely some orders could not be repriced
+			m.log.Debug("liquidity update error", logging.Error(err))
 		}
 	}
 

--- a/fee/engine.go
+++ b/fee/engine.go
@@ -74,9 +74,12 @@ func (e *Engine) UpdateFeeFactors(fees types.Fees) error {
 	}
 	e.f.infrastructureFee = f
 
-	if err := e.SetLiquidityFee(fees.Factors.LiquidityFee); err != nil {
-		e.log.Error("unable to load liquidityfee", logging.Error(err))
-		return err
+	// liquidity fee is not required to create a network
+	if len(fees.Factors.LiquidityFee) > 0 {
+		if err := e.SetLiquidityFee(fees.Factors.LiquidityFee); err != nil {
+			e.log.Error("unable to load liquidityfee", logging.Error(err))
+			return err
+		}
 	}
 
 	e.feeCfg = fees

--- a/governance/market.go
+++ b/governance/market.go
@@ -148,7 +148,6 @@ func createMarket(
 	// get factors for the market
 	makerFee, _ := netp.Get(netparams.MarketFeeFactorsMakerFee)
 	infraFee, _ := netp.Get(netparams.MarketFeeFactorsInfrastructureFee)
-	liquiFee, _ := netp.Get(netparams.MarketFeeFactorsLiquidityFee)
 	// get the margin scaling factors
 	scalingFactors := types.ScalingFactors{}
 	_ = netp.GetJSONStruct(netparams.MarketMarginScalingFactors, &scalingFactors)
@@ -171,7 +170,6 @@ func createMarket(
 			Factors: &types.FeeFactors{
 				MakerFee:          makerFee,
 				InfrastructureFee: infraFee,
-				LiquidityFee:      liquiFee,
 			},
 		},
 		OpeningAuction: &types.AuctionDuration{

--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -17,7 +17,6 @@ func defaultNetParams() map[string]value {
 		MarketMarginScalingFactors:                      NewJSON(&proto.ScalingFactors{}, checks.MarginScalingFactor()).Mutable(true).MustUpdate(`{"search_level": 1.1, "initial_margin": 1.2, "collateral_release": 1.4}`),
 		MarketFeeFactorsMakerFee:                        NewFloat(FloatGTE(0), FloatLTE(1)).Mutable(true).MustUpdate("0.00025"),
 		MarketFeeFactorsInfrastructureFee:               NewFloat(FloatGTE(0), FloatLTE(1)).Mutable(true).MustUpdate("0.0005"),
-		MarketFeeFactorsLiquidityFee:                    NewFloat(FloatGTE(0), FloatLTE(1)).Mutable(true).MustUpdate("0.001"),
 		MarketAuctionMinimumDuration:                    NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("30m0s"),
 		MarketAuctionMaximumDuration:                    NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate(week),
 		MarketLiquidityBondPenaltyParameter:             NewFloat(FloatGTE(0)).Mutable(true).MustUpdate("1"),

--- a/netparams/keys.go
+++ b/netparams/keys.go
@@ -5,7 +5,6 @@ const (
 	MarketMarginScalingFactors                      = "market.margin.scalingFactors"
 	MarketFeeFactorsMakerFee                        = "market.fee.factors.makerFee"
 	MarketFeeFactorsInfrastructureFee               = "market.fee.factors.infrastructureFee"
-	MarketFeeFactorsLiquidityFee                    = "market.fee.factors.liquidityFee"
 	MarketAuctionMinimumDuration                    = "market.auction.minimumDuration"
 	MarketAuctionMaximumDuration                    = "market.auction.maximumDuration"
 	MarketLiquidityBondPenaltyParameter             = "market.liquidity.bondPenaltyParameter"
@@ -69,7 +68,6 @@ var AllKeys = map[string]struct{}{
 	MarketMarginScalingFactors:                            {},
 	MarketFeeFactorsMakerFee:                              {},
 	MarketFeeFactorsInfrastructureFee:                     {},
-	MarketFeeFactorsLiquidityFee:                          {},
 	MarketAuctionMinimumDuration:                          {},
 	MarketAuctionMaximumDuration:                          {},
 	MarketLiquidityBondPenaltyParameter:                   {},


### PR DESCRIPTION
This pull request remove the liquidity fee network parameter and switch to the liquidity fee selection from the liquididyt provisions submissions.

Do not merge until @3jtechtest have time to update his tests.

close #3231 