### PR TITLE
Migrate docker and GitHub publish steps to Jenkins

### DIFF
--- a/.drone-github.yml
+++ b/.drone-github.yml
@@ -73,35 +73,6 @@ steps:
       event:
         - pull_request
 
-  - name: build_docker_image-PR
-    image: docker.pkg.github.com/vegaprotocol/devops-infra/cipipeline-docker:18.09.9
-    volumes:
-      - name: dockersock
-        path: /run/docker.sock
-    environment:
-      DOCKER_HOST: unix:///run/docker.sock
-      DOCKER_CONFIG_JSON:
-        from_secret: dockerconfig
-    commands:
-      - mkdir -p docker/bin
-      - find cmd -maxdepth 1 -and -not -name cmd | sed -e 's#^cmd/##' | while read -r app ; do
-          if test -f "cmd/$$app/$$app-linux-amd64" ; then
-            cp -a "cmd/$$app/$$app-linux-amd64" "docker/bin/$$app" || exit 1 ;
-          else
-            echo "dummy_noop" >"docker/bin/$$app" ;
-          fi ;
-        done
-      - tmptag="$$(openssl rand -hex 10)"
-      - docker build -t "docker.pkg.github.com/vegaprotocol/vega/vega:$$tmptag" docker/
-      - rm -rf docker/bin
-      - mkdir -p "$$HOME/.docker" ; echo "$$DOCKER_CONFIG_JSON" >"$$HOME/.docker/config.json" ; unset DOCKER_CONFIG_JSON
-      - docker rmi "docker.pkg.github.com/vegaprotocol/vega/vega:$$tmptag"
-    depends_on:
-      - build-PR
-    when:
-      event:
-        - pull_request
-
   - name: test-PR
     image: docker.pkg.github.com/vegaprotocol/devops-infra/cipipeline:1.16.2
     volumes:
@@ -285,42 +256,6 @@ steps:
       event:
         - push
 
-  - name: build_docker_image
-    image: docker.pkg.github.com/vegaprotocol/devops-infra/cipipeline-docker:18.09.9
-    volumes:
-      - name: dockersock
-        path: /run/docker.sock
-    environment:
-      DOCKER_HOST: unix:///run/docker.sock
-      DOCKER_CONFIG_JSON:
-        from_secret: dockerconfig
-    commands:
-      - mkdir -p docker/bin
-      - find cmd -maxdepth 1 -and -not -name cmd | sed -e 's#^cmd/##' | while read -r app ; do
-          cp -a "cmd/$$app/$$app-linux-amd64" "docker/bin/$$app" || exit 1 ;
-        done
-      - tmptag="$$(openssl rand -hex 10)"
-      - docker build -t "docker.pkg.github.com/vegaprotocol/vega/vega:$$tmptag" docker/
-      - rm -rf docker/bin
-      - mkdir -p "$$HOME/.docker" ; echo "$$DOCKER_CONFIG_JSON" >"$$HOME/.docker/config.json" ; unset DOCKER_CONFIG_JSON
-      - if test -n "$$DRONE_TAG" ; then
-          docker tag "docker.pkg.github.com/vegaprotocol/vega/vega:$$tmptag" "docker.pkg.github.com/vegaprotocol/vega/vega:$$DRONE_TAG" ;
-          docker push "docker.pkg.github.com/vegaprotocol/vega/vega:$$DRONE_TAG" ;
-        fi
-      - if test -n "$$DRONE_BRANCH" ; then
-          sanitised_branch="$$(echo -n "$$DRONE_BRANCH" | tr -c 'A-Za-z0-9._' '-')" ;
-          docker tag "docker.pkg.github.com/vegaprotocol/vega/vega:$$tmptag" "docker.pkg.github.com/vegaprotocol/vega/vega:$$sanitised_branch" ;
-          docker push "docker.pkg.github.com/vegaprotocol/vega/vega:$$sanitised_branch" ;
-        fi
-      - docker rmi "docker.pkg.github.com/vegaprotocol/vega/vega:$$tmptag"
-    depends_on:
-      - build-branch
-    when:
-      ref:
-        - refs/heads/master
-        - refs/heads/develop
-        - refs/tags/*
-
   - name: build-multiarch
     image: docker.pkg.github.com/vegaprotocol/devops-infra/cipipeline:1.16.2
     pull: always
@@ -345,35 +280,9 @@ steps:
       - unset GITHUB_DEPLOY_SSH_PRIVATE_KEY
       - ./script/build-multiarch-no-cgo.sh all
     depends_on:
-      - build_docker_image
+      - build-branch
     when:
       event: tag
-
-  # http://plugins.drone.io/drone-plugins/drone-github-release/
-  - name: publish_artefacts
-    image: plugins/github-release
-    pull: always
-    settings:
-      api_key:
-        from_secret: GITHUB_API_TOKEN
-      files:
-        - cmd/vega/vega-*
-    when:
-      event: tag
-    depends_on:
-      - build-multiarch
-
-  - name: changelog_slack
-    image: docker.pkg.github.com/vegaprotocol/devops-infra/cipipeline:1.16.2
-    environment:
-      SLACK_HOOK_URL:
-        from_secret: SLACK_HOOK_URL
-    commands:
-      - /usr/local/bin/changelog-slack.sh "$$DRONE_TAG" "$$SLACK_HOOK_URL" "#engineering"
-    when:
-      event: tag
-    depends_on:
-      - publish_artefacts
 
 volumes:
   - name: dockersock


### PR DESCRIPTION
Part of #3756.
Migrate steps:
* to build and publish docker images,
* publish releases,

to Jenkinsfile.
At the same time, disable those steps in the drone.