### PR TITLE
auction interaction test

### DIFF
--- a/integration/features/3362-failing-system-tests-trigger-close-out.feature
+++ b/integration/features/3362-failing-system-tests-trigger-close-out.feature
@@ -45,7 +45,6 @@ Feature: Replicate failing system tests after changes to price monitoring (not t
     Then the mark price should be "0" for the market "ETH/DEC20"
     And the trading mode should be "TRADING_MODE_OPENING_AUCTION" for the market "ETH/DEC20"
 
-    Then debug market data for "ETH/DEC20"
     When the opening auction period ends for market "ETH/DEC20"
     Then the mark price should be "100000" for the market "ETH/DEC20"
 

--- a/integration/features/3362-failing-system-tests-trigger-with-gtt.feature
+++ b/integration/features/3362-failing-system-tests-trigger-with-gtt.feature
@@ -53,11 +53,9 @@ Feature: Replicate failing system tests after changes to price monitoring (trigg
       | trader1 | ETH/DEC20 | buy  | 1      | 100150 | 0                | TYPE_LIMIT  | TIF_GTC |
       | trader2 | ETH/DEC20 | sell | 1      | 100150 | 1                | TYPE_LIMIT  | TIF_GTC |
     ## price bounds are 99771 to 100290 (99845 and 100156)
-    And debug market data for "ETH/DEC20"
     And the traders place the following orders:
       | trader  | market id | side | volume | price  | resulting trades | type        | tif     | expires in |
       | trader3 | ETH/DEC20 | sell | 1      | 99770  | 0                | TYPE_LIMIT  | TIF_GTT | 6          |
-    And debug market data for "ETH/DEC20"
     Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
     And the mark price should be "100150" for the market "ETH/DEC20"
 

--- a/integration/features/3362-failing-system-tests.feature
+++ b/integration/features/3362-failing-system-tests.feature
@@ -58,8 +58,6 @@ Feature: Replicate failing system tests after changes to price monitoring (not t
     Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
     And the mark price should be "100150" for the market "ETH/DEC20"
 
-    And debug market data for "ETH/DEC20"
-
     When the traders place the following orders:
       | trader  | market id | side | volume | price  | resulting trades | type        | tif     |
       | trader1 | ETH/DEC20 | buy  | 2      | 100213 | 0                | TYPE_LIMIT  | TIF_GTC |
@@ -77,6 +75,6 @@ Feature: Replicate failing system tests after changes to price monitoring (not t
     ## We'll see the mark price move as we've uncrossed with the orders at 100213 and 100050 we've just placed
     When the traders place the following orders:
       | trader  | market id | side | volume | price  | resulting trades | type        | tif     |
-      | trader2 | ETH/DEC20 | sell | 3      | 100000 | 2                | TYPE_LIMIT  | TIF_GTC |
+      | trader2 | ETH/DEC20 | sell | 1      | 100000 | 2                | TYPE_LIMIT  | TIF_GTC |
     Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
     And the mark price should be "100213" for the market "ETH/DEC20"

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -214,7 +214,9 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
       | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
 
@@ -233,7 +235,7 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
       | trader1 | ETH/DEC21 | ORDER_ERROR_NON_PERSISTENT_ORDER_OUT_OF_PRICE_BOUNDS |
     And the market data for the market "ETH/DEC21" should be:
      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-     | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+     | 1000       | TRADING_MODE_CONTINUOUS | 1       | 1000      | 1020      | 1000         | 1000           | 10            |
 
 
 Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> leave auction mode
@@ -251,8 +253,10 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
       | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
 
     When the opening auction period ends for market "ETH/DEC21"
@@ -260,6 +264,7 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
       | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+    And debug orders
 
     # If the order traded there'd be insufficient liquidity for the market to operate, hence the order doesn't trade
     # and the market enters a liquidity monitoring auction
@@ -283,6 +288,8 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
       | trader1 | cancel-me-1 |
       | trader2 | cancel-me-2 |
 
+    When the network moves ahead "1" blocks
+    Then debug orders
     And debug market data for "ETH/DEC21"
 
     And the traders submit the following liquidity provision:

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -1,0 +1,387 @@
+Feature: Test interactions between different auction types
+
+  Background:
+    Given the following network parameters are set:
+      | name                              | value |
+      | market.stake.target.timeWindow    | 86400 |
+      | market.stake.target.scalingFactor | 1     |
+    And the simple risk model named "simple-risk-model-1":
+      | long | short | max move up | min move down | probability of trading |
+      | 0.1  | 0.1   | 10          | -10           | 0.1                    |
+    And the log normal risk model named "log-normal-risk-model-1":
+      | risk aversion | tau | mu | r   | sigma |
+      | 0.000001      | 0.1 | 0  | 1.4 | -1    |
+    And the fees configuration named "fees-config-1":
+      | maker fee | infrastructure fee | liquidity fee |
+      | 0.004     | 0.001              | 0.3           |
+    And the price monitoring updated every "0" seconds named "price-monitoring-1":
+      | horizon | probability | auction extension |
+      | 1       | 0.99        | 300               |
+    And the markets:
+      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | oracle config          | maturity date        |
+      | ETH/DEC21 | BTC        | BTC   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 2021-12-31T23:59:59Z |
+    And the oracles broadcast data signed with "0xDEADBEEF":
+      | name             | value |
+      | prices.ETH.value | 100   |
+    And the liquidity order collection object with reference "buy_shape":
+      | reference | offet | proportion |
+      | BEST_BID  | -2    | 1          |
+      | MID       | -1    | 2          |
+    And the liquidity order collection object with reference "sell_shape":
+      | reference | offet | proportion |
+      | BEST_ASK  | 2     | 1          |
+      | MID       | 1     | 2          |
+    And the traders deposit on asset's general account the following amount:
+      | trader  | asset | amount     |
+      | trader0 | ETH   | 1000000000 |
+      | trader1 | ETH   | 100000000  |
+      | trader2 | ETH   | 100000000  |
+
+  Scenario: When trying to exit opening auction liquidity monitoring doesn't get triggered, hence the opening auction uncrosses and market goes into continuous trading mode.
+
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0     |
+
+
+    And the traders submit the following liquidity provision:
+      | id  | trader  | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | buy        | BID             | 500              | -10          |
+      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | sell       | ASK             | 500              | 10           |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-2  |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-1 |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1000 x 10 x 1 x 0.1
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 10000
+
+  Scenario: When trying to exit opening auction liquidity monitoring is triggered due to missing best bid, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0     |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 10000             | 0.001   | "buy_shape"      | "sell_shape"      |
+    Then the traders submit the following liquidity provision:
+      | id  | party   | market id | commitment amount | fee | order side | order reference | order proportion | order offset |
+      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | buy        | BID             | 500              | -10        |
+      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | sell       | ASK             | 500              | 10         |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the auction ends resulting in traded volume of "10" at a price of "1000"
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 10000
+
+  Scenario: When trying to exit opening auction liquidity monitoring is triggered due to insufficient supplied stake, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
+
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 700               | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+
+    When traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 800               | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+
+    When traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 801               | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+
+    When traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 10000
+
+  Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> leave auction mode
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 1000
+
+    # If the order traded there'd be insufficient liquidity for the market to operate, hence the order doesn't trade
+    # and the market enters a liquidity monitoring auction
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
+      | trader2 | ETH/DEC19 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
+
+    And the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    And the trading mode for the market "ETH/DEC19" is "TRADING_MODE_MONITORING_AUCTION"
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the traders cancel the following orders:
+      | trader  | reference   |
+      | trader1 | cancel-me-1 |
+      | trader2 | cancel-me-2 |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 3060              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    And the time is advance beyond "min_auction_length"
+    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_PRICE" trigger
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the auction duration is "3s"
+
+    When the time is advanced by "4s"
+    Then the auction ends resulting in traded volume of "20" at a price of "1020"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "30"
+    And the mark price should be "1020" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[1010,1030]]
+    And the target stake should be "3060" for the market "ETH/DEC21"
+    And the supplied stake is 3060
+
+  Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode
+
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 1000
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
+      | trader2 | ETH/DEC19 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
+
+    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the traders cancel the following orders:
+      | trader  | reference   |
+      | trader1 | cancel-me-1 |
+      | trader2 | cancel-me-2 |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 3060              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_PRICE" trigger
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the auction duration is "3s"
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the time is advanced by "4s"
+    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    And the trading mode for the market "ETH/DEC19" is "TRADING_MODE_MONITORING_AUCTION"
+
+    When traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 5000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    Then the auction ends resulting in traded volume of "30" at a price of "1020"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "40"
+    And the mark price should be "1020" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[1010,1030]]
+    And the target stake should be "4080" for the market "ETH/DEC21"
+    And the supplied stake is 5000
+
+  Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode
+
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 1000
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
+      | trader2 | ETH/DEC19 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
+
+    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_PRICE" trigger
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the auction duration is "3s"
+
+    When the time is advanced by "4s"
+    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    And the trading mode for the market "ETH/DEC19" is "TRADING_MODE_MONITORING_AUCTION"
+
+    When traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 5000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    Then the auction ends resulting in traded volume of "20" at a price of "1020"
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the mark price should be "1020" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[1010,1030]]
+    And the target stake should be "3060" for the market "ETH/DEC21"
+    And the supplied stake is 5000
+
+  Scenario: Once market is in continuous trading mode: post a GFN order that should trigger liquidity auction, check that the order gets rejected, appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+    And traders place following liquidity provisions:
+      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the price monitoring bounds are []
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 1000
+
+    When the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | trader1 | ETH/DEC19 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GFN |           |
+      | trader2 | ETH/DEC19 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | reject-me |
+    And the order with reference "reject-me" gets rejected
+    And the event informing that non-persistent order was rejected due to violating trigger "AUCTION_TRIGGER_LIQUIDITY"
+
+    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the max_oi for the market "ETH/DEC21" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the price monitoring bounds are [[990,1010]]
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake is 1000

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -61,8 +61,8 @@ Feature: Test interactions between different auction types
     When the opening auction period ends for market "ETH/DEC19"
     Then the auction ends resulting in traded volume of "10" at a price of "1000"
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the max_oi for the market "ETH/DEC19" is "10"
+    And the mark price should be "1000" for the market "ETH/DEC19"
     And the price monitoring bounds are [[990,1010]]
     # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1000 x 10 x 1 x 0.1
     And the target stake should be "1000" for the market "ETH/DEC21"

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -264,7 +264,6 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
       | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
-    And debug orders
 
     # If the order traded there'd be insufficient liquidity for the market to operate, hence the order doesn't trade
     # and the market enters a liquidity monitoring auction
@@ -289,30 +288,30 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
       | trader2 | cancel-me-2 |
 
     When the network moves ahead "1" blocks
-    Then debug orders
-    And debug market data for "ETH/DEC21"
-
-    And the traders submit the following liquidity provision:
+    Then  the traders submit the following liquidity provision:
       | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | buy        | BID             | 1                | -2           |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | buy        | MID             | 2                | -1           |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | sell       | ASK             | 1                | 2            |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | sell       | MID             | 2                | 1            |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | buy        | BID             | 1                | -2           |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | buy        | MID             | 2                | -1           |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | sell       | ASK             | 1                | 2            |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | sell       | MID             | 2                | 1            |
 
     # leave liquidity auction
     When the network moves ahead "2" blocks
-    # should trigger price monitoring extension
+    # We should be able to leave liquidity auction now
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode                    | auction trigger           |
-      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+      | trading mode            | auction trigger             |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
+    And the traders place the following orders:
+      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC21 | buy  | 1      | 999   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC21 | sell | 1      | 1030  | 0                | TYPE_LIMIT | TIF_GTC |
 
     # price monitoring extension ends
     # End price auction extension
     When the network moves ahead "301" blocks
-    Then the auction ends with a traded volume of "20" at a price of "1020"
-    And the market data for the market "ETH/DEC21" should be:
-      | mark price | trading mode                    | auction trigger       | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1020       | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 1       | 1010      | 1030      | 3060         | 3060           | 30            |
+    Then the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | auction trigger             | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1       | 1010      | 1030      | 4080         | 4080           | 824635360400  |
 
 Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode
     Given the following network parameters are set:

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -175,7 +175,9 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
       | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
 
@@ -187,8 +189,11 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
 
     Then the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN |
+      | trader1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+      #And clear order events
+      #And debug market data for "ETH/DEC21"
+      #And debug orders
     And the market data for the market "ETH/DEC21" should be:
      | trading mode                    | auction trigger           | target stake | supplied stake | open interest |
      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY | 1000         | 1000           | 10            |

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -3,7 +3,7 @@ Feature: Test interactions between different auction types
   Background:
     Given the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 86400 |
+      | market.stake.target.timeWindow                | 24h   |
       | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.targetstake.triggering.ratio | 0     |
     And the average block duration is "1"

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -185,16 +185,13 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
      | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
 
-    When the network moves ahead "1" blocks
     Then the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      | trader1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN |
       | trader2 | ETH/DEC21 | sell | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_FOK |
-    And the network moves ahead "1" blocks
     And the market data for the market "ETH/DEC21" should be:
-     | trading mode                    | auction trigger             | target stake | supplied stake | open interest |
-     | TRADING_MODE_CONTINUOUS         | AUCTION_TRIGGER_UNSPECIFIED | 1000         | 1000           | 10            |
-     #| TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY | 1000         | 1000           | 10            |
+     | trading mode                    | auction trigger           | target stake | supplied stake | open interest |
+     | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY | 1000         | 1000           | 10            |
 
 
 Scenario: Once market is in continuous trading mode: post a GFN order that should trigger price auction, check that the order gets stopped, appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -328,8 +328,10 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
       | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
 
     When the opening auction period ends for market "ETH/DEC21"
@@ -346,103 +348,117 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     Then the market data for the market "ETH/DEC21" should be:
       | trading mode                    | auction trigger           |
       | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+    And the network moves ahead "1" blocks
 
     When the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
 
-    And the traders cancel the following orders:
+    Then the traders cancel the following orders:
       | trader  | reference   |
       | trader1 | cancel-me-1 |
       | trader2 | cancel-me-2 |
 
-    And the traders submit the following liquidity provision:
-      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | buy        | BID             | 1                | -2           |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | buy        | MID             | 2                | -1           |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | sell       | ASK             | 1                | 2            |
-      | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | sell       | MID             | 2                | 1            |
+    When the network moves ahead "2" blocks
 
+    Then the traders submit the following liquidity provision:
+      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | buy        | BID             | 1                | -2           |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | buy        | MID             | 2                | -1           |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | sell       | ASK             | 1                | 2            |
+      | lp1 | trader0 | ETH/DEC21 | 4080              | 0.001 | sell       | MID             | 2                | 1            |
+
+    # We're still in liquidity auction
+    And the market data for the market "ETH/DEC21" should be:
+      | trading mode                    | auction trigger           |
+      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+
+    # We were in liquidity auction, we've updated the commitment amount
+    When the traders submit the following liquidity provision:
+      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+      | lp1 | trader0 | ETH/DEC21 | 5100              | 0.001 | buy        | BID             | 1                | -2           |
+      | lp1 | trader0 | ETH/DEC21 | 5100              | 0.001 | buy        | MID             | 2                | -1           |
+      | lp1 | trader0 | ETH/DEC21 | 5100              | 0.001 | sell       | ASK             | 1                | 2            |
+      | lp1 | trader0 | ETH/DEC21 | 5100              | 0.001 | sell       | MID             | 2                | 1            |
+    And the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode                    | auction trigger       |
-      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE |
+      | trading mode            | auction trigger             |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
 
     When the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
 
+    # Now we place some orders that are outside the price range
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode                    | auction trigger           |
-      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+      | trading mode                    | auction trigger       |
+      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE |
 
-    And the traders submit the following liquidity provision:
-      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | buy        | BID             | 1                | -2           |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | buy        | MID             | 2                | -1           |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | sell       | ASK             | 1                | 2            |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | sell       | MID             | 2                | 1            |
-
-    Then the auction ends with a traded volume of "30" at a price of "1020"
-
-    # end auction
+    # jump ahead to the end of the auction
     When the network moves ahead "301" blocks
-    Then the auction ends with a traded volume of "20" at a price of "1020"
+    Then the market data for the market "ETH/DEC21" should be:
+      | trading mode            | auction trigger             |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1020       | TRADING_MODE_CONTINUOUS | 1       | 1010      | 1030      | 4080         | 5000           | 40            |
+      | 1020       | TRADING_MODE_CONTINUOUS | 1       | 1010      | 1030      | 5100         | 5100           | 50            |
 
-Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
 
-    And the traders submit the following liquidity provision:
-      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | BID             | 1                | -2           |
-      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | MID             | 2                | -1           |
-      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | ASK             | 1                | 2            |
-      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | MID             | 2                | 1            |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    When the opening auction period ends for market "ETH/DEC21"
-    Then the auction ends with a traded volume of "10" at a price of "1000"
-    And the market data for the market "ETH/DEC21" should be:
-     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-     | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC21 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC21 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    Then the market data for the market "ETH/DEC21" should be:
-      | trading mode                    | auction trigger       |
-      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE |
-    And the network moves ahead "1" blocks
-
-    # end price auction
-    When the network moves ahead "300" blocks
-    Then the market data for the market "ETH/DEC21" should be:
-      | trading mode                    | auction trigger           |
-      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
-
-    And the traders submit the following liquidity provision:
-      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | buy        | BID             | 1                | -2           |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | buy        | MID             | 2                | -1           |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | sell       | ASK             | 1                | 2            |
-      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | sell       | MID             | 2                | 1            |
-
-    When the network moves ahead "1" blocks
-    Then the auction ends with a traded volume of "20" at a price of "1020"
-    And the market data for the market "ETH/DEC21" should be:
-     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-     | 1020       | TRADING_MODE_CONTINUOUS | 1       | 1010      | 1030      | 3060         | 5000           | 20            |
+      #Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode
+      #    Given the following network parameters are set:
+      #      | name                                          | value |
+      #      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+      #
+      #    And the traders submit the following liquidity provision:
+      #      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+      #      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | BID             | 1                | -2           |
+      #      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | MID             | 2                | -1           |
+      #      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | ASK             | 1                | 2            |
+      #      | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | MID             | 2                | 1            |
+      #
+      #    And the traders place the following orders:
+      #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      #      | trader1 | ETH/DEC21 | buy  | 10     | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      #      | trader1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      #      | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      #      | trader2 | ETH/DEC21 | sell | 10     | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      #      | trader2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+      #      | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      #
+      #    When the opening auction period ends for market "ETH/DEC21"
+      #    Then the auction ends with a traded volume of "10" at a price of "1000"
+      #    And the market data for the market "ETH/DEC21" should be:
+      #     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      #     | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+      #
+      #    When the traders place the following orders:
+      #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+      #      | trader1 | ETH/DEC21 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+      #      | trader2 | ETH/DEC21 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+      #    And debug trades
+      #
+      #    Then the market data for the market "ETH/DEC21" should be:
+      #      | trading mode                    | auction trigger       |
+      #      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE |
+      #    And the network moves ahead "1" blocks
+      #
+      #    # end price auction
+      #    When the network moves ahead "300" blocks
+      #    Then the market data for the market "ETH/DEC21" should be:
+      #      | trading mode                    | auction trigger           |
+      #      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+      #
+      #    And the traders submit the following liquidity provision:
+      #      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+      #      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | buy        | BID             | 1                | -2           |
+      #      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | buy        | MID             | 2                | -1           |
+      #      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | sell       | ASK             | 1                | 2            |
+      #      | lp1 | trader0 | ETH/DEC21 | 5000              | 0.001 | sell       | MID             | 2                | 1            |
+      #
+      #    When the network moves ahead "1" blocks
+      #    Then the auction ends with a traded volume of "20" at a price of "1020"
+      #    And the market data for the market "ETH/DEC21" should be:
+      #     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      #     | 1020       | TRADING_MODE_CONTINUOUS | 1       | 1010      | 1030      | 3060         | 5000           | 20            |

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -187,9 +187,9 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
 
     When the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | trader2 | ETH/DEC21 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | no-reject |
-      | trader1 | ETH/DEC21 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GFN | reject-me |
-    Then the following orders should be rejected:
+      | trader2 | ETH/DEC21 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | no-reject |
+      | trader1 | ETH/DEC21 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GFN | reject-me |
+    Then the following orders should be stopped:
       | trader  | market id | reason                                               |
       | trader1 | ETH/DEC21 | ORDER_ERROR_NON_PERSISTENT_ORDER_OUT_OF_PRICE_BOUNDS |
 

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -311,7 +311,7 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     When the network moves ahead "301" blocks
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1       | 1010      | 1030      | 4080         | 4080           | 824635360400  |
+      | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1       | 1010      | 1030      | 4080         | 4080           | 40            |
 
 Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode
     Given the following network parameters are set:

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -2,9 +2,11 @@ Feature: Test interactions between different auction types
 
   Background:
     Given the following network parameters are set:
-      | name                              | value |
-      | market.stake.target.timeWindow    | 86400 |
-      | market.stake.target.scalingFactor | 1     |
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 86400 |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.targetstake.triggering.ratio | 0     |
+    And the average block duration is "1"
     And the simple risk model named "simple-risk-model-1":
       | long | short | max move up | min move down | probability of trading |
       | 0.1  | 0.1   | 10          | -10           | 0.1                    |
@@ -14,23 +16,23 @@ Feature: Test interactions between different auction types
     And the fees configuration named "fees-config-1":
       | maker fee | infrastructure fee | liquidity fee |
       | 0.004     | 0.001              | 0.3           |
-    And the price monitoring updated every "0" seconds named "price-monitoring-1":
+    And the price monitoring updated every "1" seconds named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 300               |
     And the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | oracle config          | maturity date        |
-      | ETH/DEC21 | BTC        | BTC   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 2021-12-31T23:59:59Z |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 2021-12-31T23:59:59Z |
     And the oracles broadcast data signed with "0xDEADBEEF":
       | name             | value |
       | prices.ETH.value | 100   |
-    And the liquidity order collection object with reference "buy_shape":
-      | reference | offet | proportion |
-      | BEST_BID  | -2    | 1          |
-      | MID       | -1    | 2          |
-    And the liquidity order collection object with reference "sell_shape":
-      | reference | offet | proportion |
-      | BEST_ASK  | 2     | 1          |
-      | MID       | 1     | 2          |
+      #And the liquidity order collection object with reference "buy_shape":
+      #  | reference | offet | proportion |
+      #  | BEST_BID  | -2    | 1          |
+      #  | MID       | -1    | 2          |
+      #And the liquidity order collection object with reference "sell_shape":
+      #  | reference | offet | proportion |
+      #  | BEST_ASK  | 2     | 1          |
+      #  | MID       | 1     | 2          |
     And the traders deposit on asset's general account the following amount:
       | trader  | asset | amount     |
       | trader0 | ETH   | 1000000000 |
@@ -39,349 +41,367 @@ Feature: Test interactions between different auction types
 
   Scenario: When trying to exit opening auction liquidity monitoring doesn't get triggered, hence the opening auction uncrosses and market goes into continuous trading mode.
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0     |
-
-
-    And the traders submit the following liquidity provision:
-      | id  | trader  | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | buy        | BID             | 500              | -10          |
-      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | sell       | ASK             | 500              | 10           |
+    Given the traders submit the following liquidity provision:
+      | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+      | lp1 | trader0 | ETH/DEC21 | 10000             | 0.001 | buy        | BID             | 500              | -10          |
+      | lp1 | trader0 | ETH/DEC21 | 10000             | 0.001 | sell       | ASK             | 500              | 10           |
 
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-2  |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-1 |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
+      | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
+      | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-2  |
+      | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-1 |
+      | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
 
-    And the price monitoring bounds are []
+    # this is a bit pointless, we're still in auction, price bounds aren't checked
+    # And the price monitoring bounds are []
 
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC19" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC19"
-    And the price monitoring bounds are [[990,1010]]
+    When the opening auction period ends for market "ETH/DEC21"
+    Then the auction ends with a traded volume of "10" at a price of "1000"
     # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1000 x 10 x 1 x 0.1
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 10000
-
-  Scenario: When trying to exit opening auction liquidity monitoring is triggered due to missing best bid, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0     |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 10000             | 0.001   | "buy_shape"      | "sell_shape"      |
-    Then the traders submit the following liquidity provision:
-      | id  | party   | market id | commitment amount | fee | order side | order reference | order proportion | order offset |
-      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | buy        | BID             | 500              | -10        |
-      | lp1 | trader0 | ETH/DEC19 | 10000             | 0.001 | sell       | ASK             | 500              | 10         |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the price monitoring bounds are []
-
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the auction ends resulting in traded volume of "10" at a price of "1000"
-    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 10000
-
-  Scenario: When trying to exit opening auction liquidity monitoring is triggered due to insufficient supplied stake, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
-
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 700               | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the price monitoring bounds are []
-
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-
-    When traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 800               | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-
-    When traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 801               | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-
-    When traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 10000
-
-  Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> leave auction mode
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the price monitoring bounds are []
-
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 1000
-
-    # If the order traded there'd be insufficient liquidity for the market to operate, hence the order doesn't trade
-    # and the market enters a liquidity monitoring auction
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
-      | trader2 | ETH/DEC19 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
-
-    And the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_LIQUIDITY" trigger
-    And the trading mode for the market "ETH/DEC19" is "TRADING_MODE_MONITORING_AUCTION"
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the traders cancel the following orders:
-      | trader  | reference   |
-      | trader1 | cancel-me-1 |
-      | trader2 | cancel-me-2 |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 3060              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    And the time is advance beyond "min_auction_length"
-    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_PRICE" trigger
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-    And the auction duration is "3s"
-
-    When the time is advanced by "4s"
-    Then the auction ends resulting in traded volume of "20" at a price of "1020"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "30"
-    And the mark price should be "1020" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[1010,1030]]
-    And the target stake should be "3060" for the market "ETH/DEC21"
-    And the supplied stake is 3060
-
-  Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode
-
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the price monitoring bounds are []
-
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 1000
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
-      | trader2 | ETH/DEC19 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
-
-    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_LIQUIDITY" trigger
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the traders cancel the following orders:
-      | trader  | reference   |
-      | trader1 | cancel-me-1 |
-      | trader2 | cancel-me-2 |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 3060              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_PRICE" trigger
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-    And the auction duration is "3s"
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the time is advanced by "4s"
-    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
-    And the trading mode for the market "ETH/DEC19" is "TRADING_MODE_MONITORING_AUCTION"
-
-    When traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 5000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    Then the auction ends resulting in traded volume of "30" at a price of "1020"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "40"
-    And the mark price should be "1020" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[1010,1030]]
-    And the target stake should be "4080" for the market "ETH/DEC21"
-    And the supplied stake is 5000
-
-  Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode
-
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the price monitoring bounds are []
-
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 1000
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
-      | trader2 | ETH/DEC19 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
-
-    Then the auction for market "ETH/DEC19" gets started with the "AUCTION_TRIGGER_PRICE" trigger
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-    And the auction duration is "3s"
-
-    When the time is advanced by "4s"
-    Then the auction for market "ETH/DEC19" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
-    And the trading mode for the market "ETH/DEC19" is "TRADING_MODE_MONITORING_AUCTION"
-
-    When traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 5000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    Then the auction ends resulting in traded volume of "20" at a price of "1020"
-    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
-    And the mark price should be "1020" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[1010,1030]]
-    And the target stake should be "3060" for the market "ETH/DEC21"
-    And the supplied stake is 5000
-
-  Scenario: Once market is in continuous trading mode: post a GFN order that should trigger liquidity auction, check that the order gets rejected, appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
-
-    And traders place following liquidity provisions:
-      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
-      | trader0 | ETH/DEC19 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
-
-    And the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader1 | ETH/DEC19 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader2 | ETH/DEC19 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-    And the price monitoring bounds are []
-
-    When the opening auction period ends for market "ETH/DEC19"
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 1000
-
-    When the traders place the following orders:
-      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | trader1 | ETH/DEC19 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GFN |           |
-      | trader2 | ETH/DEC19 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | reject-me |
-    And the order with reference "reject-me" gets rejected
-    And the event informing that non-persistent order was rejected due to violating trigger "AUCTION_TRIGGER_LIQUIDITY"
-
-    Then the auction ends resulting in traded volume of "10" at a price of "1000"
-    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
-    And the max_oi for the market "ETH/DEC21" is "10"
-    And the mark price should be "1000" for the market "ETH/DEC21"
-    And the price monitoring bounds are [[990,1010]]
-    And the target stake should be "1000" for the market "ETH/DEC21"
-    And the supplied stake is 1000
+    And the market data for the market "ETH/DEC21" should be:
+     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+     | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 10000          | 10            |
+
+Scenario: When trying to exit opening auction liquidity monitoring is triggered due to missing best bid, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
+
+  # This ought to be "buy_shape" and "sell_shape" equivalents
+  Given the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 10000             | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 10000             | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 10000             | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 10000             | 0.001 | sell       | MID             | 2                | 1            |
+
+  And the traders place the following orders:
+    | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+  # Again, pointless to check this in auction
+  # And the price monitoring bounds are []
+
+  When the opening auction period ends for market "ETH/DEC21"
+  # Perhaps the reason for extending could be changed to reflect which check actually failed
+  # In this case, though, it's the orderbook status, which applies to all auctions alike
+  # So the trigger being AUCTION_TRIGGER_OPENING is as accurate as any
+  Then the market data for the market "ETH/DEC21" should be:
+    | trading mode                 | auction trigger            |
+    | TRADING_MODE_OPENING_AUCTION | AUCTION_TRIGGER_OPENING    |
+
+  And the traders place the following orders:
+    | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+
+  When the network moves ahead "1" blocks
+  Then the auction ends with a traded volume of "10" at a price of "1000"
+
+  And the market data for the market "ETH/DEC21" should be:
+    | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+    | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 10000          | 10            |
+  # how can we trade, and still be in auction?
+  # And the market data for the market "ETH/DEC21" should be:
+  #   | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest |
+  #   | 1000       | TRADING_MODE_MONITORING_AUCTION | 1       | 990       | 1010      | 1000         | 10000          | 10            |
+
+
+Scenario: When trying to exit opening auction liquidity monitoring is triggered due to insufficient supplied stake, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
+
+  Given the following network parameters are set:
+    | name                                          | value |
+    | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+  And the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 700               | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 700               | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 700               | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 700               | 0.001 | sell       | MID             | 2                | 1            |
+
+  And the traders place the following orders:
+    | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+  When the opening auction period ends for market "ETH/DEC21"
+  # In this case, the required time has expired, and the book is fine, so the trigger probably should be LIQUIDITY
+  Then the market data for the market "ETH/DEC21" should be:
+    | trading mode                    | auction trigger           |
+    | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+    #| TRADING_MODE_OPENING_AUCTION | AUCTION_TRIGGER_OPENING    |
+
+  And the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 800               | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 800               | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 800               | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 800               | 0.001 | sell       | MID             | 2                | 1            |
+
+  When the network moves ahead "1" blocks
+  Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+
+  And the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 801               | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 801               | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 801               | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 801               | 0.001 | sell       | MID             | 2                | 1            |
+
+  When the network moves ahead "1" blocks
+
+  Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+
+  And the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | MID             | 2                | 1            |
+
+  When the network moves ahead "1" blocks
+
+  Then the auction ends with a traded volume of "10" at a price of "1000"
+  And the market data for the market "ETH/DEC21" should be:
+    | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+    | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+   
+
+Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> leave auction mode
+  Given the following network parameters are set:
+    | name                                          | value |
+    | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+  And the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 1000              | 0.001 | sell       | MID             | 2                | 1            |
+
+  And the traders place the following orders:
+    | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+  When the opening auction period ends for market "ETH/DEC21"
+  Then the auction ends with a traded volume of "10" at a price of "1000"
+  And the market data for the market "ETH/DEC21" should be:
+    | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+    | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+
+  # If the order traded there'd be insufficient liquidity for the market to operate, hence the order doesn't trade
+  # and the market enters a liquidity monitoring auction
+  When the traders place the following orders:
+    | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+    | trader1 | ETH/DEC21 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
+    | trader2 | ETH/DEC21 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
+
+  Then the market data for the market "ETH/DEC21" should be:
+    | trading mode                    | auction trigger           |
+    | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
+
+  When the traders place the following orders:
+    | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    | trader1 | ETH/DEC21 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+    | trader2 | ETH/DEC21 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+
+  And the traders cancel the following orders:
+    | trader  | reference   |
+    | trader1 | cancel-me-1 |
+    | trader2 | cancel-me-2 |
+  And debug market data for "ETH/DEC21"
+
+  And the traders submit the following liquidity provision:
+    | id  | party   | market id | commitment amount | fee   | order side | order reference | order proportion | order offset |
+    | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | buy        | BID             | 1                | -2           |
+    | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | buy        | MID             | 2                | -1           |
+    | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | sell       | ASK             | 1                | 2            |
+    | lp1 | trader0 | ETH/DEC21 | 3060              | 0.001 | sell       | MID             | 2                | 1            |
+
+  #And the time is advance beyond "min_auction_length"
+  #Then the auction for market "ETH/DEC21" gets started with the "AUCTION_TRIGGER_PRICE" trigger
+  #And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+  #And the auction duration is "3s"
+
+  #When the time is advanced by "4s"
+  #Then the auction ends resulting in traded volume of "20" at a price of "1020"
+  #And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+  #And the max_oi for the market "ETH/DEC21" is "30"
+  #And the mark price should be "1020" for the market "ETH/DEC21"
+  #And the price monitoring bounds are [[1010,1030]]
+  #And the target stake should be "3060" for the market "ETH/DEC21"
+  #And the supplied stake is 3060
+    #
+    #  Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode
+    #
+    #    Given the following network parameters are set:
+    #      | name                                          | value |
+    #      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    #
+    #    And traders place following liquidity provisions:
+    #      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+    #      | trader0 | ETH/DEC21 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+    #
+    #    And the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    #      | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    #
+    #    And the price monitoring bounds are []
+    #
+    #    When the opening auction period ends for market "ETH/DEC21"
+    #    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    #    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    #    And the max_oi for the market "ETH/DEC21" is "10"
+    #    And the mark price should be "1000" for the market "ETH/DEC21"
+    #    And the price monitoring bounds are [[990,1010]]
+    #    And the target stake should be "1000" for the market "ETH/DEC21"
+    #    And the supplied stake is 1000
+    #
+    #    When the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
+    #
+    #    Then the auction for market "ETH/DEC21" gets started with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    #    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+    #
+    #    When the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    #      | trader1 | ETH/DEC21 | buy  | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 20     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+    #
+    #    And the traders cancel the following orders:
+    #      | trader  | reference   |
+    #      | trader1 | cancel-me-1 |
+    #      | trader2 | cancel-me-2 |
+    #
+    #    And traders place following liquidity provisions:
+    #      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+    #      | trader0 | ETH/DEC21 | 3060              | 0.001   | "buy_shape"      | "sell_shape"      |
+    #
+    #    Then the auction for market "ETH/DEC21" gets started with the "AUCTION_TRIGGER_PRICE" trigger
+    #    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+    #    And the auction duration is "3s"
+    #
+    #    When the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+    #
+    #    And the time is advanced by "4s"
+    #    Then the auction for market "ETH/DEC21" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    #    And the trading mode for the market "ETH/DEC21" is "TRADING_MODE_MONITORING_AUCTION"
+    #
+    #    When traders place following liquidity provisions:
+    #      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+    #      | trader0 | ETH/DEC21 | 5000              | 0.001   | "buy_shape"      | "sell_shape"      |
+    #
+    #    Then the auction ends resulting in traded volume of "30" at a price of "1020"
+    #    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    #    And the max_oi for the market "ETH/DEC21" is "40"
+    #    And the mark price should be "1020" for the market "ETH/DEC21"
+    #    And the price monitoring bounds are [[1010,1030]]
+    #    And the target stake should be "4080" for the market "ETH/DEC21"
+    #    And the supplied stake is 5000
+    #
+    #  Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode
+    #
+    #    Given the following network parameters are set:
+    #      | name                                          | value |
+    #      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    #
+    #    And traders place following liquidity provisions:
+    #      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+    #      | trader0 | ETH/DEC21 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+    #
+    #    And the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    #      | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    #
+    #    And the price monitoring bounds are []
+    #
+    #    When the opening auction period ends for market "ETH/DEC21"
+    #    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    #    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    #    And the max_oi for the market "ETH/DEC21" is "10"
+    #    And the mark price should be "1000" for the market "ETH/DEC21"
+    #    And the price monitoring bounds are [[990,1010]]
+    #    And the target stake should be "1000" for the market "ETH/DEC21"
+    #    And the supplied stake is 1000
+    #
+    #    When the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-1 |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC | cancel-me-2 |
+    #
+    #    Then the auction for market "ETH/DEC21" gets started with the "AUCTION_TRIGGER_PRICE" trigger
+    #    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+    #    And the auction duration is "3s"
+    #
+    #    When the time is advanced by "4s"
+    #    Then the auction for market "ETH/DEC21" gets extended with the "AUCTION_TRIGGER_LIQUIDITY" trigger
+    #    And the trading mode for the market "ETH/DEC21" is "TRADING_MODE_MONITORING_AUCTION"
+    #
+    #    When traders place following liquidity provisions:
+    #      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+    #      | trader0 | ETH/DEC21 | 5000              | 0.001   | "buy_shape"      | "sell_shape"      |
+    #
+    #    Then the auction ends resulting in traded volume of "20" at a price of "1020"
+    #    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC21"
+    #    And the mark price should be "1020" for the market "ETH/DEC21"
+    #    And the price monitoring bounds are [[1010,1030]]
+    #    And the target stake should be "3060" for the market "ETH/DEC21"
+    #    And the supplied stake is 5000
+    #
+    #  Scenario: Once market is in continuous trading mode: post a GFN order that should trigger liquidity auction, check that the order gets rejected, appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS
+    #    Given the following network parameters are set:
+    #      | name                                          | value |
+    #      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    #
+    #    And traders place following liquidity provisions:
+    #      | trader  | market id | commitment amount | fee bid | buy shape object | sell shape object |
+    #      | trader0 | ETH/DEC21 | 1000              | 0.001   | "buy_shape"      | "sell_shape"      |
+    #
+    #    And the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     |
+    #      | trader1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    #
+    #    And the price monitoring bounds are []
+    #
+    #    When the opening auction period ends for market "ETH/DEC21"
+    #    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    #    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    #    And the max_oi for the market "ETH/DEC21" is "10"
+    #    And the mark price should be "1000" for the market "ETH/DEC21"
+    #    And the price monitoring bounds are [[990,1010]]
+    #    And the target stake should be "1000" for the market "ETH/DEC21"
+    #    And the supplied stake is 1000
+    #
+    #    When the traders place the following orders:
+    #      | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+    #      | trader1 | ETH/DEC21 | buy  | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GFN |           |
+    #      | trader2 | ETH/DEC21 | sell | 10     | 1010  | 0                | TYPE_LIMIT | TIF_GTC | reject-me |
+    #    And the order with reference "reject-me" gets rejected
+    #    And the event informing that non-persistent order was rejected due to violating trigger "AUCTION_TRIGGER_LIQUIDITY"
+    #
+    #    Then the auction ends resulting in traded volume of "10" at a price of "1000"
+    #    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    #    And the max_oi for the market "ETH/DEC21" is "10"
+    #    And the mark price should be "1000" for the market "ETH/DEC21"
+    #    And the price monitoring bounds are [[990,1010]]
+    #    And the target stake should be "1000" for the market "ETH/DEC21"
+    #    And the supplied stake is 1000

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -2,7 +2,6 @@ package core_test
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -149,11 +148,9 @@ func FeatureContext(s *godog.Suite) {
 			return err
 		}
 		t, _ := execsetup.timeService.GetTimeNow()
-		fmt.Printf("time is now: %s\n", t)
 		block := time.Duration(blockDuration) * time.Second
 		for i := int64(0); i < n; i++ {
 			t = t.Add(block)
-			fmt.Printf("time is now: %s\n", t)
 			execsetup.timeService.SetTime(t)
 		}
 		return nil

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -205,6 +205,9 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the following orders should be rejected:$`, func(table *gherkin.DataTable) error {
 		return steps.TheFollowingOrdersShouldBeRejected(execsetup.broker, table)
 	})
+	s.Step(`^the following orders should be stopped:$`, func(table *gherkin.DataTable) error {
+		return steps.TheFollowingOrdersShouldBeStopped(execsetup.broker, table)
+	})
 	s.Step(`^"([^"]*)" should have general account balance of "([^"]*)" for asset "([^"]*)"$`, func(trader, balance, asset string) error {
 		return steps.TraderShouldHaveGeneralAccountBalanceForAsset(execsetup.broker, trader, asset, balance)
 	})

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -39,6 +39,7 @@ func TestMain(m *testing.M) {
 }
 
 func FeatureContext(s *godog.Suite) {
+	var blockDuration int64
 	s.BeforeScenario(func(_ interface{}) {
 		execsetup = newExecutionTestSetup()
 	})
@@ -131,6 +132,14 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the oracles broadcast data signed with "([^"]*)":$`, func(pubKeys string, properties *gherkin.DataTable) error {
 		return steps.OraclesBroadcastDataSignedWithKeys(execsetup.oracleEngine, pubKeys, properties)
 	})
+	s.Step(`^the average block duration is "([^"]+)"$`, func(blockTime string) error {
+		bt, err := steps.TheBlockTimeIs(blockTime)
+		if err != nil {
+			return err
+		}
+		blockDuration = bt
+		return nil
+	})
 
 	// Assertion steps
 	s.Step(`^the following amendments should be rejected:$`, func(table *gherkin.DataTable) error {
@@ -205,7 +214,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^the supplied stake should be "([^"]*)" for the market "([^"]*)"$`, func(stake, marketID string) error {
 		return steps.TheSuppliedStakeShouldBeForTheMarket(execsetup.executionEngine, marketID, stake)
 	})
-	s.Step(`^the open interest should be "([^"]*)" for the market "([^"]*)"$`, func(stake , marketID string) error {
+	s.Step(`^the open interest should be "([^"]*)" for the market "([^"]*)"$`, func(stake, marketID string) error {
 		return steps.TheOpenInterestShouldBeForTheMarket(execsetup.executionEngine, marketID, stake)
 	})
 	s.Step(`^the liquidity provider fee shares for the market "([^"]*)" should be:$`, func(marketID string, table *gherkin.DataTable) error {

--- a/integration/steps/block_time.go
+++ b/integration/steps/block_time.go
@@ -1,0 +1,7 @@
+package steps
+
+import "strconv"
+
+func TheBlockTimeIs(bt string) (int64, error) {
+	return strconv.ParseInt(bt, 10, 0)
+}

--- a/integration/steps/market/defaults/price-monitoring/default-basic.json
+++ b/integration/steps/market/defaults/price-monitoring/default-basic.json
@@ -1,17 +1,17 @@
 {
-    "parameters": {
-	"triggers": [
-	    {
-		"horizon": 5,
-		"probability": 0.95,
-		"auctionExtension": 6
-	    },
-	    {
-		"horizon": 10,
-		"probability": 0.99,
-		"auctionExtension": 8
-	    }
-	]
-    },
-    "updateFrequency": 60
+  "parameters": {
+    "triggers": [
+      {
+        "horizon": 5,
+        "probability": 0.95,
+        "auctionExtension": 6
+      },
+      {
+        "horizon": 10,
+        "probability": 0.99,
+        "auctionExtension": 8
+      }
+    ]
+  },
+  "updateFrequency": 60
 }

--- a/integration/steps/network_params.go
+++ b/integration/steps/network_params.go
@@ -33,6 +33,12 @@ func TheFollowingNetworkParametersAreSet(exec *execution.Engine, netParams *netp
 			if err := netParams.Update(ctx, netparams.MarketLiquidityTargetStakeTriggeringRatio, n); err != nil {
 				return err
 			}
+		case netparams.MarketTargetStakeTimeWindow:
+			f := row.MustDurationSec("value")
+			str := f.String()
+			if err := netParams.Update(ctx, netparams.MarketTargetStakeTimeWindow, str); err != nil {
+				return err
+			}
 		default:
 			value := row.MustStr("value")
 			if err := netParams.Update(ctx, name, value); err != nil {

--- a/integration/steps/network_params.go
+++ b/integration/steps/network_params.go
@@ -27,6 +27,12 @@ func TheFollowingNetworkParametersAreSet(exec *execution.Engine, netParams *netp
 			if err := netParams.Update(ctx, netparams.MarketTargetStakeScalingFactor, n); err != nil {
 				return err
 			}
+		case netparams.MarketLiquidityTargetStakeTriggeringRatio:
+			f := row.MustF64("value")
+			n := strconv.FormatFloat(f, 'f', -1, 64)
+			if err := netParams.Update(ctx, netparams.MarketLiquidityTargetStakeTriggeringRatio, n); err != nil {
+				return err
+			}
 		default:
 			value := row.MustStr("value")
 			if err := netParams.Update(ctx, name, value); err != nil {

--- a/integration/steps/network_params.go
+++ b/integration/steps/network_params.go
@@ -34,7 +34,7 @@ func TheFollowingNetworkParametersAreSet(exec *execution.Engine, netParams *netp
 				return err
 			}
 		case netparams.MarketTargetStakeTimeWindow:
-			f := row.MustDurationSec("value")
+			f := row.MustDurationStr("value")
 			str := f.String()
 			if err := netParams.Update(ctx, netparams.MarketTargetStakeTimeWindow, str); err != nil {
 				return err

--- a/integration/steps/table_wrapper.go
+++ b/integration/steps/table_wrapper.go
@@ -552,6 +552,13 @@ func (r RowWrapper) MustDuration(name string) time.Duration {
 	return time.Duration(r.MustU64(name))
 }
 
+func (r RowWrapper) MustDurationStr(name string) time.Duration {
+	s := r.MustStr(name)
+	d, err := time.ParseDuration(s)
+	panicW(name, err)
+	return d
+}
+
 func (r RowWrapper) Duration(name string) time.Duration {
 	return time.Duration(r.U64(name))
 }

--- a/integration/steps/the_following_orders_should_be_rejected.go
+++ b/integration/steps/the_following_orders_should_be_rejected.go
@@ -36,6 +36,34 @@ func TheFollowingOrdersShouldBeRejected(broker *stubs.BrokerStub, orders *gherki
 	return nil
 }
 
+func TheFollowingOrdersShouldBeStopped(broker *stubs.BrokerStub, orders *gherkin.DataTable) error {
+	var orderNotRejected []string
+	count := len(orders.Rows) - 1
+	for _, row := range TableWrapper(*orders).Parse() {
+		trader := row.MustStr("trader")
+		marketID := row.MustStr("market id")
+		reason := row.MustStr("reason")
+
+		data := broker.GetOrderEvents()
+		for _, o := range data {
+			v := o.Order()
+			if v.PartyId == trader && v.MarketId == marketID {
+				if v.Status == types.Order_STATUS_STOPPED && v.Reason.String() == reason {
+					count -= 1
+					continue
+				}
+				orderNotRejected = append(orderNotRejected, v.Reference)
+			}
+		}
+	}
+
+	if count > 0 {
+		return errOrderNotRejected(orderNotRejected)
+	}
+
+	return nil
+}
+
 func errOrderNotRejected(orderNotRejected []string) error {
 	return fmt.Errorf("orders with reference %v were not rejected", orderNotRejected)
 }

--- a/integration/steps/the_following_trades_happened.go
+++ b/integration/steps/the_following_trades_happened.go
@@ -36,7 +36,7 @@ func TheFollowingTradesShouldBeExecuted(
 	return err
 }
 
-// pass in time at which the trades should happen in case there are previous trades in the broker stub
+// TheAuctionTradedVolumeAndPriceShouldBe pass in time at which the trades should happen in case there are previous trades in the broker stub
 func TheAuctionTradedVolumeAndPriceShouldBe(broker *stubs.BrokerStub, volume, price string, now time.Time) error {
 	v, err := U64(volume)
 	if err != nil {

--- a/integration/steps/the_following_trades_happened.go
+++ b/integration/steps/the_following_trades_happened.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cucumber/godog/gherkin"
 
@@ -33,6 +34,41 @@ func TheFollowingTradesShouldBeExecuted(
 	}
 
 	return err
+}
+
+// pass in time at which the trades should happen in case there are previous trades in the broker stub
+func TheAuctionTradedVolumeAndPriceShouldBe(broker *stubs.BrokerStub, volume, price string, now time.Time) error {
+	v, err := U64(volume)
+	if err != nil {
+		return err
+	}
+	p, err := U64(price)
+	if err != nil {
+		return err
+	}
+	// get all trades from stub
+	trades := broker.GetTrades()
+	sawV := uint64(0)
+	for _, t := range trades {
+		// no trades after the given time
+		if t.Timestamp > now.UnixNano() {
+			continue
+		}
+		if t.Price != p {
+			return fmt.Errorf(
+				"expected trades to happen at price %d, instead saw a trade of size %d at price %d (%#v)",
+				p, t.Size, t.Price, t,
+			)
+		}
+		sawV += t.Size
+	}
+	if sawV != v {
+		return fmt.Errorf(
+			"expected a total traded volume of %d, instead saw a traded volume of %d len(%d): (%#v)",
+			v, sawV, len(trades), trades,
+		)
+	}
+	return nil
 }
 
 func errMissingTrade(buyer string, seller string, price uint64, volume uint64) error {

--- a/integration/steps/the_market_data_should_be.go
+++ b/integration/steps/the_market_data_should_be.go
@@ -53,14 +53,14 @@ func TheMarketDataShouldBe(engine *execution.Engine, mID string, data *gherkin.D
 	for _, u := range u64Set {
 		e, g := cmp.u64Map[u], parsed.u64Map[u] // get pointers to both fields
 		if *e != *g {
-			errs = append(errs, fmt.Errorf("expected '%d' for %s, instead got '%d'", e, u, g))
+			errs = append(errs, fmt.Errorf("expected '%d' for %s, instead got '%d'", *e, u, *g))
 		}
 	}
 	// compare int64
 	for _, i := range i64Set {
 		e, g := cmp.i64Map[i], parsed.i64Map[i]
 		if *e != *g {
-			errs = append(errs, fmt.Errorf("expected '%d' for %s, instead fot '%d'", e, i, g))
+			errs = append(errs, fmt.Errorf("expected '%d' for %s, instead fot '%d'", *e, i, *g))
 		}
 	}
 	// compare strings

--- a/integration/steps/the_market_data_should_be.go
+++ b/integration/steps/the_market_data_should_be.go
@@ -1,0 +1,226 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	"code.vegaprotocol.io/vega/execution"
+	types "code.vegaprotocol.io/vega/proto"
+
+	"github.com/cucumber/godog/gherkin"
+)
+
+type MappedMD struct {
+	md     types.MarketData
+	u64Map map[string]*uint64
+	strMap map[string]*string
+	i64Map map[string]*int64
+	tm     *types.Market_TradingMode
+	tr     *types.AuctionTrigger
+}
+
+type ErrStack []error
+
+func TheMarketDataShouldBe(engine *execution.Engine, mID string, data *gherkin.DataTable) error {
+	actual, err := engine.GetMarketData(mID)
+	if err != nil {
+		return err
+	}
+	// create a copy (deep copy), override the values we've gotten with those from the table so we can compare the objects
+	expect := mappedMD(actual)
+	// special fields first, these need to be compared manually
+	u64Set := expect.parseU64(data)
+	i64Set := expect.parseI64(data)
+	strSet := expect.parseStr(data)
+	expect.parseSpecial(data)
+	if pm := getPriceBounds(data); len(pm) > 0 {
+		expect.md.PriceMonitoringBounds = pm
+	}
+	// this might be a sparse check
+	if lp := getLPFeeShare(data); len(lp) > 0 {
+		expect.md.LiquidityProviderFeeShare = lp
+	}
+	cmp := mappedMD(actual)
+	parsed := mappedMD(expect.md)
+	errs := make([]error, 0, len(u64Set)+len(i64Set)+len(strSet)+2)
+	if expect.tm != nil && *expect.tm != expect.md.MarketTradingMode {
+		errs = append(errs, fmt.Errorf("expected '%s' trading mode, instead got '%s'", *expect.tm, expect.md.MarketTradingMode))
+	}
+	if expect.tr != nil && *expect.tr != expect.md.Trigger {
+		errs = append(errs, fmt.Errorf("expected '%s' auction trigger, instead got '%s'", *expect.tr, expect.md.Trigger))
+	}
+	// compare uint64
+	for _, u := range u64Set {
+		e, g := cmp.u64Map[u], parsed.u64Map[u] // get pointers to both fields
+		if *e != *g {
+			errs = append(errs, fmt.Errorf("expected '%d' for %s, instead got '%d'", e, u, g))
+		}
+	}
+	// compare int64
+	for _, i := range i64Set {
+		e, g := cmp.i64Map[i], parsed.i64Map[i]
+		if *e != *g {
+			errs = append(errs, fmt.Errorf("expected '%d' for %s, instead fot '%d'", e, i, g))
+		}
+	}
+	// compare strings
+	for _, s := range strSet {
+		e, g := cmp.strMap[s], parsed.strMap[s]
+		if *e != *g {
+			errs = append(errs, fmt.Errorf("expected '%s' for %s, instead got '%s'", *e, s, *g))
+		}
+	}
+	// wrap all errors in a single error type for complete information
+	if len(errs) > 0 {
+		return ErrStack(errs)
+	}
+	// compare special fields (trading mode and auction trigger)
+	return nil
+}
+
+func getPriceBounds(data *gherkin.DataTable) (ret []*types.PriceMonitoringBounds) {
+	for _, row := range TableWrapper(*data).Parse() {
+		h := row.I64("horizon")
+		if h == 0 {
+			continue
+		}
+		expected := &types.PriceMonitoringBounds{
+			MinValidPrice: row.MustU64("min bound"),
+			MaxValidPrice: row.MustU64("max bound"),
+			Trigger: &types.PriceMonitoringTrigger{
+				Horizon: h,
+			},
+		}
+		ret = append(ret, expected)
+	}
+	return ret
+}
+
+func getLPFeeShare(data *gherkin.DataTable) (ret []*types.LiquidityProviderFeeShare) {
+	for _, r := range TableWrapper(*data).Parse() {
+		avg := r.Str("average entry valuation")
+		if avg == "" {
+			continue
+		}
+		ret = append(ret, &types.LiquidityProviderFeeShare{
+			Party:                 r.MustStr("party"),
+			EquityLikeShare:       r.MustStr("equity share"),
+			AverageEntryValuation: avg,
+		})
+	}
+	return ret
+}
+
+func (m *MappedMD) parseSpecial(data *gherkin.DataTable) {
+	todo := map[string]struct{}{
+		"trading mode":    {},
+		"auction trigger": {},
+	}
+	for _, r := range TableWrapper(*data).Parse() {
+		for k := range todo {
+			if _, ok := r.StrB(k); ok {
+				switch k {
+				case "trading mode":
+					tm := r.MustTradingMode(k)
+					m.tm = &tm
+				case "auction trigger":
+					at := r.MustAuctionTrigger(k)
+					m.tr = &at
+				}
+				delete(todo, k)
+			}
+		}
+		if len(todo) == 0 {
+			return
+		}
+	}
+}
+
+// parses the data, and returns a slice of keys for the values that were provided
+func (m *MappedMD) parseU64(data *gherkin.DataTable) []string {
+	set := make([]string, 0, len(m.u64Map))
+	for _, r := range TableWrapper(*data).Parse() {
+		for k, ptr := range m.u64Map {
+			if u, ok := r.U64B(k); ok {
+				*ptr = u
+				set = append(set, k)
+				// avoid reassignments in following iterations
+				delete(m.u64Map, k)
+			}
+		}
+	}
+	return set
+}
+
+func (m *MappedMD) parseI64(data *gherkin.DataTable) []string {
+	set := make([]string, 0, len(m.i64Map))
+	for _, r := range TableWrapper(*data).Parse() {
+		for k, ptr := range m.i64Map {
+			if i, ok := r.I64B(k); ok {
+				*ptr = i
+				set = append(set, k)
+				// again: avoid reassignments when parsing the next row
+				delete(m.i64Map, k)
+			}
+		}
+	}
+	return set
+}
+
+func (m *MappedMD) parseStr(data *gherkin.DataTable) []string {
+	set := make([]string, 0, len(m.strMap))
+	for _, r := range TableWrapper(*data).Parse() {
+		for k, ptr := range m.strMap {
+			if i, ok := r.StrB(k); ok {
+				*ptr = i
+				set = append(set, k)
+				// again: avoid reassignments when parsing the next row
+				delete(m.strMap, k)
+			}
+		}
+	}
+	return set
+}
+
+func mappedMD(md types.MarketData) *MappedMD {
+	r := &MappedMD{
+		md: md,
+	}
+	r.u64Map = map[string]*uint64{
+		"mark price":               &r.md.MarkPrice,
+		"best bid price":           &r.md.BestBidPrice,
+		"best bid volume":          &r.md.BestBidVolume,
+		"best offer price":         &r.md.BestOfferPrice,
+		"best offer volume":        &r.md.BestOfferVolume,
+		"best static bid price":    &r.md.BestStaticBidPrice,
+		"best static bid volume":   &r.md.BestStaticBidVolume,
+		"best static offer price":  &r.md.BestStaticOfferPrice,
+		"best static offer volume": &r.md.BestStaticOfferVolume,
+		"mid price":                &r.md.MidPrice,
+		"static mid price":         &r.md.StaticMidPrice,
+		"open interest":            &r.md.OpenInterest,
+		"indicative price":         &r.md.IndicativePrice,
+		"indicative volume":        &r.md.IndicativeVolume,
+	}
+	r.strMap = map[string]*string{
+		"target stake":       &r.md.TargetStake,
+		"supplied stake":     &r.md.SuppliedStake,
+		"market value proxy": &r.md.MarketValueProxy,
+		"market":             &r.md.Market, // this is a bit pointless, but might as well add it
+	}
+	r.i64Map = map[string]*int64{
+		"timestamp":     &r.md.Timestamp,
+		"auction end":   &r.md.AuctionEnd,
+		"auction start": &r.md.AuctionStart,
+	}
+	return r
+}
+
+// Error so we print out the wrong matches line by line
+func (e ErrStack) Error() string {
+	str := make([]string, 0, len(e))
+	for _, v := range e {
+		str = append(str, v.Error())
+	}
+	return strings.Join(str, "\n")
+}

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -131,6 +131,12 @@ func NewMonitor(riskModel RangeProvider, settings types.PriceMonitoringSettings)
 		updateFrequency: time.Duration(settings.UpdateFrequency) * time.Second,
 		bounds:          bounds,
 	}
+	// hack to work around the update frequency being 0 causing an infinite loop
+	// for now, this will do
+	// @TODO go through integration and system tests once we validate this properly
+	if settings.UpdateFrequency == 0 {
+		e.updateFrequency = time.Second
+	}
 	return e, nil
 }
 

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -277,7 +277,7 @@ func (e *Engine) UpdateMarkPrice(markPrice uint64) []events.MarketPosition {
 }
 
 func (e *Engine) GetOpenInterest() uint64 {
-	var openInterest uint64
+	openInterest := uint64(0)
 	for _, pos := range e.positions {
 		if pos.size > 0 {
 			openInterest += uint64(pos.size)


### PR DESCRIPTION
Implemented the feature file provided by @witgaw 

* A couple of scenario's currently aren't passing yet, due to a bug that's currently being worked on.
* The scenario that checked that non-persistent orders triggering a liquidity auction would be rejected was changed to check non-persistent orders triggering a PRICE auction are stopped. After checking with Barney and David, it was decided that liquidity auctions should indeed be triggered (and the order would not be rejected).
* Integration tests can now update vegatime (`the network moves ahead "N" blocks`)
* Checking market data can be done using a data table