### PR TITLE
add a GetCloseoutPrice method to the caching

### DIFF
--- a/matching/cached_orderbook.go
+++ b/matching/cached_orderbook.go
@@ -96,11 +96,3 @@ func (b *CachedOrderBook) GetIndicativePrice() uint64 {
 	}
 	return price
 }
-
-func (b *CachedOrderBook) GetCloseoutPrice(volume uint64, side types.Side) (uint64, error) {
-	// yes this is moving logic in the caching layer.
-	if b.OrderBook.auction {
-		return b.GetIndicativePrice(), nil
-	}
-	return b.OrderBook.GetCloseoutPrice(volume, side)
-}

--- a/matching/cached_orderbook.go
+++ b/matching/cached_orderbook.go
@@ -96,3 +96,11 @@ func (b *CachedOrderBook) GetIndicativePrice() uint64 {
 	}
 	return price
 }
+
+func (b *CachedOrderBook) GetCloseoutPrice(volume uint64, side types.Side) (uint64, error) {
+	// yes this is moving logic in the caching layer.
+	if b.OrderBook.auction {
+		return b.GetIndicativePrice(), nil
+	}
+	return b.OrderBook.GetCloseoutPrice(volume, side)
+}

--- a/risk/engine.go
+++ b/risk/engine.go
@@ -22,6 +22,7 @@ var (
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/orderbook_mock.go -package mocks code.vegaprotocol.io/vega/risk Orderbook
 type Orderbook interface {
 	GetCloseoutPrice(volume uint64, side types.Side) (uint64, error)
+	GetIndicativePrice() uint64
 }
 
 // AuctionState represents the current auction state of the market, previously we got this information from the matching engine, but really... that's not its job

--- a/risk/margins_calculation.go
+++ b/risk/margins_calculation.go
@@ -77,10 +77,18 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice int64, rf types.Ris
 			slippagePerUnit int64
 		)
 		if slippageVolume > 0 {
-			exitPrice, err := e.ob.GetCloseoutPrice(uint64(slippageVolume), types.Side_SIDE_BUY)
-			if err != nil && e.log.GetLevel() == logging.DebugLevel {
-				e.log.Debug("got non critical error from GetCloseoutPrice for Buy side",
-					logging.Error(err))
+			var (
+				exitPrice uint64
+				err       error
+			)
+			if auction {
+				exitPrice = e.ob.GetIndicativePrice()
+			} else {
+				exitPrice, err = e.ob.GetCloseoutPrice(uint64(slippageVolume), types.Side_SIDE_BUY)
+				if err != nil && e.log.GetLevel() == logging.DebugLevel {
+					e.log.Debug("got non critical error from GetCloseoutPrice for Buy side",
+						logging.Error(err))
+				}
 			}
 			slippagePerUnit = markPrice - int64(exitPrice)
 		}
@@ -101,10 +109,18 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice int64, rf types.Ris
 		)
 		// slippageVolume would be negative we abs it in the next phase
 		if slippageVolume < 0 {
-			exitPrice, err := e.ob.GetCloseoutPrice(uint64(-slippageVolume), types.Side_SIDE_SELL)
-			if err != nil && e.log.GetLevel() == logging.DebugLevel {
-				e.log.Debug("got non critical error from GetCloseoutPrice for Sell side",
-					logging.Error(err))
+			var (
+				exitPrice uint64
+				err       error
+			)
+			if auction {
+				exitPrice = e.ob.GetIndicativePrice()
+			} else {
+				exitPrice, err = e.ob.GetCloseoutPrice(uint64(-slippageVolume), types.Side_SIDE_SELL)
+				if err != nil && e.log.GetLevel() == logging.DebugLevel {
+					e.log.Debug("got non critical error from GetCloseoutPrice for Sell side",
+						logging.Error(err))
+				}
 			}
 			slippagePerUnit = -1 * (markPrice - int64(exitPrice))
 		}

--- a/risk/mocks/orderbook_mock.go
+++ b/risk/mocks/orderbook_mock.go
@@ -47,3 +47,17 @@ func (mr *MockOrderbookMockRecorder) GetCloseoutPrice(arg0, arg1 interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloseoutPrice", reflect.TypeOf((*MockOrderbook)(nil).GetCloseoutPrice), arg0, arg1)
 }
+
+// GetIndicativePrice mocks base method
+func (m *MockOrderbook) GetIndicativePrice() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIndicativePrice")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetIndicativePrice indicates an expected call of GetIndicativePrice
+func (mr *MockOrderbookMockRecorder) GetIndicativePrice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndicativePrice", reflect.TypeOf((*MockOrderbook)(nil).GetIndicativePrice))
+}


### PR DESCRIPTION
~The caching layer was caching the right function, although the orderbook is not aware of the cached value when calling GetCloseoutPrice, this now add GetCloseoutPrice into the caching latyer.~

This was indeed pretty bad, I thought the GetCloseoutPrice function was called in much more places, and it would required more changes from the risk engine.

Luckily it does not, so now we just call the appropriate function when needed instead of letting the matching engine figure out what to do.