### PR TITLE
Remove optional replay protection

### DIFF
--- a/blockchain/abci/abci_test.go
+++ b/blockchain/abci/abci_test.go
@@ -175,7 +175,7 @@ func TestReplayProtectionByDistance(t *testing.T) {
 		height      int
 		expectError bool
 	}{
-		{"within distance: low", 91, false},
+		{"within distance: low", 91, true},
 		{"within distance: high", 109, false},
 
 		{"same heights", 100, false},
@@ -231,7 +231,7 @@ func TestReplayProtectionByCache(t *testing.T) {
 	})
 
 	// forward to a given block
-	beginBlockN(app, 0)
+	beginBlockN(app, 2)
 	req := types.RequestDeliverTx{Tx: tx}
 	resp1 := app.DeliverTx(req)
 	resp2 := app.DeliverTx(req)

--- a/blockchain/abci/replay_protection.go
+++ b/blockchain/abci/replay_protection.go
@@ -64,11 +64,6 @@ func (rp *ReplayProtector) Add(key string) bool {
 
 // DeliverTx excercises both strategies (cache and tolerance) to determine if a Tx should be allowed or not.
 func (rp *ReplayProtector) DeliverTx(tx Tx) error {
-	// skip replay protection if the Tx didn't specify the block height.
-	if tx.BlockHeight() == 0 {
-		return nil
-	}
-
 	// We perform 2 verifications:
 	// First we make sure that the Tx is not on the ring buffer.
 	key := string(tx.Hash())
@@ -94,11 +89,6 @@ func (rp *ReplayProtector) DeliverTx(tx Tx) error {
 
 // CheckTx excercises the strategies  tolerance to determine if a Tx should be allowed or not.
 func (rp *ReplayProtector) CheckTx(tx Tx) error {
-	// skip replay protection if the Tx didn't specify the block height.
-	if tx.BlockHeight() == 0 {
-		return nil
-	}
-
 	// We perform 2 verifications:
 	// First we make sure that the Tx is not on the ring buffer.
 	key := string(tx.Hash())

--- a/blockchain/abci/replay_protection.go
+++ b/blockchain/abci/replay_protection.go
@@ -5,8 +5,9 @@ import (
 )
 
 var (
-	ErrTxAlreadyInCache = errors.New("reply protection: already in the cache")
-	ErrTxStaled         = errors.New("reply protection: staled")
+	ErrTxAlreadyInCache   = errors.New("reply protection: already in the cache")
+	ErrTxStaled           = errors.New("reply protection: staled")
+	ErrTxReferFutureBlock = errors.New("reply protection: tx refer future block")
 )
 
 // ReplayProtector implement a block distance and ring buffer cache
@@ -75,7 +76,7 @@ func (rp *ReplayProtector) DeliverTx(tx Tx) error {
 
 	// If the tx is on a future block, we accept.
 	if tx.BlockHeight() > rp.height {
-		return nil
+		return ErrTxReferFutureBlock
 	}
 
 	// Calculate the distance
@@ -100,7 +101,7 @@ func (rp *ReplayProtector) CheckTx(tx Tx) error {
 
 	// If the tx is on a future block, we accept.
 	if tx.BlockHeight() > rp.height {
-		return nil
+		return ErrTxReferFutureBlock
 	}
 
 	// Calculate the distance


### PR DESCRIPTION
From this commit every single transaction sent to the network requires the replay-protection mecanism

Closes #3588 