### PR TITLE
Fixes on lp order deployment

### DIFF
--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -744,7 +744,6 @@ func (e *Engine) createOrdersFromShape(party string, supplied []*supplied.Liquid
 		// properly by the engine.
 		if o.LiquidityImpliedVolume == 0 ||
 			(order != nil && (!order.HasTraded() && order.Size == o.LiquidityImpliedVolume) || o.Price == 0) {
-			fmt.Printf("CONTINUE?????\n")
 			continue
 		}
 

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -742,7 +742,9 @@ func (e *Engine) createOrdersFromShape(party string, supplied []*supplied.Liquid
 		// we check o.Price == 0 just to make sure we are able to price
 		// the order, in which case the size will have been calculated
 		// properly by the engine.
-		if o.LiquidityImpliedVolume == 0 || (order != nil && (!order.HasTraded()) || o.Price == 0) {
+		if o.LiquidityImpliedVolume == 0 ||
+			(order != nil && (!order.HasTraded() && order.Size == o.LiquidityImpliedVolume) || o.Price == 0) {
+			fmt.Printf("CONTINUE?????\n")
 			continue
 		}
 

--- a/proto/vega_ext.go
+++ b/proto/vega_ext.go
@@ -40,6 +40,10 @@ func (l *LiquidityProvision) Float64Fee() float64 {
 	return v
 }
 
+func (o *Order) IsLiquidityOrder() bool {
+	return len(o.LiquidityProvisionId) > 0
+}
+
 // Create sets the creation time (CreatedAt) to t and returns the
 // updated order.
 func (o *Order) Create(t time.Time) *Order {


### PR DESCRIPTION
- Ensure all amends and create are being returned
- do not try to evaluate liquidity when submitting / cancelling an LP.

It fixes one thing: The order generated by liquidity where not done properly, but it was working, because we were re-validationg liquidity recursively when submitting / cancelling liquidity order.

so what was happeningwas:
- the engine was returning theorder to cancels
- the market was cancelling the orders
- by cancelling the order liquidity checks were triggered
- the liquidity check was re-creatingthe order as it was cancelled.
Now the cancellation do not trigger a new liquidity check (which may be the cause of the panic)
But the orders are properly cancelled / created thanks to the fix in the liquidity engine.