### PR TITLE
ensure we do not Unregister order not being deployed

### DIFF
--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -220,7 +220,10 @@ func (m *Market) amendLiquidityProvisionContinuous(
 	// first remove all existing orders from the potential positions
 	lorders := m.liquidity.GetLiquidityOrders(party)
 	for _, v := range lorders {
-		pos.UnregisterOrder(m.log, v)
+		// ensure the order is on the actual potential position first
+		if order, foundOnBook, _ := m.getOrderByID(v.Id); foundOnBook {
+			pos.UnregisterOrder(m.log, order)
+		}
 	}
 
 	// then add all the newly created ones


### PR DESCRIPTION
In amend LP, we do a copy of the party position, to calculate a potential margin.
Although if the LP orders are not deployed, we would panic.
This change ensure the order are deployed before Unregistering from the position copy.