### PR TITLE
Add wrapped decimal

### DIFF
--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -596,9 +596,9 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 		// now if this price+offset is < to maxPrice,
 		// nothing needs to be changed. we return
 		// both the current price, and the offset
-		if basePrice.LTE(maxPrice) {
+		if basePrice.LTE(maxPrice.Representation()) {
 			// now we also need to make sure we are > minPrice
-			if basePrice.GTE(minPrice) {
+			if basePrice.GTE(minPrice.Representation()) {
 				return basePrice, po, nil
 			}
 
@@ -622,13 +622,13 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 		// we have two posibilitied now, maxPrice is
 		// bigger than the price we got, then we use it
 		// or we will use price if it's higher.
-		if price.LT(maxPrice) {
+		if price.LT(maxPrice.Representation()) {
 			// this is the case where maxPrice is > to price,
 			// then we need to adapt the offset
-			off := num.Zero().Sub(maxPrice, price)
+			off := num.Zero().Sub(maxPrice.Representation(), price)
 			po.Offset = int64(off.Uint64())
 			// and our price is the maxPrice
-			return maxPrice, po, nil
+			return maxPrice.Representation(), po, nil
 		}
 
 		// then this is the last case, were maxPrice would be smaller
@@ -661,8 +661,8 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 		// and this would cover anycase where minPrice
 		// would be 0, it's safe to return this offset
 		// minPrice <= basePrice <= price
-		if basePrice.GTE(minPrice) {
-			if basePrice.LTE(maxPrice) {
+		if basePrice.GTE(minPrice.Representation()) {
+			if basePrice.LTE(maxPrice.Representation()) {
 				return basePrice, po, nil
 			}
 
@@ -684,8 +684,8 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 
 		// now this is the case where basePrice is < minPrice
 		// and minPrice is non-negative + inferior to bestBid
-		if !minPrice.IsZero() && minPrice.LT(price) {
-			off := num.Zero().Sub(price, minPrice)
+		if !minPrice.Representation().IsZero() && minPrice.Representation().LT(price) {
+			off := num.Zero().Sub(price, minPrice.Representation())
 			po.Offset = -int64(off.Uint64())
 			return price.Sub(price, off), po, nil
 		}
@@ -712,7 +712,7 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 	// would be negative, so we need to handle 2 cases
 	// either minPrice is a non-0 price after offset
 	// and it's smaller that price, or we will use price
-	if minPrice.IsZero() || minPrice.GT(price) {
+	if minPrice.Representation().IsZero() || minPrice.Representation().GT(price) {
 		// here we use the price as both case are invalid
 		// for using minPrice
 		switch po.Reference {
@@ -725,7 +725,7 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 	}
 
 	// this is the last case where we can use the minPrice
-	off := num.Zero().Sub(price, minPrice)
+	off := num.Zero().Sub(price, minPrice.Representation())
 	po.Offset = -int64(off.Uint64())
 	return price.Sub(price, off), po, nil
 }

--- a/execution/market.go
+++ b/execution/market.go
@@ -93,7 +93,7 @@ type PriceMonitor interface {
 	CheckPrice(ctx context.Context, as price.AuctionState, p *num.Uint, v uint64, now time.Time, persistent bool) error
 	GetCurrentBounds() []*types.PriceMonitoringBounds
 	SetMinDuration(d time.Duration)
-	GetValidPriceRange() (*num.Uint, *num.Uint)
+	GetValidPriceRange() (num.WrappedDecimal, num.WrappedDecimal)
 }
 
 // LiquidityMonitor

--- a/integration/features/volume-near-price-mon-bounds-2.feature
+++ b/integration/features/volume-near-price-mon-bounds-2.feature
@@ -58,7 +58,7 @@ Feature: Test margin for lp near price monitoring boundaries
 
     And the market data for the market "ETH2/MAR22" should be:
        | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest   |
-       | 100000     | TRADING_MODE_CONTINUOUS | 43200   | 89942     | 110965    | 361194       | 3000000        | 10            |
+       | 100000     | TRADING_MODE_CONTINUOUS | 43200   | 89942     | 110965    | 361190       | 3000000        | 10            |
 
     And the order book should have the following volumes for market "ETH2/MAR22":
       | side | price    | volume |
@@ -104,7 +104,7 @@ Feature: Test margin for lp near price monitoring boundaries
 
     And the market data for the market "ETH2/MAR22" should be:
        | mark price   | trading mode            | horizon | min bound   | max bound   | target stake   | supplied stake | open interest  |
-       | 100000       | TRADING_MODE_CONTINUOUS | 43200   | 89942       | 110965      | 361194         | 3000000        | 10             |
+       | 100000       | TRADING_MODE_CONTINUOUS | 43200   | 89942       | 110965      | 361190         | 3000000        | 10             |
 
 
     # # the lp1 one volume on this side should go to 89843 but because price monitoring bound is still 89942 it gets pushed to 89942.

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -31,7 +31,7 @@ type Broker interface {
 
 // RiskModel allows calculation of min/max price range and a probability of trading.
 type RiskModel interface {
-	ProbabilityOfTrading(currentPrice, orderPrice, minPrice, maxPrice *num.Uint, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal
+	ProbabilityOfTrading(currentPrice, orderPrice *num.Uint, minPrice, maxPrice num.Decimal, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal
 
 	GetProjectionHorizon() num.Decimal
 }
@@ -39,7 +39,7 @@ type RiskModel interface {
 // PriceMonitor provides the range of valid prices, that is prices that
 // wouldn't trade the current trading mode
 type PriceMonitor interface {
-	GetValidPriceRange() (*num.Uint, *num.Uint)
+	GetValidPriceRange() (num.WrappedDecimal, num.WrappedDecimal)
 }
 
 // IDGen is an id generator for orders.

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -207,7 +207,7 @@ func TestInitialDeployFailsWorksLater(t *testing.T) {
 	}
 
 	// Expectations
-	tng.priceMonitor.EXPECT().GetValidPriceRange().Return(num.Zero(), num.NewUint(100)).AnyTimes()
+	tng.priceMonitor.EXPECT().GetValidPriceRange().Return(num.NewWrappedDecimal(num.Zero(), num.DecimalZero()), num.NewWrappedDecimal(num.NewUint(100), num.DecimalFromInt64(100))).AnyTimes()
 	any := gomock.Any()
 	tng.riskModel.EXPECT().ProbabilityOfTrading(
 		any, any, any, any, any, any, any,
@@ -396,7 +396,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Expectations
-	tng.priceMonitor.EXPECT().GetValidPriceRange().Return(num.Zero(), num.NewUint(100)).AnyTimes()
+	tng.priceMonitor.EXPECT().GetValidPriceRange().Return(num.NewWrappedDecimal(num.Zero(), num.DecimalZero()), num.NewWrappedDecimal(num.NewUint(100), num.DecimalFromInt64(100))).AnyTimes()
 	any := gomock.Any()
 	tng.riskModel.EXPECT().ProbabilityOfTrading(
 		any, any, any, any, any, any, any,

--- a/liquidity/mocks/mocks.go
+++ b/liquidity/mocks/mocks.go
@@ -50,7 +50,7 @@ func (mr *MockRiskModelMockRecorder) GetProjectionHorizon() *gomock.Call {
 }
 
 // ProbabilityOfTrading mocks base method
-func (m *MockRiskModel) ProbabilityOfTrading(arg0, arg1, arg2, arg3 *num.Uint, arg4 decimal.Decimal, arg5, arg6 bool) decimal.Decimal {
+func (m *MockRiskModel) ProbabilityOfTrading(arg0, arg1 *num.Uint, arg2, arg3, arg4 decimal.Decimal, arg5, arg6 bool) decimal.Decimal {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProbabilityOfTrading", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(decimal.Decimal)
@@ -87,11 +87,11 @@ func (m *MockPriceMonitor) EXPECT() *MockPriceMonitorMockRecorder {
 }
 
 // GetValidPriceRange mocks base method
-func (m *MockPriceMonitor) GetValidPriceRange() (*num.Uint, *num.Uint) {
+func (m *MockPriceMonitor) GetValidPriceRange() (num.WrappedDecimal, num.WrappedDecimal) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidPriceRange")
-	ret0, _ := ret[0].(*num.Uint)
-	ret1, _ := ret[1].(*num.Uint)
+	ret0, _ := ret[0].(num.WrappedDecimal)
+	ret1, _ := ret[1].(num.WrappedDecimal)
 	return ret0, ret1
 }
 

--- a/liquidity/supplied/engine_test.go
+++ b/liquidity/supplied/engine_test.go
@@ -26,8 +26,8 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
 
 	// Prices are integers but for now the functions take float64 TODO UINT
-	minPrice := num.NewUint(89)
-	maxPrice := num.NewUint(111)
+	minPrice := num.NewWrappedDecimal(num.NewUint(89), num.DecimalFromInt64(89))
+	maxPrice := num.NewWrappedDecimal(num.NewUint(111), num.DecimalFromInt64(111))
 
 	// No orders
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(1)
@@ -48,7 +48,7 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 
 	buyOrder1Prob := num.DecimalFromFloat(0.256)
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice.Clone(), buyOrder1.Price.Clone(), minPrice.Clone(), MarkPrice.Clone(), Horizon, true, true).Return(buyOrder1Prob).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice.Clone(), buyOrder1.Price.Clone(), minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(buyOrder1Prob).Times(1)
 
 	liquidity = engine.CalculateSuppliedLiquidity(MarkPrice.Clone(), MarkPrice.Clone(), []*types.Order{buyOrder1})
 	require.Equal(t, num.NewUint(0), liquidity)
@@ -90,8 +90,8 @@ func TestCalculateSuppliedLiquidity(t *testing.T) {
 	expectedLiquidity := num.Min(buyLiquidity, sellLiquidity)
 
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice.Clone(), sellOrder1.Price.Clone(), MarkPrice.Clone(), maxPrice.Clone(), Horizon, false, true).Return(sellOrder1Prob).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice.Clone(), sellOrder2.Price.Clone(), MarkPrice.Clone(), maxPrice.Clone(), Horizon, false, true).Return(sellOrder2Prob).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice.Clone(), sellOrder1.Price.Clone(), MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(sellOrder1Prob).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice.Clone(), sellOrder2.Price.Clone(), MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(sellOrder2Prob).Times(1)
 
 	liquidity = engine.CalculateSuppliedLiquidity(MarkPrice.Clone(), MarkPrice.Clone(), []*types.Order{buyOrder1, sellOrder1, sellOrder2})
 	require.Equal(t, expectedLiquidity, liquidity)
@@ -126,14 +126,14 @@ func Test_InteralConsistency(t *testing.T) {
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
 	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
-	minPrice := num.NewUint(89)
-	maxPrice := num.NewUint(111)
+	minPrice := num.NewWrappedDecimal(num.NewUint(89), num.DecimalFromInt64(89))
+	maxPrice := num.NewWrappedDecimal(num.NewUint(111), num.DecimalFromInt64(111))
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(2)
 
 	limitOrders := []*types.Order{}
 
 	buy := &supplied.LiquidityOrder{
-		Price:      minPrice.Clone(),
+		Price:      minPrice.Representation(),
 		Proportion: 1,
 	}
 	buyShapes := []*supplied.LiquidityOrder{
@@ -141,7 +141,7 @@ func Test_InteralConsistency(t *testing.T) {
 	}
 
 	sell := &supplied.LiquidityOrder{
-		Price:      maxPrice.Clone(),
+		Price:      maxPrice.Representation(),
 		Proportion: 1,
 	}
 
@@ -150,8 +150,8 @@ func Test_InteralConsistency(t *testing.T) {
 	}
 	validBuy1Prob := num.DecimalFromFloat(0.1)
 	validSell1Prob := num.DecimalFromFloat(0.22)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, buy.Price, minPrice, MarkPrice, Horizon, true, true).Return(validBuy1Prob).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, sell.Price, MarkPrice, maxPrice, Horizon, false, true).Return(validSell1Prob).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, buy.Price, minPrice.Original(), num.DecimalFromUint(MarkPrice), Horizon, true, true).Return(validBuy1Prob).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, sell.Price, num.DecimalFromUint(MarkPrice), maxPrice.Original(), Horizon, false, true).Return(validSell1Prob).Times(1)
 
 	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
@@ -177,19 +177,19 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
 	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
-	minPrice := num.NewUint(89)
-	maxPrice := num.NewUint(111)
+	minPrice := num.NewWrappedDecimal(num.NewUint(89), num.DecimalFromInt64(89))
+	maxPrice := num.NewWrappedDecimal(num.NewUint(111), num.DecimalFromInt64(111))
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(6)
 
 	limitOrders := []*types.Order{}
 
 	validBuy1 := &supplied.LiquidityOrder{
-		Price:      minPrice.Clone(),
+		Price:      minPrice.Representation(),
 		Proportion: 20,
 	}
 
 	validBuy2 := &supplied.LiquidityOrder{
-		Price:      num.NewUint(0).Add(minPrice, num.NewUint(1)),
+		Price:      num.NewUint(0).Add(minPrice.Representation(), num.NewUint(1)),
 		Proportion: 30,
 	}
 	buyShapes := []*supplied.LiquidityOrder{
@@ -197,11 +197,11 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 		validBuy2,
 	}
 	validSell1 := &supplied.LiquidityOrder{
-		Price:      num.NewUint(0).Sub(maxPrice, num.NewUint(1)),
+		Price:      num.NewUint(0).Sub(maxPrice.Representation(), num.NewUint(1)),
 		Proportion: 11,
 	}
 	validSell2 := &supplied.LiquidityOrder{
-		Price:      maxPrice.Clone(),
+		Price:      maxPrice.Representation(),
 		Proportion: 22,
 	}
 	sellShapes := []*supplied.LiquidityOrder{
@@ -212,10 +212,10 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 	validBuy2Prob := num.DecimalFromFloat(0.2)
 	validSell1Prob := num.DecimalFromFloat(0.22)
 	validSell2Prob := num.DecimalFromFloat(0.11)
-	riskModel.EXPECT().ProbabilityOfTrading(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), Horizon, true, true).MinTimes(2).MaxTimes(10).DoAndReturn(func(mPrice, orderPrice, min, max *num.Uint, _ num.Decimal, _, _ bool) num.Decimal {
+	riskModel.EXPECT().ProbabilityOfTrading(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), Horizon, true, true).MinTimes(2).MaxTimes(10).DoAndReturn(func(mPrice, orderPrice *num.Uint, min, max num.Decimal, _ num.Decimal, _, _ bool) num.Decimal {
 		require.True(t, mPrice.EQ(MarkPrice))
-		require.True(t, min.EQ(minPrice))
-		require.True(t, max.EQ(MarkPrice))
+		require.True(t, min.Equal(minPrice.Original()))
+		require.True(t, max.Equal(MarkPrice.ToDecimal()))
 		if orderPrice.EQ(validBuy1.Price) {
 			return validBuy1Prob
 		}
@@ -225,10 +225,10 @@ func TestCalculateLiquidityImpliedSizes_NoLimitOrders(t *testing.T) {
 		require.True(t, false, "given order price unknown: %d", orderPrice.Uint64())
 		return num.DecimalFromFloat(0)
 	})
-	riskModel.EXPECT().ProbabilityOfTrading(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), Horizon, false, true).MinTimes(2).MaxTimes(11).DoAndReturn(func(mPrice, orderPrice, min, max *num.Uint, _ num.Decimal, _, _ bool) num.Decimal {
+	riskModel.EXPECT().ProbabilityOfTrading(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), Horizon, false, true).MinTimes(2).MaxTimes(11).DoAndReturn(func(mPrice, orderPrice *num.Uint, min, max num.Decimal, _ num.Decimal, _, _ bool) num.Decimal {
 		require.True(t, mPrice.EQ(MarkPrice))
-		require.True(t, min.EQ(MarkPrice))
-		require.True(t, max.EQ(maxPrice))
+		require.True(t, min.Equal(MarkPrice.ToDecimal()))
+		require.True(t, max.Equals(maxPrice.Original()))
 		if orderPrice.EQ(validSell1.Price) {
 			return validSell1Prob
 		}
@@ -315,16 +315,16 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
 	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
-	minPrice := num.NewUint(89)
-	maxPrice := num.NewUint(111)
+	minPrice := num.NewWrappedDecimal(num.NewUint(89), num.DecimalFromInt64(89))
+	maxPrice := num.NewWrappedDecimal(num.NewUint(111), num.DecimalFromInt64(111))
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(12)
 
 	validBuy1 := &supplied.LiquidityOrder{
-		Price:      minPrice.Clone(),
+		Price:      minPrice.Representation(),
 		Proportion: 20,
 	}
 	validBuy2 := &supplied.LiquidityOrder{
-		Price:      num.NewUint(0).Add(minPrice, num.NewUint(1)),
+		Price:      num.NewUint(0).Add(minPrice.Representation(), num.NewUint(1)),
 		Proportion: 30,
 	}
 	buyShapes := []*supplied.LiquidityOrder{
@@ -332,11 +332,11 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 		validBuy2,
 	}
 	validSell1 := &supplied.LiquidityOrder{
-		Price:      num.NewUint(0).Sub(maxPrice, num.NewUint(1)),
+		Price:      num.NewUint(0).Sub(maxPrice.Representation(), num.NewUint(1)),
 		Proportion: 11,
 	}
 	validSell2 := &supplied.LiquidityOrder{
-		Price:      maxPrice.Clone(),
+		Price:      maxPrice.Representation(),
 		Proportion: 22,
 	}
 	sellShapes := []*supplied.LiquidityOrder{
@@ -370,17 +370,17 @@ func TestCalculateLiquidityImpliedSizes_WithLimitOrders(t *testing.T) {
 		},
 	}
 
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, limitOrders[0].Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.175)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, limitOrders[1].Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.312)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, limitOrders[2].Price, MarkPrice, maxPrice, Horizon, false, true).Return(num.DecimalFromFloat(0.5)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, limitOrders[0].Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.175)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, limitOrders[1].Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.312)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, limitOrders[2].Price, MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(num.DecimalFromFloat(0.5)).Times(1)
 
 	limitOrdersSuppliedLiquidity := engine.CalculateSuppliedLiquidity(MarkPrice.Clone(), MarkPrice.Clone(), collateOrders(limitOrders, nil, nil))
 	require.True(t, limitOrdersSuppliedLiquidity.LT(liquidityObligation))
 
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validBuy1.Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.1)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validBuy2.Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.2)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validSell1.Price, MarkPrice, maxPrice, Horizon, false, true).Return(num.DecimalFromFloat(0.22)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validSell2.Price, MarkPrice, maxPrice, Horizon, false, true).Return(num.DecimalFromFloat(0.11)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validBuy1.Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.1)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validBuy2.Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.2)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validSell1.Price, MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(num.DecimalFromFloat(0.22)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, validSell2.Price, MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(num.DecimalFromFloat(0.11)).Times(1)
 
 	err := engine.CalculateLiquidityImpliedVolumes(MarkPrice.Clone(), MarkPrice.Clone(), liquidityObligation, limitOrders, buyShapes, sellShapes)
 	require.NoError(t, err)
@@ -522,28 +522,28 @@ func TestCalculateLiquidityImpliedSizes_NoValidOrders(t *testing.T) {
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
 	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
-	minPrice := num.NewUint(89)
-	maxPrice := num.NewUint(111)
+	minPrice := num.NewWrappedDecimal(num.NewUint(89), num.DecimalFromInt64(89))
+	maxPrice := num.NewWrappedDecimal(num.NewUint(111), num.DecimalFromInt64(111))
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(2)
 
 	limitOrders := []*types.Order{}
 
 	invalidBuy := &supplied.LiquidityOrder{
-		Price:      num.NewUint(0).Sub(minPrice, num.NewUint(1)),
+		Price:      num.NewUint(0).Sub(minPrice.Representation(), num.NewUint(1)),
 		Proportion: 10,
 	}
 	buyShapes := []*supplied.LiquidityOrder{
 		invalidBuy,
 	}
 	invalidSell := &supplied.LiquidityOrder{
-		Price:      num.NewUint(0).Add(maxPrice, num.NewUint(1)),
+		Price:      num.NewUint(0).Add(maxPrice.Representation(), num.NewUint(1)),
 		Proportion: 33,
 	}
 	sellShapes := []*supplied.LiquidityOrder{
 		invalidSell,
 	}
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, invalidBuy.Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.0)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, invalidSell.Price, MarkPrice, maxPrice, Horizon, false, true).Return(num.DecimalFromFloat(0.0)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, invalidBuy.Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.0)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, invalidSell.Price, MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(num.DecimalFromFloat(0.0)).Times(1)
 
 	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
@@ -564,17 +564,17 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	riskModel := mocks.NewMockRiskModel(ctrl)
 	priceMonitor := mocks.NewMockPriceMonitor(ctrl)
 	riskModel.EXPECT().GetProjectionHorizon().Return(Horizon).Times(1)
-	minPrice := num.NewUint(89)
-	maxPrice := num.NewUint(111)
+	minPrice := num.NewWrappedDecimal(num.NewUint(89), num.DecimalFromInt64(89))
+	maxPrice := num.NewWrappedDecimal(num.NewUint(111), num.DecimalFromInt64(111))
 
 	order1 := &types.Order{
-		Price:     minPrice.Clone(),
+		Price:     minPrice.Representation(),
 		Size:      15,
 		Remaining: 11,
 		Side:      types.Side_SIDE_BUY,
 	}
 	order2 := &types.Order{
-		Price:     maxPrice.Clone(),
+		Price:     maxPrice.Representation(),
 		Size:      60,
 		Remaining: 60,
 		Side:      types.Side_SIDE_SELL,
@@ -586,8 +586,8 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	}
 
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order1.Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.123)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order2.Price, MarkPrice, maxPrice, Horizon, false, true).Return(num.DecimalFromFloat(0.234)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order1.Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.123)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order2.Price, MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(num.DecimalFromFloat(0.234)).Times(1)
 
 	engine := supplied.NewEngine(riskModel, priceMonitor)
 	require.NotNil(t, engine)
@@ -596,11 +596,11 @@ func TestProbabilityOfTradingRecomputedAfterPriceRangeChange(t *testing.T) {
 	require.True(t, liquidity1.GT(num.NewUint(0)))
 
 	// Change minPrice, maxPrice and verify that probability of trading is called with new values
-	minPrice.Sub(minPrice, num.NewUint(10))
-	maxPrice.Add(maxPrice, num.NewUint(10))
+	minPrice = num.NewWrappedDecimal(num.NewUint(89-10), num.DecimalFromInt64(89-10))
+	maxPrice = num.NewWrappedDecimal(num.NewUint(111+10), num.DecimalFromInt64(111+10))
 	priceMonitor.EXPECT().GetValidPriceRange().Return(minPrice, maxPrice).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order1.Price, minPrice, MarkPrice, Horizon, true, true).Return(num.DecimalFromFloat(0.123)).Times(1)
-	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order2.Price, MarkPrice, maxPrice, Horizon, false, true).Return(num.DecimalFromFloat(0.234)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order1.Price, minPrice.Original(), MarkPrice.ToDecimal(), Horizon, true, true).Return(num.DecimalFromFloat(0.123)).Times(1)
+	riskModel.EXPECT().ProbabilityOfTrading(MarkPrice, order2.Price, MarkPrice.ToDecimal(), maxPrice.Original(), Horizon, false, true).Return(num.DecimalFromFloat(0.234)).Times(1)
 
 	liquidity2 := engine.CalculateSuppliedLiquidity(MarkPrice.Clone(), MarkPrice.Clone(), orders)
 	require.True(t, liquidity2.GT(num.NewUint(0)))

--- a/liquidity/supplied/mocks/price_monitor_mock.go
+++ b/liquidity/supplied/mocks/price_monitor_mock.go
@@ -34,11 +34,11 @@ func (m *MockPriceMonitor) EXPECT() *MockPriceMonitorMockRecorder {
 }
 
 // GetValidPriceRange mocks base method
-func (m *MockPriceMonitor) GetValidPriceRange() (*num.Uint, *num.Uint) {
+func (m *MockPriceMonitor) GetValidPriceRange() (num.WrappedDecimal, num.WrappedDecimal) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidPriceRange")
-	ret0, _ := ret[0].(*num.Uint)
-	ret1, _ := ret[1].(*num.Uint)
+	ret0, _ := ret[0].(num.WrappedDecimal)
+	ret1, _ := ret[1].(num.WrappedDecimal)
 	return ret0, ret1
 }
 

--- a/liquidity/supplied/mocks/risk_model_mock.go
+++ b/liquidity/supplied/mocks/risk_model_mock.go
@@ -49,7 +49,7 @@ func (mr *MockRiskModelMockRecorder) GetProjectionHorizon() *gomock.Call {
 }
 
 // ProbabilityOfTrading mocks base method
-func (m *MockRiskModel) ProbabilityOfTrading(arg0, arg1, arg2, arg3 *num.Uint, arg4 decimal.Decimal, arg5, arg6 bool) decimal.Decimal {
+func (m *MockRiskModel) ProbabilityOfTrading(arg0, arg1 *num.Uint, arg2, arg3, arg4 decimal.Decimal, arg5, arg6 bool) decimal.Decimal {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProbabilityOfTrading", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(decimal.Decimal)

--- a/monitor/price/pricemonitoring_test.go
+++ b/monitor/price/pricemonitoring_test.go
@@ -876,15 +876,15 @@ func TestGetValidPriceRange_NoTriggers(t *testing.T) {
 
 	expMax := num.MaxUint()
 	min, max := pm.GetValidPriceRange()
-	require.True(t, min.IsZero())
-	require.Equal(t, expMax.String(), max.String())
+	require.True(t, min.Representation().IsZero())
+	require.Equal(t, expMax.String(), max.Representation().String())
 
 	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, now, true)
 	require.NoError(t, err)
 
 	min, max = pm.GetValidPriceRange()
-	require.True(t, min.IsZero())
-	require.Equal(t, expMax.String(), max.String())
+	require.True(t, min.Representation().IsZero())
+	require.Equal(t, expMax.String(), max.Representation().String())
 }
 
 func TestGetValidPriceRange_2triggers(t *testing.T) {
@@ -960,16 +960,16 @@ func TestGetValidPriceRange_2triggers(t *testing.T) {
 
 	min, max := pm.GetValidPriceRange()
 
-	err = pm.CheckPrice(ctx, auctionStateMock, min, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, min.Representation(), 1, now, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, max, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, max.Representation(), 1, now, true)
 	require.NoError(t, err)
 
 	// Should trigger an auction
 	auctionStateMock.EXPECT().StartPriceAuction(now, gomock.Any()).Times(1)
 
-	cPrice.Sub(min, one)
+	cPrice.Sub(min.Representation(), one)
 	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
 	require.NoError(t, err)
 
@@ -979,15 +979,15 @@ func TestGetValidPriceRange_2triggers(t *testing.T) {
 
 	min, max = pm.GetValidPriceRange()
 
-	err = pm.CheckPrice(ctx, auctionStateMock, min, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, min.Representation(), 1, now, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, max, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, max.Representation(), 1, now, true)
 	require.NoError(t, err)
 
 	// Should trigger an auction
 	auctionStateMock.EXPECT().StartPriceAuction(now, gomock.Any()).Times(1)
-	cPrice.Add(max, one)
+	cPrice.Add(max.Representation(), one)
 	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
 	require.NoError(t, err)
 }

--- a/risk/mocks/risk_model_mock.go
+++ b/risk/mocks/risk_model_mock.go
@@ -95,7 +95,7 @@ func (mr *MockModelMockRecorder) PriceRange(arg0, arg1, arg2 interface{}) *gomoc
 }
 
 // ProbabilityOfTrading mocks base method
-func (m *MockModel) ProbabilityOfTrading(arg0, arg1, arg2, arg3 *num.Uint, arg4 decimal.Decimal, arg5, arg6 bool) decimal.Decimal {
+func (m *MockModel) ProbabilityOfTrading(arg0, arg1 *num.Uint, arg2, arg3, arg4 decimal.Decimal, arg5, arg6 bool) decimal.Decimal {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProbabilityOfTrading", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(decimal.Decimal)

--- a/risk/model.go
+++ b/risk/model.go
@@ -23,7 +23,7 @@ type Model interface {
 	CalculationInterval() time.Duration
 	CalculateRiskFactors(current *types.RiskResult) (bool, *types.RiskResult)
 	PriceRange(price, yearFraction, probability num.Decimal) (minPrice, maxPrice num.Decimal)
-	ProbabilityOfTrading(currentP, orderP, minP, maxP *num.Uint, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal
+	ProbabilityOfTrading(currentP, orderP *num.Uint, minP, maxP, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal
 	GetProjectionHorizon() num.Decimal
 }
 

--- a/risk/models/lognormal.go
+++ b/risk/models/lognormal.go
@@ -91,11 +91,11 @@ func (f *LogNormal) PriceRange(currentP, yFrac, probabilityLevel num.Decimal) (n
 
 // ProbabilityOfTrading of trading returns the probability of trading given current mark price, projection horizon expressed as year fraction, order price and side (isBid).
 // Additional arguments control optional truncation of probability density outside the [minPrice,maxPrice] range.
-func (f *LogNormal) ProbabilityOfTrading(currentP, orderP, minP, maxP *num.Uint, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal {
+func (f *LogNormal) ProbabilityOfTrading(currentP, orderP *num.Uint, minP, maxP num.Decimal, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal {
 	dist := f.getDistribution(currentP, yFrac)
-	min := math.Max(minP.Float64(), 0)
+	min := math.Max(minP.InexactFloat64(), 0)
 	// still, quant uses floats
-	prob := pd.ProbabilityOfTrading(dist, orderP.Float64(), isBid, applyMinMax, min, maxP.Float64())
+	prob := pd.ProbabilityOfTrading(dist, orderP.Float64(), isBid, applyMinMax, min, maxP.InexactFloat64())
 	return num.DecimalFromFloat(prob)
 }
 

--- a/risk/models/simple.go
+++ b/risk/models/simple.go
@@ -58,12 +58,12 @@ func (f *Simple) PriceRange(currentP, _, _ num.Decimal) (num.Decimal, num.Decima
 
 // ProbabilityOfTrading of trading returns the probability of trading given current mark price, projection horizon expressed as year fraction, order price and side (isBid).
 // Additional arguments control optional truncation of probability density outside the [minPrice,maxPrice] range.
-func (f *Simple) ProbabilityOfTrading(currentP, orderP, minP, maxP *num.Uint, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal {
-	if !applyMinMax {
-		return f.prob
-	}
-	if orderP.LT(minP) || orderP.GT(maxP) {
-		return num.DecimalZero()
+func (f *Simple) ProbabilityOfTrading(currentP, orderP *num.Uint, minP, maxP, yFrac num.Decimal, isBid, applyMinMax bool) num.Decimal {
+	if applyMinMax {
+		p := orderP.ToDecimal()
+		if p.LessThan(minP) || p.GreaterThan(maxP) {
+			return num.DecimalZero()
+		}
 	}
 	return f.prob
 }

--- a/types/num/wrapped.go
+++ b/types/num/wrapped.go
@@ -1,0 +1,21 @@
+package num
+
+type WrappedDecimal struct {
+	u *Uint
+	d Decimal
+}
+
+//NewWrappedDecimal returns a new instance of a decimal coupled with the Uint representaiton that has been chosen for it
+func NewWrappedDecimal(integerRepresentation *Uint, underlyingValue Decimal) WrappedDecimal {
+	return WrappedDecimal{u: integerRepresentation, d: underlyingValue}
+}
+
+//Representation returns the Uint representation of a decimal that has been affixed when calling the constructor
+func (w WrappedDecimal) Representation() *Uint {
+	return w.u.Clone()
+}
+
+//Original returns the underlying decimal value
+func (w WrappedDecimal) Original() Decimal {
+	return w.d
+}

--- a/types/num/wrapped.go
+++ b/types/num/wrapped.go
@@ -5,7 +5,7 @@ type WrappedDecimal struct {
 	d Decimal
 }
 
-//NewWrappedDecimal returns a new instance of a decimal coupled with the Uint representaiton that has been chosen for it
+//NewWrappedDecimal returns a new instance of a decimal coupled with the Uint representation that has been chosen for it
 func NewWrappedDecimal(integerRepresentation *Uint, underlyingValue Decimal) WrappedDecimal {
 	return WrappedDecimal{u: integerRepresentation, d: underlyingValue}
 }


### PR DESCRIPTION
Adds a WrappedDecimal datatype which fixes a `Uint` representation for a `Decimal` to be used within `vega`, but holds on to the underlying `Decimal` in case it needs to be fed back into external libraries (`quant` library in this case - though to be exact that itself get's parsed into a float first).