### PR TITLE
Fix spelling in GQL schema

### DIFF
--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -4802,7 +4802,7 @@ type Mutation {
     side: Side!
     "TimeInForce of the order"
     timeInForce: OrderTimeInForce!
-    "exiration of the the order"
+    "expiration of the the order"
     expiration: String
     "type of the order"
     type: OrderType!

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -23,7 +23,7 @@ type Mutation {
     side: Side!
     "TimeInForce of the order"
     timeInForce: OrderTimeInForce!
-    "exiration of the the order"
+    "expiration of the the order"
     expiration: String
     "type of the order"
     type: OrderType!


### PR DESCRIPTION
This micro-PR fixes a spelling the the GraphQL schema.