### PR TITLE
Clean up th governance engine unit tests

### DIFF
--- a/governance/engine.go
+++ b/governance/engine.go
@@ -447,7 +447,7 @@ func (e *Engine) validateOpenProposal(proposal types.Proposal) (types.ProposalEr
 			logging.Time("provided", enactTime),
 			logging.String("id", proposal.Id))
 		return types.ProposalError_PROPOSAL_ERROR_ENACT_TIME_TOO_LATE,
-			fmt.Errorf("proposal enactment time too lat, expected < %v, got %v", maxEnactTime, enactTime)
+			fmt.Errorf("proposal enactment time too late, expected < %v, got %v", maxEnactTime, enactTime)
 	}
 
 	if e.isTwoStepsProposal(&proposal) {


### PR DESCRIPTION
## Result on code coverage from code refactoring

file | coverage before | coverage after
--- | --- | ---
asset.go | 0% statements |  0% statements 
config.go | 100% statements | 100% statements
engine.go | 42.3% statements | **79.7% statements**
market.go | 65.7% statements | 65.7% statements
netparams.go | 60.9% statements | 60.9% statements
node_validation.go | 5.3% statements | **11.8% statements**
proposal.go | 22.7% statements | **36.4% statements**
service.go | 0% statements | 0% statements




Close #2011 