### PR TITLE
Fix binary version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
 
         stage('Compile') {
             environment {
-                LDFLAGS      = "-X main.CLIVersion=\"${version}\" -X main.CLIVersionHash=\"${versionHash}\""
+                LDFLAGS      = "-X main.CLIVersion=${version} -X main.CLIVersionHash=${versionHash}"
             }
             failFast true
             parallel {


### PR DESCRIPTION
Closes #3873.
This will have to be cherry-picked onto master, if you want to fix the version for the current release of `v0.41.x`.