### PR TITLE
Bump dlv and geth to latest (#3968)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM docker.pkg.github.com/vegaprotocol/devops-infra/dlv:1.6.1 AS dlv
 FROM ubuntu:20.04
 ENTRYPOINT ["/bin/bash"]
 EXPOSE 3002/tcp 3003/tcp 3004/tcp 26658/tcp 40000/tcp
-COPY --from=dlv /go/bin/dlv /usr/local/bin/
+COPY --from=dlv /usr/local/bin/dlv /usr/local/bin/
 COPY --from=geth /usr/local/bin/geth /usr/local/bin/
 RUN chmod 1777 /tmp
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends ca-certificates

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.pkg.github.com/vegaprotocol/devops-infra/geth:1.10.8 AS geth
-FROM docker.pkg.github.com/vegaprotocol/devops-infra/dlv:1.5.0 AS dlv
+FROM docker.pkg.github.com/vegaprotocol/devops-infra/dlv:1.6.1 AS dlv
 
 FROM ubuntu:20.04
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.pkg.github.com/vegaprotocol/devops-infra/geth:1.9.25 AS geth
+FROM docker.pkg.github.com/vegaprotocol/devops-infra/geth:1.10.8 AS geth
 FROM docker.pkg.github.com/vegaprotocol/devops-infra/dlv:1.5.0 AS dlv
 
 FROM ubuntu:20.04


### PR DESCRIPTION
This PR bumps `dlv` and `geth` inside the Docker container, which is used by DV.

closes #3968 
