### PR TITLE
Fix average entry valuation during opening auction

### DIFF
--- a/execution/equity_shares_test.go
+++ b/execution/equity_shares_test.go
@@ -27,6 +27,7 @@ func testAverageEntryValuation(t *testing.T) {
 
 	es.SetPartyStake("LP1", uint64(100))
 	require.EqualValues(t, decimal.NewFromFloat(100.), es.AvgEntryValuation("LP1"))
+	es.OpeningAuctionEnded()
 
 	es.SetPartyStake("LP1", uint64(200))
 	require.True(t, decimal.NewFromFloat(100.).Equal(es.AvgEntryValuation("LP1")))
@@ -276,14 +277,14 @@ func testWithinMarket(t *testing.T) {
 		"LiquidityFeeAccount should be empty after a fee distribution")
 
 	assert.EqualValues(t,
-		int(float64(originalBalance)*(2.25/3)),
+		int(float64(originalBalance)*(2./3)),
 		int(esm.PartyMarginAccount("party1").Balance-party1Balance),
-		"party1 should get 2.25/3 of the fees",
+		"party1 should get 2/3 of the fees",
 	)
 
 	assert.EqualValues(t,
-		int(float64(originalBalance)*(0.75/3)),
+		int(float64(originalBalance)*(1./3)),
 		int(esm.PartyMarginAccount("party2").Balance-party2Balance),
-		"party2 should get 0.75/3 of the fees",
+		"party2 should get 2/3 of the fees",
 	)
 }

--- a/execution/market.go
+++ b/execution/market.go
@@ -559,6 +559,8 @@ func (m *Market) OnChainTimeUpdate(ctx context.Context, t time.Time) (closed boo
 				m.mkt.State = types.Market_STATE_ACTIVE
 				m.broker.Send(events.NewMarketUpdatedEvent(ctx, *m.mkt))
 
+				m.equityShares.OpeningAuctionEnded()
+
 				// start the market fee window
 				m.feeSplitter.TimeWindowStart(t)
 			}

--- a/integration/features/lp-distressed-closeout.feature
+++ b/integration/features/lp-distressed-closeout.feature
@@ -169,8 +169,8 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     # getting closer to distressed LP, still in continuous trading
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
-      | trader0 | ETH   | ETH/DEC21 | 1764   | 0       | 0    |
-    And the insurance pool balance should be "4648" for the market "ETH/DEC21"
+      | trader0 | ETH   | ETH/DEC21 | 1762   | 0       | 0    |
+    And the insurance pool balance should be "4649" for the market "ETH/DEC21"
 
     # Move price out of bounds
     When the network moves ahead "2" blocks
@@ -182,7 +182,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
      | 1010       | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 2323         | 10000          | 23            |
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
-      | trader0 | ETH   | ETH/DEC21 | 1772   | 0       | 0    |
+      | trader0 | ETH   | ETH/DEC21 | 1768   | 0       | 0    |
 
     # end price auction
     When the network moves ahead "301" blocks
@@ -191,7 +191,5 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
      | 1055       | TRADING_MODE_CONTINUOUS | 1       | 1045      | 1065      | 3482         | 5000           | 33            |
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
-      | trader0 | ETH   | ETH/DEC21 | 1266   | 416     | 0    |
-    And the insurance pool balance should be "4648" for the market "ETH/DEC21"
-
-
+      | trader0 | ETH   | ETH/DEC21 | 1266   | 412     | 0    |
+    And the insurance pool balance should be "4649" for the market "ETH/DEC21"

--- a/integration/features/setting-fee-and-rewarding-lps.feature
+++ b/integration/features/setting-fee-and-rewarding-lps.feature
@@ -160,8 +160,8 @@ Feature: Test liquidity provider reward distribution
 
     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
       | party | equity like share  | average entry valuation |
-      | lp1   |              0.666 |                    5000 |
-      | lp2   |              0.333 |                   10000 |
+      | lp1   |                0.5 |                   10000 |
+      | lp2   |                0.5 |                   10000 |
 
     And the price monitoring bounds for the market "ETH/DEC21" should be:
       | min bound | max bound |
@@ -192,8 +192,8 @@ Feature: Test liquidity provider reward distribution
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
       | from    | to  | from account                | to account           | market id | amount  | asset |
-      | market  | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 26      | ETH   |
-      | market  | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 14      | ETH   |
+      | market  | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 20      | ETH   |
+      | market  | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 20      | ETH   |
 
 
     Then the traders place the following orders:
@@ -214,8 +214,8 @@ Feature: Test liquidity provider reward distribution
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
       | from    | to  | from account                | to account           | market id | amount  | asset |
-      | market  | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 21      | ETH   |
-      | market  | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 11      | ETH   |
+      | market  | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 16      | ETH   |
+      | market  | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 16      | ETH   |
 
   Scenario: 2 LPs joining at start, unequal commitments
 
@@ -260,8 +260,8 @@ Feature: Test liquidity provider reward distribution
 
     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
       | party | equity like share  | average entry valuation |
-      | lp1   |              0.833 |                    8000 |
-      | lp2   |              0.166 |                   10000 |
+      | lp1   |                0.8 |                   10000 |
+      | lp2   |                0.2 |                   10000 |
 
     And the price monitoring bounds for the market "ETH/DEC21" should be:
       | min bound | max bound |
@@ -366,8 +366,8 @@ Feature: Test liquidity provider reward distribution
 
     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
       | party | equity like share  | average entry valuation |
-      | lp1   |              0.833 |                    8000 |
-      | lp2   |              0.166 |                   10000 |
+      | lp1   |                0.8 |                   10000 |
+      | lp2   |                0.2 |                   10000 |
 
     And the price monitoring bounds for the market "ETH/DEC21" should be:
       | min bound | max bound |
@@ -412,9 +412,9 @@ Feature: Test liquidity provider reward distribution
 
     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
       | party | equity like share  | average entry valuation |
-      | lp1   |             0.7772 |                    8000 |
-      | lp2   |             0.1554 |                   10000 |
-      | lp3   |             0.0673 |                  115397 |
+      | lp1   |             0.7362 |                   10000 |
+      | lp2   |             0.1840 |                   10000 |
+      | lp3   |             0.0797 |                  115397 |
 
     Then the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
@@ -435,8 +435,8 @@ Feature: Test liquidity provider reward distribution
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
       | from    | to  | from account                | to account           | market id | amount  | asset |
-      | market  | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 23      | ETH   |
-      | market  | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 4       | ETH   |
+      | market  | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 22      | ETH   |
+      | market  | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 5       | ETH   |
       | market  | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN  | ETH/DEC21 | 3       | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"


### PR DESCRIPTION
During opening auction, the average entry valuation is the same for every trader, after that it's calculated with the Market Value Proxy as expected.

close #3492 