### PR TITLE
build: add Makefile target to run QA feature tests from specs repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ test: ## Run unit tests
 integrationtest: ## run integration tests, showing ledger movements and full scenario output
 	@./script/build.sh -a integrationtest
 
+.PHONY: qatest
+qatest: ## run integration tests in the specs internal repo
+	@specsrepo="$(PWD)/../specs-internal" \
+	./script/build.sh -a qatest
+
 .PHONY: race
 race: ## Run data race detector
 	@./script/build.sh -a race

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ test: ## Run unit tests
 integrationtest: ## run integration tests, showing ledger movements and full scenario output
 	@./script/build.sh -a integrationtest
 
-.PHONY: qatest
-qatest: ## run integration tests in the specs internal repo
+.PHONY: spec_feature_test
+spec_feature_test: ## run integration tests in the specs internal repo
 	@specsrepo="$(PWD)/../specs-internal" \
-	./script/build.sh -a qatest
+	./script/build.sh -a spec_feature_test
 
 .PHONY: race
 race: ## Run data race detector

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -3,7 +3,6 @@ package core_test
 import (
 	"flag"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -3,6 +3,8 @@ package core_test
 import (
 	"flag"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cucumber/godog"
@@ -18,15 +20,23 @@ var (
 		Output: colors.Colored(os.Stdout),
 		Format: "progress",
 	}
+
+	features string
 )
 
 func init() {
 	godog.BindFlags("godog.", flag.CommandLine, &gdOpts)
+	flag.StringVar(&features, "features", "", "a coma separated list of paths to the feature files")
 }
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	gdOpts.Paths = flag.Args()
+
+	if features != "" {
+		paths := strings.Split(features, ",")
+		gdOpts.Paths = paths
+	}
 
 	status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
 		FeatureContext(s)

--- a/script/build.sh
+++ b/script/build.sh
@@ -277,7 +277,6 @@ run() {
 		return "$?"
 		;;
 	qatest) ## Run qa integration tests (godog)
-		local specsrepo
 	  if test -z "$specsrepo" ; then
 	    echo "specsrepo not specified"
 	    exit 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -276,7 +276,7 @@ run() {
 		go test -v ./integration/... -godog.format=pretty
 		return "$?"
 		;;
-	qatest) ## Run qa integration tests (godog)
+	spec_feature_test) ## Run qa integration tests (godog)
 		local repo="${specsrepo:?}"
 		if test -z "$repo"; then
 			echo "specsrepo not specified"

--- a/script/build.sh
+++ b/script/build.sh
@@ -277,6 +277,7 @@ run() {
 		return "$?"
 		;;
 	qatest) ## Run qa integration tests (godog)
+		local specsrepo
 	  if test -z "$specsrepo" ; then
 	    echo "specsrepo not specified"
 	    exit 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -276,6 +276,17 @@ run() {
 		go test -v ./integration/... -godog.format=pretty
 		return "$?"
 		;;
+	qatest) ## Run qa integration tests (godog)
+	  if test -z "$specsrepo" ; then
+	    echo "specsrepo not specified"
+	    exit 1
+	  fi
+	  local features
+	  features="${specsrepo}/qa-scenarios"
+	  echo "features = $features"
+	  go test -v ./integration/... --features="$features" -godog.format=pretty
+	  return "$?"
+	  ;;
 	mocks) ## Generate mocks
 		go generate ./...
 		return "$?"

--- a/script/build.sh
+++ b/script/build.sh
@@ -76,7 +76,7 @@ set_version() {
 }
 
 set_ldflags() {
-    ldflags="-X main.CLIVersion=$version -X main.CLIVersionHash=$version_hash"
+	ldflags="-X main.CLIVersion=$version -X main.CLIVersionHash=$version_hash"
 }
 
 parse_args() {
@@ -277,16 +277,16 @@ run() {
 		return "$?"
 		;;
 	qatest) ## Run qa integration tests (godog)
-	  if test -z "$specsrepo" ; then
-	    echo "specsrepo not specified"
-	    exit 1
-	  fi
-	  local features
-	  features="${specsrepo}/qa-scenarios"
-	  echo "features = $features"
-	  go test -v ./integration/... --features="$features" -godog.format=pretty
-	  return "$?"
-	  ;;
+		if test -z "$specsrepo" ; then
+			echo "specsrepo not specified"
+			exit 1
+		fi
+		local features
+		features="${specsrepo}/qa-scenarios"
+		echo "features = $features"
+		go test -v ./integration/... --features="$features" -godog.format=pretty
+		return "$?"
+		;;
 	mocks) ## Generate mocks
 		go generate ./...
 		return "$?"
@@ -308,7 +308,7 @@ run() {
 		return "$?"
 		;;
 	buflint) ## Run
-	        buf lint
+		buf lint
 		return "$?"
 		;;
 	misspell) ## Run misspell

--- a/script/build.sh
+++ b/script/build.sh
@@ -277,12 +277,13 @@ run() {
 		return "$?"
 		;;
 	qatest) ## Run qa integration tests (godog)
-		if test -z "$specsrepo" ; then
+		local repo="${specsrepo:?}"
+		if test -z "$repo"; then
 			echo "specsrepo not specified"
 			exit 1
 		fi
 		local features
-		features="${specsrepo}/qa-scenarios"
+		features="${repo}/qa-scenarios"
 		echo "features = $features"
 		go test -v ./integration/... --features="$features" -godog.format=pretty
 		return "$?"


### PR DESCRIPTION
This adds support to run feature files from the specs repo. It's meant to be used to implement Step 18 for Issue ##3628

Closes #3467 