### PR TITLE
Reapply #2814

### DIFF
--- a/nodewallet/eth/config.go
+++ b/nodewallet/eth/config.go
@@ -15,6 +15,6 @@ type Config struct {
 func NewDefaultConfig() Config {
 	return Config{
 		Level:   encoding.LogLevel{Level: logging.InfoLevel},
-		Address: "https://ropsten.infura.io/v3/2d4acb74430e4792b8d783fdfaa3ae82",
+		Address: "https://ropsten.infura.io/v3/YOUR_TOKEN_HERE",
 	}
 }


### PR DESCRIPTION
Closes #2699.

The original ticket caused issues when landed.
Also from @jeremyletang:
> We may just want to keep it like so, as it eases development when running a node locally against ropsten.
> I’d say ignore this for now.