### PR TITLE
 include TX_ERROR events for type ALL subscribers

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -296,7 +296,7 @@ func (b *Broker) subscribe(s Subscriber) int {
 		for t := range b.tSubs {
 			// Don't add ALL subs to the map they're already in, and don't add it to the
 			// special TxErrEvent map, but we should add them to all other maps
-			if t != events.All && t != events.TxErrEvent {
+			if t != events.All {
 				b.tSubs[t][k] = &sub
 			}
 		}

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -226,7 +226,7 @@ func (b *Broker) Send(event events.Event) {
 func (b *Broker) getSubsByType(t events.Type) map[int]*subscription {
 	// we add the entire ALL map to type-specific maps, so if set, we can return this map directly
 	subs, ok := b.tSubs[t]
-	if !ok && t != events.TxErrEvent {
+	if !ok {
 		// if a typed map isn't set (yet), and it's not the error event, we can return
 		// ALL subscribers directly instead
 		subs = b.tSubs[events.All]
@@ -243,6 +243,7 @@ func (b *Broker) getSubsByType(t events.Type) map[int]*subscription {
 func (b *Broker) Subscribe(s Subscriber) int {
 	b.mu.Lock()
 	k := b.subscribe(s)
+	s.SetID(k)
 	b.mu.Unlock()
 	return k
 }

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -95,6 +95,7 @@ func TestSendEvent(t *testing.T) {
 }
 
 func testSequenceIDGenSeveralBlocksOrdered(t *testing.T) {
+	t.Parallel()
 	tstBroker := getBroker(t)
 	defer tstBroker.Finish()
 	ctxH1, ctxH2 := contextutil.WithTraceID(tstBroker.ctx, "hash-1"), contextutil.WithTraceID(tstBroker.ctx, "hash-2")
@@ -143,6 +144,7 @@ func testSequenceIDGenSeveralBlocksOrdered(t *testing.T) {
 }
 
 func testSequenceIDGenSeveralBlocksUnordered(t *testing.T) {
+	t.Parallel()
 	tstBroker := getBroker(t)
 	defer tstBroker.Finish()
 	ctxH1, ctxH2 := contextutil.WithTraceID(tstBroker.ctx, "hash-1"), contextutil.WithTraceID(tstBroker.ctx, "hash-2")
@@ -192,6 +194,7 @@ func testSequenceIDGenSeveralBlocksUnordered(t *testing.T) {
 }
 
 func testSubUnsubSuccess(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -215,6 +218,7 @@ func testSubUnsubSuccess(t *testing.T) {
 }
 
 func testSubReuseKey(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -233,6 +237,7 @@ func testSubReuseKey(t *testing.T) {
 }
 
 func testAutoUnsubscribe(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -268,6 +273,7 @@ func testAutoUnsubscribe(t *testing.T) {
 }
 
 func testSendBatch(t *testing.T) {
+	t.Parallel()
 	tstBroker := getBroker(t)
 	sub := mocks.NewMockSubscriber(tstBroker.ctrl)
 	cancelCh := make(chan struct{})
@@ -301,6 +307,7 @@ func testSendBatch(t *testing.T) {
 }
 
 func testSendBatchChannel(t *testing.T) {
+	t.Parallel()
 	tstBroker := getBroker(t)
 	sub := mocks.NewMockSubscriber(tstBroker.ctrl)
 	skipCh, closedCh, cCh := make(chan struct{}), make(chan struct{}), make(chan []events.Event, 1)
@@ -382,6 +389,7 @@ func testSendBatchChannel(t *testing.T) {
 }
 
 func testSkipOptional(t *testing.T) {
+	t.Parallel()
 	tstBroker := getBroker(t)
 	sub := mocks.NewMockSubscriber(tstBroker.ctrl)
 	skipCh, closedCh, cCh := make(chan struct{}), make(chan struct{}), make(chan []events.Event, 1)
@@ -452,6 +460,7 @@ func testSkipOptional(t *testing.T) {
 }
 
 func testStopCtx(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -472,6 +481,7 @@ func testStopCtx(t *testing.T) {
 }
 
 func testStopCtxSendAgain(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -494,6 +504,7 @@ func testStopCtxSendAgain(t *testing.T) {
 }
 
 func testSubscriberSkip(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -538,6 +549,7 @@ func testSubscriberSkip(t *testing.T) {
 
 // test making sure that events are sent only to subs that are interested in it
 func testEventTypeSubscription(t *testing.T) {
+	t.Parallel()
 	broker := getBroker(t)
 	defer broker.Finish()
 	sub := mocks.NewMockSubscriber(broker.ctrl)
@@ -596,6 +608,7 @@ func testEventTypeSubscription(t *testing.T) {
 }
 
 func testStreamsOverSocket(t *testing.T) {
+	t.Parallel()
 	ctx, cfunc := context.WithCancel(context.Background())
 	ctrl := gomock.NewController(t)
 	config := broker.NewDefaultConfig()
@@ -634,6 +647,7 @@ func testStreamsOverSocket(t *testing.T) {
 }
 
 func testStopsProcessOnStreamError(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("RUN_TEST") == "1" {
 		ctx, cfunc := context.WithCancel(context.Background())
 		ctrl := gomock.NewController(t)

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -129,6 +129,7 @@ func testSequenceIDGenSeveralBlocksOrdered(t *testing.T) {
 			close(done)
 		}
 	})
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k := tstBroker.Subscribe(sub)
 	// send batches for both events - hash 2 after hash 1
 	tstBroker.SendBatch(dataH1)
@@ -174,6 +175,7 @@ func testSequenceIDGenSeveralBlocksUnordered(t *testing.T) {
 			close(done)
 		}
 	})
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k := tstBroker.Subscribe(sub)
 	// We can't use sendBatch here: we use the traceID of the first event in the batch to determine
 	// the hash (batch-sending events can only happen within a single block)
@@ -202,8 +204,10 @@ func testSubUnsubSuccess(t *testing.T) {
 	// subscribe + unsubscribe -> 2 calls
 	sub.EXPECT().Types().Times(2).Return(nil)
 	sub.EXPECT().Ack().Times(1).Return(false)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	reqSub.EXPECT().Types().Times(2).Return(nil)
 	reqSub.EXPECT().Ack().Times(1).Return(true)
+	reqSub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := broker.Subscribe(sub)    // not required
 	k2 := broker.Subscribe(reqSub) // required
 	assert.NotZero(t, k1)
@@ -221,6 +225,7 @@ func testSubReuseKey(t *testing.T) {
 	sub := mocks.NewMockSubscriber(broker.ctrl)
 	sub.EXPECT().Types().Times(4).Return(nil)
 	sub.EXPECT().Ack().Times(1).Return(false)
+	sub.EXPECT().SetID(gomock.Any()).Times(2)
 	k1 := broker.Subscribe(sub)
 	sub.EXPECT().Ack().Times(1).Return(true)
 	assert.NotZero(t, k1)
@@ -239,6 +244,7 @@ func testAutoUnsubscribe(t *testing.T) {
 	// sub, auto-unsub, sub again
 	sub.EXPECT().Types().Times(3).Return(nil)
 	sub.EXPECT().Ack().Times(1).Return(true)
+	sub.EXPECT().SetID(gomock.Any()).Times(2)
 	k1 := broker.Subscribe(sub)
 	assert.NotZero(t, k1)
 	// set up sub to be closed
@@ -276,6 +282,7 @@ func testSendBatch(t *testing.T) {
 	}()
 	sub.EXPECT().Types().Times(1).Return(nil)
 	sub.EXPECT().Ack().AnyTimes().Return(true)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := tstBroker.Subscribe(sub)
 	assert.NotZero(t, k1)
 	data := []events.Event{
@@ -313,6 +320,7 @@ func testSendBatchChannel(t *testing.T) {
 		twg.Done()
 	})
 	sub.EXPECT().Ack().AnyTimes().Return(false)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := tstBroker.Subscribe(sub)
 	assert.NotZero(t, k1)
 	batch2 := []events.Event{
@@ -393,6 +401,7 @@ func testSkipOptional(t *testing.T) {
 		twg.Done()
 	})
 	sub.EXPECT().Ack().AnyTimes().Return(false)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := tstBroker.Subscribe(sub)
 	assert.NotZero(t, k1)
 
@@ -458,6 +467,7 @@ func testStopCtx(t *testing.T) {
 	broker.cfunc()
 	sub.EXPECT().Types().Times(2).Return(nil)
 	sub.EXPECT().Ack().AnyTimes().Return(true)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := broker.Subscribe(sub) // required sub
 	assert.NotZero(t, k1)
 	broker.Send(broker.randomEvt())
@@ -477,6 +487,7 @@ func testStopCtxSendAgain(t *testing.T) {
 	broker.cfunc()
 	sub.EXPECT().Types().Times(2).Return(nil)
 	sub.EXPECT().Ack().AnyTimes().Return(true)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := broker.Subscribe(sub) // required sub
 	assert.NotZero(t, k1)
 	broker.Send(broker.randomEvt())
@@ -517,6 +528,7 @@ func testSubscriberSkip(t *testing.T) {
 	sub.EXPECT().Push(events[1]).Times(1)
 	sub.EXPECT().Types().Times(2).Return(nil)
 	sub.EXPECT().Ack().AnyTimes().Return(true)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := broker.Subscribe(sub) // required sub
 	assert.NotZero(t, k1)
 	for _, e := range events {
@@ -566,6 +578,9 @@ func testEventTypeSubscription(t *testing.T) {
 	sub.EXPECT().Ack().AnyTimes().Return(true)
 	diffSub.EXPECT().Ack().AnyTimes().Return(true)
 	allSub.EXPECT().Ack().AnyTimes().Return(true)
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
+	diffSub.EXPECT().SetID(gomock.Any()).Times(1)
+	allSub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := broker.Subscribe(sub)     // required sub
 	k2 := broker.Subscribe(diffSub) // required sub, but won't be used anyway
 	k3 := broker.Subscribe(allSub)
@@ -629,6 +644,8 @@ func testTxErrNotAll(t *testing.T) {
 		Value:      types.Vote_VALUE_YES,
 		ProposalId: "prop-1",
 	})
+	sub.EXPECT().SetID(gomock.Any()).Times(1)
+	allSub.EXPECT().SetID(gomock.Any()).Times(1)
 	k1 := broker.Subscribe(sub)
 	k2 := broker.Subscribe(allSub)
 	assert.NotZero(t, k1)


### PR DESCRIPTION
Also fixed issue where subscriber ID wasn't being set for individual `Subscribe()` calls

Fixes #3915 