### PR TITLE
Price bounds and target stake

### DIFF
--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -651,6 +651,9 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 				po.Offset = 0
 			case types.PeggedReference_PEGGED_REFERENCE_MID:
 				po.Offset = -1
+				if m.as.InAuction() {
+					po.Offset = 0
+				}
 			}
 			return price - uint64(-po.Offset), po, nil
 		}
@@ -666,6 +669,9 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 			po.Offset = 0
 		case types.PeggedReference_PEGGED_REFERENCE_MID:
 			po.Offset = -1
+			if m.as.InAuction() {
+				po.Offset = 0
+			}
 		}
 		return price - uint64(-po.Offset), po, nil
 	}

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -2193,12 +2193,12 @@ func TestMarketValueProxyIsUpdatedWithTrades(t *testing.T) {
 	// 1 second so factor = t_market_value_window_length / active_window_length = 2.
 	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(1*time.Second))
 	md = tm.market.GetMarketData()
-	assert.Equal(t, "2221978", md.MarketValueProxy)
+	assert.Equal(t, "10000", md.MarketValueProxy)
 
 	// we increase the time for another second
 	tm.market.OnChainTimeUpdate(ctx, auctionEnd.Add(2*time.Second))
 	md = tm.market.GetMarketData()
-	assert.Equal(t, "1110989", md.MarketValueProxy)
+	assert.Equal(t, "10000", md.MarketValueProxy)
 
 	// now we increase the time for another second, which makes us slide
 	// out of the window, and reset the tradeValue + window

--- a/execution/market.go
+++ b/execution/market.go
@@ -572,7 +572,13 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 			if evt := m.as.AuctionExtended(ctx); evt != nil {
 				m.broker.Send(evt)
 			}
-			m.checkLiquidity(ctx, nil)
+			ft := []*types.Trade{
+				{
+					Size:  v,
+					Price: p,
+				},
+			}
+			m.checkLiquidity(ctx, ft)
 			// price monitoring engine and liquidity monitoring engine both indicated auction can end
 			if m.as.AuctionEnd() {
 				if m.matching.BidAndAskPresentAfterAuction() {

--- a/execution/market.go
+++ b/execution/market.go
@@ -572,6 +572,8 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 			if evt := m.as.AuctionExtended(ctx); evt != nil {
 				m.broker.Send(evt)
 			}
+			// hacky way to ensure the liquidity monitoring will calculate the target stake based on the target stake
+			// SHOULD we leave the auction. Otherwise, we would leave a liquidity auction, and immediately enter a new one
 			ft := []*types.Trade{
 				{
 					Size:  v,

--- a/integration/features/509-auction-interaction.feature
+++ b/integration/features/509-auction-interaction.feature
@@ -92,10 +92,6 @@ Scenario: When trying to exit opening auction liquidity monitoring is triggered 
   And the market data for the market "ETH/DEC21" should be:
     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
     | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 10000          | 10            |
-  # how can we trade, and still be in auction?
-  # And the market data for the market "ETH/DEC21" should be:
-  #   | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest |
-  #   | 1000       | TRADING_MODE_MONITORING_AUCTION | 1       | 990       | 1010      | 1000         | 10000          | 10            |
 
 
 Scenario: When trying to exit opening auction liquidity monitoring is triggered due to insufficient supplied stake, hence the opening auction gets extended, the markets trading mode is TRADING_MODE_MONITORING_AUCTION and the trigger is AUCTION_TRIGGER_LIQUIDITY.
@@ -192,8 +188,6 @@ Scenario: Once market is in continuous trading mode: post a GFN order that shoul
       | trader1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
       #And clear order events
-      #And debug market data for "ETH/DEC21"
-      #And debug orders
     And the market data for the market "ETH/DEC21" should be:
      | trading mode                    | auction trigger           | target stake | supplied stake | open interest |
      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY | 1000         | 1000           | 10            |
@@ -299,8 +293,8 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     When the network moves ahead "2" blocks
     # We should be able to leave liquidity auction now
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode            | auction trigger             |
-      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
+      | trading mode                    | auction trigger           |
+      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 1      | 999   | 0                | TYPE_LIMIT | TIF_GTC |
@@ -311,7 +305,7 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
     When the network moves ahead "301" blocks
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1       | 1010      | 1030      | 4080         | 4080           | 40            |
+      | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1       | 1010      | 1030      | 3060         | 4080           | 30            |
 
 Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode
     Given the following network parameters are set:
@@ -383,27 +377,28 @@ Scenario: Once market is in continuous trading mode: enter liquidity monitoring 
       | lp1 | trader0 | ETH/DEC21 | 5100              | 0.001 | sell       | MID             | 2                | 1            |
     And the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode            | auction trigger             |
-      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
+      | trading mode                    | auction trigger           |
+      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
 
     When the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
       | trader1 | ETH/DEC21 | buy  | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 10     | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the network moves ahead "10" blocks
 
-    # Now we place some orders that are outside the price range
+    # Now we place some orders that are outside the price range, auction is extended by price (300)
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode                    | auction trigger       |
-      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE |
+      | trading mode                    | auction trigger           |
+      | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
 
     # jump ahead to the end of the auction
-    When the network moves ahead "301" blocks
+    When the network moves ahead "291" blocks
     Then the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             |
       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1020       | TRADING_MODE_CONTINUOUS | 1       | 1010      | 1030      | 5100         | 5100           | 50            |
+      | 1020       | TRADING_MODE_CONTINUOUS | 1       | 1010      | 1030      | 4080         | 5100           | 40            |
 
 
       #Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode

--- a/liquidity/amendments.go
+++ b/liquidity/amendments.go
@@ -100,6 +100,7 @@ func (e *Engine) GetPotentialShapeOrders(
 			}
 			order := &supplied.LiquidityOrder{
 				Proportion: uint64(lorder.Proportion),
+				Peg:        pegged,
 			}
 			price, _, err := repriceFn(pegged, side)
 			if err != nil {
@@ -160,7 +161,7 @@ func (e *Engine) buildPotentialShapeOrders(party string, supplied []*supplied.Li
 		// no need to make it a proper pegged order, set an actual ID etc here
 		// as we actually just return this order as a template for margin
 		// calculation
-		order := e.buildOrder(side, nil, o.Price, party, e.marketID, o.LiquidityImpliedVolume, "", "")
+		order := e.buildOrder(side, o.Peg, o.Price, party, e.marketID, o.LiquidityImpliedVolume, "", "")
 		orders = append(orders, order)
 	}
 

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -288,7 +288,9 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p, v uint64, n
 	as.ExtendAuctionPrice(types.AuctionDuration{
 		Duration: duration,
 	})
-	e.reset(last.Price, last.Volume, now)
+	if !as.IsPriceAuction() {
+		e.reset(last.Price, last.Volume, now)
+	}
 
 	return nil
 }

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -288,6 +288,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p, v uint64, n
 	as.ExtendAuctionPrice(types.AuctionDuration{
 		Duration: duration,
 	})
+	e.reset(last.Price, last.Volume, now)
 
 	return nil
 }


### PR DESCRIPTION
The target stake when leaving an auction was based on the old mark price, meaning we could leave an auction and enter a new one.

In the process of fixing this, another situation where the price bounds seemed to vanish emerged