### PR TITLE
use default when instanciating markete if LiquidityMonitoringParameters is nil OR LiquidityMonitoringParameters.TargetStakeParameters is nil

### DIFF
--- a/governance/market.go
+++ b/governance/market.go
@@ -163,7 +163,8 @@ func createMarket(
 		definition.Changes.PriceMonitoringParameters = pmParams
 	}
 
-	if definition.Changes.LiquidityMonitoringParameters == nil {
+	if definition.Changes.LiquidityMonitoringParameters == nil ||
+		definition.Changes.LiquidityMonitoringParameters.TargetStakeParameters == nil {
 		// get target stake parameters
 		tsTimeWindow, _ := netp.GetDuration(netparams.MarketTargetStakeTimeWindow)
 		tsScalingFactor, _ := netp.GetFloat(netparams.MarketTargetStakeScalingFactor)

--- a/governance/market.go
+++ b/governance/market.go
@@ -171,12 +171,18 @@ func createMarket(
 		//get triggering ratio
 		triggeringRatio, _ := netp.GetFloat(netparams.MarketLiquidityTargetStakeTriggeringRatio)
 
-		definition.Changes.LiquidityMonitoringParameters = &types.LiquidityMonitoringParameters{
-			TargetStakeParameters: &types.TargetStakeParameters{
-				TimeWindow:    int64(tsTimeWindow.Seconds()),
-				ScalingFactor: tsScalingFactor,
-			},
-			TriggeringRatio: triggeringRatio,
+		params := &types.TargetStakeParameters{
+			TimeWindow:    int64(tsTimeWindow.Seconds()),
+			ScalingFactor: tsScalingFactor,
+		}
+
+		if definition.Changes.LiquidityMonitoringParameters == nil {
+			definition.Changes.LiquidityMonitoringParameters = &types.LiquidityMonitoringParameters{
+				TargetStakeParameters: params,
+				TriggeringRatio:       triggeringRatio,
+			}
+		} else {
+			definition.Changes.LiquidityMonitoringParameters.TargetStakeParameters = params
 		}
 	}
 


### PR DESCRIPTION
When instanciating the market from the governance, we use default if the liquidity monitoring parameter was not specificied, but we do not check if what's inside was. We now check for both, and will use default if any isn't.

close #3393 