### PR TITLE
Top-up bond accounts prior to checking liquidity

### DIFF
--- a/execution/bond_topup.go
+++ b/execution/bond_topup.go
@@ -2,7 +2,6 @@ package execution
 
 import (
 	"context"
-	"fmt"
 
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/logging"
@@ -40,7 +39,6 @@ func (m *Market) checkBondBalance(ctx context.Context) {
 			},
 			MinAmount: amt,
 		}
-		fmt.Printf("top-up for party %s: short %d, transfer for %d\n", party, bondShort, amt)
 		resp, err := m.collateral.BondUpdate(ctx, mID, party, t)
 		if err != nil {
 			m.log.Panic("Failed to top up bond balance",

--- a/execution/bond_topup.go
+++ b/execution/bond_topup.go
@@ -1,0 +1,65 @@
+package execution
+
+import (
+	"context"
+	"fmt"
+
+	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
+	types "code.vegaprotocol.io/vega/proto"
+)
+
+func (m *Market) checkBondBalance(ctx context.Context) {
+	lps := m.liquidity.ProvisionsPerParty().Slice()
+	mID := m.GetID()
+	asset, _ := m.mkt.GetAsset()
+	transfers := make([]*types.TransferResponse, 0, len(lps))
+	for _, lp := range lps {
+		party := lp.PartyId
+		bondAcc, err := m.collateral.GetPartyBondAccount(mID, party, asset)
+		if err != nil || bondAcc == nil {
+			continue
+		}
+		// commitment is covered by bond balance already
+		if bondAcc.Balance >= lp.CommitmentAmount {
+			continue
+		}
+		gen, err := m.collateral.GetPartyGeneralAccount(party, asset)
+		// no balance in general account
+		if err != nil || gen.Balance == 0 {
+			continue
+		}
+		bondShort := lp.CommitmentAmount - bondAcc.Balance
+		amt := min(bondShort, gen.Balance)
+		t := &types.Transfer{
+			Owner: party,
+			Type:  types.TransferType_TRANSFER_TYPE_BOND_LOW,
+			Amount: &types.FinancialAmount{
+				Asset:  asset,
+				Amount: amt,
+			},
+			MinAmount: amt,
+		}
+		fmt.Printf("top-up for party %s: short %d, transfer for %d\n", party, bondShort, amt)
+		resp, err := m.collateral.BondUpdate(ctx, mID, party, t)
+		if err != nil {
+			m.log.Panic("Failed to top up bond balance",
+				logging.String("market-id", mID),
+				logging.String("party", party),
+				logging.Error(err))
+		}
+		if len(resp.Transfers) > 0 {
+			transfers = append(transfers, resp)
+		}
+	}
+	if len(transfers) > 0 {
+		m.broker.Send(events.NewTransferResponse(ctx, transfers))
+	}
+}
+
+func min(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/execution/market.go
+++ b/execution/market.go
@@ -3070,6 +3070,9 @@ func (m *Market) OnMarketAuctionMinimumDurationUpdate(ctx context.Context, d tim
 }
 
 func (m *Market) checkLiquidity(ctx context.Context, trades []*types.Trade) {
+	// before we check liquidity, ensure we've moved all funds that can go towards
+	// provided stake to the bond accounts so we don't trigger liquidity auction for no reason
+	m.checkBondBalance(ctx)
 	_, vBid, _ := m.getBestStaticBidPriceAndVolume()
 	_, vAsk, _ := m.getBestStaticAskPriceAndVolume()
 

--- a/integration/features/lp-distressed-closeout.feature
+++ b/integration/features/lp-distressed-closeout.feature
@@ -83,17 +83,21 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     When the network moves ahead "2" blocks
     And the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     |
-      | trader3 | ETH/DEC21 | buy  | 10     | 1022  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 15     | 1030  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader3 | ETH/DEC21 | buy  | 10     | 1022  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader3 | ETH/DEC21 | buy  | 3      | 1020  | 0                | TYPE_LIMIT | TIF_GTC |
       | trader2 | ETH/DEC21 | sell | 5      | 1030  | 0                | TYPE_LIMIT | TIF_GTC |
+    Then the traders should have the following account balances:
+      | trader  | asset | market id | margin | general | bond |
+      | trader0 | ETH   | ETH/DEC21 | 1789   | 0       | 0    |
+    And the insurance pool balance should be "4646" for the market "ETH/DEC21"
     Then the market data for the market "ETH/DEC21" should be:
      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
      | 1010       | TRADING_MODE_CONTINUOUS | 1       | 993       | 1012      | 2323         | 5000           | 23            |
     # getting closer to distressed LP, still in continuous trading
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
-      | trader0 | ETH   | ETH/DEC21 | 1810   | 0       | 0    |
+      | trader0 | ETH   | ETH/DEC21 | 1789   | 0       | 0    |
 
     When the network moves ahead "2" blocks
     And the traders place the following orders:
@@ -105,9 +109,9 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
      | 1012       | TRADING_MODE_MONITORING_AUCTION | 1       | 1000      | 1020      | 2834         | 0              | 28            |
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
-      | trader0 | ETH   | ETH/DEC21 | 1808   | 0       | 0    |
+      | trader0 | ETH   | ETH/DEC21 | 1787   | 0       | 0    |
     # make sure bond slashing moved money to insurance pool
-    And the insurance pool balance should be "4625" for the market "ETH/DEC21"
+    And the insurance pool balance should be "4646" for the market "ETH/DEC21"
 
 
   Scenario: LP gets distressed after auction
@@ -191,5 +195,5 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
      | 1055       | TRADING_MODE_CONTINUOUS | 1       | 1045      | 1065      | 3482         | 5000           | 33            |
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
-      | trader0 | ETH   | ETH/DEC21 | 1266   | 412     | 0    |
-    And the insurance pool balance should be "4649" for the market "ETH/DEC21"
+      | trader0 | ETH   | ETH/DEC21 | 1266   | 0       | 0    |
+    And the insurance pool balance should be "5061" for the market "ETH/DEC21"

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -449,7 +449,7 @@ func (e *Engine) Update(
 		e.updatePartyOrders(po.Party, po.Orders)
 	}
 
-	for _, lp := range e.provisions.slice() {
+	for _, lp := range e.provisions.Slice() {
 		creates, cancels, err := e.createOrUpdateForParty(ctx, bestBidPrice, bestAskPrice, lp.PartyId, repriceFn)
 		if err != nil {
 			return nil, nil, err

--- a/liquidity/types.go
+++ b/liquidity/types.go
@@ -71,8 +71,8 @@ func (l LiquidityProvisions) sortByFee() LiquidityProvisions {
 // Provisions is a map of parties to *types.LiquidityProvision
 type ProvisionsPerParty map[string]*types.LiquidityProvision
 
-// slice returns the parties as a slice.
-func (l ProvisionsPerParty) slice() LiquidityProvisions {
+// Slice returns the parties as a slice.
+func (l ProvisionsPerParty) Slice() LiquidityProvisions {
 	slice := make(LiquidityProvisions, 0, len(l))
 	for _, p := range l {
 		slice = append(slice, p)
@@ -83,7 +83,7 @@ func (l ProvisionsPerParty) slice() LiquidityProvisions {
 }
 
 func (l ProvisionsPerParty) FeeForTarget(v uint64) string {
-	return l.slice().sortByFee().feeForTarget(v)
+	return l.Slice().sortByFee().feeForTarget(v)
 }
 
 // TotalStake returns the sum of all CommitmentAmount, which corresponds to the


### PR DESCRIPTION
Closes #3238 

Required small changes to some integration tests, as the bond top-ups meant there was balance in the bond account more often, leading to more bond slashing and an increase in the insurance poo;l balance. Fees went to bond account, and were then slashed, instead of increasing the margin account