### PR TITLE
use a custom http client for the tendermint client

### DIFF
--- a/blockchain/abci/client.go
+++ b/blockchain/abci/client.go
@@ -28,7 +28,12 @@ func NewClient(addr string) (*Client, error) {
 		return nil, ErrEmptyClientAddr
 	}
 
-	clt, err := tmclihttp.New(addr, "/websocket")
+	hClient, err := defaultHTTPClient(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	clt, err := tmclihttp.NewWithClient(addr, "/websocket", hClient)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/abci/http_client.go
+++ b/blockchain/abci/http_client.go
@@ -1,0 +1,21 @@
+package abci
+
+import (
+	"net/http"
+	"time"
+)
+
+func defaultHTTPClient(remoteAddr string) (*http.Client, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			// Set to true to prevent GZIP-bomb DoS attacks
+			DisableCompression: true,
+			DisableKeepAlives:  true,
+			MaxIdleConns:       100,
+			IdleConnTimeout:    5 * time.Second,
+		},
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
For a while tendermint seems to have been using quite a lot of socket, and not releasing as well.

Just now, looking at staging, there's ~200 socket open by tendermint, the vega node have just as few as ~45.

Let's try to use a custom http client, and set a couple of option manually.

Closes #3879 
