### PR TITLE
Remove unused parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
         skipDefaultCheckout true
     }
     parameters {
-        string(name: 'VEGA_CORE_BRANCH', defaultValue: "${CHANGE_BRANCH}", description: 'Git branch name of the vegaprotocol/vega repository')
         string(name: 'SYSTEM_TESTS_BRANCH', defaultValue: 'develop', description: 'Git branch name of the vegaprotocol/system-tests repository')
         string(name: 'DEVOPS_INFRA_BRANCH', defaultValue: 'master', description: 'Git branch name of the vegaprotocol/devops-infra repository')
     }


### PR DESCRIPTION
This caused an issue when running the Jenkinsfile pipeline after merging to `develop` (i.e. when running for a specific branch and not a PR).