### PR TITLE
Send error events in processor through wrapper

### DIFF
--- a/api/trading.go
+++ b/api/trading.go
@@ -354,15 +354,6 @@ func (t *tradingService) ObserveEventBus(
 	if err != nil {
 		return apiError(codes.InvalidArgument, ErrMalformedRequest, err)
 	}
-	if len(req.PartyId) == 0 {
-		// no PartyID filter
-		for _, t := range types {
-			// subscription to TxErr events
-			if t == events.TxErrEvent {
-				return apiError(codes.InvalidArgument, ErrMalformedRequest, errors.New("missing party filter for TxError stream"))
-			}
-		}
-	}
 	filters := []subscribers.EventFilter{}
 	if len(req.MarketId) > 0 && len(req.PartyId) > 0 {
 		filters = append(filters, events.GetPartyAndMarketFilter(req.MarketId, req.PartyId))

--- a/blockchain/abci/abci_test.go
+++ b/blockchain/abci/abci_test.go
@@ -35,6 +35,7 @@ func (tx *testTx) Party() string        { return hex.EncodeToString(tx.pubkey) }
 func (tx *testTx) Hash() []byte         { return tx.hash }
 func (tx *testTx) Command() txn.Command { return tx.command }
 func (tx *testTx) BlockHeight() uint64  { return tx.blockHeight }
+func (tx *testTx) GetCmd() interface{}  { return nil }
 func (tx *testTx) Validate() error {
 	if fn := tx.validateFn; fn != nil {
 		return fn()

--- a/blockchain/abci/types.go
+++ b/blockchain/abci/types.go
@@ -17,6 +17,7 @@ type Tx interface {
 	Signature() []byte
 	Validate() error
 	BlockHeight() uint64
+	GetCmd() interface{}
 }
 
 type Codec interface {

--- a/events/tx_error.go
+++ b/events/tx_error.go
@@ -2,10 +2,10 @@ package events
 
 import (
 	"context"
+	"fmt"
 
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
 	eventspb "code.vegaprotocol.io/protos/vega/events/v1"
-	"code.vegaprotocol.io/vega/types"
 )
 
 type TxErr struct {
@@ -22,86 +22,48 @@ func NewTxErrEvent(ctx context.Context, err error, partyID string, tx interface{
 		},
 	}
 	switch tv := tx.(type) {
-	case *types.ProposalSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_Proposal{
-			Proposal: tv.IntoProto(),
-		}
-	case types.ProposalSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_Proposal{
-			Proposal: tv.IntoProto(),
-		}
-	case *types.VoteSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_VoteSubmission{
-			VoteSubmission: tv.IntoProto(),
-		}
-	case types.VoteSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_VoteSubmission{
-			VoteSubmission: tv.IntoProto(),
-		}
-	case *types.OrderSubmission:
+	case *commandspb.OrderSubmission:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_OrderSubmission{
-			OrderSubmission: tv.IntoProto(),
+			OrderSubmission: tv,
 		}
-	case types.OrderSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_OrderSubmission{
-			OrderSubmission: tv.IntoProto(),
-		}
-	case *types.OrderCancellation:
+	case *commandspb.OrderCancellation:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_OrderCancellation{
-			OrderCancellation: tv.IntoProto(),
+			OrderCancellation: tv,
 		}
-	case types.OrderCancellation:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_OrderCancellation{
-			OrderCancellation: tv.IntoProto(),
-		}
-	case *types.OrderAmendment:
+	case *commandspb.OrderAmendment:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_OrderAmendment{
-			OrderAmendment: tv.IntoProto(),
+			OrderAmendment: tv,
 		}
-	case types.OrderAmendment:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_OrderAmendment{
-			OrderAmendment: tv.IntoProto(),
+	case *commandspb.VoteSubmission:
+		evt.evt.Transaction = &eventspb.TxErrorEvent_VoteSubmission{
+			VoteSubmission: tv,
 		}
-	case *types.LiquidityProvisionSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_LiquidityProvisionSubmission{
-			LiquidityProvisionSubmission: tv.IntoProto(),
-		}
-	case types.LiquidityProvisionSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_LiquidityProvisionSubmission{
-			LiquidityProvisionSubmission: tv.IntoProto(),
-		}
-	case *types.WithdrawSubmission:
+	case *commandspb.WithdrawSubmission:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_WithdrawSubmission{
-			WithdrawSubmission: tv.IntoProto(),
+			WithdrawSubmission: tv,
 		}
-	case types.WithdrawSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_WithdrawSubmission{
-			WithdrawSubmission: tv.IntoProto(),
+	case *commandspb.LiquidityProvisionSubmission:
+		evt.evt.Transaction = &eventspb.TxErrorEvent_LiquidityProvisionSubmission{
+			LiquidityProvisionSubmission: tv,
+		}
+	case *commandspb.ProposalSubmission:
+		evt.evt.Transaction = &eventspb.TxErrorEvent_Proposal{
+			Proposal: tv,
 		}
 	case *commandspb.DelegateSubmission:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_DelegateSubmission{
 			DelegateSubmission: tv,
 		}
-	case commandspb.DelegateSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_DelegateSubmission{
-			DelegateSubmission: &tv,
-		}
 	case *commandspb.UndelegateSubmission:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_UndelegateSubmission{
 			UndelegateSubmission: tv,
-		}
-	case commandspb.UndelegateSubmission:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_UndelegateSubmission{
-			UndelegateSubmission: &tv,
 		}
 	case *commandspb.RestoreSnapshot:
 		evt.evt.Transaction = &eventspb.TxErrorEvent_RestoreSnapshot{
 			RestoreSnapshot: tv,
 		}
-	case commandspb.RestoreSnapshot:
-		evt.evt.Transaction = &eventspb.TxErrorEvent_RestoreSnapshot{
-			RestoreSnapshot: &tv,
-		}
+	case error: // unsupported command error
+		evt.evt.ErrMsg = fmt.Sprintf("%v - %v", err, tv)
 	}
 	return evt
 }

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -422,7 +422,6 @@ func (e *Engine) SubmitOrder(
 	timer := metrics.NewTimeCounter(submission.MarketId, "execution", "SubmitOrder")
 	defer func() {
 		timer.EngineTimeCounterAdd()
-		e.notifyFailureOnError(ctx, returnedErr, submission, party)
 	}()
 
 	if e.log.IsDebug() {
@@ -451,7 +450,6 @@ func (e *Engine) AmendOrder(ctx context.Context, amendment *types.OrderAmendment
 	timer := metrics.NewTimeCounter(amendment.MarketID, "execution", "AmendOrder")
 	defer func() {
 		timer.EngineTimeCounterAdd()
-		e.notifyFailureOnError(ctx, returnedErr, amendment, party)
 	}()
 
 	if e.log.IsDebug() {
@@ -499,7 +497,6 @@ func (e *Engine) CancelOrder(ctx context.Context, cancel *types.OrderCancellatio
 	timer := metrics.NewTimeCounter(cancel.MarketId, "execution", "CancelOrder")
 	defer func() {
 		timer.EngineTimeCounterAdd()
-		e.notifyFailureOnError(ctx, returnedErr, cancel, party)
 	}()
 
 	if e.log.IsDebug() {
@@ -578,7 +575,6 @@ func (e *Engine) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 	timer := metrics.NewTimeCounter(sub.MarketID, "execution", "LiquidityProvisionSubmission")
 	defer func() {
 		timer.EngineTimeCounterAdd()
-		e.notifyFailureOnError(ctx, returnedErr, sub, party)
 	}()
 
 	if e.log.IsDebug() {
@@ -928,10 +924,4 @@ func (e *Engine) OnMarketMinProbabilityOfTradingForLPOrdersUpdate(ctx context.Co
 	e.npv.minProbabilityOfTradingLPOrders = v
 
 	return nil
-}
-
-func (e *Engine) notifyFailureOnError(ctx context.Context, err error, tx interface{}, partyID string) {
-	if err != nil {
-		e.broker.Send(events.NewTxErrEvent(ctx, err, partyID, tx))
-	}
 }

--- a/governance/checkpoint_test.go
+++ b/governance/checkpoint_test.go
@@ -86,9 +86,6 @@ func testCheckpointSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
 
-	// setup
-	eng.broker.EXPECT().Send(voteMatcher{}).Times(1)
-
 	// when
 	err = eng.AddVote(ctx, types.VoteSubmission{
 		Value:      proto.Vote_VALUE_NO,

--- a/governance/engine.go
+++ b/governance/engine.go
@@ -306,10 +306,6 @@ func (e *Engine) SubmitProposal(
 	}
 
 	defer func() {
-		if err != nil {
-			// also submit a TxErr
-			e.broker.Send(events.NewTxErrEvent(ctx, err, party, psub))
-		}
 		e.broker.Send(events.NewProposalEvent(ctx, p))
 	}()
 	perr, err := e.validateOpenProposal(p)
@@ -535,8 +531,6 @@ func (e *Engine) AddVote(ctx context.Context, cmd types.VoteSubmission, party st
 			logging.String("vote", cmd.String()),
 			logging.Error(err),
 		)
-		// vote was not created/accepted, send TxErrEvent
-		e.broker.Send(events.NewTxErrEvent(ctx, err, party, cmd))
 		return err
 	}
 

--- a/governance/engine_test.go
+++ b/governance/engine_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	proto "code.vegaprotocol.io/protos/vega"
-	eventspb "code.vegaprotocol.io/protos/vega/events/v1"
 	oraclesv1 "code.vegaprotocol.io/protos/vega/oracles/v1"
 	bmock "code.vegaprotocol.io/vega/broker/mocks"
 	"code.vegaprotocol.io/vega/events"
@@ -27,11 +26,6 @@ import (
 var (
 	errNoBalanceForParty = errors.New("no balance for party")
 )
-
-type streamEvt interface {
-	events.Event
-	StreamMessage() *eventspb.BusEvent
-}
 
 type tstEngine struct {
 	*governance.Engine

--- a/governance/engine_test.go
+++ b/governance/engine_test.go
@@ -33,8 +33,6 @@ type streamEvt interface {
 	StreamMessage() *eventspb.BusEvent
 }
 
-type voteMatcher struct{}
-
 type tstEngine struct {
 	*governance.Engine
 	ctrl            *gomock.Controller
@@ -270,7 +268,6 @@ func testSubmittingProposalWithNonexistingAccountFails(t *testing.T) {
 	// setup
 	eng.expectAnyAsset()
 	eng.expectNoAccountForParty(noAccountPartyID)
-	eng.expectSendTxErrorProposalEvent(t, noAccountPartyID)
 	eng.expectSendRejectedProposalEvent(t, noAccountPartyID)
 
 	// when
@@ -292,7 +289,6 @@ func testSubmittingProposalWithoutEnoughStakeFails(t *testing.T) {
 	// setup
 	eng.setMinProposerBalance("10000")
 	eng.expectAnyAsset()
-	eng.expectSendTxErrorProposalEvent(t, emptyParty.Id)
 	eng.expectSendRejectedProposalEvent(t, emptyParty.Id)
 
 	// when
@@ -335,7 +331,6 @@ func testSubmittingProposalWithBadClosingTimeFails(t *testing.T) {
 
 			// setup
 			eng.expectAnyAsset()
-			eng.expectSendTxErrorProposalEvent(t, party.Id)
 			eng.expectSendRejectedProposalEvent(t, party.Id)
 
 			// when
@@ -380,7 +375,6 @@ func testSubmittingProposalWithBadEnactmentTimeFails(t *testing.T) {
 
 			// setup
 			eng.expectAnyAsset()
-			eng.expectSendTxErrorProposalEvent(t, party.Id)
 			eng.expectSendRejectedProposalEvent(t, party.Id)
 
 			// when
@@ -410,7 +404,7 @@ func testSubmittingProposalWithBadRiskParameter(t *testing.T) {
 	}
 
 	// setup
-	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(1)
 
 	// when
 	_, err := eng.SubmitProposal(context.Background(), *types.ProposalSubmissionFromProposal(&proposal), proposal.ID, party.Id)
@@ -432,7 +426,7 @@ func testSubmittingProposalWithClosingTimeBeforeValidationTimeFails(t *testing.T
 	proposal.Terms.Change = &types.ProposalTerms_NewAsset{}
 
 	// setup
-	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(1)
 
 	// when
 	_, err := eng.SubmitProposal(context.Background(), *types.ProposalSubmissionFromProposal(&proposal), proposal.ID, party.Id)
@@ -487,7 +481,6 @@ func testSubmittingVoteOnNonexistingProposalFails(t *testing.T) {
 
 	// setup
 	eng.expectAnyAsset()
-	eng.expectSendProposalNotFoundErrorEvent(t, voteSub)
 
 	// when
 	err := eng.AddVote(context.Background(), voteSub, voter.Id)
@@ -524,7 +517,6 @@ func testSubmittingVoteWithNonexistingAccountFails(t *testing.T) {
 
 	// setup
 	eng.expectNoAccountForParty(voterNoAccount)
-	eng.expectSendAccountNotFoundErrorEvent(t, vote)
 
 	// when
 	err = eng.AddVote(context.Background(), vote, voterNoAccount)
@@ -554,9 +546,6 @@ func testSubmittingVoteWithoutTokenFails(t *testing.T) {
 
 	// given
 	voterWithEmptyAccount := eng.newValidParty("empty-account", 0)
-
-	// setup
-	eng.expectSendInsufficientTokensErrorEvent(t)
 
 	// when
 	err = eng.AddVote(context.Background(), types.VoteSubmission{
@@ -625,9 +614,6 @@ func testSubmittingMajorityOfYesVoteMakesProposalPassed(t *testing.T) {
 	// when
 	eng.OnChainTimeUpdate(context.Background(), afterClosing)
 
-	// setup
-	eng.broker.EXPECT().Send(voteMatcher{}).Times(1)
-
 	// when
 	err = eng.AddVote(context.Background(), types.VoteSubmission{
 		Value:      proto.Vote_VALUE_NO,
@@ -648,9 +634,6 @@ func testSubmittingMajorityOfYesVoteMakesProposalPassed(t *testing.T) {
 	// then
 	assert.Len(t, toBeEnacted, 1)
 	assert.Equal(t, proposal.ID, toBeEnacted[0].Proposal().ID)
-
-	// setup
-	eng.broker.EXPECT().Send(voteMatcher{}).Times(1)
 
 	// when
 	err = eng.AddVote(context.Background(), types.VoteSubmission{
@@ -1217,59 +1200,6 @@ func (e *tstEngine) expectSendRejectedProposalEvent(t *testing.T, partyID string
 	})
 }
 
-func (e *tstEngine) expectSendTxErrorProposalEvent(t *testing.T, partyID string) {
-	e.broker.EXPECT().Send(gomock.Any()).Times(1).Do(func(e events.Event) {
-		pe, ok := e.(*events.TxErr)
-		assert.True(t, ok)
-		assert.True(t, pe.IsParty(partyID))
-	})
-}
-
-func (e *tstEngine) expectSendProposalNotFoundErrorEvent(t *testing.T, vote types.VoteSubmission) {
-	e.broker.EXPECT().Send(voteMatcher{}).Times(1).Do(func(evt events.Event) {
-		assert.Equal(t, events.TxErrEvent, evt.Type())
-		se, ok := evt.(streamEvt)
-		assert.True(t, ok)
-		be := se.StreamMessage()
-		assert.Equal(t, eventspb.BusEventType_BUS_EVENT_TYPE_TX_ERROR, be.Type)
-		txErr := be.GetTxErrEvent()
-		assert.NotNil(t, txErr)
-		assert.Equal(t, governance.ErrProposalNotFound.Error(), txErr.ErrMsg)
-		v := txErr.GetVoteSubmission()
-		assert.NotNil(t, v)
-		pvote := vote.IntoProto()
-		assert.Equal(t, *pvote, *v)
-	})
-}
-
-func (e *tstEngine) expectSendAccountNotFoundErrorEvent(t *testing.T, vote types.VoteSubmission) {
-	e.broker.EXPECT().Send(voteMatcher{}).Times(1).Do(func(evt events.Event) {
-		assert.Equal(t, events.TxErrEvent, evt.Type())
-		se, ok := evt.(streamEvt)
-		assert.True(t, ok)
-		be := se.StreamMessage()
-		assert.Equal(t, eventspb.BusEventType_BUS_EVENT_TYPE_TX_ERROR, be.Type)
-		txErr := be.GetTxErrEvent()
-		assert.NotNil(t, txErr)
-		assert.Equal(t, errNoBalanceForParty.Error(), txErr.ErrMsg)
-		v := txErr.GetVoteSubmission()
-		assert.NotNil(t, v)
-		pvote := vote.IntoProto()
-		assert.Equal(t, *pvote, *v)
-	})
-}
-
-func (e *tstEngine) expectSendInsufficientTokensErrorEvent(t *testing.T) {
-	e.broker.EXPECT().Send(voteMatcher{}).Times(1).Do(func(evt events.Event) {
-		ve, ok := evt.(streamEvt)
-		assert.True(t, ok)
-		be := ve.StreamMessage()
-		txErr := be.GetTxErrEvent()
-		assert.NotNil(t, txErr)
-		assert.Equal(t, governance.ErrVoterInsufficientTokens.Error(), txErr.ErrMsg)
-	})
-}
-
 func (e *tstEngine) expectNoAccountForParty(partyID string) {
 	e.accounts.EXPECT().GetAvailableBalance(partyID).Times(1).Return(nil, errNoBalanceForParty)
 }
@@ -1293,27 +1223,4 @@ func (e *tstEngine) expectSendVoteEvent(t *testing.T, party *proto.Party, propos
 		assert.Equal(t, proposal.ID, vote.ProposalId)
 		assert.Equal(t, party.Id, vote.PartyId)
 	})
-}
-
-func (v voteMatcher) String() string {
-	return "Vote TX error event"
-}
-
-func (v voteMatcher) Matches(x interface{}) bool {
-	evt, ok := x.(streamEvt)
-	if !ok {
-		return false
-	}
-	if evt.Type() != events.TxErrEvent {
-		return false
-	}
-	be := evt.StreamMessage()
-	txErr := be.GetTxErrEvent()
-	if txErr == nil {
-		return false
-	}
-	if vote := txErr.GetVoteSubmission(); vote == nil {
-		return false
-	}
-	return true
 }

--- a/processor/process_withdraw.go
+++ b/processor/process_withdraw.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 )
@@ -14,11 +13,6 @@ var (
 )
 
 func (app *App) processWithdraw(ctx context.Context, w *types.WithdrawSubmission, id string, party string) (err error) {
-	defer func() {
-		if err != nil {
-			app.broker.Send(events.NewTxErrEvent(ctx, err, party, w))
-		}
-	}()
 	asset, err := app.assets.Get(w.Asset)
 	if err != nil {
 		app.log.Error("invalid vega asset ID for withdrawal",

--- a/processor/tx_v2.go
+++ b/processor/tx_v2.go
@@ -117,6 +117,43 @@ func (t TxV2) Command() txn.Command {
 	}
 }
 
+func (t TxV2) GetCmd() interface{} {
+	switch cmd := t.inputData.Command.(type) {
+	case *commandspb.InputData_OrderSubmission:
+		return cmd.OrderSubmission
+	case *commandspb.InputData_OrderCancellation:
+		return cmd.OrderCancellation
+	case *commandspb.InputData_OrderAmendment:
+		return cmd.OrderAmendment
+	case *commandspb.InputData_VoteSubmission:
+		return cmd.VoteSubmission
+	case *commandspb.InputData_WithdrawSubmission:
+		return cmd.WithdrawSubmission
+	case *commandspb.InputData_LiquidityProvisionSubmission:
+		return cmd.LiquidityProvisionSubmission
+	case *commandspb.InputData_ProposalSubmission:
+		return cmd.ProposalSubmission
+	case *commandspb.InputData_NodeRegistration:
+		return cmd.NodeRegistration
+	case *commandspb.InputData_NodeVote:
+		return cmd.NodeVote
+	case *commandspb.InputData_NodeSignature:
+		return cmd.NodeSignature
+	case *commandspb.InputData_ChainEvent:
+		return cmd.ChainEvent
+	case *commandspb.InputData_OracleDataSubmission:
+		return cmd.OracleDataSubmission
+	case *commandspb.InputData_DelegateSubmission:
+		return cmd.DelegateSubmission
+	case *commandspb.InputData_UndelegateSubmission:
+		return cmd.UndelegateSubmission
+	case *commandspb.InputData_RestoreSnapshotSubmission:
+		return cmd.RestoreSnapshotSubmission
+	default:
+		return errors.New("unsupported command")
+	}
+}
+
 func (t TxV2) Unmarshal(i interface{}) error {
 	switch cmd := t.inputData.Command.(type) {
 	case *commandspb.InputData_OrderSubmission:


### PR DESCRIPTION
Send transaction error for all received transactions that returned an error, so we don't have to think about doing so throughout the core.

In addition, removed required party filter when streaming error events.

Closed #4030 