### PR TITLE
Prevent messages being sent when nothing changes (#3299)

### DIFF
--- a/markets/service_race_test.go
+++ b/markets/service_race_test.go
@@ -3,6 +3,7 @@
 package markets_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -47,7 +48,10 @@ func TestMarketObserveDepthRetryLimit(t *testing.T) {
 	})
 
 	// at least == to number of retries
-	svc.marketDepth.EXPECT().GetMarketDepth(gomock.Any(), marketArg, uint64(0)).MinTimes(1).Return(&depth, nil)
+	svc.marketDepth.EXPECT().GetMarketDepth(gomock.Any(), marketArg, uint64(0)).MinTimes(1).Return(&depth, nil).Do(
+		func(ctx context.Context, market string, limit uint64) {
+			depth.SequenceNumber++
+		})
 	// waitgroup here ensures that unsubscribe was indeed called
 	svc.order.EXPECT().Unsubscribe(ref).Times(1).DoAndReturn(func(id uint64) error {
 		svc.cfunc() // cancel writeToChannel

--- a/markets/service_test.go
+++ b/markets/service_test.go
@@ -164,7 +164,10 @@ func testMarketObserveDepthSuccess(t *testing.T) {
 		go writeToChannel(ch)
 	})
 
-	svc.marketDepth.EXPECT().GetMarketDepth(gomock.Any(), marketArg, uint64(0)).Times(1).Return(&depth, nil)
+	svc.marketDepth.EXPECT().GetMarketDepth(gomock.Any(), marketArg, uint64(0)).Times(1).Return(&depth, nil).Do(
+		func(ctx context.Context, market string, limit uint64) {
+			depth.SequenceNumber++
+		})
 	// waitgroup here ensures that unsubscribe was indeed called
 	svc.order.EXPECT().Unsubscribe(uint64(1)).Times(1).Return(nil).Do(func(_ uint64) {
 		wg.Done()

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -267,8 +267,6 @@ func (mdb *MarketDepthBuilder) updateMarketDepth(order *types.Order) {
 		mdb.marketDepths[order.MarketId] = md
 	}
 
-	md.sequenceNumber++
-
 	// Initialise changes slice ready for new items
 	md.changes = []*priceLevel{}
 
@@ -297,6 +295,7 @@ func (mdb *MarketDepthBuilder) updateMarketDepth(order *types.Order) {
 	if len(md.changes) == 0 {
 		return
 	}
+	md.sequenceNumber++
 
 	buyPtr := []*types.PriceLevel{}
 	sellPtr := []*types.PriceLevel{}


### PR DESCRIPTION
We no longer increase the sequence number for the market depth if the book does not change.
Updated a unit test or two which relied on messages being sent even if nothing changed.
