### PR TITLE
Correcting event types and adding panics to catch mistakes

### DIFF
--- a/api_test/testutil_test.go
+++ b/api_test/testutil_test.go
@@ -91,7 +91,7 @@ func NewTestServer(t testing.TB, ctx context.Context, blocking bool) (conn *grpc
 		return
 	}
 	accountService := accounts.NewService(logger, conf.Accounts, accountStore)
-	accountSub := subscribers.NewAccountSub(ctx, accountStore, true)
+	accountSub := subscribers.NewAccountSub(ctx, accountStore, logger, true)
 
 	candleStore, err := storage.NewCandles(logger, conf.Storage, cancel)
 	if err != nil {

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -173,21 +173,21 @@ func (l *NodeCommand) loadMarketsConfig() error {
 }
 
 func (l *NodeCommand) setupSubscibers() {
-	l.transferSub = subscribers.NewTransferResponse(l.ctx, l.transferResponseStore, true)
+	l.transferSub = subscribers.NewTransferResponse(l.ctx, l.transferResponseStore, l.Log, true)
 	l.marketEventSub = subscribers.NewMarketEvent(l.ctx, l.conf.Subscribers, l.Log, false)
 	l.orderSub = subscribers.NewOrderEvent(l.ctx, l.conf.Subscribers, l.Log, l.orderStore, true)
-	l.accountSub = subscribers.NewAccountSub(l.ctx, l.accounts, true)
-	l.partySub = subscribers.NewPartySub(l.ctx, l.partyStore, true)
-	l.tradeSub = subscribers.NewTradeSub(l.ctx, l.tradeStore, true)
-	l.marginLevelSub = subscribers.NewMarginLevelSub(l.ctx, l.riskStore, true)
-	l.governanceSub = subscribers.NewGovernanceDataSub(l.ctx, true)
-	l.voteSub = subscribers.NewVoteSub(l.ctx, false, true)
-	l.marketDataSub = subscribers.NewMarketDataSub(l.ctx, l.marketDataStore, true)
-	l.newMarketSub = subscribers.NewMarketSub(l.ctx, l.marketStore, true)
-	l.marketUpdatedSub = subscribers.NewMarketUpdatedSub(l.ctx, l.marketStore, true)
-	l.candleSub = subscribers.NewCandleSub(l.ctx, l.candleStore, true)
+	l.accountSub = subscribers.NewAccountSub(l.ctx, l.accounts, l.Log, true)
+	l.partySub = subscribers.NewPartySub(l.ctx, l.partyStore, l.Log, true)
+	l.tradeSub = subscribers.NewTradeSub(l.ctx, l.tradeStore, l.Log, true)
+	l.marginLevelSub = subscribers.NewMarginLevelSub(l.ctx, l.riskStore, l.Log, true)
+	l.governanceSub = subscribers.NewGovernanceDataSub(l.ctx, l.Log, true)
+	l.voteSub = subscribers.NewVoteSub(l.ctx, false, true, l.Log)
+	l.marketDataSub = subscribers.NewMarketDataSub(l.ctx, l.marketDataStore, l.Log, true)
+	l.newMarketSub = subscribers.NewMarketSub(l.ctx, l.marketStore, l.Log, true)
+	l.marketUpdatedSub = subscribers.NewMarketUpdatedSub(l.ctx, l.marketStore, l.Log, true)
+	l.candleSub = subscribers.NewCandleSub(l.ctx, l.candleStore, l.Log, true)
 	l.marketDepthSub = subscribers.NewMarketDepthBuilder(l.ctx, l.Log, true)
-	l.riskFactorSub = subscribers.NewRiskFactorSub(l.ctx, l.riskStore, true)
+	l.riskFactorSub = subscribers.NewRiskFactorSub(l.ctx, l.riskStore, l.Log, true)
 }
 
 func (l *NodeCommand) setupStorages() (err error) {

--- a/events/governance_proposal.go
+++ b/events/governance_proposal.go
@@ -10,19 +10,18 @@ import (
 
 type Proposal struct {
 	*Base
-	p types.Proposal
+	p proto.Proposal
 }
 
 func NewProposalEvent(ctx context.Context, p types.Proposal) *Proposal {
-	cpy := p.DeepClone()
 	return &Proposal{
 		Base: newBase(ctx, ProposalEvent),
-		p:    *cpy,
+		p:    *p.IntoProto(),
 	}
 }
 
 func (p *Proposal) Proposal() proto.Proposal {
-	return *p.p.IntoProto()
+	return p.p
 }
 
 // ProposalID - for combined subscriber, communal interface
@@ -40,8 +39,7 @@ func (p *Proposal) PartyID() string {
 }
 
 func (p Proposal) Proto() proto.Proposal {
-	pr := p.p.IntoProto()
-	return *pr
+	return p.p
 }
 
 func (p Proposal) StreamMessage() *eventspb.BusEvent {
@@ -50,7 +48,7 @@ func (p Proposal) StreamMessage() *eventspb.BusEvent {
 		Block: p.TraceID(),
 		Type:  p.et.ToProto(),
 		Event: &eventspb.BusEvent_Proposal{
-			Proposal: p.p.IntoProto(),
+			Proposal: &p.p,
 		},
 	}
 }

--- a/events/margin_levels.go
+++ b/events/margin_levels.go
@@ -11,17 +11,17 @@ import (
 // MarginLevels - the margin levels event
 type MarginLevels struct {
 	*Base
-	l types.MarginLevels
+	l proto.MarginLevels
 }
 
 func NewMarginLevelsEvent(ctx context.Context, l types.MarginLevels) *MarginLevels {
 	return &MarginLevels{
 		Base: newBase(ctx, MarginLevelsEvent),
-		l:    l,
+		l:    *l.IntoProto(),
 	}
 }
 
-func (m MarginLevels) MarginLevels() types.MarginLevels {
+func (m MarginLevels) MarginLevels() proto.MarginLevels {
 	return m.l
 }
 
@@ -42,8 +42,7 @@ func (m MarginLevels) Asset() string {
 }
 
 func (m MarginLevels) Proto() proto.MarginLevels {
-	p := m.l.IntoProto()
-	return *p
+	return m.l
 }
 
 func (m MarginLevels) StreamMessage() *eventspb.BusEvent {
@@ -52,7 +51,7 @@ func (m MarginLevels) StreamMessage() *eventspb.BusEvent {
 		Block: m.TraceID(),
 		Type:  m.et.ToProto(),
 		Event: &eventspb.BusEvent_MarginLevels{
-			MarginLevels: m.l.IntoProto(),
+			MarginLevels: &m.l,
 		},
 	}
 }

--- a/events/network_parameter.go
+++ b/events/network_parameter.go
@@ -3,27 +3,27 @@ package events
 import (
 	"context"
 
-	types "code.vegaprotocol.io/vega/proto"
+	"code.vegaprotocol.io/vega/proto"
 	eventspb "code.vegaprotocol.io/vega/proto/events/v1"
 )
 
 type NetworkParameter struct {
 	*Base
-	np types.NetworkParameter
+	np proto.NetworkParameter
 }
 
 func NewNetworkParameterEvent(ctx context.Context, key, value string) *NetworkParameter {
 	return &NetworkParameter{
 		Base: newBase(ctx, NetworkParameterEvent),
-		np:   types.NetworkParameter{Key: key, Value: value},
+		np:   proto.NetworkParameter{Key: key, Value: value},
 	}
 }
 
-func (n *NetworkParameter) NetworkParameter() types.NetworkParameter {
+func (n *NetworkParameter) NetworkParameter() proto.NetworkParameter {
 	return n.np
 }
 
-func (n NetworkParameter) Proto() types.NetworkParameter {
+func (n NetworkParameter) Proto() proto.NetworkParameter {
 	return n.np
 }
 

--- a/events/party.go
+++ b/events/party.go
@@ -3,16 +3,16 @@ package events
 import (
 	"context"
 
-	types "code.vegaprotocol.io/vega/proto"
+	"code.vegaprotocol.io/vega/proto"
 	eventspb "code.vegaprotocol.io/vega/proto/events/v1"
 )
 
 type Party struct {
 	*Base
-	p types.Party
+	p proto.Party
 }
 
-func NewPartyEvent(ctx context.Context, p types.Party) *Party {
+func NewPartyEvent(ctx context.Context, p proto.Party) *Party {
 	cpy := p.DeepClone()
 	return &Party{
 		Base: newBase(ctx, PartyEvent),
@@ -24,11 +24,11 @@ func (p Party) IsParty(id string) bool {
 	return p.p.Id == id
 }
 
-func (p *Party) Party() types.Party {
+func (p *Party) Party() proto.Party {
 	return p.p
 }
 
-func (p Party) Proto() types.Party {
+func (p Party) Proto() proto.Party {
 	return p.p
 }
 

--- a/events/risk_factor.go
+++ b/events/risk_factor.go
@@ -10,13 +10,13 @@ import (
 
 type RiskFactor struct {
 	*Base
-	r types.RiskFactor
+	r proto.RiskFactor
 }
 
 func NewRiskFactorEvent(ctx context.Context, r types.RiskFactor) *RiskFactor {
 	return &RiskFactor{
 		Base: newBase(ctx, RiskFactorEvent),
-		r:    r,
+		r:    *r.IntoProto(),
 	}
 }
 
@@ -24,13 +24,12 @@ func (r RiskFactor) MarketID() string {
 	return r.r.Market
 }
 
-func (r *RiskFactor) RiskFactor() types.RiskFactor {
+func (r *RiskFactor) RiskFactor() proto.RiskFactor {
 	return r.r
 }
 
 func (r RiskFactor) Proto() proto.RiskFactor {
-	p := r.r.IntoProto()
-	return *p
+	return r.r
 }
 
 func (r RiskFactor) StreamMessage() *eventspb.BusEvent {
@@ -39,7 +38,7 @@ func (r RiskFactor) StreamMessage() *eventspb.BusEvent {
 		Block: r.TraceID(),
 		Type:  r.et.ToProto(),
 		Event: &eventspb.BusEvent_RiskFactor{
-			RiskFactor: r.r.IntoProto(),
+			RiskFactor: &r.r,
 		},
 	}
 }

--- a/governance/service.go
+++ b/governance/service.go
@@ -79,7 +79,7 @@ func (s *Svc) ObserveGovernance(ctx context.Context, retries int) <-chan []proto
 	out := make(chan []proto.GovernanceData)
 	ctx, cfunc := context.WithCancel(ctx)
 	// use non-acking subscriber
-	sub := subscribers.NewGovernanceSub(ctx, false)
+	sub := subscribers.NewGovernanceSub(ctx, s.log, false)
 	id := s.bus.Subscribe(sub)
 	go func() {
 		defer func() {
@@ -118,7 +118,7 @@ func (s *Svc) getCompleteGovernanceData(data []proto.GovernanceData) []proto.Gov
 		} else if len(gd.No) > 0 {
 			id = gd.No[0].ProposalId
 		}
-		if p, err := s.GetProposalByID(id); err != nil && p != nil {
+		if p, err := s.GetProposalByID(id); err == nil && p != nil {
 			gds = append(gds, *p)
 		} else {
 			s.log.Debug("invalid proposal id",
@@ -133,7 +133,7 @@ func (s *Svc) getCompleteGovernanceData(data []proto.GovernanceData) []proto.Gov
 // ObservePartyProposals streams proposals submitted by the specific party
 func (s *Svc) ObservePartyProposals(ctx context.Context, retries int, partyID string) <-chan []proto.GovernanceData {
 	ctx, cfunc := context.WithCancel(ctx)
-	sub := subscribers.NewGovernanceSub(ctx, false, subscribers.Proposals(subscribers.ProposalByPartyID(partyID)))
+	sub := subscribers.NewGovernanceSub(ctx, s.log, false, subscribers.Proposals(subscribers.ProposalByPartyID(partyID)))
 	out := make(chan []proto.GovernanceData)
 	id := s.bus.Subscribe(sub)
 	go func() {

--- a/governance/service.go
+++ b/governance/service.go
@@ -167,7 +167,7 @@ func (s *Svc) ObservePartyVotes(ctx context.Context, retries int, partyID string
 	out := make(chan []proto.Vote)
 	// new subscriber, in "stream mode" (changes only), filtered by party ID
 	// and make subscriber non-acking, missed votes are ignored
-	sub := subscribers.NewVoteSub(ctx, true, false, subscribers.VoteByPartyID(partyID))
+	sub := subscribers.NewVoteSub(ctx, true, false, s.log, subscribers.VoteByPartyID(partyID))
 	id := s.bus.Subscribe(sub)
 	go func() {
 		defer func() {
@@ -202,7 +202,7 @@ func (s *Svc) ObserveProposalVotes(ctx context.Context, retries int, proposalID 
 	ctx, cfunc := context.WithCancel(ctx)
 	out := make(chan []proto.Vote)
 	// new subscriber, in "stream mode" (changes only), filtered by proposal ID
-	sub := subscribers.NewVoteSub(ctx, true, false, subscribers.VoteByProposalID(proposalID))
+	sub := subscribers.NewVoteSub(ctx, true, false, s.log, subscribers.VoteByProposalID(proposalID))
 	id := s.bus.Subscribe(sub)
 	go func() {
 		defer func() {

--- a/integration/stubs/broker_stub.go
+++ b/integration/stubs/broker_stub.go
@@ -351,13 +351,13 @@ func (b *BrokerStub) GetMarginByPartyAndMarket(partyID, marketID string) (types.
 			if _, ok := mapped[ml.PartyId]; !ok {
 				mapped[ml.PartyId] = map[string]types.MarginLevels{}
 			}
-			mapped[ml.PartyId][ml.MarketId] = *ml.IntoProto()
+			mapped[ml.PartyId][ml.MarketId] = ml
 		case events.MarginLevels:
 			ml := et.MarginLevels()
 			if _, ok := mapped[ml.PartyId]; !ok {
 				mapped[ml.PartyId] = map[string]types.MarginLevels{}
 			}
-			mapped[ml.PartyId][ml.MarketId] = *ml.IntoProto()
+			mapped[ml.PartyId][ml.MarketId] = ml
 		}
 	}
 	mkts, ok := mapped[partyID]

--- a/risk/engine_test.go
+++ b/risk/engine_test.go
@@ -11,6 +11,7 @@ import (
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/matching"
+	"code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/risk"
 	"code.vegaprotocol.io/vega/risk/mocks"
 	"code.vegaprotocol.io/vega/types"
@@ -22,7 +23,7 @@ import (
 
 type MLEvent interface {
 	events.Event
-	MarginLevels() types.MarginLevels
+	MarginLevels() proto.MarginLevels
 }
 
 type testEngine struct {

--- a/subscribers/account_events.go
+++ b/subscribers/account_events.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -22,13 +23,15 @@ type AccountSub struct {
 	store AccountStore
 	mu    sync.Mutex
 	buf   map[string]*types.Account
+	log   *logging.Logger
 }
 
-func NewAccountSub(ctx context.Context, store AccountStore, ack bool) *AccountSub {
+func NewAccountSub(ctx context.Context, store AccountStore, log *logging.Logger, ack bool) *AccountSub {
 	a := &AccountSub{
 		Base:  NewBase(ctx, 10, ack),
 		store: store,
 		buf:   map[string]*types.Account{},
+		log:   log,
 	}
 	if a.isRunning() {
 		go a.loop(a.ctx)
@@ -65,6 +68,8 @@ func (a *AccountSub) Push(evts ...events.Event) {
 			a.buf[k] = &acc
 		case TimeEvent:
 			a.flush()
+		default:
+			a.log.Panic("Unknown event type in account subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 	a.mu.Unlock()

--- a/subscribers/governance_data.go
+++ b/subscribers/governance_data.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -14,14 +15,16 @@ type GovernanceDataSub struct {
 	proposals map[string]types.Proposal
 	byPID     map[string]*types.GovernanceData
 	all       []*types.GovernanceData
+	log       *logging.Logger
 }
 
-func NewGovernanceDataSub(ctx context.Context, ack bool) *GovernanceDataSub {
+func NewGovernanceDataSub(ctx context.Context, log *logging.Logger, ack bool) *GovernanceDataSub {
 	gd := &GovernanceDataSub{
 		Base:      NewBase(ctx, 10, ack),
 		proposals: map[string]types.Proposal{},
 		byPID:     map[string]*types.GovernanceData{},
 		all:       []*types.GovernanceData{},
+		log:       log,
 	}
 	if gd.isRunning() {
 		go gd.loop(gd.ctx)
@@ -65,6 +68,8 @@ func (g *GovernanceDataSub) Push(evts ...events.Event) {
 				delete(gd.YesParty, vote.PartyId)
 				gd.NoParty[vote.PartyId] = &vote
 			}
+		default:
+			g.log.Panic("Unknown event type in governance subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/governance_data_test.go
+++ b/subscribers/governance_data_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/subscribers"
 	"code.vegaprotocol.io/vega/types"
@@ -26,7 +27,7 @@ func TestFilterOne(t *testing.T) {
 func testGetByID(t *testing.T) {
 	ctx, cfunc := context.WithCancel(context.Background())
 	defer cfunc()
-	sub := subscribers.NewGovernanceDataSub(ctx, true)
+	sub := subscribers.NewGovernanceDataSub(ctx, logging.NewTestLogger(), true)
 	ids := []string{
 		"prop1",
 		"prop2",
@@ -55,7 +56,7 @@ func testGetByID(t *testing.T) {
 func testFilterByState(t *testing.T) {
 	ctx, cfunc := context.WithCancel(context.Background())
 	defer cfunc()
-	sub := subscribers.NewGovernanceDataSub(ctx, true)
+	sub := subscribers.NewGovernanceDataSub(ctx, logging.NewTestLogger(), true)
 	party := "test-party"
 	states := []proto.Proposal_State{
 		proto.Proposal_STATE_OPEN,
@@ -92,7 +93,7 @@ func testFilterByState(t *testing.T) {
 
 func testFilterByParty(t *testing.T) {
 	ctx, cfunc := context.WithCancel(context.Background())
-	sub := subscribers.NewGovernanceDataSub(ctx, true)
+	sub := subscribers.NewGovernanceDataSub(ctx, logging.NewTestLogger(), true)
 	assert.Empty(t, sub.Filter(false))
 	party := "test-party"
 	ids := []string{
@@ -123,7 +124,7 @@ func testFilterByParty(t *testing.T) {
 func testNoFilterVotes(t *testing.T) {
 	ctx, cfunc := context.WithCancel(context.Background())
 	defer cfunc()
-	sub := subscribers.NewGovernanceDataSub(ctx, true)
+	sub := subscribers.NewGovernanceDataSub(ctx, logging.NewTestLogger(), true)
 	parties := []string{
 		"party1",
 		"party2",

--- a/subscribers/margin_levels.go
+++ b/subscribers/margin_levels.go
@@ -53,12 +53,10 @@ func (m *MarginLevelSub) loop(ctx context.Context) {
 }
 
 func (m *MarginLevelSub) Push(evts ...events.Event) {
-	m.log.Error("Margin level pushing events")
 	for _, e := range evts {
-		switch te := e.(type) {
+		switch et := e.(type) {
 		case MLE:
-			m.log.Error("Margin level MLE")
-			ml := te.MarginLevels()
+			ml := et.MarginLevels()
 			m.mu.Lock()
 			if _, ok := m.buf[ml.PartyId]; !ok {
 				m.buf[ml.PartyId] = map[string]types.MarginLevels{}
@@ -68,7 +66,7 @@ func (m *MarginLevelSub) Push(evts ...events.Event) {
 		case TimeEvent:
 			m.flush()
 		default:
-			m.log.Error("Margin levels:", logging.String("Type", te.Type().String()))
+			m.log.Panic("Unknown event type in margin level subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/market_depth.go
+++ b/subscribers/market_depth.go
@@ -90,9 +90,11 @@ func (mdb *MarketDepthBuilder) loop(ctx context.Context) {
 // Push takes order messages and applied them to the makret depth structure
 func (mdb *MarketDepthBuilder) Push(evts ...events.Event) {
 	for _, e := range evts {
-		switch te := e.(type) {
+		switch et := e.(type) {
 		case OE:
-			mdb.updateMarketDepth(types.OrderFromProto(te.Order()))
+			mdb.updateMarketDepth(types.OrderFromProto(et.Order()))
+		default:
+			mdb.log.Panic("Unknown event type in market depth builder", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/market_updated.go
+++ b/subscribers/market_updated.go
@@ -47,8 +47,11 @@ func (m *MarketUpdated) loop(ctx context.Context) {
 func (m *MarketUpdated) Push(evts ...events.Event) {
 	batch := make([]types.Market, 0, len(evts))
 	for _, e := range evts {
-		if te, ok := e.(MEE); ok {
-			batch = append(batch, te.Proto())
+		switch et := e.(type) {
+		case MEE:
+			batch = append(batch, et.Proto())
+		default:
+			m.log.Panic("Unknown event type in market updated subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 	if len(batch) > 0 {

--- a/subscribers/market_updated.go
+++ b/subscribers/market_updated.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -15,9 +16,10 @@ type MEE interface {
 type MarketUpdated struct {
 	*Base
 	store MarketStore
+	log   *logging.Logger
 }
 
-func NewMarketUpdatedSub(ctx context.Context, store MarketStore, ack bool) *MarketUpdated {
+func NewMarketUpdatedSub(ctx context.Context, store MarketStore, log *logging.Logger, ack bool) *MarketUpdated {
 	m := &MarketUpdated{
 		Base:  NewBase(ctx, 1, ack),
 		store: store,

--- a/subscribers/order_events.go
+++ b/subscribers/order_events.go
@@ -60,11 +60,13 @@ func (o *OrderEvent) loop(ctx context.Context) {
 
 func (o *OrderEvent) Push(evts ...events.Event) {
 	for _, e := range evts {
-		switch te := e.(type) {
+		switch et := e.(type) {
 		case OE:
-			o.write(te)
+			o.write(et)
 		case TimeEvent:
 			o.flush()
+		default:
+			o.log.Panic("Unknown event type in order subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/party_events.go
+++ b/subscribers/party_events.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -22,13 +23,15 @@ type PartySub struct {
 	mu    sync.Mutex
 	store PartyStore
 	buf   []types.Party
+	log   *logging.Logger
 }
 
-func NewPartySub(ctx context.Context, store PartyStore, ack bool) *PartySub {
+func NewPartySub(ctx context.Context, store PartyStore, log *logging.Logger, ack bool) *PartySub {
 	a := &PartySub{
 		Base:  NewBase(ctx, 10, ack),
 		store: store,
 		buf:   []types.Party{},
+		log:   log,
 	}
 	if a.isRunning() {
 		go a.loop(a.ctx)
@@ -60,6 +63,8 @@ func (p *PartySub) Push(evts ...events.Event) {
 			p.mu.Unlock()
 		case TimeEvent:
 			p.flush()
+		default:
+			p.log.Panic("Unknown event type in party subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/risk_factors.go
+++ b/subscribers/risk_factors.go
@@ -64,7 +64,7 @@ func (m *RiskFactorSub) Push(evts ...events.Event) {
 		case TimeEvent:
 			m.flush()
 		default:
-			m.log.Panic("Unknown event type in account subscriber", logging.String("Type", et.Type().String()))
+			m.log.Panic("Unknown event type in risk factor subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/risk_factors.go
+++ b/subscribers/risk_factors.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -22,13 +23,15 @@ type RiskFactorSub struct {
 	store RFStore
 	mu    sync.Mutex
 	buf   map[string]types.RiskFactor
+	log   *logging.Logger
 }
 
-func NewRiskFactorSub(ctx context.Context, store RFStore, ack bool) *RiskFactorSub {
+func NewRiskFactorSub(ctx context.Context, store RFStore, log *logging.Logger, ack bool) *RiskFactorSub {
 	m := RiskFactorSub{
 		Base:  NewBase(ctx, 10, ack),
 		store: store,
 		buf:   map[string]types.RiskFactor{},
+		log:   log,
 	}
 	if m.isRunning() {
 		go m.loop(m.ctx)
@@ -52,14 +55,16 @@ func (m *RiskFactorSub) loop(ctx context.Context) {
 
 func (m *RiskFactorSub) Push(evts ...events.Event) {
 	for _, e := range evts {
-		switch te := e.(type) {
+		switch et := e.(type) {
 		case RF:
-			rf := te.RiskFactor()
+			rf := et.RiskFactor()
 			m.mu.Lock()
 			m.buf[rf.Market] = rf
 			m.mu.Unlock()
 		case TimeEvent:
 			m.flush()
+		default:
+			m.log.Panic("Unknown event type in account subscriber", logging.String("Type", et.Type().String()))
 		}
 	}
 }

--- a/subscribers/trade_event.go
+++ b/subscribers/trade_event.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -22,9 +23,10 @@ type TradeSub struct {
 	mu    sync.Mutex
 	buf   []types.Trade
 	store TradeStore
+	log   *logging.Logger
 }
 
-func NewTradeSub(ctx context.Context, store TradeStore, ack bool) *TradeSub {
+func NewTradeSub(ctx context.Context, store TradeStore, log *logging.Logger, ack bool) *TradeSub {
 	t := &TradeSub{
 		Base:  NewBase(ctx, 10, ack),
 		buf:   []types.Trade{},
@@ -62,6 +64,8 @@ func (t *TradeSub) Push(evts ...events.Event) {
 			t.buf = append(t.buf, te.Trade())
 		case TimeEvent:
 			t.flush()
+		default:
+			t.log.Panic("Unknown event type in trade subscriber", logging.String("Type", te.Type().String()))
 		}
 	}
 	t.mu.Unlock()

--- a/subscribers/transfer_response_test.go
+++ b/subscribers/transfer_response_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 	"code.vegaprotocol.io/vega/subscribers"
 	"code.vegaprotocol.io/vega/subscribers/mocks"
@@ -35,7 +36,7 @@ func getTestSub(t *testing.T, ack bool) *trTst {
 	ctrl := gomock.NewController(t)
 	ctx, cfunc := context.WithCancel(context.Background())
 	store := mocks.NewMockTransferResponseStore(ctrl)
-	tr := subscribers.NewTransferResponse(ctx, store, ack)
+	tr := subscribers.NewTransferResponse(ctx, store, logging.NewTestLogger(), ack)
 	return &trTst{
 		TransferResponse: tr,
 		ctrl:             ctrl,

--- a/subscribers/votes.go
+++ b/subscribers/votes.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
 	types "code.vegaprotocol.io/vega/proto"
 )
 
@@ -15,6 +16,7 @@ type VoteSub struct {
 	filters []VoteFilter
 	stream  bool
 	update  chan struct{}
+	log     *logging.Logger
 }
 
 // VoteByPartyID filters votes cast by given party
@@ -30,7 +32,7 @@ func VoteByProposalID(id string) VoteFilter {
 	}
 }
 
-func NewVoteSub(ctx context.Context, stream, ack bool, filters ...VoteFilter) *VoteSub {
+func NewVoteSub(ctx context.Context, stream, ack bool, log *logging.Logger, filters ...VoteFilter) *VoteSub {
 	v := &VoteSub{
 		Base:    NewBase(ctx, 10, ack),
 		mu:      &sync.Mutex{},
@@ -38,6 +40,7 @@ func NewVoteSub(ctx context.Context, stream, ack bool, filters ...VoteFilter) *V
 		filters: filters,
 		stream:  stream,
 		update:  make(chan struct{}),
+		log:     log,
 	}
 	if v.isRunning() {
 		go v.loop(v.ctx)
@@ -65,9 +68,10 @@ func (v *VoteSub) Push(evts ...events.Event) {
 	}
 	add := make([]types.Vote, 0, len(evts))
 	for _, e := range evts {
-		te, ok := e.(VoteE)
-		if ok {
-			vote := te.Vote()
+		switch et := e.(type) {
+		case VoteE:
+			var ok bool = true
+			vote := et.Vote()
 			for _, f := range v.filters {
 				if !f(vote) {
 					ok = false
@@ -77,6 +81,9 @@ func (v *VoteSub) Push(evts ...events.Event) {
 			if ok {
 				add = append(add, vote)
 			}
+		default:
+			v.log.Panic("Unknown event type in vote subscriber", logging.String("Type", et.Type().String()))
+
 		}
 	}
 	if len(add) == 0 {


### PR DESCRIPTION
After we updated the proto types to domain types a few weeks back, we have broken some of the event handlers as they are expecting a different type of object. This was causing the issue shown in the ticket where the margin values were not being updated after they were initially set.

This PR fixes the wrong types and adds panics into the event handlers to catch wrong types being sent.

Closes #3618 