### PR TITLE
Auditing the position tracking in the execution engine

### DIFF
--- a/execution/collateral.go
+++ b/execution/collateral.go
@@ -61,10 +61,7 @@ func (m *Market) transferMarginsAuction(ctx context.Context, risk []events.Risk,
 		// create event
 		evts = append(evts, events.NewOrderEvent(ctx, o))
 		// remove order from positions
-		if _, err := m.position.UnregisterOrder(o); err != nil {
-			// @TODO handle this
-			return err
-		}
+		_ = m.position.UnregisterOrder(o)
 	}
 	m.broker.SendBatch(evts)
 	return nil

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -220,7 +220,7 @@ func (m *Market) amendLiquidityProvisionContinuous(
 	// first remove all existing orders from the potential positions
 	lorders := m.liquidity.GetLiquidityOrders(party)
 	for _, v := range lorders {
-		pos.UnregisterOrder(v)
+		pos.UnregisterOrder(m.log, v)
 	}
 
 	// then add all the newly created ones

--- a/execution/market.go
+++ b/execution/market.go
@@ -1422,7 +1422,7 @@ func (m *Market) applyFees(ctx context.Context, order *types.Order, trades []*ty
 			logging.String("order-id", order.Id),
 			logging.String("market-id", m.GetID()),
 			logging.Error(err))
-		return err
+		return types.OrderError_ORDER_ERROR_INSUFFICIENT_FUNDS_TO_PAY_FEES
 	}
 
 	// send transfers through the broker

--- a/execution/market.go
+++ b/execution/market.go
@@ -2763,7 +2763,7 @@ func (m *Market) RemoveExpiredOrders(
 	for _, order := range m.expiringOrders.Expire(timestamp) {
 		// The pegged expiry orders are copies and do not reflect the
 		// current state of the order, therefore we look it up
-		originalOrder, _, err := m.getOrderByID(order.Id)
+		originalOrder, foundOnBook, err := m.getOrderByID(order.Id)
 		if err == nil {
 			// assign to the order the order from the book
 			// so we get the most recent version from the book
@@ -2773,8 +2773,7 @@ func (m *Market) RemoveExpiredOrders(
 			// if the order was on the book basically
 			// either a pegged + non parked
 			// or a non-pegged order
-			if (order.PeggedOrder != nil && order.Status != types.Order_STATUS_PARKED) ||
-				order.PeggedOrder == nil {
+			if foundOnBook {
 				m.position.UnregisterOrder(&order)
 				m.matching.DeleteOrder(&order)
 			}

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -113,28 +113,28 @@ func (e *Engine) UnregisterOrder(order *types.Order) *MarketPosition {
 
 	pos, found := e.positions[order.PartyId]
 	if !found {
-		e.log.Panic("could not find position in engine",
+		e.log.Panic("could not find position in engine when unregistering order",
 			logging.Order(*order))
 	}
 
-	pos.UnregisterOrder(order)
+	pos.UnregisterOrder(e.log, order)
 	return pos
 }
 
 // AmendOrder unregisters the original order and then registers the newly amended order
 // this method is a quicker way of handling separate unregister+register pairs
-func (e *Engine) AmendOrder(originalOrder, newOrder *types.Order) (pos *MarketPosition, err error) {
+func (e *Engine) AmendOrder(originalOrder, newOrder *types.Order) *MarketPosition {
 	timer := metrics.NewTimeCounter("-", "positions", "AmendOrder")
 
 	pos, found := e.positions[originalOrder.PartyId]
 	if !found {
-		// If we can't find the original, we can't amend it
-		err = ErrPositionNotFound
-		return
+		e.log.Panic("could not find position in engine when amending order",
+			logging.Order(*originalOrder),
+			logging.Order(*newOrder))
 	}
-	pos.AmendOrder(originalOrder, newOrder)
+	pos.AmendOrder(e.log, originalOrder, newOrder)
 	timer.EngineTimeCounterAdd()
-	return
+	return pos
 }
 
 // UpdateNetwork - functionally the same as the Update func, except for ignoring the network

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -108,16 +108,17 @@ func (e *Engine) RegisterOrder(order *types.Order) *MarketPosition {
 
 // UnregisterOrder undoes the actions of RegisterOrder. It is used when an order
 // has been rejected by the Risk Engine, or when an order is amended or canceled.
-func (e *Engine) UnregisterOrder(order *types.Order) (*MarketPosition, error) {
+func (e *Engine) UnregisterOrder(order *types.Order) *MarketPosition {
 	defer metrics.NewTimeCounter("-", "positions", "UnregisterOrder").EngineTimeCounterAdd()
 
 	pos, found := e.positions[order.PartyId]
 	if !found {
-		return nil, ErrPositionNotFound
+		e.log.Panic("could not find position in engine",
+			logging.Order(*order))
 	}
 
 	pos.UnregisterOrder(order)
-	return pos, nil
+	return pos
 }
 
 // AmendOrder unregisters the original order and then registers the newly amended order

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -217,8 +217,7 @@ func testUnregisterOrderSuccessful(t *testing.T) {
 	pos := e.RegisterOrder(&orderBuy)
 	assert.Equal(t, buysize, pos.Buy())
 
-	pos, err := e.UnregisterOrder(&orderBuy)
-	assert.NoError(t, err)
+	pos = e.UnregisterOrder(&orderBuy)
 	assert.Zero(t, pos.Buy())
 
 	orderSell := types.Order{
@@ -231,8 +230,7 @@ func testUnregisterOrderSuccessful(t *testing.T) {
 	assert.Zero(t, pos.Buy())
 	assert.Equal(t, sellsize, pos.Sell())
 
-	pos, err = e.UnregisterOrder(&orderSell)
-	assert.NoError(t, err)
+	pos = e.UnregisterOrder(&orderSell)
 	assert.Zero(t, pos.Buy())
 	assert.Zero(t, pos.Sell())
 }
@@ -245,9 +243,9 @@ func testUnregisterOrderUnsuccessful(t *testing.T) {
 		Size:      uint64(999),
 		Remaining: uint64(999),
 	}
-	pos, err := e.UnregisterOrder(&orderBuy)
-	assert.Equal(t, err, positions.ErrPositionNotFound)
-	assert.Nil(t, pos)
+	require.Panics(t, func() {
+		_ = e.UnregisterOrder(&orderBuy)
+	})
 }
 
 func getTestEngine(t *testing.T) *positions.Engine {

--- a/positions/positions_acceptance_criteria_test.go
+++ b/positions/positions_acceptance_criteria_test.go
@@ -855,8 +855,7 @@ func testOrderCancelled(t *testing.T) {
 
 	// first add the orders
 	for _, c := range cases.orders {
-		_, err := engine.UnregisterOrder(&c)
-		assert.NoError(t, err)
+		_ = engine.UnregisterOrder(&c)
 	}
 
 	// test everything is back to 0 once orders are unregistered

--- a/positions/positions_acceptance_criteria_test.go
+++ b/positions/positions_acceptance_criteria_test.go
@@ -89,6 +89,8 @@ func testTradeOccurIncreaseShortAndLong(t *testing.T) {
 
 	for _, c := range cases {
 		// call an update on the positions with the trade
+		registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+		registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 		positions := engine.Update(&c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
@@ -152,6 +154,8 @@ func testTradeOccurDecreaseShortAndLong(t *testing.T) {
 
 	for _, c := range cases {
 		// call an update on the positions with the trade
+		registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+		registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 		positions := engine.Update(&c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
@@ -214,6 +218,8 @@ func testTradeOccurClosingShortAndLong(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+		registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 		positions := engine.Update(&c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
@@ -276,6 +282,8 @@ func testTradeOccurShortBecomeLongAndLongBecomeShort(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+		registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 		// call an update on the positions with the trade
 		positions := engine.Update(&c.trade)
 		pos := engine.Positions()
@@ -322,6 +330,8 @@ func testNoOpenPositionsTradeOccurOpenLongAndShortPosition(t *testing.T) {
 	assert.Empty(t, engine.Positions())
 
 	// now create a trade an make sure the positions are created an correct
+	registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+	registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 	positions := engine.Update(&c.trade)
 	pos := engine.Positions()
 	assert.Equal(t, 2, len(pos))
@@ -411,6 +421,8 @@ func testOpenPosTradeOccurCloseThanOpenPositioAgain(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+		registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 		positions := engine.Update(&c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, c.posSize, len(pos), fmt.Sprintf("all pos trade: %v", c.trade.Id))
@@ -477,6 +489,8 @@ func testWashTradeDoNotChangePosition(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		registerOrder(engine, types.Side_SIDE_BUY, c.trade.Buyer, c.trade.Price, c.trade.Size)
+		registerOrder(engine, types.Side_SIDE_SELL, c.trade.Seller, c.trade.Price, c.trade.Size)
 		// call an update on the positions with the trade
 		positions := engine.Update(&c.trade)
 		pos := engine.Positions()


### PR DESCRIPTION
This will add a couple of things:
- ensure that we are registering / unregistering positions in the rights places
- Add panics when needed as we should always be able to register / unregister positions in the engine.

I'll try to keep the commit message sensible, please review eventually them one by one.