### PR TITLE
Address flakey tests

### DIFF
--- a/api_test/testutil_test.go
+++ b/api_test/testutil_test.go
@@ -317,7 +317,6 @@ func waitForTime(tmConf *TimeSub, now time.Time) bool {
 			}
 		}
 	}
-	return false
 }
 
 func randomPort() int {

--- a/api_test/testutil_test.go
+++ b/api_test/testutil_test.go
@@ -299,8 +299,8 @@ func PublishEvents(t *testing.T, ctx context.Context, b *broker.Broker, convertE
 	cfunc()
 	// unsubscribe the ad-hoc subscriber
 	b.Unsubscribe(id)
-	// we've received the tim event, but that could've been received before the account event. Now send out a second time event to ensure
-	// the account events get flushed/persisted
+	// we've received the time event, but that could've been received before the other events.
+	// Now send out a second time event to ensure the other events get flushed/persisted
 	b.Send(events.NewTime(ctx, now.Add(time.Second)))
 }
 

--- a/api_test/testutil_test.go
+++ b/api_test/testutil_test.go
@@ -255,6 +255,7 @@ func PublishEvents(t *testing.T, ctx context.Context, b *broker.Broker, convertE
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
+	evts := map[events.Type][]events.Event{}
 	for scanner.Scan() {
 		jsonBytes := scanner.Bytes()
 		var be eventspb.BusEvent
@@ -267,11 +268,56 @@ func PublishEvents(t *testing.T, ctx context.Context, b *broker.Broker, convertE
 		if err != nil {
 			t.Fatalf("failed to convert BusEvent to Event: %v", err)
 		}
-		b.Send(e)
+		s, ok := evts[e.Type()]
+		if !ok {
+			s = []events.Event{}
+		}
+		s = append(s, e)
+		evts[e.Type()] = s
+	}
+	// we've grouped events per type, now send them all in batches
+	for _, e := range evts {
+		b.SendBatch(e)
 	}
 
+	// add time event subscriber so we can verify the time event was received at the end
+	sCtx, cfunc := context.WithCancel(ctx)
+	tmConf := NewTimeSub(sCtx)
+	id := b.Subscribe(tmConf)
+
+	// whatever time it is now + 1 second
+	now := time.Now()
 	// the broker reacts to Time events to trigger writes the data stores
-	b.Send(events.NewTime(ctx, time.Now()))
+	b.Send(events.NewTime(ctx, now))
+	// await confirmation that we've actually received the time update event
+	if !waitForTime(tmConf, now) {
+		t.Fatal("Did not receive the expected time event within reasonable time")
+	}
+	// halt the subscriber
+	tmConf.Halt()
+	// cancel the subscriber ctx
+	cfunc()
+	// unsubscribe the ad-hoc subscriber
+	b.Unsubscribe(id)
+	// we've received the tim event, but that could've been received before the account event. Now send out a second time event to ensure
+	// the account events get flushed/persisted
+	b.Send(events.NewTime(ctx, now.Add(time.Second)))
+}
+
+func waitForTime(tmConf *TimeSub, now time.Time) bool {
+	for {
+		times := tmConf.GetReveivedTimes()
+		if times == nil {
+			// the subscriber context was cancelled, no need to wait for this anylonger
+			return false
+		}
+		for _, tm := range times {
+			if tm.Equal(now) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func randomPort() int {

--- a/api_test/time_confirm_test.go
+++ b/api_test/time_confirm_test.go
@@ -1,0 +1,108 @@
+package api_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/subscribers"
+)
+
+type TimeEvent interface {
+	Time() time.Time
+}
+
+type TimeSub struct {
+	*subscribers.Base
+	mu  *sync.Mutex
+	ch  chan time.Time
+	rCh chan struct{}
+	rcv bool
+}
+
+func NewTimeSub(ctx context.Context) *TimeSub {
+	t := &TimeSub{
+		Base: subscribers.NewBase(ctx, 10, true),
+		mu:   &sync.Mutex{},
+		ch:   make(chan time.Time, 10),
+		rCh:  make(chan struct{}),
+	}
+	return t
+}
+
+func (t *TimeSub) Push(evts ...events.Event) {
+	if len(evts) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.ch == nil {
+		panic("time channel is closed")
+	}
+	// lock now, this could be a batch in the future
+	for _, e := range evts {
+		switch et := e.(type) {
+		case TimeEvent:
+			if !t.rcv {
+				close(t.rCh)
+				t.rcv = true
+			}
+			t.ch <- et.Time()
+		}
+	}
+}
+
+func (t *TimeSub) GetReveivedTimes() []time.Time {
+	<-t.rCh
+	t.mu.Lock()
+	// sub has been halted
+	if t.ch == nil {
+		t.mu.Unlock()
+		return nil
+	}
+	ch := t.getTimeCh()
+	// reset reveive channel
+	t.rCh = make(chan struct{})
+	t.rcv = false
+	t.mu.Unlock()
+	// this shouldn't be possible
+	if ch == nil {
+		return nil
+	}
+	r := make([]time.Time, 0, len(ch))
+	for tm := range ch {
+		r = append(r, tm)
+	}
+	return r
+}
+
+func (t *TimeSub) getTimeCh() <-chan time.Time {
+	if len(t.ch) == 0 {
+		return nil
+	}
+	ch := t.ch
+	t.ch = make(chan time.Time, 10)
+	close(ch)
+	return ch
+}
+
+func (t *TimeSub) Halt() {
+	// we don't need to call Halt on base
+	// we're cancelling the context which takes care of the cleanup already
+	// t.Base.Halt()
+	t.mu.Lock()
+	close(t.ch)
+	t.ch = nil
+	if !t.rcv {
+		close(t.rCh)
+	}
+	t.rCh = nil
+	t.mu.Unlock()
+}
+
+func (_ *TimeSub) Types() []events.Type {
+	return []events.Type{
+		events.TimeUpdate,
+	}
+}

--- a/api_test/time_confirm_test.go
+++ b/api_test/time_confirm_test.go
@@ -101,7 +101,7 @@ func (t *TimeSub) Halt() {
 	t.mu.Unlock()
 }
 
-func (_ *TimeSub) Types() []events.Type {
+func (*TimeSub) Types() []events.Type {
 	return []events.Type{
 		events.TimeUpdate,
 	}


### PR DESCRIPTION
The issue with flakey tests was caused by the time event and other events (ie accounts) not being guaranteed to be pushed to the subscriber in the same order. To address the issue, a temporary subscriber is added to verify whether or not the initial time event was delivered. Once it has, we know the time event was sent to the account subscriber and the time subscriber. This means the account subscriber is free to process any other events (account events).

In case the account event was received after the time event, this still didn't solve the problem, we send a second time event to ensure the account events are persisted, and the API can be expected to return the information we're after