### PR TITLE
small util funcs

### DIFF
--- a/types/num/uint.go
+++ b/types/num/uint.go
@@ -43,9 +43,9 @@ func UintFromString(str string, base int) (*Uint, bool) {
 }
 
 // Sum just removes the need to write num.NewUint(0).Sum(x, y, z)
-// so you can write num.Sum(x, y, z) instead
+// so you can write num.Sum(x, y, z) instead, equivalent to x + y + z
 func Sum(vals ...*Uint) *Uint {
-	return NewUint(0).Sum(vals...)
+	return NewUint(0).AddSum(vals...)
 }
 
 func (z *Uint) Set(oth *Uint) *Uint {
@@ -73,8 +73,9 @@ func (z *Uint) Add(x, y *Uint) *Uint {
 	return z
 }
 
-// Sum adds multiple values at the same time
-func (z *Uint) Sum(vals ...*Uint) *Uint {
+// AddSum adds multiple values at the same time to a given uint
+// so x.AddSum(y, z) is equivalent to x + y + z
+func (z *Uint) AddSum(vals ...*Uint) *Uint {
 	for _, x := range vals {
 		z.u.Add(&z.u, &x.u)
 	}

--- a/types/num/uint.go
+++ b/types/num/uint.go
@@ -42,6 +42,12 @@ func UintFromString(str string, base int) (*Uint, bool) {
 	return UintFromBig(b)
 }
 
+// Sum just removes the need to write num.NewUint(0).Sum(x, y, z)
+// so you can write num.Sum(x, y, z) instead
+func Sum(vals ...*Uint) *Uint {
+	return NewUint(0).Sum(vals...)
+}
+
 func (z *Uint) Set(oth *Uint) *Uint {
 	z.u.Set(&oth.u)
 	return z
@@ -64,6 +70,14 @@ func (z Uint) Uint64() uint64 {
 // new variable is created.
 func (z *Uint) Add(x, y *Uint) *Uint {
 	z.u.Add(&x.u, &y.u)
+	return z
+}
+
+// Sum adds multiple values at the same time
+func (z *Uint) Sum(vals ...*Uint) *Uint {
+	for _, x := range vals {
+		z.u.Add(&z.u, &x.u)
+	}
 	return z
 }
 

--- a/types/num/uint_test.go
+++ b/types/num/uint_test.go
@@ -138,7 +138,7 @@ func TestSum(t *testing.T) {
 		zero := num.NewUint(0)
 		fSum := num.Sum(x, y, z)
 		assert.Equal(t, exp.String(), fSum.String())
-		ptr := zero.Sum(x, y, z)
+		ptr := zero.AddSum(x, y, z)
 		assert.Equal(t, exp.String(), zero.String())
 		assert.Equal(t, zero, ptr)
 		// compare to manual:

--- a/types/num/uint_test.go
+++ b/types/num/uint_test.go
@@ -114,6 +114,44 @@ func TestUint256Delta(t *testing.T) {
 	}
 }
 
+func TestSum(t *testing.T) {
+	data := []struct {
+		x, y, z uint64
+		exp     uint64
+	}{
+		{
+			x:   1,
+			y:   2,
+			z:   3,
+			exp: 1 + 2 + 3,
+		},
+		{
+			x:   123,
+			y:   456,
+			z:   789,
+			exp: 123 + 456 + 789,
+		},
+	}
+	for _, set := range data {
+		x, y, z := num.NewUint(set.x), num.NewUint(set.y), num.NewUint(set.z)
+		exp := num.NewUint(set.exp)
+		zero := num.NewUint(0)
+		fSum := num.Sum(x, y, z)
+		assert.Equal(t, exp.String(), fSum.String())
+		ptr := zero.Sum(x, y, z)
+		assert.Equal(t, exp.String(), zero.String())
+		assert.Equal(t, zero, ptr)
+		// compare to manual:
+		manual := num.NewUint(0)
+		manual = manual.Add(manual, x)
+		assert.NotEqual(t, exp.String(), manual.String(), "manual x only")
+		manual = manual.Add(manual, y)
+		assert.NotEqual(t, exp.String(), manual.String(), "manual x+y only")
+		manual = manual.Add(manual, z)
+		assert.Equal(t, exp.String(), manual.String())
+	}
+}
+
 func TestDeferDoCopy(t *testing.T) {
 	var (
 		expected1 uint64 = 42


### PR DESCRIPTION
* Add `Sum` function to replace `num.NewUint(0).Add(foo, bar)` with `num.Sum(foo, bar)`, or code where we want to sum multiple values and currently need several calls like `x.Add(x, y)` then `x.Add(x, z)`, so we can write `x.Sum(y, z)`

The name `Sum` as a method might be a bit wonky. It reads a bit like we'd be assigning the sum of `y+z` to `x`, whereas it really is `x+y+z`, so maybe a rename to `AddSum` makes more sense... let me know here.