### PR TITLE
Modify drone to trigger dockerised-system-tests in Jenkins

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -146,10 +146,15 @@ steps:
     image: alpine
     pull: always
     environment:
+      # Jenkins trigger url with token
       JENKINS_SYSTEMTESTS_WEBHOOK_URL:
         from_secret: JENKINS_SYSTEMTESTS_WEBHOOK_URL
     commands:
+      - if ! test -x cmd/vega/vega-linux-amd64 ; then
+          echo "No vega binary. Skipping system-tests." ; exit 0 ;
+        fi
       - apk add curl
+      # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
       - export STATUSES_URL="https://api.github.com/repos/$${DRONE_REPO}/statuses/$${DRONE_COMMIT_SHA}"
       - |
         curl \\

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -142,21 +142,20 @@ steps:
       event:
         - pull_request
 
-  - name: systemtests-PR
-    image: docker.pkg.github.com/vegaprotocol/system-tests/system-tests:develop
+  - name: Trigger systemtests for PR
+    image: alpine
     pull: always
     environment:
-      GITHUB_API_TOKEN:
-        from_secret: GITHUB_API_TOKEN
-      SLACK_HOOK_URL:
-        from_secret: SLACK_HOOK_URL
+      JENKINS_SYSTEMTESTS_WEBHOOK_URL:
+        from_secret: JENKINS_SYSTEMTESTS_WEBHOOK_URL
     commands:
-      # https://github.com/vegaprotocol/system-tests/blob/master/ci.sh
-      - if test -x cmd/vega/vega-linux-amd64 ; then
-          /usr/local/bin/ci.sh ;
-        else
-          echo "No vega binary. Skipping system-tests." ;
-        fi
+      - apk add curl
+      - |
+        curl \\
+          --request POST \\
+          --header "Content-Type: application/json" \\
+          --data "{\"pull_request\":{\"head\":{\"ref\":\"$${DRONE_REPO_NAME}\"},\"statuses_url\":\"https://api.github.com/repos/$${DRONE_REPO}/statuses/$${DRONE_COMMIT_SHA}\"}}" \\
+          "$${JENKINS_SYSTEMTESTS_WEBHOOK_URL}"
     depends_on:
       - test-PR
     when:

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -155,7 +155,7 @@ steps:
         curl \\
           --request POST \\
           --header "Content-Type: application/json" \\
-          --data "{\"pull_request\":{\"head\":{\"ref\":\"$${DRONE_REPO_NAME}\"},\"statuses_url\":\"$${STATUSES_URL}\"}}" \\
+          --data "{\"pull_request\":{\"head\":{\"ref\":\"$${DRONE_SOURCE_BRANCH}\"},\"statuses_url\":\"$${STATUSES_URL}\"}}" \\
           "$${JENKINS_SYSTEMTESTS_WEBHOOK_URL}"
     depends_on:
       - test-PR

--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -150,11 +150,12 @@ steps:
         from_secret: JENKINS_SYSTEMTESTS_WEBHOOK_URL
     commands:
       - apk add curl
+      - export STATUSES_URL="https://api.github.com/repos/$${DRONE_REPO}/statuses/$${DRONE_COMMIT_SHA}"
       - |
         curl \\
           --request POST \\
           --header "Content-Type: application/json" \\
-          --data "{\"pull_request\":{\"head\":{\"ref\":\"$${DRONE_REPO_NAME}\"},\"statuses_url\":\"https://api.github.com/repos/$${DRONE_REPO}/statuses/$${DRONE_COMMIT_SHA}\"}}" \\
+          --data "{\"pull_request\":{\"head\":{\"ref\":\"$${DRONE_REPO_NAME}\"},\"statuses_url\":\"$${STATUSES_URL}\"}}" \\
           "$${JENKINS_SYSTEMTESTS_WEBHOOK_URL}"
     depends_on:
       - test-PR


### PR DESCRIPTION
Modify Drone to trigger `dockerised-system-tests` in Jenkins instead of running `system-tests` in Drone.
`system-tests` are triggered after all the other checks are ok.
Also `system-tests` are not run if there were no vega core code changes.
The `dockerised-system-tests` Jenkins job is triggered the same way as GitHub webhook does it.

You can preview how it works in this PR, by checking the results for `Split too long line` and/or `fix drone variable` commits here.