### PR TITLE
More float related optimisation

### DIFF
--- a/execution/2965_refresh_lp_orders_size_test.go
+++ b/execution/2965_refresh_lp_orders_size_test.go
@@ -33,7 +33,7 @@ func TestRefreshLiquidityProvisionOrdersSizes(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -263,7 +263,7 @@ func TestRefreshLiquidityProvisionOrdersSizesCrashOnSubmitOrder(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -329,7 +329,7 @@ func TestCommitmentIsDeployed(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -34,7 +34,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -456,7 +456,7 @@ func TestCancelUndeployedCommitmentDuringAuction(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -549,7 +549,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -679,7 +679,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuri
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -258,7 +258,7 @@ func TestLiquidityProvisionFeeValidation(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -309,7 +309,7 @@ func TestLiquidityProvisionFeeValidation(t *testing.T) {
 		"invalid liquidity provision fee",
 	)
 
-	lpSubmission.Fee = num.DecimalFromFloat(0)
+	lpSubmission.Fee = num.DecimalZero()
 
 	// submit our lp
 	require.NoError(t,
@@ -1045,7 +1045,7 @@ func TestLpCannotGetClosedOutWhenDeployingOrderForTheFirstTime(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -1140,7 +1140,7 @@ func TestCloseOutLPTraderContIssue3086(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -1345,7 +1345,7 @@ func TestLiquidityFeeIsSelectedProperly(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -1488,7 +1488,7 @@ func TestLiquidityOrderGeneratedSizes(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(2),
 			},
@@ -1679,7 +1679,7 @@ func TestRejectedMarketStopLiquidityProvision(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(2),
 			},
@@ -1772,7 +1772,7 @@ func TestParkOrderPanicOrderNotFoundInBook(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(10),
 			},
@@ -1962,7 +1962,7 @@ func TestLotsOfPeggedAndNonPeggedOrders(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(2),
 			},
@@ -2143,7 +2143,7 @@ func TestMarketValueProxyIsUpdatedWithTrades(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(2),
 			},
@@ -2282,7 +2282,7 @@ func TestFeesNotPaidToUndeployedLPs(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(2),
 			},
@@ -2417,7 +2417,7 @@ func TestLPProviderSubmitLimitOrderWhichExpiresLPOrderAreRedeployed(t *testing.T
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(5),
 			},

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -863,7 +863,7 @@ func TestSetMarketID(t *testing.T) {
 						RiskAversionParameter: num.DecimalFromFloat(0.01),
 						Tau:                   num.DecimalFromFloat(1.0 / 365.25 / 24),
 						Params: &types.LogNormalModelParams{
-							Mu:    num.DecimalFromFloat(0),
+							Mu:    num.DecimalZero(),
 							R:     num.DecimalFromFloat(0.016),
 							Sigma: num.DecimalFromFloat(0.09),
 						},
@@ -4559,7 +4559,7 @@ func TestLPOrdersRollback(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -4779,7 +4779,7 @@ func Test3008CancelLiquidityProvisionWhenTargetStakeNotReached(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -4944,7 +4944,7 @@ func Test3008And3007CancelLiquidityProvision(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -5255,7 +5255,7 @@ func Test2963EnsureMarketValueProxyAndEquitityShareAreInMarketData(t *testing.T)
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -5442,7 +5442,7 @@ func Test3045DistributeFeesToManyProviders(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -5692,7 +5692,7 @@ func TestAverageEntryValuation(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},
@@ -5800,7 +5800,7 @@ func TestBondAccountIsReleasedItMarketRejected(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -2672,7 +2672,7 @@ func Test2965EnsureLPOrdersAreNotCancelleableWithCancelAll(t *testing.T) {
 			RiskAversionParameter: num.DecimalFromFloat(0.001),
 			Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 			Params: &types.LogNormalModelParams{
-				Mu:    num.DecimalFromFloat(0),
+				Mu:    num.DecimalZero(),
 				R:     num.DecimalFromFloat(0.016),
 				Sigma: num.DecimalFromFloat(20),
 			},

--- a/fee/engine.go
+++ b/fee/engine.go
@@ -319,7 +319,7 @@ func (e *Engine) CalculateFeeForPositionResolution(
 	// no we accumulated all the absolute position, we
 	// will get the share of each party
 	for _, v := range partiesShare {
-		v.share = num.DecimalFromFloat(float64(v.pos)).Div(num.DecimalFromFloat(float64(totalAbsolutePos)))
+		v.share = num.DecimalFromInt64(int64(v.pos)).Div(num.DecimalFromInt64(int64(totalAbsolutePos)))
 	}
 
 	// now we have the share of each distressed parties
@@ -509,7 +509,7 @@ func (e *Engine) calculateContinuousModeFees(trade *types.Trade) *types.Fee {
 
 func (e *Engine) calculateAuctionModeFees(trade *types.Trade) *types.Fee {
 	fee := e.calculateContinuousModeFees(trade)
-	two := num.DecimalFromFloat(2)
+	two := num.DecimalFromInt64(2)
 	inf, _ := num.UintFromDecimal(fee.InfrastructureFee.ToDecimal().Div(two).Ceil())
 	lf, _ := num.UintFromDecimal(fee.LiquidityFee.ToDecimal().Div(two).Ceil())
 	return &types.Fee{

--- a/governance/engine.go
+++ b/governance/engine.go
@@ -524,7 +524,7 @@ func (e *Engine) AddVote(ctx context.Context, cmd types.VoteSubmission, party st
 		Value:                       cmd.Value,
 		Timestamp:                   e.currentTime.UnixNano(),
 		TotalGovernanceTokenBalance: num.Zero(),
-		TotalGovernanceTokenWeight:  num.DecimalFromFloat(0),
+		TotalGovernanceTokenWeight:  num.DecimalZero(),
 	}
 
 	// we only want to count the last vote, so add to yes/no map, delete from the other

--- a/governance/engine_test.go
+++ b/governance/engine_test.go
@@ -1011,7 +1011,7 @@ func newValidMarketTerms() *types.ProposalTerms_NewMarket {
 						RiskAversionParameter: num.DecimalFromFloat(0.01),
 						Tau:                   num.DecimalFromFloat(0.00011407711613050422),
 						Params: &types.LogNormalModelParams{
-							Mu:    num.DecimalFromFloat(0),
+							Mu:    num.DecimalZero(),
 							R:     num.DecimalFromFloat(0.016),
 							Sigma: num.DecimalFromFloat(0.09),
 						},

--- a/governance/market.go
+++ b/governance/market.go
@@ -341,7 +341,7 @@ func validateCommitment(
 		return proto.ProposalError_PROPOSAL_ERROR_MISSING_COMMITMENT_AMOUNT,
 			fmt.Errorf("proposal commitment amount is 0 or missing")
 	}
-	if commitment.Fee.LessThanOrEqual(num.DecimalFromFloat(0)) || commitment.Fee.GreaterThan(maxFeeDec) {
+	if commitment.Fee.LessThanOrEqual(num.DecimalZero()) || commitment.Fee.GreaterThan(maxFeeDec) {
 		return proto.ProposalError_PROPOSAL_ERROR_INVALID_FEE_AMOUNT,
 			errors.New("invalid liquidity provision fee")
 	}

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -103,13 +103,13 @@ func NewEngine(config Config,
 		broker:                  broker,
 		idGen:                   idGen,
 		suppliedEngine:          supplied.NewEngine(riskModel, priceMonitor),
-		stakeToObligationFactor: num.DecimalFromFloat(1),
+		stakeToObligationFactor: num.DecimalFromInt64(1),
 		provisions:              map[string]*types.LiquidityProvision{},
 		orders:                  map[string]map[string]*types.Order{},
 		liquidityOrders:         map[string]map[string]*types.Order{},
 		pendings:                map[string]struct{}{},
 		maxShapesSize:           100, // set it to the same default than the netparams
-		maxFee:                  num.DecimalFromFloat(1.0),
+		maxFee:                  num.DecimalFromInt64(1),
 	}
 }
 

--- a/liquidity/supplied/engine.go
+++ b/liquidity/supplied/engine.go
@@ -67,7 +67,7 @@ func NewEngine(riskModel RiskModel, priceMonitor PriceMonitor) *Engine {
 		pm: priceMonitor,
 
 		horizon:                        riskModel.GetProjectionHorizon(),
-		probabilityOfTradingTauScaling: num.DecimalFromFloat(1.0), // this is the same as the default in the netparams
+		probabilityOfTradingTauScaling: num.DecimalFromInt64(1), // this is the same as the default in the netparams
 		minProbabilityOfTrading:        defaultMinimumProbabilityOfTrading,
 		bCache:                         map[num.Uint]num.Decimal{},
 		sCache:                         map[num.Uint]num.Decimal{},
@@ -130,8 +130,8 @@ func (e *Engine) calculateBuySellLiquidityWithMinMax(
 	orders []*types.Order,
 	minPrice, maxPrice *num.Uint,
 ) (*num.Uint, *num.Uint) {
-	bLiq := num.DecimalFromFloat(0.0)
-	sLiq := num.DecimalFromFloat(0.0)
+	bLiq := num.DecimalZero()
+	sLiq := num.DecimalZero()
 	for _, o := range orders {
 		if o.Side == types.Side_SIDE_BUY {
 			// float64(o.Price.Uint64()) * float64(o.Remaining) * prob
@@ -165,7 +165,7 @@ func (e *Engine) updateSizes(
 		return nil
 	}
 
-	sum := num.DecimalFromFloat(0.0)
+	sum := num.DecimalZero()
 	probs := make([]num.Decimal, 0, len(orders))
 	validatedProportions := make([]num.Decimal, 0, len(orders))
 	for _, o := range orders {

--- a/liquidity/types.go
+++ b/liquidity/types.go
@@ -40,7 +40,7 @@ type LiquidityProvisions []*types.LiquidityProvision
 // that's required. If no such k exists we set k=N.
 func (l LiquidityProvisions) feeForTarget(t *num.Uint) num.Decimal {
 	if len(l) == 0 {
-		return num.DecimalFromFloat(0)
+		return num.DecimalZero()
 	}
 
 	n := num.Zero()

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -329,8 +329,8 @@ func (e *Engine) reset(price *num.Uint, volume uint64, now time.Time) {
 func (e *Engine) resetBounds() {
 	for _, b := range e.bounds {
 		b.Active = true
-		b.DownFactor = num.DecimalFromFloat(0)
-		b.UpFactor = num.DecimalFromFloat(0)
+		b.DownFactor = num.DecimalZero()
+		b.UpFactor = num.DecimalZero()
 	}
 }
 

--- a/plugins/positions.go
+++ b/plugins/positions.go
@@ -227,7 +227,7 @@ func closeV(p *Position, closedVolume int64, tradedPrice *num.Uint) num.Decimal 
 	if closedVolume == 0 {
 		return num.DecimalZero()
 	}
-	realisedPnlDelta := num.DecimalFromUint(tradedPrice).Sub(p.AverageEntryPriceFP).Mul(num.DecimalFromFloat(float64(closedVolume)))
+	realisedPnlDelta := num.DecimalFromUint(tradedPrice).Sub(p.AverageEntryPriceFP).Mul(num.DecimalFromInt64(closedVolume))
 	p.RealisedPnlFP = p.RealisedPnlFP.Add(realisedPnlDelta)
 	p.OpenVolume -= closedVolume
 	return realisedPnlDelta
@@ -238,8 +238,8 @@ func updateVWAP(vwap num.Decimal, volume int64, addVolume int64, addPrice *num.U
 		return num.DecimalZero()
 	}
 
-	volumeDec := num.DecimalFromFloat(float64(volume))
-	addVolumeDec := num.DecimalFromFloat(float64(addVolume))
+	volumeDec := num.DecimalFromInt64(volume)
+	addVolumeDec := num.DecimalFromInt64(addVolume)
 	addPriceDec := num.DecimalFromUint(addPrice)
 
 	//	return ((vwap * float64(volume)) + (float64(addPrice) * float64(addVolume))) / (float64(volume) + float64(addVolume))
@@ -259,7 +259,7 @@ func mtm(p *Position, markPrice *num.Uint) {
 		return
 	}
 	markPriceDec := num.DecimalFromUint(markPrice)
-	openVolumeDec := num.DecimalFromFloat(float64(p.OpenVolume))
+	openVolumeDec := num.DecimalFromInt64(p.OpenVolume)
 
 	//	p.UnrealisedPnlFP = float64(p.OpenVolume) * (float64(markPrice) - p.AverageEntryPriceFP)
 	p.UnrealisedPnlFP = openVolumeDec.Mul(markPriceDec.Sub(p.AverageEntryPriceFP))

--- a/risk/margins_calculation.go
+++ b/risk/margins_calculation.go
@@ -52,15 +52,14 @@ func (e *Engine) calculateAuctionMargins(m events.Margin, markPrice *num.Uint, r
 	// calculate margins without order positions
 	ml := e.calculateMargins(m, markPrice, rf, true, true)
 	// now add the margin levels for orders
-	long, short := num.DecimalFromFloat(float64(m.Buy())), num.DecimalFromFloat(float64(m.Sell()))
-	zeroD := num.DecimalFromFloat(0)
+	long, short := num.DecimalFromInt64(m.Buy()), num.DecimalFromInt64(m.Sell())
 	var (
 		lMargin, sMargin num.Decimal
 	)
-	if long.GreaterThan(zeroD) {
+	if long.GreaterThan(num.DecimalZero()) {
 		lMargin = long.Mul(rf.Long.Mul(m.VWBuy().ToDecimal()))
 	}
-	if short.GreaterThan(zeroD) {
+	if short.GreaterThan(num.DecimalZero()) {
 		sMargin = short.Mul(rf.Short.Mul(m.VWSell().ToDecimal()))
 	}
 	// add buy/sell order margins to the margin requirements
@@ -94,16 +93,15 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 	}
 
 	mPriceDec := markPrice.ToDecimal()
-	zeroD := num.DecimalFromFloat(0)
 	// calculate margin maintenance long only if riskiest is > 0
 	// marginMaintenanceLng will be 0 by default
 	if riskiestLng > 0 {
 		var (
-			slippageVolume  = num.DecimalFromFloat(float64(max(openVolume, 0)))
+			slippageVolume  = num.DecimalFromInt64(max(openVolume, 0))
 			slippagePerUnit = num.Zero()
 			negSlippage     bool
 		)
-		if slippageVolume.GreaterThan(zeroD) {
+		if slippageVolume.GreaterThan(num.DecimalZero()) {
 			var (
 				exitPrice *num.Uint
 				err       error
@@ -121,17 +119,17 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 			slippagePerUnit, negSlippage = num.Zero().Delta(markPrice, exitPrice)
 		}
 
-		bDec := num.DecimalFromFloat(float64(m.Buy()))
+		bDec := num.DecimalFromInt64(m.Buy())
 		if auction {
 			marginMaintenanceLng = slippageVolume.Mul(rf.Long.Mul(mPriceDec)).Add(bDec.Mul(rf.Long).Mul(mPriceDec))
 			// marginMaintenanceLng = float64(slippageVolume)*(rf.Long*float64(markPrice)) + (float64(m.Buy()) * rf.Long * float64(markPrice))
 		} else {
 			slip := slippagePerUnit.ToDecimal().Mul(slippageVolume)
 			if negSlippage {
-				slip = slip.Mul(num.DecimalFromFloat(-1))
+				slip = slip.Mul(num.DecimalFromInt64(-1))
 			}
 			marginMaintenanceLng = slippageVolume.Mul(rf.Long.Mul(mPriceDec)).Add(bDec.Mul(rf.Long).Mul(mPriceDec))
-			if slip.GreaterThan(zeroD) {
+			if slip.GreaterThan(num.DecimalZero()) {
 				marginMaintenanceLng = marginMaintenanceLng.Add(slip)
 			}
 		}
@@ -140,11 +138,11 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 	// marginMaintenanceSht will be 0 by default
 	if riskiestSht < 0 {
 		var (
-			slippageVolume  = num.DecimalFromFloat(float64(min(openVolume, 0)))
+			slippageVolume  = num.DecimalFromInt64(min(openVolume, 0))
 			slippagePerUnit = num.Zero()
 		)
 		// slippageVolume would be negative we abs it in the next phase
-		if slippageVolume.LessThan(zeroD) {
+		if slippageVolume.LessThan(num.DecimalZero()) {
 			var (
 				exitPrice *num.Uint
 				err       error
@@ -164,7 +162,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 			// slippagePerUnit = -1 * (markPrice - int64(exitPrice))
 		}
 
-		sDec := num.DecimalFromFloat(float64(m.Sell()))
+		sDec := num.DecimalFromInt64(m.Sell())
 		if auction {
 			marginMaintenanceSht = slippageVolume.Abs().Mul(rf.Short.Mul(mPriceDec)).Add(sDec.Mul(rf.Short).Mul(mPriceDec))
 		} else {
@@ -173,10 +171,10 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 	}
 
 	// the greatest liability is the most positive number
-	if marginMaintenanceLng.GreaterThan(marginMaintenanceSht) && marginMaintenanceLng.GreaterThan(zeroD) {
+	if marginMaintenanceLng.GreaterThan(marginMaintenanceSht) && marginMaintenanceLng.GreaterThan(num.DecimalZero()) {
 		return newMarginLevels(marginMaintenanceLng, e.scalingFactorsUint)
 	}
-	if marginMaintenanceSht.GreaterThan(zeroD) {
+	if marginMaintenanceSht.GreaterThan(num.DecimalZero()) {
 		return newMarginLevels(marginMaintenanceSht, e.scalingFactorsUint)
 	}
 

--- a/risk/margins_calculation.go
+++ b/risk/margins_calculation.go
@@ -56,10 +56,10 @@ func (e *Engine) calculateAuctionMargins(m events.Margin, markPrice *num.Uint, r
 	var (
 		lMargin, sMargin num.Decimal
 	)
-	if long.GreaterThan(num.DecimalZero()) {
+	if long.IsPositive() {
 		lMargin = long.Mul(rf.Long.Mul(m.VWBuy().ToDecimal()))
 	}
-	if short.GreaterThan(num.DecimalZero()) {
+	if short.IsPositive() {
 		sMargin = short.Mul(rf.Short.Mul(m.VWSell().ToDecimal()))
 	}
 	// add buy/sell order margins to the margin requirements
@@ -101,7 +101,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 			slippagePerUnit = num.Zero()
 			negSlippage     bool
 		)
-		if slippageVolume.GreaterThan(num.DecimalZero()) {
+		if slippageVolume.IsPositive() {
 			var (
 				exitPrice *num.Uint
 				err       error
@@ -129,7 +129,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 				slip = slip.Mul(num.DecimalFromInt64(-1))
 			}
 			marginMaintenanceLng = slippageVolume.Mul(rf.Long.Mul(mPriceDec)).Add(bDec.Mul(rf.Long).Mul(mPriceDec))
-			if slip.GreaterThan(num.DecimalZero()) {
+			if slip.IsPositive() {
 				marginMaintenanceLng = marginMaintenanceLng.Add(slip)
 			}
 		}
@@ -142,7 +142,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 			slippagePerUnit = num.Zero()
 		)
 		// slippageVolume would be negative we abs it in the next phase
-		if slippageVolume.LessThan(num.DecimalZero()) {
+		if slippageVolume.IsNegative() {
 			var (
 				exitPrice *num.Uint
 				err       error
@@ -171,10 +171,10 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 	}
 
 	// the greatest liability is the most positive number
-	if marginMaintenanceLng.GreaterThan(marginMaintenanceSht) && marginMaintenanceLng.GreaterThan(num.DecimalZero()) {
+	if marginMaintenanceLng.GreaterThan(marginMaintenanceSht) && marginMaintenanceLng.IsPositive() {
 		return newMarginLevels(marginMaintenanceLng, e.scalingFactorsUint)
 	}
-	if marginMaintenanceSht.GreaterThan(num.DecimalZero()) {
+	if marginMaintenanceSht.IsPositive() {
 		return newMarginLevels(marginMaintenanceSht, e.scalingFactorsUint)
 	}
 

--- a/risk/models/simple.go
+++ b/risk/models/simple.go
@@ -63,12 +63,12 @@ func (f *Simple) ProbabilityOfTrading(currentP, orderP, minP, maxP *num.Uint, yF
 		return f.prob
 	}
 	if orderP.LT(minP) || orderP.GT(maxP) {
-		return num.DecimalFromFloat(0)
+		return num.DecimalZero()
 	}
 	return f.prob
 }
 
 // GetProjectionHorizon returns 0 and the simple model doesn't rely on any proabilistic calculations
 func (f *Simple) GetProjectionHorizon() num.Decimal {
-	return num.DecimalFromFloat(0)
+	return num.DecimalZero()
 }

--- a/types/num/decimal.go
+++ b/types/num/decimal.go
@@ -33,6 +33,10 @@ func DecimalFromUint(u *Uint) Decimal {
 	return decimal.NewFromUint(&u.u)
 }
 
+func DecimalFromInt64(i int64) Decimal {
+	return decimal.NewFromInt(i)
+}
+
 func DecimalFromFloat(v float64) Decimal {
 	return decimal.NewFromFloat(v)
 }

--- a/types/pricemonitoring.go
+++ b/types/pricemonitoring.go
@@ -132,7 +132,7 @@ func (p PriceMonitoringBounds) DeepClone() *PriceMonitoringBounds {
 func PriceMonitoringTriggerFromProto(p *proto.PriceMonitoringTrigger) *PriceMonitoringTrigger {
 	return &PriceMonitoringTrigger{
 		Horizon:          p.Horizon,
-		HDec:             num.DecimalFromFloat(float64(p.Horizon)),
+		HDec:             num.DecimalFromInt64(p.Horizon),
 		Probability:      num.DecimalFromFloat(p.Probability),
 		AuctionExtension: p.AuctionExtension,
 	}
@@ -160,7 +160,7 @@ func (p PriceMonitoringTrigger) DeepClone() *PriceMonitoringTrigger {
 
 func (p *PriceMonitoringTrigger) FromProto(pr *proto.PriceMonitoringTrigger) {
 	p.Horizon = pr.Horizon
-	p.HDec = num.DecimalFromFloat(float64(pr.Horizon))
+	p.HDec = num.DecimalFromInt64(pr.Horizon)
 	p.Probability = num.DecimalFromFloat(pr.Probability)
 	p.AuctionExtension = pr.AuctionExtension
 }


### PR DESCRIPTION
Looking at the pprof profile, it appears constructing decimals from float take a massive amount of time. Looking at the implementation it indeed appear a lot of processing is done compared to the NewFromInt64 constructor.

This replace calls to NewFromFloat to NewFromInt64 when possible.
num.DecimalZero() is also used when possible.