### PR TITLE
fix position engine hash state

### DIFF
--- a/positions/engine.go
+++ b/positions/engine.go
@@ -70,9 +70,11 @@ func (e *Engine) Hash() []byte {
 
 		// Add bytes for VWBuy and VWSell here
 		b := p.VWBuy().Bytes()
-		output = append(output, b[:]...)
+		copy(output[i:], b[:])
+		i += 32
 		s := p.VWBuy().Bytes()
-		output = append(output, s[:]...)
+		copy(output[i:], s[:])
+		i += 32
 	}
 
 	return crypto.Hash(output)

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -569,7 +569,7 @@ func TestHash(t *testing.T) {
 
 	hash := e.Hash()
 	require.Equal(t,
-		"9d22a4052353969fe753a81c6a064fb6b032f48b36736d4c54cc8dd2376ebaa4",
+		"6ad38d53e438c8a0c5d67f6304c1e29e436b24491a72934e3b748bd1e21768e4",
 		hex.EncodeToString(hash),
 		"It should match against the known hash",
 	)


### PR DESCRIPTION
Maybe / maybe not the reason for the state issue, but the hash is implemented the wrong way there.

slice is built with len + capacite = same, which means that it's fine to copy stuff in the slice at given indexes, but not to append, as append would be done at the end of the slice (keeping things empty in middle). Ultimately that should not be the source of our issue, but eh...