### PR TITLE
set order status to active only when about to submit to the book.

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1206,7 +1206,6 @@ func (m *Market) submitValidatedOrder(ctx context.Context, order *types.Order) (
 				m.broker.Send(events.NewOrderEvent(ctx, order))
 				return &types.OrderConfirmation{Order: order}, nil
 			}
-			order.Status = types.Order_STATUS_ACTIVE
 		}
 	}
 
@@ -1273,6 +1272,9 @@ func (m *Market) submitValidatedOrder(ctx context.Context, order *types.Order) (
 			return nil, err
 		}
 	}
+
+	order.Status = types.Order_STATUS_ACTIVE
+
 	// Send the aggressive order into matching engine
 	confirmation, err := m.matching.SubmitOrder(order)
 	if err != nil {


### PR DESCRIPTION
We use to setup the pegged order to active straight after repricing. Although by doing so, rest of the code assume it's on the book. Hence while trying to parkOrder following a Enter price monitoring auction trigger, we are trying to remove the order from the book (where it's not). 

We now set the order status to active only when we are sure no auction is triggered, and the order is really going to the book.

close #3256 