### PR TITLE
Feature/3293 add probability of trading tau scaling

### DIFF
--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -643,6 +643,10 @@ func (l *NodeCommand) setupNetParameters() error {
 			Param:   netparams.MarketAuctionMinimumDuration,
 			Watcher: l.executionEngine.OnMarketAuctionMinimumDurationUpdate,
 		},
+		netparams.WatchParam{
+			Param:   netparams.MarketProbabilityOfTradingTauScaling,
+			Watcher: l.executionEngine.OnMarketProbabilityOfTradingTauScalingUpdate,
+		},
 	)
 }
 

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -73,6 +73,7 @@ type netParamsValues struct {
 	bondPenaltyFactor               float64
 	targetStakeTriggeringRatio      float64
 	auctionMinDuration              time.Duration
+	probabilityOfTradingTauScaling  float64
 }
 
 func defaultNetParamsValues() netParamsValues {
@@ -90,6 +91,7 @@ func defaultNetParamsValues() netParamsValues {
 		bondPenaltyFactor:               -1,
 		targetStakeTriggeringRatio:      -1,
 		auctionMinDuration:              -1,
+		probabilityOfTradingTauScaling:  -1,
 	}
 }
 
@@ -341,6 +343,9 @@ func (e *Engine) submitMarket(ctx context.Context, marketConfig *types.Market) e
 }
 
 func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) error {
+	if e.npv.probabilityOfTradingTauScaling != -1 {
+		mkt.OnMarketProbabilitOfTradingTauScalingUpdate(ctx, e.npv.probabilityOfTradingTauScaling)
+	}
 	if e.npv.auctionMinDuration != -1 {
 		mkt.OnMarketAuctionMinimumDurationUpdate(ctx, e.npv.auctionMinDuration)
 	}
@@ -875,6 +880,22 @@ func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context
 	}
 
 	e.npv.targetStakeTriggeringRatio = v
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context, v float64) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update probability of trading tau scaling",
+			logging.Float64("probability of trading tau scaling", v),
+		)
+	}
+
+	for _, mkt := range e.marketsCpy {
+		mkt.OnMarketProbabilitOfTradingTauScalingUpdate(ctx)
+	}
+
+	e.npv.probabilityOfTradingTauScaling = v
 
 	return nil
 }

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -344,7 +344,7 @@ func (e *Engine) submitMarket(ctx context.Context, marketConfig *types.Market) e
 
 func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) error {
 	if e.npv.probabilityOfTradingTauScaling != -1 {
-		mkt.OnMarketProbabilitOfTradingTauScalingUpdate(ctx, e.npv.probabilityOfTradingTauScaling)
+		mkt.OnMarketProbabilityOfTradingTauScalingUpdate(ctx, e.npv.probabilityOfTradingTauScaling)
 	}
 	if e.npv.auctionMinDuration != -1 {
 		mkt.OnMarketAuctionMinimumDurationUpdate(ctx, e.npv.auctionMinDuration)
@@ -884,7 +884,7 @@ func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context
 	return nil
 }
 
-func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context, v float64) error {
+func (e *Engine) OnMarketProbabilityOfTradingTauScalingUpdate(ctx context.Context, v float64) error {
 	if e.log.IsDebug() {
 		e.log.Debug("update probability of trading tau scaling",
 			logging.Float64("probability of trading tau scaling", v),
@@ -892,7 +892,7 @@ func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context
 	}
 
 	for _, mkt := range e.marketsCpy {
-		mkt.OnMarketProbabilitOfTradingTauScalingUpdate(ctx)
+		mkt.OnMarketProbabilityOfTradingTauScalingUpdate(ctx, v)
 	}
 
 	e.npv.probabilityOfTradingTauScaling = v

--- a/execution/market.go
+++ b/execution/market.go
@@ -3111,6 +3111,10 @@ func (m *Market) OnMarketLiquidityMaximumLiquidityFeeFactorLevelUpdate(v float64
 	m.liquidity.OnMaximumLiquidityFeeFactorLevelUpdate(v)
 }
 
+func (m *Market) OnMarketProbabilityOfTradingTauScalingUpdate(_ context.Context, v float64) {
+	m.liquidity.OnProbabilityOfTradingTauScalingUpdate(v)
+}
+
 func (m *Market) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context, v float64) {
 	m.lMonitor.UpdateTargetStakeTriggerRatio(ctx, v)
 	//TODO: Send an event containing updated parameter

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -116,6 +116,10 @@ func (e *Engine) OnChainTimeUpdate(ctx context.Context, now time.Time) {
 	e.currentTime = now
 }
 
+func (e *Engine) OnProbabilityOfTradingTauScalingUpdate(v float64) {
+	e.suppliedEngine.OnProbabilityOfTradingTauScalingUpdate(v)
+}
+
 // OnSuppliedStakeToObligationFactorUpdate updates the stake factor
 func (e *Engine) OnSuppliedStakeToObligationFactorUpdate(v float64) {
 	e.stakeToObligationFactor = v

--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -24,6 +24,7 @@ func defaultNetParams() map[string]value {
 		MarketLiquidityStakeToCCYSiskas:                 NewFloat(FloatGT(0)).Mutable(true).MustUpdate("1"),
 		MarketLiquidityProvidersFeeDistribitionTimeStep: NewDuration(DurationGTE(0 * time.Second)).Mutable(true).MustUpdate("0s"),
 		MarketLiquidityTargetStakeTriggeringRatio:       NewFloat(FloatGTE(0)).Mutable(true).MustUpdate("0"),
+		MarketProbabilityOfTradingTauScaling:            NewFloat(FloatGTE(1.)).Mutable(true).MustUpdate("1"),
 		MarketTargetStakeTimeWindow:                     NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("1h0m0s"),
 		MarketTargetStakeScalingFactor:                  NewFloat(FloatGTE(0)).Mutable(true).MustUpdate("10"),
 		MarketValueWindowLength:                         NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate(week),

--- a/netparams/keys.go
+++ b/netparams/keys.go
@@ -12,6 +12,7 @@ const (
 	MarketLiquidityStakeToCCYSiskas                 = "market.liquidity.stakeToCcySiskas"
 	MarketLiquidityProvidersFeeDistribitionTimeStep = "market.liquidity.providers.fee.distributionTimeStep"
 	MarketLiquidityTargetStakeTriggeringRatio       = "market.liquidity.targetstake.triggering.ratio"
+	MarketProbabilityOfTradingTauScaling            = "market.liquidity.probabilityOfTrading.tau.scaling"
 	MarketTargetStakeTimeWindow                     = "market.stake.target.timeWindow"
 	MarketTargetStakeScalingFactor                  = "market.stake.target.scalingFactor"
 	MarketValueWindowLength                         = "market.value.windowLength"


### PR DESCRIPTION
Add the network parameter
Propagate it down to the suppied liquidity engine
Use it to factor the Tau from the risk model beforesending to the GetProbability of trading calculation.

close #3293 