### PR TITLE
remove a couple of metrics calls

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1896,8 +1896,6 @@ func (m *Market) zeroOutNetwork(ctx context.Context, traders []events.MarketPosi
 }
 
 func (m *Market) checkMarginForOrder(ctx context.Context, pos *positions.MarketPosition, order *types.Order) error {
-	timer := metrics.NewTimeCounter(m.mkt.Id, "market", "checkMarginForOrder")
-	defer timer.EngineTimeCounterAdd()
 	risk, closed, err := m.calcMargins(ctx, pos, order)
 	// margin error
 	if err != nil {

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -7,7 +7,6 @@ import (
 	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/logging"
-	"code.vegaprotocol.io/vega/metrics"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 
@@ -688,10 +687,7 @@ func (b *OrderBook) GetTrades(order *types.Order) ([]*types.Trade, error) {
 
 // SubmitOrder Add an order and attempt to uncross the book, returns a TradeSet protobuf message object
 func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, error) {
-	timer := metrics.NewTimeCounter(b.marketID, "matching", "SubmitOrder")
-
 	if err := b.validateOrder(order); err != nil {
-		timer.EngineTimeCounterAdd()
 		return nil, err
 	}
 
@@ -796,7 +792,6 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 	}
 
 	orderConfirmation := makeResponse(order, trades, impactedOrders)
-	timer.EngineTimeCounterAdd()
 	return orderConfirmation, nil
 }
 

--- a/matching/side.go
+++ b/matching/side.go
@@ -7,7 +7,6 @@ import (
 
 	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/logging"
-	"code.vegaprotocol.io/vega/metrics"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 
@@ -399,8 +398,6 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order) ([]*types.Trade, error) {
 }
 
 func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, []*types.Order, *num.Uint, error) {
-	timer := metrics.NewTimeCounter("-", "matching", "OrderBookSide.uncross")
-
 	var (
 		trades            []*types.Trade
 		impactedOrders    []*types.Order
@@ -446,7 +443,6 @@ func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*type
 		}
 
 		if totalVolumeToFill < agg.Remaining {
-			timer.EngineTimeCounterAdd()
 			return trades, impactedOrders, lastTradedPrice, nil
 		}
 	}
@@ -513,7 +509,6 @@ func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*type
 	if len(trades) > 0 {
 		lastTradedPrice = trades[len(trades)-1].Price.Clone()
 	}
-	timer.EngineTimeCounterAdd()
 	return trades, impactedOrders, lastTradedPrice, err
 }
 

--- a/matching/validation.go
+++ b/matching/validation.go
@@ -2,7 +2,6 @@ package matching
 
 import (
 	"code.vegaprotocol.io/vega/logging"
-	"code.vegaprotocol.io/vega/metrics"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 )
@@ -11,7 +10,6 @@ const minOrderIDLen = 22
 const maxOrderIDLen = 22
 
 func (b OrderBook) validateOrder(orderMessage *types.Order) (err error) {
-	timer := metrics.NewTimeCounter(b.marketID, "matching", "validateOrder")
 	if orderMessage.Price == nil {
 		orderMessage.Price = num.Zero()
 	}
@@ -48,7 +46,6 @@ func (b OrderBook) validateOrder(orderMessage *types.Order) (err error) {
 	} else if orderMessage.ExpiresAt > 0 && orderMessage.Type == types.Order_TYPE_MARKET {
 		err = types.ErrInvalidExpirationDatetime
 	}
-	timer.EngineTimeCounterAdd()
 	return
 }
 


### PR DESCRIPTION
Removing a couple of calls to the metrics. Prometheus should not be call in part of the code which are called a lot (e.g: orderbook, positions engine, etc).

These which are removed in this PR were accounting for ~4.5% of the runtime...