### PR TITLE
add tm subcommand

### DIFF
--- a/cmd/vega/faucet.go
+++ b/cmd/vega/faucet.go
@@ -13,6 +13,7 @@ import (
 type FaucetCmd struct {
 	Init faucetInit `command:"init" description:"Generates the faucet configuration"`
 	Run  faucetRun  `command:"run" description:"Runs the faucet"`
+	Help bool       `short:"h" long:"help" description:"Show this help message"`
 }
 
 // faucetCmd is a global variable that holds generic options for the faucet

--- a/cmd/vega/gateway.go
+++ b/cmd/vega/gateway.go
@@ -16,9 +16,17 @@ type gatewayCmd struct {
 	ctx context.Context
 	gateway.Config
 	config.RootPathFlag
+	Help bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *gatewayCmd) Execute(args []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega gateway subcommand help",
+		}
+	}
+
 	ctx, cancel := context.WithCancel(opts.ctx)
 	defer cancel()
 

--- a/cmd/vega/genesis.go
+++ b/cmd/vega/genesis.go
@@ -29,9 +29,16 @@ type genesisCmd struct {
 
 	InPlace bool   `short:"i" long:"in-place" description:"Edit the genesis file in-place"`
 	TmRoot  string `short:"t" long:"tm-root" description:"The root path of tendermint"`
+	Help    bool   `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *genesisCmd) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega genesis subcommand help",
+		}
+	}
 	tmCfg := tmconfig.DefaultConfig()
 	tmCfg.SetRoot(os.ExpandEnv(opts.TmRoot))
 

--- a/cmd/vega/init.go
+++ b/cmd/vega/init.go
@@ -37,11 +37,16 @@ type InitCmd struct {
 	Force      bool `short:"f" long:"force" description:"Erase exiting vega configuration at the specified path"`
 	GenDev     bool `short:"g" long:"gen-dev-nodewallet" description:"Generate dev wallet for all vega supported chains (not for production)"`
 	GenBuiltin bool `short:"b" long:"gen-builtinasset-faucet" description:"Generate the builtin asset configuration (not for production)"`
+
+	Help bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 var initCmd InitCmd
 
 func (opts *InitCmd) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{Type: flags.ErrHelp, Message: "vega init subcommand help"}
+	}
 	logger := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
 	defer logger.AtExit()
 

--- a/cmd/vega/main.go
+++ b/cmd/vega/main.go
@@ -41,7 +41,7 @@ func main() {
 }
 
 func Main(ctx context.Context) error {
-	parser := flags.NewParser(&config.Empty{}, flags.Default)
+	parser := flags.NewParser(&config.Empty{}, flags.PrintErrors|flags.PassDoubleDash)
 
 	if err := Register(ctx, parser,
 		Faucet,
@@ -54,17 +54,16 @@ func Main(ctx context.Context) error {
 		Version,
 		Wallet,
 		Watch,
+		Tm,
 	); err != nil {
 		fmt.Printf("%+v\n", err)
 		return err
 	}
 
 	if _, err := parser.Parse(); err != nil {
-		switch t := err.(type) {
+		switch err.(type) {
 		case *flags.Error:
-			if t.Type != flags.ErrHelp {
-				parser.WriteHelp(os.Stdout)
-			}
+			parser.WriteHelp(os.Stdout)
 		}
 		return err
 	}

--- a/cmd/vega/main.go
+++ b/cmd/vega/main.go
@@ -41,6 +41,11 @@ func main() {
 }
 
 func Main(ctx context.Context) error {
+	// special case for the tendermint subcommand, so we bypass the command line
+	if len(os.Args) >= 2 && os.Args[1] == "tm" {
+		return (&tmCmd{}).Execute(nil)
+	}
+
 	parser := flags.NewParser(&config.Empty{}, flags.PrintErrors|flags.PassDoubleDash)
 
 	if err := Register(ctx, parser,

--- a/cmd/vega/node.go
+++ b/cmd/vega/node.go
@@ -14,11 +14,18 @@ type NodeCmd struct {
 	config.RootPathFlag
 
 	config.Config
+	Help bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 var nodeCmd NodeCmd
 
 func (cmd *NodeCmd) Execute(args []string) error {
+	if cmd.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega node subcommand help",
+		}
+	}
 	log := logging.NewLoggerFromConfig(
 		logging.NewDefaultConfig(),
 	)

--- a/cmd/vega/nodewallet.go
+++ b/cmd/vega/nodewallet.go
@@ -18,8 +18,9 @@ type NodeWalletCmd struct {
 	config.PassphraseFlag
 
 	// Subcommands
-	Import nodeWalletImport `command:"import"`
-	Verify nodeWalletVerify `command:"verify"`
+	Import nodeWalletImport `command:"import" description:"Import the configuration of a wallet required by the vega node"`
+	Verify nodeWalletVerify `command:"verify" description:"Verify the configuration imported in the nodewallet"`
+	Help   bool             `short:"h" long:"help" description:"Show this help message"`
 }
 
 var nodeWalletCmd NodeWalletCmd
@@ -54,12 +55,19 @@ type nodeWalletImport struct {
 
 	WalletPassphrase config.Passphrase `short:"w" long:"wallet-passphrase"`
 
-	Chain      string `short:"c" long:"chain" required:"true"`
-	WalletPath string `long:"wallet-path" required:"true"`
-	Force      bool   `long:"force"`
+	Chain      string `short:"c" long:"chain" required:"true" description:"The chain to be imported (vega, ethereum)"`
+	WalletPath string `long:"wallet-path" required:"true" description:"The path to the wallet file to import"`
+	Force      bool   `long:"force" description:"Should the command re-write an existing nodewallet file if it exists"`
+	Help       bool   `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *nodeWalletImport) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega nodewallet import subcommand help",
+		}
+	}
 	log := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
 	defer log.AtExit()
 
@@ -116,9 +124,17 @@ func (opts *nodeWalletImport) Execute(_ []string) error {
 
 type nodeWalletVerify struct {
 	Config nodewallet.Config
+	Help   bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *nodeWalletVerify) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega nodewallet verify subcommand help",
+		}
+	}
+
 	if ok, err := fsutil.PathExists(nodeWalletCmd.RootPath); !ok {
 		return fmt.Errorf("invalid root directory path: %w", err)
 	}

--- a/cmd/vega/tm.go
+++ b/cmd/vega/tm.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/jessevdk/go-flags"
+
+	cmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
+	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/cli"
+	nm "github.com/tendermint/tendermint/node"
+)
+
+type tmCmd struct {
+	Help []bool `short:"h" long:"help" description:"Show this help message"`
+}
+
+func (opts *tmCmd) Execute(_ []string) error {
+
+	os.Args = os.Args[1:]
+	rootCmd := cmd.RootCmd
+	rootCmd.AddCommand(
+		cmd.GenValidatorCmd,
+		cmd.InitFilesCmd,
+		cmd.ProbeUpnpCmd,
+		cmd.LiteCmd,
+		cmd.ReplayCmd,
+		cmd.ReplayConsoleCmd,
+		cmd.ResetAllCmd,
+		cmd.ResetPrivValidatorCmd,
+		cmd.ShowValidatorCmd,
+		cmd.TestnetFilesCmd,
+		cmd.ShowNodeIDCmd,
+		cmd.GenNodeKeyCmd,
+		cmd.VersionCmd,
+		debug.DebugCmd,
+		cli.NewCompletionCmd(rootCmd, true),
+	)
+
+	nodeFunc := nm.DefaultNewNode
+
+	// Create & start node
+	rootCmd.AddCommand(cmd.NewRunNodeCmd(nodeFunc))
+
+	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir)))
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
+
+	return nil
+}
+
+func Tm(ctx context.Context, parser *flags.Parser) error {
+	_, err := parser.AddCommand(
+		"tm",
+		"Run tendermint nodes",
+		"Run a tendermint node",
+		&tmCmd{},
+	)
+
+	return err
+}

--- a/cmd/vega/verify.go
+++ b/cmd/vega/verify.go
@@ -11,6 +11,7 @@ import (
 type VerifyCmd struct {
 	Asset   verify.AssetCmd   `command:"passet" description:"verify an asset proposal payload"`
 	Genesis verify.GenesisCmd `command:"genesis" description:"verify a vega genesis app state"`
+	Help    bool              `short:"h" long:"help" description:"Show this help message"`
 }
 
 var verifyCmd VerifyCmd

--- a/cmd/vega/verify/asset.go
+++ b/cmd/vega/verify/asset.go
@@ -4,11 +4,20 @@ import (
 	"time"
 
 	types "code.vegaprotocol.io/vega/proto"
+	"github.com/jessevdk/go-flags"
 )
 
-type AssetCmd struct{}
+type AssetCmd struct {
+	Help bool `short:"h" long:"help" description:"Show this help message"`
+}
 
 func (opts *AssetCmd) Execute(params []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega verify passet subcommand help",
+		}
+	}
 	return verifier(params, verifyAsset)
 }
 

--- a/cmd/vega/verify/genesis.go
+++ b/cmd/vega/verify/genesis.go
@@ -7,13 +7,22 @@ import (
 	"code.vegaprotocol.io/vega/broker"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/netparams"
+	"github.com/jessevdk/go-flags"
 
 	types "code.vegaprotocol.io/vega/proto"
 )
 
-type GenesisCmd struct{}
+type GenesisCmd struct {
+	Help bool `short:"h" long:"help" description:"Show this help message"`
+}
 
 func (opts *GenesisCmd) Execute(params []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega verify genesis subcommand help",
+		}
+	}
 	return verifier(params, verifyGenesis)
 }
 

--- a/cmd/vega/version.go
+++ b/cmd/vega/version.go
@@ -10,9 +10,16 @@ import (
 type VersionCmd struct {
 	version string
 	hash    string
+	Help    bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (cmd *VersionCmd) Execute(_ []string) error {
+	if cmd.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega version subcommand help",
+		}
+	}
 	fmt.Printf("Vega CLI %s (%s)\n", cmd.version, cmd.hash)
 	return nil
 }
@@ -25,6 +32,6 @@ func Version(ctx context.Context, parser *flags.Parser) error {
 		hash:    CLIVersionHash,
 	}
 
-	_, err := parser.AddCommand("version", "", "", &versionCmd)
+	_, err := parser.AddCommand("version", "Show version info", "Show version info", &versionCmd)
 	return err
 }

--- a/cmd/vega/wallet.go
+++ b/cmd/vega/wallet.go
@@ -27,6 +27,7 @@ type WalletCmd struct {
 	Taint   walletTaint   `command:"taint" description:"Taints a public key" long-description:"Taints a public key"`
 	Meta    walletMeta    `command:"meta" description:"Adds metadata to a public key" long-description:"Adds a list of metadata to a public key"`
 	Service walletService `command:"service" description:"The wallet service" long-description:"Runs or initializes the wallet service"`
+	Help    bool          `short:"h" long:"help" description:"Show this help message"`
 }
 
 // walletCmd is a global variable that holds generic options for the wallet
@@ -68,9 +69,17 @@ func readWallet(rootPath, name, pass string) (*wallet.Wallet, error) {
 type walletGenkey struct {
 	config.PassphraseFlag
 	Name string `short:"n" long:"name" description:"Name of the wallet to user" required:"true"`
+	Help bool   `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletGenkey) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet genkey subcommand help",
+		}
+	}
+
 	name := opts.Name
 	pass, err := opts.Passphrase.Get(name)
 	if err != nil {
@@ -115,9 +124,16 @@ func (opts *walletGenkey) Execute(_ []string) error {
 type walletList struct {
 	config.PassphraseFlag
 	Name string `short:"n" long:"name" description:"Name of the wallet to user" required:"true"`
+	Help bool   `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletList) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet list subcommand help",
+		}
+	}
 	name := opts.Name
 	pass, err := opts.Passphrase.Get(name)
 	if err != nil {
@@ -144,9 +160,16 @@ type walletSign struct {
 	Name    string          `short:"n" long:"name" description:"Name of the wallet to user" required:"true"`
 	Message encoding.Base64 `short:"m" long:"message" description:"Message to be signed (base64 encoded)" required:"true"`
 	PubKey  string          `short:"k" long:"pubkey" description:"Public key to be used (hex encoded)" required:"true"`
+	Help    bool            `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletSign) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet sign subcommand help",
+		}
+	}
 	name := opts.Name
 	pass, err := opts.Passphrase.Get(name)
 	if err != nil {
@@ -191,9 +214,16 @@ type walletVerify struct {
 	Message encoding.Base64 `short:"m" long:"message" description:"Message to be signed (base64 encoded)" required:"true"`
 	PubKey  string          `short:"k" long:"pubkey" description:"Public key to be used (hex encoded)" required:"true"`
 	Sig     encoding.Base64 `short:"s" long:"signature" description:"Signature to be verified (base64 encoded)" required:"true"`
+	Help    bool            `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletVerify) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet verify subcommand help",
+		}
+	}
 	name := opts.Name
 	pass, err := opts.Passphrase.Get(name)
 	if err != nil {
@@ -233,9 +263,16 @@ type walletTaint struct {
 	config.PassphraseFlag
 	Name   string `short:"n" long:"name" description:"Name of the wallet to user" required:"true"`
 	PubKey string `short:"k" long:"pubkey" description:"Public key to be used (hex encoded)" required:"true"`
+	Help   bool   `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletTaint) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet taint subcommand help",
+		}
+	}
 	name := opts.Name
 	pass, err := opts.Passphrase.Get(name)
 	if err != nil {
@@ -271,9 +308,16 @@ type walletMeta struct {
 	Name   string `short:"n" long:"name" description:"Name of the wallet to user" required:"true"`
 	PubKey string `short:"k" long:"pubkey" description:"Public key to be used (hex encoded)" required:"true"`
 	Metas  string `short:"m" long:"metas" description:"A list of metadata e.g:'primary:true;asset:BTC'" required:"true"`
+	Help   bool   `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletMeta) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet meta subcommand help",
+		}
+	}
 	name := opts.Name
 	pass, err := opts.Passphrase.Get(name)
 	if err != nil {
@@ -318,9 +362,16 @@ func (opts *walletMeta) Execute(_ []string) error {
 type walletServiceInit struct {
 	Force  bool `short:"f" long:"force" description:"Erase existing configuration at specified path"`
 	GenRSA bool `short:"g" long:"genrsakey" description:"Generates RSA for the JWT tokens"`
+	Help   bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletServiceInit) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet service init subcommand help",
+		}
+	}
 	if ok, err := fsutil.PathExists(walletCmd.RootPath); !ok {
 		return fmt.Errorf("invalid root directory path: %v", err)
 	}
@@ -335,9 +386,16 @@ func (opts *walletServiceInit) Execute(_ []string) error {
 type walletServiceRun struct {
 	ctx    context.Context
 	Config wallet.Config
+	Help   bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *walletServiceRun) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega wallet service run subcommand help",
+		}
+	}
 	cfg, err := wallet.LoadConfig(walletCmd.RootPath)
 	if err != nil {
 		return err

--- a/cmd/vega/watch.go
+++ b/cmd/vega/watch.go
@@ -17,9 +17,17 @@ type watch struct {
 	Positional struct {
 		Filters []string `positional-arg-name:"<FILTERS>"`
 	} `positional-args:"true"`
+	Help bool `short:"h" long:"help" description:"Show this help message"`
 }
 
 func (opts *watch) Execute(_ []string) error {
+	if opts.Help {
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: "vega watch subcommand help",
+		}
+	}
+
 	args := opts.Positional.Filters
 	if len(args) == 0 {
 		return errors.New("error: watch requires at least one filter")


### PR DESCRIPTION
This PR introduce a new `tm` subcommand which will allow use to run a tendermint node via the vega subcommand. Basically all the tendermint subcommand is  exposed as a vega subcommand.

In order to implement this I had to change a bit more code than expected so the default Help feature of the command line is disable, which was preventing the tm subcommand to work properly (hence all the Help field added in all existing command to support the -h/--help flags).

@ashleyvega / @fkondej you guys may be interested with this too.

close #3633