### PR TITLE
return better errors when replay-protection happen

### DIFF
--- a/blockchain/abci/abci.go
+++ b/blockchain/abci/abci.go
@@ -1,6 +1,8 @@
 package abci
 
 import (
+	"errors"
+
 	"github.com/tendermint/tendermint/abci/types"
 )
 
@@ -56,11 +58,11 @@ func (app *App) Commit() (resp types.ResponseCommit) {
 func (app *App) CheckTx(req types.RequestCheckTx) (resp types.ResponseCheckTx) {
 	tx, code, err := app.getTx(req.GetTx())
 	if err != nil {
-		return NewResponseCheckTx(code, err.Error())
+		return NewResponseCheckTxError(code, err)
 	}
 
 	if err := app.replayProtector.CheckTx(tx); err != nil {
-		return NewResponseCheckTx(AbciTxnValidationFailure, err.Error())
+		return NewResponseCheckTxError(AbciTxnValidationFailure, err)
 	}
 
 	ctx := app.ctx
@@ -89,12 +91,12 @@ func (app *App) CheckTx(req types.RequestCheckTx) (resp types.ResponseCheckTx) {
 func (app *App) DeliverTx(req types.RequestDeliverTx) (resp types.ResponseDeliverTx) {
 	tx, code, err := app.getTx(req.GetTx())
 	if err != nil {
-		return NewResponseDeliverTx(code, err.Error())
+		return NewResponseDeliverTxError(code, err)
 	}
 	app.removeTxFromCache(req.GetTx())
 
 	if err := app.replayProtector.DeliverTx(tx); err != nil {
-		return NewResponseDeliverTx(AbciTxnValidationFailure, err.Error())
+		return NewResponseDeliverTxError(AbciTxnValidationFailure, err)
 	}
 
 	// It's been validated by CheckTx so we can skip the validation here
@@ -109,11 +111,11 @@ func (app *App) DeliverTx(req types.RequestDeliverTx) (resp types.ResponseDelive
 	// Lookup for deliver tx, fail if not found
 	fn := app.deliverTxs[tx.Command()]
 	if fn == nil {
-		return NewResponseDeliverTx(AbciUnknownCommandError, "")
+		return NewResponseDeliverTxError(AbciUnknownCommandError, errors.New("invalid vega command"))
 	}
 
 	if err := fn(ctx, tx); err != nil {
-		return NewResponseDeliverTx(AbciTxnInternalError, err.Error())
+		return NewResponseDeliverTxError(AbciTxnInternalError, err)
 	}
 
 	return NewResponseDeliverTx(types.CodeTypeOK, "")

--- a/blockchain/abci/replay_protection.go
+++ b/blockchain/abci/replay_protection.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	ErrTxAlreadyInCache   = errors.New("reply protection: already in the cache")
+	ErrTxAlreadyInCache   = errors.New("reply protection: tx already in the cache")
 	ErrTxStaled           = errors.New("reply protection: staled")
 	ErrTxReferFutureBlock = errors.New("reply protection: tx refer future block")
 )

--- a/blockchain/abci/response.go
+++ b/blockchain/abci/response.go
@@ -12,6 +12,7 @@ func NewResponseCheckTx(code uint32, info string) types.ResponseCheckTx {
 func NewResponseCheckTxError(code uint32, err error) types.ResponseCheckTx {
 	return types.ResponseCheckTx{
 		Code: code,
+		Info: err.Error(),
 		Data: []byte(err.Error()),
 	}
 }
@@ -26,6 +27,7 @@ func NewResponseDeliverTx(code uint32, info string) types.ResponseDeliverTx {
 func NewResponseDeliverTxError(code uint32, err error) types.ResponseDeliverTx {
 	return types.ResponseDeliverTx{
 		Code: code,
+		Info: err.Error(),
 		Data: []byte(err.Error()),
 	}
 }

--- a/blockchain/abci/response.go
+++ b/blockchain/abci/response.go
@@ -9,9 +9,23 @@ func NewResponseCheckTx(code uint32, info string) types.ResponseCheckTx {
 	}
 }
 
+func NewResponseCheckTxError(code uint32, err error) types.ResponseCheckTx {
+	return types.ResponseCheckTx{
+		Code: code,
+		Data: []byte(err.Error()),
+	}
+}
+
 func NewResponseDeliverTx(code uint32, info string) types.ResponseDeliverTx {
 	return types.ResponseDeliverTx{
 		Code: code,
 		Info: info,
+	}
+}
+
+func NewResponseDeliverTxError(code uint32, err error) types.ResponseDeliverTx {
+	return types.ResponseDeliverTx{
+		Code: code,
+		Data: []byte(err.Error()),
 	}
 }


### PR DESCRIPTION
This adds errors from the replay protection in the Data field from the tendermint response, which allows us to parse them out from the go-wallet.