### PR TITLE
Calculation without decimals in liquidity target

### DIFF
--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -829,15 +829,15 @@ func (m *Market) amendOrCancelLiquidityProvision(
 	// rejected.
 	if sub.CommitmentAmount.LT(lp.CommitmentAmount) {
 		// first - does the market have enough stake
-		supplied := num.DecimalFromUint(m.getSuppliedStake())
-		if m.getTargetStake().GreaterThanOrEqual(supplied) {
+		supplied := m.getSuppliedStake()
+		if m.getTargetStake().GTE(supplied) {
 			return ErrNotEnoughStake
 		}
 
 		// now if the stake surplus is > than the change we are OK
-		surplus := supplied.Sub(m.getTargetStake())
-		diff := num.DecimalFromUint(num.Zero().Sub(lp.CommitmentAmount, sub.CommitmentAmount))
-		if surplus.LessThan(diff) {
+		surplus := supplied.Sub(supplied, m.getTargetStake())
+		diff := num.Zero().Sub(lp.CommitmentAmount, sub.CommitmentAmount)
+		if surplus.LT(diff) {
 			return ErrNotEnoughStake
 		}
 	}

--- a/integration/features/lp-distressed-closeout.feature
+++ b/integration/features/lp-distressed-closeout.feature
@@ -197,7 +197,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     When the network moves ahead "301" blocks
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1055       | TRADING_MODE_CONTINUOUS | 1       | 1045      | 1065      | 3482         | 5000           | 33            |
+      | 1055       | TRADING_MODE_CONTINUOUS | 1       | 1045      | 1065      | 3481         | 5000           | 33            |
     And the traders should have the following account balances:
       | trader  | asset | market id | margin | general | bond |
       | trader0 | ETH   | ETH/DEC21 | 265    | 1407    | 0    |

--- a/integration/features/volume-near-price-mon-bounds.feature
+++ b/integration/features/volume-near-price-mon-bounds.feature
@@ -64,7 +64,7 @@ Feature: Test margin for lp near price monitoring boundaries
     # so the best bid/ask coincides with the price monitoring bounds.
     # Since the lp1 offset is +/- 100 the lp1 volume "should" go to 800 and 1200
     # but because the price monitoring bounds are 900 and 1100 the volume gets pushed to these
-    # i.e. it's placed at 900 / 1100. 
+    # i.e. it's placed at 900 / 1100.
     # As these are the best bid / best ask the probability of trading used is 1/2.
 
     And the traders should have the following margin levels:
@@ -88,9 +88,9 @@ Feature: Test margin for lp near price monitoring boundaries
     Then the traders place the following orders:
       | trader  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | trader1 | ETH/DEC21 | buy  | 1      | 901   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-4 |
-    
+
     # the lp1 one volume on this side should go to 801 but because price monitoring bound is still 900 it gets pushed to 900.
-    # but 900 is no longer the best bid, so the risk model is used to get prob of trading. This is 0.1 (see above). 
+    # but 900 is no longer the best bid, so the risk model is used to get prob of trading. This is 0.1 (see above).
     # Hence a lot more volume is required to meet commitment and thus the margin requirement jumps substantially.
 
     And the traders should have the following margin levels:
@@ -144,7 +144,7 @@ Feature: Test margin for lp near price monitoring boundaries
 
     And the market data for the market "ETH2/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | TRADING_MODE_CONTINUOUS | 43200   | 900       | 1109      | 3612         | 50000000       | 10            |
+      | 1000       | TRADING_MODE_CONTINUOUS | 43200   | 900       | 1109      | 3611         | 50000000       | 10            |
 
     And the order book should have the following volumes for market "ETH2/MAR22":
       | side | price | volume |
@@ -157,7 +157,7 @@ Feature: Test margin for lp near price monitoring boundaries
     # so the best bid/ask coincides with the price monitoring bounds.
     # Since the lp1 offset is +/- 100 the lp1 volume "should" go to 800 and 1209
     # but because the price monitoring bounds are 900 and 1109 the volume gets pushed to these
-    # i.e. it's placed at 900 / 1109. 
+    # i.e. it's placed at 900 / 1109.
     # As these are the best bid / best ask the probability of trading used is 1/2.
 
     And the traders should have the following margin levels:
@@ -175,7 +175,7 @@ Feature: Test margin for lp near price monitoring boundaries
 
     And the market data for the market "ETH2/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | TRADING_MODE_CONTINUOUS | 43200   | 900       | 1109      | 3612         | 50000000       | 10            |
+      | 1000       | TRADING_MODE_CONTINUOUS | 43200   | 900       | 1109      | 3611         | 50000000       | 10            |
     Then debug liquidity submission errors
     And debug transaction errors
     And debug liquidity provision events
@@ -198,8 +198,8 @@ Feature: Test margin for lp near price monitoring boundaries
 
     And the market data for the market "ETH2/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | TRADING_MODE_CONTINUOUS | 43200   | 900       | 1109      | 3612         | 0              | 10            |
-    
+      | 1000       | TRADING_MODE_CONTINUOUS | 43200   | 900       | 1109      | 3611         | 0              | 10            |
+
 
     # the lp1 one volume on this side should go to 801 but because price monitoring bound is still 900 it gets pushed to 900.
     # but 900 is no longer the best bid, so the risk model is used to get prob of trading. This now given by the log-normal model
@@ -216,6 +216,3 @@ Feature: Test margin for lp near price monitoring boundaries
     And the traders should have the following margin levels:
       | trader | market id  | maintenance | search   | initial  | release  |
       | lp1    | ETH2/MAR22 | 32569511    | 35826462 | 39083413 | 45597315 |
-
-
-    

--- a/liquidity/target/engine_test.go
+++ b/liquidity/target/engine_test.go
@@ -191,7 +191,7 @@ func TestGetTheoreticalTargetStake(t *testing.T) {
 	theoreticalOI := oi
 	oiCalc.EXPECT().GetOpenInterestGivenTrades(trades).Return(theoreticalOI).MaxTimes(1)
 	expectedTheoreticalTargetStake, _ := num.UintFromDecimal(expectedTargetStake)
-	theoreticalTargetStake := engine.GetTheoreticalTargetStake(rf, now, markPrice, trades)
+	theoreticalTargetStake := engine.GetTheoreticalTargetStake(rf, now, markPrice.Clone(), trades)
 
 	require.Equal(t, expectedTheoreticalTargetStake, theoreticalTargetStake)
 

--- a/liquidity/target/engine_test.go
+++ b/liquidity/target/engine_test.go
@@ -47,7 +47,7 @@ func TestGetTargetStake_NoRecordedOpenInterest(t *testing.T) {
 
 	targetStake := engine.GetTargetStake(rf, now, num.NewUint(123))
 
-	require.Equal(t, num.DecimalFromFloat(0.0), targetStake)
+	require.Equal(t, num.Zero(), targetStake)
 }
 
 func TestGetTargetStake_VerifyFormula(t *testing.T) {
@@ -76,15 +76,16 @@ func TestGetTargetStake_VerifyFormula(t *testing.T) {
 	err := engine.RecordOpenInterest(oi, now)
 	require.NoError(t, err)
 
-	targetStakeNow := engine.GetTargetStake(rf, now, markPrice)
-	targetStakeLaterInWindow := engine.GetTargetStake(rf, now.Add(time.Minute), markPrice)
-	targetStakeAtEndOfWindow := engine.GetTargetStake(rf, now.Add(tWindow), markPrice)
-	targetStakeAfterWindow := engine.GetTargetStake(rf, now.Add(tWindow).Add(time.Nanosecond), markPrice)
+	targetStakeNow := engine.GetTargetStake(rf, now, markPrice.Clone())
+	targetStakeLaterInWindow := engine.GetTargetStake(rf, now.Add(time.Minute), markPrice.Clone())
+	targetStakeAtEndOfWindow := engine.GetTargetStake(rf, now.Add(tWindow), markPrice.Clone())
+	targetStakeAfterWindow := engine.GetTargetStake(rf, now.Add(tWindow).Add(time.Nanosecond), markPrice.Clone())
 
-	require.Equal(t, expectedTargetStake, targetStakeNow)
-	require.Equal(t, expectedTargetStake, targetStakeLaterInWindow)
-	require.Equal(t, expectedTargetStake, targetStakeAtEndOfWindow)
-	require.Equal(t, expectedTargetStake, targetStakeAfterWindow)
+	expectedUint, _ := num.UintFromDecimal(expectedTargetStake)
+	require.Equal(t, expectedUint, targetStakeNow)
+	require.Equal(t, expectedUint, targetStakeLaterInWindow)
+	require.Equal(t, expectedUint, targetStakeAtEndOfWindow)
+	require.Equal(t, expectedUint, targetStakeAfterWindow)
 }
 
 func TestGetTargetStake_VerifyMaxOI(t *testing.T) {
@@ -94,7 +95,7 @@ func TestGetTargetStake_VerifyMaxOI(t *testing.T) {
 	rfLong := num.DecimalFromFloat(0.3)
 	rfShort := num.DecimalFromFloat(0.1)
 	markPrice := num.NewUint(123)
-	expectedTargetStake := func(oi uint64) num.Decimal {
+	expectedTargetStake := func(oi uint64) *num.Uint {
 		// float64(markPrice.Uint64()*oi) * math.Max(rfLong, rfShort) * scalingFactor
 		mp := num.DecimalFromUint(markPrice)
 		mp = mp.Mul(num.DecimalFromUint(num.NewUint(oi)))
@@ -103,7 +104,8 @@ func TestGetTargetStake_VerifyMaxOI(t *testing.T) {
 			factor = rfShort
 		}
 		mp = mp.Mul(factor.Mul(scalingFactor))
-		return mp
+		ump, _ := num.UintFromDecimal(mp)
+		return ump
 	}
 
 	engine := target.NewEngine(params, nil)
@@ -116,8 +118,8 @@ func TestGetTargetStake_VerifyMaxOI(t *testing.T) {
 	var maxOI uint64 = 23
 	err := engine.RecordOpenInterest(maxOI, now)
 	require.NoError(t, err)
-	actualTargetStake1 := engine.GetTargetStake(rf, now, markPrice)
-	actualTargetStake2 := engine.GetTargetStake(rf, now.Add(time.Minute), markPrice)
+	actualTargetStake1 := engine.GetTargetStake(rf, now, markPrice.Clone())
+	actualTargetStake2 := engine.GetTargetStake(rf, now.Add(time.Minute), markPrice.Clone())
 	require.Equal(t, expectedTargetStake(maxOI), actualTargetStake1)
 	require.Equal(t, expectedTargetStake(maxOI), actualTargetStake2)
 	// Max in past
@@ -125,8 +127,8 @@ func TestGetTargetStake_VerifyMaxOI(t *testing.T) {
 	markPrice = num.NewUint(456)
 	err = engine.RecordOpenInterest(maxOI-1, now)
 	require.NoError(t, err)
-	actualTargetStake1 = engine.GetTargetStake(rf, now, markPrice)
-	actualTargetStake2 = engine.GetTargetStake(rf, now.Add(time.Minute), markPrice)
+	actualTargetStake1 = engine.GetTargetStake(rf, now, markPrice.Clone())
+	actualTargetStake2 = engine.GetTargetStake(rf, now.Add(time.Minute), markPrice.Clone())
 	require.Equal(t, expectedTargetStake(maxOI), actualTargetStake1)
 	require.Equal(t, expectedTargetStake(maxOI), actualTargetStake2)
 
@@ -136,8 +138,8 @@ func TestGetTargetStake_VerifyMaxOI(t *testing.T) {
 	markPrice = num.NewUint(23)
 	err = engine.RecordOpenInterest(maxOI, now)
 	require.NoError(t, err)
-	actualTargetStake1 = engine.GetTargetStake(rf, now, markPrice)
-	actualTargetStake2 = engine.GetTargetStake(rf, now.Add(time.Minute), markPrice)
+	actualTargetStake1 = engine.GetTargetStake(rf, now, markPrice.Clone())
+	actualTargetStake2 = engine.GetTargetStake(rf, now.Add(time.Minute), markPrice.Clone())
 	require.Equal(t, expectedTargetStake(maxOI), actualTargetStake1)
 	require.Equal(t, expectedTargetStake(maxOI), actualTargetStake2)
 
@@ -182,8 +184,9 @@ func TestGetTheoreticalTargetStake(t *testing.T) {
 	err := engine.RecordOpenInterest(oi, now)
 	require.NoError(t, err)
 
-	targetStakeNow := engine.GetTargetStake(rf, now, markPrice)
-	require.Equal(t, expectedTargetStake, targetStakeNow)
+	expectedUint, _ := num.UintFromDecimal(expectedTargetStake)
+	targetStakeNow := engine.GetTargetStake(rf, now, markPrice.Clone())
+	require.Equal(t, expectedUint, targetStakeNow)
 
 	var trades []*types.Trade
 

--- a/types/num/uint.go
+++ b/types/num/uint.go
@@ -221,6 +221,11 @@ func (u *Uint) Mod(x, y *Uint) *Uint {
 	return u
 }
 
+func (u *Uint) Exp(x, y *Uint) *Uint {
+	u.u.Exp(&x.u, &y.u)
+	return u
+}
+
 // LT with check if the value stored in u is
 // lesser than oth
 // this is equivalent to:


### PR DESCRIPTION
Replacing the calculation using decimals by uint256 in the liquidity target package.

We are currently spending a considerable amount of time just converting from and into decimals / uint256 in this package. 