### PR TITLE
Add type to make calculation code a bit cleaner

### DIFF
--- a/types/num/chain.go
+++ b/types/num/chain.go
@@ -1,0 +1,137 @@
+package num
+
+import "github.com/shopspring/decimal"
+
+type uChain struct {
+	z *Uint
+}
+
+// UintChain returns a Uint that supports chainable operations
+// The Uint passed to the constructor is the value that will be updated, so be careful
+// Things like x := NewUint(0).Add(y, z)
+// x.Mul(x, foo)
+// can be written as:
+// x := UintChain(NewUint(0)).Add(y, z).Mul(foo).Get()
+func UintChain(z *Uint) *uChain {
+	return &uChain{
+		z: z,
+	}
+}
+
+// Get gets the result of the chained operation (the value of the wrapped uint)
+func (c *uChain) Get() *Uint {
+	return c.z
+}
+
+// Add is equivalent to AddSum
+func (c *uChain) Add(vals ...*Uint) *uChain {
+	if len(vals) == 0 {
+		return c
+	}
+	c.z.AddSum(vals...)
+	return c
+}
+
+// Sub subtracts any numbers from the chainable value
+func (c *uChain) Sub(vals ...*Uint) *uChain {
+	for _, v := range vals {
+		c.z.Sub(c.z, v)
+	}
+	return c
+}
+
+// Mul multiplies the current value by x
+func (c *uChain) Mul(x *Uint) *uChain {
+	c.z.Mul(c.z, x)
+	return c
+}
+
+// Div divides the current value by x
+func (c *uChain) Div(x *Uint) *uChain {
+	c.z.Div(c.z, x)
+	return c
+}
+
+type DecRounding int
+
+const (
+	DecFloor DecRounding = iota
+	DecRound
+	DecCeil
+)
+
+type dChain struct {
+	d Decimal
+}
+
+// UintDecChain returns a chainable decimal from a given uint
+// this moves the conversion stuff out from the caller
+func UintDecChain(u *Uint) *dChain {
+	// @TODO once the updates to the decimal file are merged, call the coversion function from that file
+	return &dChain{
+		d: decimal.NewFromBigInt(u.u.ToBig(), 0),
+	}
+}
+
+// DecChain offers the same chainable interface for decimals
+func DecChain(d Decimal) *dChain {
+	return &dChain{
+		d: d,
+	}
+}
+
+// Get returns the final value
+func (d *dChain) Get() Decimal {
+	return d.d
+}
+
+// GetUint returns the decimal as a uint, returns true on overflow
+// pass in type of rounding to apply
+// not that the rounding does not affect the underlying decimal value
+// rounding is applied to a copy only
+func (d *dChain) GetUint(round DecRounding) (*Uint, bool) {
+	v := d.d
+	switch round {
+	case DecFloor:
+		v = v.Floor()
+	case DecCeil:
+		v = v.Ceil()
+	case DecRound:
+		v = v.Round(0) // we're converting to Uint, so round to 0 places
+	}
+	return UintFromBig(v.BigInt())
+}
+
+// Add adds any number of decimals together
+func (d *dChain) Add(vals ...Decimal) *dChain {
+	for _, v := range vals {
+		d.d = d.d.Add(v)
+	}
+	return d
+}
+
+// Sub subtracts any number of decimals from the chainable value
+func (d *dChain) Sub(vals ...Decimal) *dChain {
+	for _, v := range vals {
+		d.d = d.d.Sub(v)
+	}
+	return d
+}
+
+// Mul multiplies, obviously
+func (d *dChain) Mul(x Decimal) *dChain {
+	d.d = d.d.Mul(x)
+	return d
+}
+
+// Div divides
+func (d *dChain) Div(x Decimal) *dChain {
+	d.d = d.d.Div(x)
+	return d
+}
+
+// DivRound divides with a specified precision
+func (d *dChain) DivRound(x Decimal, precision int32) *dChain {
+	d.d = d.d.DivRound(x, precision)
+	return d
+}

--- a/types/num/chain_test.go
+++ b/types/num/chain_test.go
@@ -1,0 +1,124 @@
+package num_test
+
+import (
+	"testing"
+
+	"code.vegaprotocol.io/vega/types/num"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUintChain(t *testing.T) {
+	start := num.NewUint(100)
+	// use the non-chainable API to get the expected result
+	vals := map[uint64]*num.Uint{
+		1: nil,
+		2: nil,
+		3: nil,
+		4: nil,
+		5: nil,
+		6: nil,
+		7: nil,
+		8: nil,
+		9: nil,
+	}
+	for k := range vals {
+		vals[k] = num.NewUint(k)
+	}
+	expect := num.Sum(start, vals[3], vals[5]) // some stuff
+	expect.AddSum(vals[9], vals[1])
+	expect.Sub(expect, vals[7])
+	expect.Mul(expect, vals[4])
+	expect.Div(expect, vals[2])
+
+	// write as one-liner
+	got := num.UintChain(num.Sum(start, vals[3], vals[5])).Add(vals[9], vals[1]).Sub(vals[7]).Mul(vals[4]).Div(vals[2]).Get()
+
+	require.Equal(t, expect.String(), got.String())
+}
+
+func TestDecChain(t *testing.T) {
+	start := decimal.NewFromInt(100)
+	vals := map[int64]num.Decimal{
+		1: decimal.Zero,
+		2: decimal.Zero,
+		3: decimal.Zero,
+		4: decimal.Zero,
+		5: decimal.Zero,
+		6: decimal.Zero,
+		7: decimal.Zero,
+		8: decimal.Zero,
+		9: decimal.Zero,
+	}
+	for k := range vals {
+		vals[k] = decimal.NewFromInt(k)
+	}
+
+	expect := start.Add(vals[3]).Add(vals[5]).Add(vals[9].Add(vals[1])).Sub(vals[7]).Mul(vals[4]).Div(vals[2])
+
+	// we could just assign got at the end, but we want to check for rounding
+	chain := num.DecChain(start).Add(vals[3], vals[5], vals[9].Add(vals[1])).Sub(vals[7]).Mul(vals[4]).Div(vals[2])
+
+	require.Equal(t, expect, chain.Get())
+
+	t.Run("compare rounding division", func(t *testing.T) {
+		expect = expect.DivRound(vals[8], 1) // 27.75 -> 27.8
+		chain.DivRound(vals[8], 1)
+		require.Equal(t, expect, chain.Get())
+	})
+
+	t.Run("compare Uint rounding", func(t *testing.T) {
+		floor, round, ceil := expect.Floor(), expect.Round(0), expect.Ceil()
+		uf, _ := chain.GetUint(num.DecFloor)
+		require.Equal(t, floor.String(), uf.String())
+		ur, _ := chain.GetUint(num.DecRound)
+		require.Equal(t, round.String(), ur.String())
+		uc, _ := chain.GetUint(num.DecCeil)
+		require.Equal(t, ceil.String(), uc.String())
+	})
+}
+
+// same as the TestDecChain, only we're starting with a Uint
+func TestDecChainFromUint(t *testing.T) {
+	sInt := int64(100)
+	start := decimal.NewFromInt(sInt)
+	uStart := num.NewUint(uint64(sInt))
+	vals := map[int64]num.Decimal{
+		1: decimal.Zero,
+		2: decimal.Zero,
+		3: decimal.Zero,
+		4: decimal.Zero,
+		5: decimal.Zero,
+		6: decimal.Zero,
+		7: decimal.Zero,
+		8: decimal.Zero,
+		9: decimal.Zero,
+	}
+	for k := range vals {
+		vals[k] = decimal.NewFromInt(k)
+	}
+
+	expect := start.Add(vals[3]).Add(vals[5]).Add(vals[9].Add(vals[1])).Sub(vals[7]).Mul(vals[4]).Div(vals[2])
+
+	// we could just assign got at the end, but we want to check for rounding
+	chain := num.UintDecChain(uStart).Add(vals[3], vals[5], vals[9].Add(vals[1])).Sub(vals[7]).Mul(vals[4]).Div(vals[2])
+
+	require.Equal(t, expect, chain.Get())
+
+	t.Run("compare rounding division", func(t *testing.T) {
+		expect = expect.DivRound(vals[8], 1) // 27.75 -> 27.8
+		chain.DivRound(vals[8], 1)
+		require.Equal(t, expect, chain.Get())
+	})
+
+	t.Run("compare Uint rounding", func(t *testing.T) {
+		floor, round, ceil := expect.Floor(), expect.Round(0), expect.Ceil()
+		uf, _ := chain.GetUint(num.DecFloor)
+		require.Equal(t, floor.String(), uf.String())
+		ur, _ := chain.GetUint(num.DecRound)
+		require.Equal(t, round.String(), ur.String())
+		uc, _ := chain.GetUint(num.DecCeil)
+		require.Equal(t, ceil.String(), uc.String())
+	})
+}


### PR DESCRIPTION
The idea behind this is to make the current uint256 code in packages that perform a fair bit of computation less verbose (stuff like price monitoring, fees, etc...).

The Uint chainable type essentially removes the need to repeat the same variable over and over in things like `foo.Add(foo, bar).Mul(foo, foobar)`. With this, we can write `foo.Add(bar).Mul(foobar).Get()`