### PR TITLE
fix(market data): update to not return error when no market data exist

### DIFF
--- a/api/trading_data.go
+++ b/api/trading_data.go
@@ -761,12 +761,20 @@ func (t *tradingDataService) MarginLevels(_ context.Context, req *protoapi.Margi
 }
 
 // MarketDataByID provides market data for the given ID.
-func (t *tradingDataService) MarketDataByID(_ context.Context, req *protoapi.MarketDataByIDRequest) (*protoapi.MarketDataByIDResponse, error) {
+func (t *tradingDataService) MarketDataByID(ctx context.Context, req *protoapi.MarketDataByIDRequest) (*protoapi.MarketDataByIDResponse, error) {
 	defer metrics.StartAPIRequestAndTimeGRPC("MarketDataByID")()
 
 	err := req.Validate()
 	if err != nil {
 		return nil, err
+	}
+
+	// validate the market exist
+	if req.MarketId != "" {
+		_, err := t.MarketService.GetByID(ctx, req.MarketId)
+		if err != nil {
+			return nil, apiError(codes.InvalidArgument, ErrInvalidMarketID, err)
+		}
 	}
 
 	md, err := t.MarketService.GetMarketDataByID(req.MarketId)

--- a/api/trading_test.go
+++ b/api/trading_test.go
@@ -353,3 +353,26 @@ func TestPrepareProposal(t *testing.T) {
 
 	g.Stop()
 }
+
+func TestMarketDataByID_marketDoesNotExist(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	defer cancel()
+
+	g, tidy, conn, err := getTestGRPCServer(t, ctx, 64201, true)
+	if err != nil {
+		t.Fatalf("Failed to get test gRPC server: %s", err.Error())
+	}
+	defer tidy()
+
+	client := protoapi.NewTradingDataServiceClient(conn)
+	assert.NotNil(t, client)
+
+	md, err := client.MarketDataByID(ctx, &protoapi.MarketDataByIDRequest{
+		MarketId: "non-existent",
+	})
+
+	assert.Error(t, err, "market does not exist")
+	assert.Nil(t, md)
+
+	g.Stop()
+}

--- a/gateway/graphql/generated.go
+++ b/gateway/graphql/generated.go
@@ -5963,7 +5963,7 @@ type Market {
   ): [Candle]
 
   "marketData for the given market"
-  data: MarketData!
+  data: MarketData
 
   "The list of the liquidity provision commitment for this market"
   liquidityProvisions(
@@ -13988,14 +13988,11 @@ func (ec *executionContext) _Market_data(ctx context.Context, field graphql.Coll
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*proto.MarketData)
 	fc.Result = res
-	return ec.marshalNMarketData2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐMarketData(ctx, field.Selections, res)
+	return ec.marshalOMarketData2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐMarketData(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Market_liquidityProvisions(ctx context.Context, field graphql.CollectedField, obj *proto.Market) (ret graphql.Marshaler) {
@@ -28980,9 +28977,6 @@ func (ec *executionContext) _Market(ctx context.Context, sel ast.SelectionSet, o
 					}
 				}()
 				res = ec._Market_data(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		case "liquidityProvisions":
@@ -36155,6 +36149,17 @@ func (ec *executionContext) marshalOMarket2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋ
 		return graphql.Null
 	}
 	return ec._Market(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOMarketData2codeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐMarketData(ctx context.Context, sel ast.SelectionSet, v proto.MarketData) graphql.Marshaler {
+	return ec._MarketData(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOMarketData2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐMarketData(ctx context.Context, sel ast.SelectionSet, v *proto.MarketData) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._MarketData(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalONetworkParameter2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotoᚐNetworkParameterᚄ(ctx context.Context, sel ast.SelectionSet, v []*proto.NetworkParameter) graphql.Marshaler {

--- a/gateway/graphql/schema.graphql
+++ b/gateway/graphql/schema.graphql
@@ -1184,7 +1184,7 @@ type Market {
   ): [Candle]
 
   "marketData for the given market"
-  data: MarketData!
+  data: MarketData
 
   "The list of the liquidity provision commitment for this market"
   liquidityProvisions(

--- a/markets/service_test.go
+++ b/markets/service_test.go
@@ -24,6 +24,7 @@ type testService struct {
 	order       *mocks.MockOrderStore
 	market      *mocks.MockMarketStore
 	marketDepth *mocks.MockMarketDepth
+	marketData  *mocks.MockMarketDataStore
 }
 
 func getTestService(t *testing.T) *testService {
@@ -52,6 +53,7 @@ func getTestService(t *testing.T) *testService {
 		order:       order,
 		market:      market,
 		marketDepth: marketdepth,
+		marketData:  marketdata,
 	}
 }
 
@@ -183,8 +185,19 @@ func testMarketObserveDepthSuccess(t *testing.T) {
 	wg.Wait() // wait for unsubscribe call
 }
 
+func TestMarketService_GetMarketDataByID(t *testing.T) {
+	svc := getTestService(t)
+	defer svc.Finish()
+	svc.marketData.EXPECT().GetByID(gomock.Any()).DoAndReturn(func(marketID string) (types.MarketData, error) {
+		return types.MarketData{}, nil
+	})
+
+	_, err := svc.GetMarketDataByID("BTC/MAY21")
+	assert.NoError(t, err)
+}
+
 func (t *testService) Finish() {
 	t.cfunc()
-	t.log.Sync()
+	_ = t.log.Sync()
 	t.ctrl.Finish()
 }

--- a/storage/markets_data.go
+++ b/storage/markets_data.go
@@ -53,14 +53,13 @@ func NewMarketData(log *logging.Logger, c Config) *MarketData {
 }
 
 func (m *MarketData) GetByID(marketID string) (proto.MarketData, error) {
-	var err error
 	m.mu.RLock()
 	md, ok := m.store[marketID]
 	m.mu.RUnlock()
 	if !ok {
-		err = ErrNoMarketDataForMarket
+		return proto.MarketData{}, nil
 	}
-	return md, err
+	return md, nil
 }
 
 func (m *MarketData) GetAll() []proto.MarketData {


### PR DESCRIPTION
BREAKING CHANGE: Callers of the service and API won't get an error when
no market data is available for a market, e.g. for newly created market
with no trades yet.

We also return an error in the API for non existing markets.