### PR TITLE
Add config to enable/disable broadcast_tx_commit, disabled by default

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -13,11 +13,12 @@ const namedLogger = "api.grpc"
 
 // Config represents the configuration of the api package
 type Config struct {
-	Level         encoding.LogLevel `long:"log-level"`
-	Timeout       encoding.Duration `long:"timeout"`
-	Port          int               `long:"port"`
-	IP            string            `long:"ip"`
-	StreamRetries int               `long:"stream-retries"`
+	Level           encoding.LogLevel `long:"log-level"`
+	Timeout         encoding.Duration `long:"timeout"`
+	Port            int               `long:"port"`
+	IP              string            `long:"ip"`
+	StreamRetries   int               `long:"stream-retries"`
+	DisableTxCommit bool              `long:"disable-tx-commit"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
@@ -27,8 +28,9 @@ func NewDefaultConfig() Config {
 		Level:   encoding.LogLevel{Level: logging.InfoLevel},
 		Timeout: encoding.Duration{Duration: 5000 * time.Millisecond},
 
-		IP:            "0.0.0.0",
-		Port:          3002,
-		StreamRetries: 3,
+		IP:              "0.0.0.0",
+		Port:            3002,
+		StreamRetries:   3,
+		DisableTxCommit: true,
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -156,6 +156,7 @@ func (g *GRPCServer) ReloadConf(cfg Config) {
 	// TODO(): not updating the the actual server for now, may need to look at this later
 	// e.g restart the http server on another port or whatever
 	g.Config = cfg
+	g.tradingService.updateConfig(cfg)
 }
 
 func remoteAddrInterceptor(log *logging.Logger) grpc.UnaryServerInterceptor {
@@ -224,6 +225,7 @@ func (g *GRPCServer) Start() {
 
 	tradingSvc := &tradingService{
 		log:               g.log,
+		conf:              g.Config,
 		blockchain:        g.client,
 		tradeOrderService: g.orderService,
 		liquidityService:  g.liquidityService,

--- a/api/trading.go
+++ b/api/trading.go
@@ -147,11 +147,10 @@ func (s *tradingService) PrepareAmendOrder(ctx context.Context, req *protoapi.Pr
 // value receiver is important, config can be updated, this avoids data race
 func (s tradingService) validateSubmitTx(ty protoapi.SubmitTransactionRequest_Type) (protoapi.SubmitTransactionRequest_Type, error) {
 	// ensure this is a known value for the type
-	if _, ok := protoapi.SubmitTransactionRequest_Type_name[ty]; !ok {
+	if _, ok := protoapi.SubmitTransactionRequest_Type_name[int32(ty)]; !ok {
 		return protoapi.SubmitTransactionRequest_TYPE_UNSPECIFIED, ErrUnknownSubmitTxRequestType
 	}
 
-	var err error
 	switch ty {
 	// FIXME(jeremy): in order to keep compatibility with existing clients
 	// we allow no submiting the Type field, and default to old behaviour

--- a/api/trading.go
+++ b/api/trading.go
@@ -145,7 +145,7 @@ func (s *tradingService) PrepareAmendOrder(ctx context.Context, req *protoapi.Pr
 }
 
 // value receiver is important, config can be updated, this avoids data race
-func (s tradingService) validateSubmitTx(ty protoapu.SubmitTransactionRequest_Type) (protoapi.SubmitTransactionRequest_Type, error) {
+func (s tradingService) validateSubmitTx(ty protoapi.SubmitTransactionRequest_Type) (protoapi.SubmitTransactionRequest_Type, error) {
 	// ensure this is a known value for the type
 	if _, ok := protoapi.SubmitTransactionRequest_Type_name[ty]; !ok {
 		return protoapi.SubmitTransactionRequest_TYPE_UNSPECIFIED, ErrUnknownSubmitTxRequestType

--- a/api/trading.go
+++ b/api/trading.go
@@ -21,7 +21,9 @@ import (
 )
 
 var (
-	ErrInvalidSignature = errors.New("invalid signature")
+	ErrInvalidSignature           = errors.New("invalid signature")
+	ErrSubmitTxCommitDisabled     = errors.New("broadcast_tx_commit is disabled")
+	ErrUnknownSubmitTxRequestType = errors.New("invalid broadcast_tx type")
 )
 
 // TradeOrderService ...
@@ -65,7 +67,8 @@ type Blockchain interface {
 }
 
 type tradingService struct {
-	log *logging.Logger
+	log  *logging.Logger
+	conf Config
 
 	blockchain        Blockchain
 	tradeOrderService TradeOrderService
@@ -76,6 +79,11 @@ type tradingService struct {
 	evtForwarder      EvtForwarder
 
 	statusChecker *monitoring.Status
+}
+
+// no need for a mutext - we only access the config through a value receiver
+func (s *tradingService) updateConfig(conf Config) {
+	s.conf = conf
 }
 
 func (s *tradingService) PrepareSubmitOrder(ctx context.Context, req *protoapi.PrepareSubmitOrderRequest) (*protoapi.PrepareSubmitOrderResponse, error) {
@@ -136,6 +144,29 @@ func (s *tradingService) PrepareAmendOrder(ctx context.Context, req *protoapi.Pr
 	}, nil
 }
 
+// value receiver is important, config can be updated, this avoids data race
+func (s tradingService) validateSubmitTx(ty protoapu.SubmitTransactionRequest_Type) (protoapi.SubmitTransactionRequest_Type, error) {
+	// ensure this is a known value for the type
+	if _, ok := protoapi.SubmitTransactionRequest_Type_name[ty]; !ok {
+		return protoapi.SubmitTransactionRequest_TYPE_UNSPECIFIED, ErrUnknownSubmitTxRequestType
+	}
+
+	var err error
+	switch ty {
+	// FIXME(jeremy): in order to keep compatibility with existing clients
+	// we allow no submiting the Type field, and default to old behaviour
+	case protoapi.SubmitTransactionRequest_TYPE_UNSPECIFIED:
+		ty = protoapi.SubmitTransactionRequest_TYPE_ASYNC
+	case protoapi.SubmitTransactionRequest_TYPE_COMMIT:
+		// commit is disabled?
+		if s.conf.DisableTxCommit {
+			return protoapi.SubmitTransactionRequest_TYPE_UNSPECIFIED, ErrSubmitTxCommitDisabled
+		}
+	}
+	// ty is a known type, and not disabled, all good
+	return ty, nil
+}
+
 func (s *tradingService) SubmitTransaction(ctx context.Context, req *protoapi.SubmitTransactionRequest) (*protoapi.SubmitTransactionResponse, error) {
 	startTime := time.Now()
 	defer metrics.APIRequestAndTimeGRPC("SubmitTransaction", startTime)
@@ -143,11 +174,9 @@ func (s *tradingService) SubmitTransaction(ctx context.Context, req *protoapi.Su
 		return nil, apiError(codes.InvalidArgument, ErrMalformedRequest)
 	}
 
-	var ty = req.Type
-	// FIXME(jeremy): in order to keep compatibility with existing clients
-	// we allow no submiting the Type field, and default to old behaviour
-	if ty == protoapi.SubmitTransactionRequest_TYPE_UNSPECIFIED {
-		ty = protoapi.SubmitTransactionRequest_TYPE_ASYNC
+	ty, err := s.validateSubmitTx(req.Type)
+	if err != nil {
+		return nil, apiError(codes.InvalidArgument, err)
 	}
 
 	if err := s.blockchain.SubmitTransaction(ctx, req.Tx, ty); err != nil {


### PR DESCRIPTION
Config added to the `api.Config` specifically for the broadcast_tx_commit stuff. We might want to consider a broader `env: {"prod", "dev", "staging"}` deal, but this addresses the issue at hand with minimal effort.