### PR TITLE
return the targetStake as a unsigned int in market data instead of a float

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -429,7 +429,7 @@ func (m *Market) GetMarketData() types.MarketData {
 		AuctionEnd:                auctionEnd,
 		MarketTradingMode:         m.as.Mode(),
 		Trigger:                   m.as.Trigger(),
-		TargetStake:               strconv.FormatFloat(m.getTargetStake(), 'f', -1, 64),
+		TargetStake:               strconv.FormatUint(uint64(math.Ceil(m.getTargetStake())), 10),
 		SuppliedStake:             strconv.FormatUint(m.getSuppliedStake(), 10),
 		PriceMonitoringBounds:     m.pMonitor.GetCurrentBounds(),
 		MarketValueProxy:          strconv.FormatFloat(m.lastMarketValueProxy, 'f', -1, 64),


### PR DESCRIPTION
Returns the targetState as an unsigned int instead of float so it's less confusing in the market data api, see issue for more details

close #3242 