### PR TITLE
do not insert lp orders in the book is an auction is started

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -1160,7 +1160,7 @@ func (m *Market) submitValidatedOrder(ctx context.Context, order *types.Order) (
 	}
 
 	// if an auction was trigger, and we are a pegged order
-	// let's return now.
+	// or a liquidity order, let's return now.
 	if m.as.InAuction() && (isPegged || order.IsLiquidityOrder()) {
 		return &types.OrderConfirmation{Order: order}, nil, nil
 	}

--- a/execution/market.go
+++ b/execution/market.go
@@ -1161,7 +1161,7 @@ func (m *Market) submitValidatedOrder(ctx context.Context, order *types.Order) (
 
 	// if an auction was trigger, and we are a pegged order
 	// let's return now.
-	if m.as.InAuction() && isPegged {
+	if m.as.InAuction() && (isPegged || order.IsLiquidityOrder()) {
 		return &types.OrderConfirmation{Order: order}, nil, nil
 	}
 

--- a/matching/order_status_test.go
+++ b/matching/order_status_test.go
@@ -71,6 +71,7 @@ func testFOKFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID1,
@@ -86,6 +87,7 @@ func testFOKFilled(t *testing.T) {
 
 	// now place our fok order to be filled
 	order := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -134,6 +136,7 @@ func testIOCPartiallyFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID1,
@@ -149,6 +152,7 @@ func testIOCPartiallyFilled(t *testing.T) {
 
 	// now place our IOC order to be filled
 	order := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -175,6 +179,7 @@ func testIOCFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID1,
@@ -190,6 +195,7 @@ func testIOCFilled(t *testing.T) {
 
 	// now place our fok order to be filled
 	order := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -317,6 +323,7 @@ func testGTCActivePartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -437,6 +444,7 @@ func testGTCFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID1,
@@ -452,6 +460,7 @@ func testGTCFilled(t *testing.T) {
 
 	// now place our GTC order to be filled
 	order := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -583,6 +592,7 @@ func testGTTActivePartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -628,6 +638,7 @@ func testGTTCancelledPartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -677,6 +688,7 @@ func testGTTStoppedPartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,
@@ -708,6 +720,7 @@ func testGTTFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID1,
@@ -724,6 +737,7 @@ func testGTTFilled(t *testing.T) {
 
 	// now place our GTT order to be filled
 	order := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     partyID2,

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -669,6 +669,9 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 	if err := b.validateOrder(order); err != nil {
 		return nil, err
 	}
+	if _, ok := b.ordersByID[order.Id]; ok {
+		b.log.Panic("an order in the book already exists with the same ID", logging.Order(*order))
+	}
 
 	if order.CreatedAt > b.latestTimestamp {
 		b.latestTimestamp = order.CreatedAt

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -356,6 +356,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -367,6 +368,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -378,6 +380,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
 		},
 		{
+			Id:          "V0000000032-0000000011",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -389,6 +392,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
 		},
 		{
+			Id:          "V0000000032-0000000012",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -422,6 +426,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -433,6 +438,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -444,6 +450,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
 		},
 		{
+			Id:          "V0000000032-0000000011",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -455,6 +462,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce: types.Order_TIME_IN_FORCE_GTC,
 		},
 		{
+			Id:          "V0000000032-0000000012",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -488,6 +496,7 @@ func getClosePNLIncompleteBuy(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -500,6 +509,7 @@ func getClosePNLIncompleteBuy(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -543,6 +553,7 @@ func getClosePNLIncompleteSell(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -555,6 +566,7 @@ func getClosePNLIncompleteSell(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -598,6 +610,7 @@ func getClosePNLBuy(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -610,6 +623,7 @@ func getClosePNLBuy(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -622,6 +636,7 @@ func getClosePNLBuy(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000011",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -663,6 +678,7 @@ func getClosePNLSell(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -675,6 +691,7 @@ func getClosePNLSell(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -687,6 +704,7 @@ func getClosePNLSell(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000011",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1668,6 +1686,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 	m[0] = []*types.Order{
 		// Side Sell
 		{
+			Id:          "V0000000032-0000000009",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1680,6 +1699,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000010",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1693,6 +1713,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		},
 		// Side Buy
 		{
+			Id:          "V0000000032-0000000011",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1705,6 +1726,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 			CreatedAt:   0,
 		},
 		{
+			Id:          "V0000000032-0000000012",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1722,6 +1744,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 	m[1] = []*types.Order{
 		// Side Sell
 		{
+			Id:          "V0000000032-0000000013",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1735,6 +1758,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		},
 		// Side Buy
 		{
+			Id:          "V0000000032-0000000014",
 			Status:      types.Order_STATUS_ACTIVE,
 			Type:        types.Order_TYPE_LIMIT,
 			MarketId:    market,
@@ -1766,6 +1790,7 @@ func TestOrderBook_SubmitOrderProRataModeOff(t *testing.T) {
 		{
 			// same price level, remaining on the passive
 			aggressiveOrder: &types.Order{
+				Id:          "V0000000032-0000000015",
 				Status:      types.Order_STATUS_ACTIVE,
 				Type:        types.Order_TYPE_LIMIT,
 				MarketId:    market,
@@ -2050,10 +2075,10 @@ func TestOrderBook_PartialFillIOCOrder(t *testing.T) {
 	logger.Debug("BEGIN PARTIAL FILL IOC ORDER")
 
 	newOrder := &types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		Type:        types.Order_TYPE_LIMIT,
 		MarketId:    market,
-		Id:          "100000",
 		Side:        types.Side_SIDE_SELL,
 		Price:       num.NewUint(100),
 		PartyId:     "A",
@@ -2069,7 +2094,7 @@ func TestOrderBook_PartialFillIOCOrder(t *testing.T) {
 
 	assert.Equal(t, nil, err)
 	assert.NotNil(t, confirmation)
-	assert.Equal(t, "100000", confirmation.Order.Id)
+	assert.Equal(t, "V0000000032-0000000009", confirmation.Order.Id)
 	assert.Equal(t, 0, len(confirmation.Trades))
 	assert.Equal(t, len(trades), len(confirmation.Trades))
 
@@ -2778,14 +2803,14 @@ func TestOrderBook_IndicativePriceAndVolume9(t *testing.T) {
 	makeOrder(t, book, market, "BuyOrder01", types.Side_SIDE_BUY, 110, "party01", 1)
 	makeOrder(t, book, market, "SellOrder01", types.Side_SIDE_SELL, 110, "party02", 1)
 
-	makeOrder(t, book, market, "BuyOrder01", types.Side_SIDE_BUY, 111, "party01", 1)
-	makeOrder(t, book, market, "SellOrder01", types.Side_SIDE_SELL, 111, "party02", 1)
+	makeOrder(t, book, market, "BuyOrder01-2", types.Side_SIDE_BUY, 111, "party01", 1)
+	makeOrder(t, book, market, "SellOrder01-2", types.Side_SIDE_SELL, 111, "party02", 1)
 
-	makeOrder(t, book, market, "BuyOrder01", types.Side_SIDE_BUY, 133, "party01", 2)
-	makeOrder(t, book, market, "SellOrder01", types.Side_SIDE_SELL, 133, "party02", 2)
+	makeOrder(t, book, market, "BuyOrder01-3", types.Side_SIDE_BUY, 133, "party01", 2)
+	makeOrder(t, book, market, "SellOrder01-3", types.Side_SIDE_SELL, 133, "party02", 2)
 
-	makeOrder(t, book, market, "BuyOrder01", types.Side_SIDE_BUY, 303, "party01", 10)
-	makeOrder(t, book, market, "SellOrder01", types.Side_SIDE_SELL, 303, "party02", 10)
+	makeOrder(t, book, market, "BuyOrder01-4", types.Side_SIDE_BUY, 303, "party01", 10)
+	makeOrder(t, book, market, "SellOrder01-4", types.Side_SIDE_SELL, 303, "party02", 10)
 
 	// Get indicative auction price and volume
 	price, volume, side := book.ob.GetIndicativePriceAndVolume()
@@ -3112,7 +3137,7 @@ func TestOrderBook_PeggedOrders(t *testing.T) {
 	sp1 := getOrder(t, book, market, "SellPeg1", types.Side_SIDE_SELL, 100, "party01", 5)
 	sp1.PeggedOrder = &types.PeggedOrder{Reference: types.PeggedReference_PEGGED_REFERENCE_MID,
 		Offset: +3}
-	book.ob.SubmitOrder(bp1)
+	book.ob.SubmitOrder(sp1)
 
 	// Leave auction and uncross the book
 	cancels := book.ob.EnterAuction()

--- a/matching/simpleorders_test.go
+++ b/matching/simpleorders_test.go
@@ -203,6 +203,7 @@ func TestOrderBookSimple_simpleLimitBuyFill(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -218,6 +219,7 @@ func TestOrderBookSimple_simpleLimitBuyFill(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -248,6 +250,7 @@ func TestOrderBookSimple_simpleLimitSellFill(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -263,6 +266,7 @@ func TestOrderBookSimple_simpleLimitSellFill(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -293,6 +297,7 @@ func TestOrderBookSimple_simpleMarketBuyFill(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -308,6 +313,7 @@ func TestOrderBookSimple_simpleMarketBuyFill(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -338,6 +344,7 @@ func TestOrderBookSimple_simpleMarketSellFill(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -353,6 +360,7 @@ func TestOrderBookSimple_simpleMarketSellFill(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -383,6 +391,7 @@ func TestOrderBookSimple_simpleNetworkBuyFill(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -398,6 +407,7 @@ func TestOrderBookSimple_simpleNetworkBuyFill(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -428,6 +438,7 @@ func TestOrderBookSimple_simpleNetworkSellFill(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -443,6 +454,7 @@ func TestOrderBookSimple_simpleNetworkSellFill(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -473,6 +485,7 @@ func TestOrderBookSimple_FillAgainstGTTOrder(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -489,6 +502,7 @@ func TestOrderBookSimple_FillAgainstGTTOrder(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -519,6 +533,7 @@ func TestOrderBookSimple_simpleWashTrade(t *testing.T) {
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -534,6 +549,7 @@ func TestOrderBookSimple_simpleWashTrade(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -555,6 +571,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -570,6 +587,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order1 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -585,6 +603,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStopped(t *testing.T)
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000011",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -608,6 +627,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStoppedDifferentPrice
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
 	order := types.Order{
+		Id:          "V0000000032-0000000009",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "B",
@@ -623,6 +643,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStoppedDifferentPrice
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order1 := types.Order{
+		Id:          "V0000000032-0000000010",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",
@@ -638,6 +659,7 @@ func TestOrderBookSimple_simpleWashTradePartiallyFilledThenStoppedDifferentPrice
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	order2 := types.Order{
+		Id:          "V0000000032-0000000011",
 		Status:      types.Order_STATUS_ACTIVE,
 		MarketId:    market,
 		PartyId:     "A",


### PR DESCRIPTION
The issue was the following:
- A market is in auction.
- A LeaveAuction is triggered
- The market is re-submitting the peggedOrders, all is fine
- The market is re-submitting the LP orders, this trigger a liquidity check, and a liquidity auction is started
- All order previously submitted are removed from the book.
- The order which triggered the liquidity  auction  however is submitted into the book
- The market finishes the Leave auction flow then (which does nothing anymore as the market is in auction)
- Then the market try again later on to leave the auction
- When the pegged orders are being submitted, he order which was submitted during the previous leave auction and got stuck in the book uncross with a pegged order
- We trigger a panic as this is not allowed.

close #3739 