### PR TITLE
Propagate/wrap invalid account errors

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -2050,7 +2050,7 @@ func (e *Engine) UpdateBalance(ctx context.Context, id string, balance uint64) e
 func (e *Engine) IncrementBalance(ctx context.Context, id string, inc uint64) error {
 	acc, ok := e.accs[id]
 	if !ok {
-		return ErrAccountDoesNotExist
+		return fmt.Errorf("account does not exist: %s", id)
 	}
 	acc.Balance += inc
 	if acc.Type != types.AccountType_ACCOUNT_TYPE_EXTERNAL {
@@ -2064,7 +2064,7 @@ func (e *Engine) IncrementBalance(ctx context.Context, id string, inc uint64) er
 func (e *Engine) DecrementBalance(ctx context.Context, id string, dec uint64) error {
 	acc, ok := e.accs[id]
 	if !ok {
-		return ErrAccountDoesNotExist
+		return fmt.Errorf("account does not exist: %s", id)
 	}
 	acc.Balance -= dec
 	if acc.Type != types.AccountType_ACCOUNT_TYPE_EXTERNAL {
@@ -2077,7 +2077,7 @@ func (e *Engine) DecrementBalance(ctx context.Context, id string, dec uint64) er
 func (e *Engine) GetAccountByID(id string) (*types.Account, error) {
 	acc, ok := e.accs[id]
 	if !ok {
-		return nil, ErrAccountDoesNotExist
+		return nil, fmt.Errorf("account does not exist: %s", id)
 	}
 	acccpy := *acc
 	return &acccpy, nil
@@ -2088,7 +2088,7 @@ func (e *Engine) GetAccountByID(id string) (*types.Account, error) {
 func (e *Engine) GetAssetTotalSupply(asset string) (uint64, error) {
 	asst, ok := e.enabledAssets[asset]
 	if !ok {
-		return 0, ErrInvalidAssetID
+		return 0, fmt.Errorf("invalid asset: %s", asset)
 	}
 
 	// not checking for error, if we

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -738,8 +738,8 @@ func testTransferLossMissingTraderAccounts(t *testing.T) {
 	}
 	resp, err := eng.FinalSettlement(context.Background(), testMarketID, pos)
 	assert.Nil(t, resp)
-	assert.Error(t, err)
-	assert.Equal(t, collateral.ErrAccountDoesNotExist, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account does not exist:")
 }
 
 func testDistributeWin(t *testing.T) {
@@ -1125,8 +1125,8 @@ func testRemoveDistressedBalance(t *testing.T) {
 
 	// check if account was deleted
 	_, err = eng.GetAccountByID(marginID)
-	assert.Error(t, err)
-	assert.Equal(t, collateral.ErrAccountDoesNotExist, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account does not exist:")
 }
 
 func testRemoveDistressedNoBalance(t *testing.T) {
@@ -1155,8 +1155,8 @@ func testRemoveDistressedNoBalance(t *testing.T) {
 
 	// check if account was deleted
 	_, err = eng.GetAccountByID(marginID)
-	assert.Error(t, err)
-	assert.Equal(t, collateral.ErrAccountDoesNotExist, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account does not exist:")
 }
 
 // most of this function is copied from the MarkToMarket test - we're using channels, sure

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"code.vegaprotocol.io/vega/collateral"
 	"code.vegaprotocol.io/vega/events"
 	types "code.vegaprotocol.io/vega/proto"
 
@@ -1288,7 +1287,8 @@ func TestCloseOutLPTraderContIssue3086(t *testing.T) {
 	t.Run("margin account is updated", func(t *testing.T) {
 		_, err := tm.collateralEngine.GetPartyMarginAccount(
 			tm.market.GetID(), ruser2, tm.asset)
-		assert.EqualError(t, err, collateral.ErrAccountDoesNotExist.Error())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "account does not exist:")
 	})
 
 	t.Run("bond account", func(t *testing.T) {

--- a/execution/market.go
+++ b/execution/market.go
@@ -3933,12 +3933,12 @@ func lpsToLiquidityProviderFeeShare(lps map[string]*lp) []*types.LiquidityProvid
 func (m *Market) distributeLiquidityFees(ctx context.Context) error {
 	asset, err := m.mkt.GetAsset()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get asset")
 	}
 
 	acc, err := m.collateral.GetMarketLiquidityFeeAccount(m.mkt.GetId(), asset)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get market liquidity fee account")
 	}
 
 	// We can't distribute any share when no balance.
@@ -3958,7 +3958,7 @@ func (m *Market) distributeLiquidityFees(ctx context.Context) error {
 
 	resp, err := m.collateral.TransferFees(ctx, m.GetID(), asset, feeTransfer)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to transfer fees")
 	}
 
 	m.broker.Send(events.NewTransferResponse(ctx, resp))

--- a/execution/market.go
+++ b/execution/market.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -32,7 +33,6 @@ import (
 	"code.vegaprotocol.io/vega/settlement"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // InitialOrderVersion is set on `Version` field for every new order submission read from the network
@@ -258,12 +258,12 @@ func NewMarket(
 
 	tradableInstrument, err := markets.NewTradableInstrument(ctx, log, mkt.TradableInstrument, oracleEngine)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to instantiate a new market")
+		return nil, fmt.Errorf("unable to instantiate a new market: %w", err)
 	}
 
 	closingAt, err := tradableInstrument.Instrument.GetMarketClosingTime()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get market closing time")
+		return nil, fmt.Errorf("unable to get market closing time: %w", err)
 	}
 
 	// @TODO -> the raw auctionstate shouldn't be something exposed to the matching engine
@@ -293,14 +293,14 @@ func NewMarket(
 
 	feeEngine, err := fee.New(log, feeConfig, *mkt.Fees, asset)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to instantiate fee engine")
+		return nil, fmt.Errorf("unable to instantiate fee engine: %w", err)
 	}
 
 	tsCalc := liquiditytarget.NewEngine(*mkt.LiquidityMonitoringParameters.TargetStakeParameters, positionEngine)
 
 	pMonitor, err := price.NewMonitor(tradableInstrument.RiskModel, *mkt.PriceMonitoringSettings)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to instantiate price monitoring engine")
+		return nil, fmt.Errorf("unable to instantiate price monitoring engine: %w", err)
 	}
 
 	lMonitor := lmon.NewMonitor(tsCalc, mkt.LiquidityMonitoringParameters)
@@ -3933,12 +3933,12 @@ func lpsToLiquidityProviderFeeShare(lps map[string]*lp) []*types.LiquidityProvid
 func (m *Market) distributeLiquidityFees(ctx context.Context) error {
 	asset, err := m.mkt.GetAsset()
 	if err != nil {
-		return errors.Wrap(err, "failed to get asset")
+		return fmt.Errorf("failed to get asset: %w", err)
 	}
 
 	acc, err := m.collateral.GetMarketLiquidityFeeAccount(m.mkt.GetId(), asset)
 	if err != nil {
-		return errors.Wrap(err, "failed to get market liquidity fee account")
+		return fmt.Errorf("failed to get market liquidity fee account: %w", err)
 	}
 
 	// We can't distribute any share when no balance.
@@ -3958,7 +3958,7 @@ func (m *Market) distributeLiquidityFees(ctx context.Context) error {
 
 	resp, err := m.collateral.TransferFees(ctx, m.GetID(), asset, feeTransfer)
 	if err != nil {
-		return errors.Wrap(err, "failed to transfer fees")
+		return fmt.Errorf("failed to transfer fees: %w", err)
 	}
 
 	m.broker.Send(events.NewTransferResponse(ctx, resp))

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -5747,10 +5747,11 @@ func TestBondAccountIsReleasedItMarketRejected(t *testing.T) {
 	)
 
 	t.Run("bond is released to general account", func(t *testing.T) {
-		// an error as the bon account is being deleted
+		// an error as the bond account is being deleted
 		_, err := tm.collateralEngine.GetPartyBondAccount(
 			tm.market.GetID(), lpparty, tm.asset)
-		assert.EqualError(t, err, collateral.ErrAccountDoesNotExist.Error())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "account does not exist:")
 		gacc, err := tm.collateralEngine.GetPartyGeneralAccount(
 			lpparty, tm.asset)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR slightly improves error handling by propagating the ID of invalid account.

It also uses `errors.Wrap(err, "info")` to show where some errors came from.