### PR TITLE
Enable CGO for --race unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,21 +286,24 @@ pipeline {
 
         stage('Run tests') {
             parallel {
-                stage('unit tests with race') {
-                    options { retry(3) }
-                    steps {
-                        dir('vega') {
-                            sh 'go test -v -race ./... 2>&1 | tee unit-test-race-results.txt && cat unit-test-race-results.txt | go-junit-report > vega-unit-test-race-report.xml'
-                            junit checksName: 'Unit Tests with Race', testResults: 'vega-unit-test-race-report.xml'
-                        }
-                    }
-                }
                 stage('unit tests') {
                     options { retry(3) }
                     steps {
                         dir('vega') {
                             sh 'go test -v ./... 2>&1 | tee unit-test-results.txt && cat unit-test-results.txt | go-junit-report > vega-unit-test-report.xml'
                             junit checksName: 'Unit Tests', testResults: 'vega-unit-test-report.xml'
+                        }
+                    }
+                }
+                stage('unit tests with race') {
+                    environment {
+                        CGO_ENABLED = 0
+                    }
+                    options { retry(3) }
+                    steps {
+                        dir('vega') {
+                            sh 'go test -v -race ./... 2>&1 | tee unit-test-race-results.txt && cat unit-test-race-results.txt | go-junit-report > vega-unit-test-race-report.xml'
+                            junit checksName: 'Unit Tests with Race', testResults: 'vega-unit-test-race-report.xml'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
             }
         }
 
-        stage('go mod download deps') {
+        stage('Dependencies') {
             options { retry(3) }
             steps {
                 dir('vega') {
@@ -98,7 +98,7 @@ pipeline {
             }
         }
 
-        stage('Compile vega core') {
+        stage('Compile') {
             environment {
                 LDFLAGS      = "-X main.CLIVersion=\"${version}\" -X main.CLIVersionHash=\"${versionHash}\""
             }
@@ -204,7 +204,7 @@ pipeline {
             }
         }
 
-        stage('Run linters') {
+        stage('Linters') {
             parallel {
                 stage('buf lint') {
                     options { retry(3) }
@@ -284,7 +284,7 @@ pipeline {
             }
         }
 
-        stage('Run tests') {
+        stage('Tests') {
             parallel {
                 stage('unit tests') {
                     options { retry(3) }
@@ -297,7 +297,7 @@ pipeline {
                 }
                 stage('unit tests with race') {
                     environment {
-                        CGO_ENABLED = 0
+                        CGO_ENABLED = 1
                     }
                     options { retry(3) }
                     steps {


### PR DESCRIPTION
Part of #3756. `--race` requires CGO enabled

The tests are not stable after this change, look at: https://jenkins-aws.ops.vega.xyz/blue/organizations/jenkins/vegaprotocol%2Fvega/activity?branch=PR-3859