### PR TITLE
remove all undeployed provision logic

### DIFF
--- a/liquidity/amendments.go
+++ b/liquidity/amendments.go
@@ -70,7 +70,6 @@ func (e *Engine) AmendLiquidityProvision(
 	if lp.Status == types.LiquidityProvision_STATUS_ACTIVE {
 		lp.Status = types.LiquidityProvision_STATUS_UNDEPLOYED
 	}
-	e.undeployedProvisions = true
 
 	e.buildLiquidityProvisionShapesReferences(lp, lps)
 


### PR DESCRIPTION
Until now, we were re-calculating price of LP orders following these reasons when calling liquidityEngine.Update():
- some order of the LP providers had been updated
- some order where still undeployed or pending.

This was all fine untile recently as we would let the market reprice the orders based on the pegged reference and offset.
Although following recent changes  this is now less acceptable, here's and example:
- an order cannot be price in the range by the market, so the price is put to the reference or the min/maxPrice, which means that the offset of the LP order shape needs to be move slighlty.

By doing that we customize the shape from the party, but that also means that in future repricing the market would reuse our dynamic offset.

We know reprice orders every time liquidity update is called so we can adjust the offset if needed, or even use back the initial offset if adjustment is not needed anymore.

close #3508