### PR TITLE
Liquidity fees paid into general account

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1199,12 +1199,8 @@ func (e *Engine) getFeeTransferRequest(
 		treq.ToAccount = []*types.Account{liquiFee}
 		return treq, nil
 	case types.TransferTypeLiquidityFeeDistribute:
-		margin, err := getMargin()
-		if err != nil {
-			return nil, err
-		}
 		treq.FromAccount = []*types.Account{liquiFee}
-		treq.ToAccount = []*types.Account{margin}
+		treq.ToAccount = []*types.Account{general}
 		return treq, nil
 	case types.TransferTypeMakerFeePay:
 		margin, err := getMargin()

--- a/execution/equity_shares_test.go
+++ b/execution/equity_shares_test.go
@@ -269,8 +269,8 @@ func testWithinMarket(t *testing.T) {
 	// before the fee distribution.
 	var (
 		originalBalance = esm.LiquidityFeeAccount().Balance.Clone()
-		party1Balance   = esm.PartyMarginAccount("party1").Balance.Clone()
-		party2Balance   = esm.PartyMarginAccount("party2").Balance.Clone()
+		party1Balance   = esm.PartyGeneralAccount("party1").Balance.Clone()
+		party2Balance   = esm.PartyGeneralAccount("party2").Balance.Clone()
 	)
 
 	curTime = curTime.Add(1 * time.Second)
@@ -282,7 +282,7 @@ func testWithinMarket(t *testing.T) {
 	// exp = originalBalance*(2/3)
 	exp := num.Zero().Mul(num.NewUint(2), originalBalance)
 	exp = exp.Div(exp, num.NewUint(3))
-	actual := num.Zero().Sub(esm.PartyMarginAccount("party1").Balance, party1Balance)
+	actual := num.Zero().Sub(esm.PartyGeneralAccount("party1").Balance, party1Balance)
 	assert.True(t,
 		exp.EQ(actual),
 		"party1 should get 2/3 of the fees (got %s expected %s)", actual.String(), exp.String(),
@@ -290,7 +290,7 @@ func testWithinMarket(t *testing.T) {
 
 	// exp = originalBalance*(1/3)
 	exp = num.Zero().Div(originalBalance, num.NewUint(3))
-	actual = num.Zero().Sub(esm.PartyMarginAccount("party2").Balance, party2Balance)
+	actual = num.Zero().Sub(esm.PartyGeneralAccount("party2").Balance, party2Balance)
 	assert.True(t,
 		exp.EQ(actual),
 		"party2 should get 2/3 of the fees (got %s expected %s)", actual.String(), exp.String(),

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -961,12 +961,6 @@ func TestTriggerByPriceNoTradesInAuction(t *testing.T) {
 	tm.market.OnChainTimeUpdate(context.Background(), openEnd)
 	now = openEnd
 
-	md := tm.market.GetMarketData()
-	fmt.Printf("Market price: %s\nOpen interest: %v\n", md.MarkPrice, md.OpenInterest)
-	for _, b := range md.PriceMonitoringBounds {
-		fmt.Printf("Price bound: %s - %s\n", b.MinValidPrice.String(), b.MaxValidPrice.String())
-	}
-
 	orderBuy1 := &types.Order{
 		Type:        types.OrderTypeLimit,
 		TimeInForce: types.OrderTimeInForceGTT,

--- a/integration/features/lp-distressed-closeout.feature
+++ b/integration/features/lp-distressed-closeout.feature
@@ -178,8 +178,8 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     # getting closer to distressed LP, still in continuous trading
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1762   | 0       | 0    |
-    And the insurance pool balance should be "4649" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 1760   | 0       | 0    |
+    And the insurance pool balance should be "4651" for the market "ETH/DEC21"
 
     # Move price out of bounds
     When the network moves ahead "2" blocks
@@ -191,7 +191,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | 1010       | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 2323         | 5000           | 23            |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1762   | 0       | 0    |
+      | party0 | ETH   | ETH/DEC21 | 1760   | 0       | 0    |
 
     # end price auction
     When the network moves ahead "301" blocks
@@ -200,7 +200,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | 1055       | TRADING_MODE_CONTINUOUS | 1       | 1045      | 1065      | 3481         | 5000           | 33            |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 265    | 1407    | 0    |
+      | party0 | ETH   | ETH/DEC21 | 265    | 1405    | 0    |
       # values before uint stuff
       # | party0 | ETH   | ETH/DEC21 | 253    | 1419    | 0    |
-    And the insurance pool balance should be "4649" for the market "ETH/DEC21"
+    And the insurance pool balance should be "4651" for the market "ETH/DEC21"

--- a/integration/features/setting-fee-and-rewarding-lps.feature
+++ b/integration/features/setting-fee-and-rewarding-lps.feature
@@ -81,8 +81,8 @@ Feature: Test liquidity provider reward distribution
     Then time is updated to "2019-11-30T00:10:05Z"
 
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 20     | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 20     | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
@@ -110,8 +110,8 @@ Feature: Test liquidity provider reward distribution
     Then time is updated to "2019-11-30T00:30:05Z"
 
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 15     | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 15     | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
@@ -189,9 +189,9 @@ Feature: Test liquidity provider reward distribution
 
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 20     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 20     | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 20     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 20     | ETH   |
 
 
     Then the parties place the following orders:
@@ -211,9 +211,9 @@ Feature: Test liquidity provider reward distribution
 
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 16     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 16     | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
 
   Scenario: 2 LPs joining at start, unequal commitments
 
@@ -289,9 +289,9 @@ Feature: Test liquidity provider reward distribution
 
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 16     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 4      | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 4      | ETH   |
 
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
@@ -313,9 +313,9 @@ Feature: Test liquidity provider reward distribution
 
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 12     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 3      | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 12     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 3      | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
@@ -393,9 +393,9 @@ Feature: Test liquidity provider reward distribution
 
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 16     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 4      | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 4      | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
@@ -430,9 +430,9 @@ Feature: Test liquidity provider reward distribution
 
     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
     Then the following transfers should happen:
-      | from   | to  | from account                | to account          | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 22     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 5      | ETH   |
-      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_MARGIN | ETH/DEC21 | 3      | ETH   |
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 22     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 5      | ETH   |
+      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 3      | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"


### PR DESCRIPTION
Update the liquidity distribution code to send money to a parties general account instead of their margin account.

Closes #3748 