### PR TITLE
Implement multi sig control signatures

### DIFF
--- a/bridges/erc20_multisigcontrol.go
+++ b/bridges/erc20_multisigcontrol.go
@@ -1,0 +1,209 @@
+package bridges
+
+import (
+	"code.vegaprotocol.io/vega/types/num"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethcmn "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type Signer interface {
+	Sign([]byte) ([]byte, error)
+}
+
+type ERC20MultiSigControl struct {
+	signer Signer
+}
+
+func NewERC20MultiSigControl(signer Signer) *ERC20MultiSigControl {
+	return &ERC20MultiSigControl{
+		signer: signer,
+	}
+}
+
+func (e *ERC20MultiSigControl) SetThreshold(
+	newThreshold uint16,
+	submitter string,
+	nonce *num.Uint,
+) (msg []byte, sig []byte, err error) {
+	typString, err := abi.NewType("string", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	typU16, err := abi.NewType("uint16", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	typU256, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	args := abi.Arguments([]abi.Argument{
+		{
+			Name: "new_threshold",
+			Type: typU16,
+		},
+		{
+			Name: "nonce",
+			Type: typU256,
+		},
+		{
+			Name: "func_name",
+			Type: typString,
+		},
+	})
+
+	buf, err := args.Pack([]interface{}{newThreshold, nonce.BigInt(), "set_threshold"}...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	msg, err = e.packBufAndSubmitter(buf, submitter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sig, err = e.sign(msg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return msg, sig, nil
+}
+
+func (e *ERC20MultiSigControl) AddSigner(
+	newSigner, submitter string,
+	nonce *num.Uint,
+) (msg []byte, sig []byte, err error) {
+	typAddr, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	typString, err := abi.NewType("string", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	typU256, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	args := abi.Arguments([]abi.Argument{
+		{
+			Name: "address",
+			Type: typAddr,
+		},
+		{
+			Name: "nonce",
+			Type: typU256,
+		},
+		{
+			Name: "func_name",
+			Type: typString,
+		},
+	})
+
+	newSignerAddr := ethcmn.HexToAddress(newSigner)
+	buf, err := args.Pack([]interface{}{newSignerAddr, nonce.BigInt(), "add_signer"}...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	msg, err = e.packBufAndSubmitter(buf, submitter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sig, err = e.sign(msg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return msg, sig, nil
+}
+
+func (e *ERC20MultiSigControl) RemoveSigner(
+	oldSigner, submitter string,
+	nonce *num.Uint,
+) (msg []byte, sig []byte, err error) {
+	typAddr, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	typString, err := abi.NewType("string", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	typU256, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	args := abi.Arguments([]abi.Argument{
+		{
+			Name: "address",
+			Type: typAddr,
+		},
+		{
+			Name: "nonce",
+			Type: typU256,
+		},
+		{
+			Name: "func_name",
+			Type: typString,
+		},
+	})
+
+	oldSignerAddr := ethcmn.HexToAddress(oldSigner)
+	buf, err := args.Pack([]interface{}{oldSignerAddr, nonce.BigInt(), "remove_signer"}...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	msg, err = e.packBufAndSubmitter(buf, submitter)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sig, err = e.sign(msg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return msg, sig, nil
+}
+
+func (e *ERC20MultiSigControl) packBufAndSubmitter(
+	buf []byte, submitter string,
+) ([]byte, error) {
+	typBytes, err := abi.NewType("bytes", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	typAddr, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	submitterAddr := ethcmn.HexToAddress(submitter)
+	args2 := abi.Arguments([]abi.Argument{
+		{
+			Name: "bytes",
+			Type: typBytes,
+		},
+		{
+			Name: "address",
+			Type: typAddr,
+		},
+	})
+
+	return args2.Pack(buf, submitterAddr)
+}
+
+func (e *ERC20MultiSigControl) sign(msg []byte) ([]byte, error) {
+	// hash our message before signing it
+	hash := crypto.Keccak256(msg)
+	return e.signer.Sign(hash)
+}

--- a/bridges/erc20_multisigcontrol.go
+++ b/bridges/erc20_multisigcontrol.go
@@ -92,7 +92,7 @@ func (e *ERC20MultiSigControl) AddSigner(
 
 	args := abi.Arguments([]abi.Argument{
 		{
-			Name: "address",
+			Name: "new_signer",
 			Type: typAddr,
 		},
 		{
@@ -143,7 +143,7 @@ func (e *ERC20MultiSigControl) RemoveSigner(
 
 	args := abi.Arguments([]abi.Argument{
 		{
-			Name: "address",
+			Name: "old_signer",
 			Type: typAddr,
 		},
 		{

--- a/bridges/erc20_multisigcontrol_test.go
+++ b/bridges/erc20_multisigcontrol_test.go
@@ -1,0 +1,96 @@
+package bridges_test
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+
+	"code.vegaprotocol.io/vega/bridges"
+	"code.vegaprotocol.io/vega/types/num"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	privKey = "9feb9cbee69c1eeb30db084544ff8bf92166bf3fddefa6a021b458b4de04c66758a127387b1dff15b71fd7d0a9fd104ed75da4aac549efd5d149051ea57cefaf"
+	pubKey  = "58a127387b1dff15b71fd7d0a9fd104ed75da4aac549efd5d149051ea57cefaf"
+)
+
+func TestERC20MultiSigControl(t *testing.T) {
+	t.Run("set threshold", testSetThreshold)
+	t.Run("add signer", testAddSigner)
+	t.Run("remove signer", testRemoveSigner)
+}
+
+func testSetThreshold(t *testing.T) {
+	signer := testSigner{}
+	bridge := bridges.NewERC20MultiSigControl(signer)
+	msg, sig, err := bridge.SetThreshold(
+		1000,
+		"0x1FaA74E181092A97Fecc923015293ce57eE1208A",
+		num.NewUint(42),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, msg)
+	assert.NotNil(t, sig)
+	assert.True(t, signer.Verify(msg, sig))
+	assert.Equal(t,
+		"a2c61b473f15a1729e8593d65748e7a9813102e0d7304598af556525206db599fb79b9750349c6cb564a2f3ecdf233dd19b1598302e0cb91218adff1c609ac09",
+		hex.EncodeToString(sig),
+	)
+
+}
+
+func testAddSigner(t *testing.T) {
+	signer := testSigner{}
+	bridge := bridges.NewERC20MultiSigControl(signer)
+	msg, sig, err := bridge.AddSigner(
+		"0xE20c747a7389B7De2c595658277132f188A074EE",
+		"0x1FaA74E181092A97Fecc923015293ce57eE1208A",
+		num.NewUint(42),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, msg)
+	assert.NotNil(t, sig)
+	assert.True(t, signer.Verify(msg, sig))
+
+	assert.Equal(t,
+		"7bdc018935610f23667b31d4eee248160ab39caa1e70ad20da49bf8971d5a16b30f71a09d9aaf5b532defdb7710d85c226e98cb90a49bc4b4401b33f3c5a1601",
+		hex.EncodeToString(sig),
+	)
+}
+
+func testRemoveSigner(t *testing.T) {
+	signer := testSigner{}
+	bridge := bridges.NewERC20MultiSigControl(signer)
+	msg, sig, err := bridge.RemoveSigner(
+		"0xE20c747a7389B7De2c595658277132f188A074EE",
+		"0x1FaA74E181092A97Fecc923015293ce57eE1208A",
+		num.NewUint(42),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, msg)
+	assert.NotNil(t, sig)
+	assert.True(t, signer.Verify(msg, sig))
+	assert.Equal(t,
+		"98ea2303c68dbb0a88bdb7dad8c6e2db9698cd992667399a378e682dbdf16e74a9d304a32e36b48de81c0e99449a7a37c1a7ef94af1e85aa88a808f8d7126c0c",
+		hex.EncodeToString(sig),
+	)
+}
+
+type testSigner struct{}
+
+func (s testSigner) Sign(msg []byte) ([]byte, error) {
+	priv, _ := hex.DecodeString(privKey)
+	return ed25519.Sign(ed25519.PrivateKey(priv), msg), nil
+}
+
+func (s testSigner) Verify(msg, sig []byte) bool {
+	pub, _ := hex.DecodeString(pubKey)
+	hash := crypto.Keccak256(msg)
+	return ed25519.Verify(ed25519.PublicKey(pub), hash, sig)
+}

--- a/cmd/vega/bridge.go
+++ b/cmd/vega/bridge.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+
+	"code.vegaprotocol.io/vega/cmd/vega/bridge"
+	"github.com/jessevdk/go-flags"
+)
+
+type BridgeCmd struct {
+	ERC20 *bridge.ERC20Cmd `command:"erc20" description:"Validator utilities to manage the erc20 bridge"`
+}
+
+var bridgeCmd BridgeCmd
+
+func Bridge(ctx context.Context, parser *flags.Parser) error {
+	bridgeCmd = BridgeCmd{
+		ERC20: bridge.ERC20(),
+	}
+
+	_, err := parser.AddCommand("bridge", "Utilities to control / manage vega bridges", "", &bridgeCmd)
+	return err
+}

--- a/cmd/vega/bridge.go
+++ b/cmd/vega/bridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"code.vegaprotocol.io/vega/cmd/vega/bridge"
+
 	"github.com/jessevdk/go-flags"
 )
 

--- a/cmd/vega/bridge/erc20.go
+++ b/cmd/vega/bridge/erc20.go
@@ -1,0 +1,207 @@
+package bridge
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"code.vegaprotocol.io/vega/bridges"
+	"code.vegaprotocol.io/vega/config"
+	vgfs "code.vegaprotocol.io/vega/libs/fs"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/nodewallet"
+	"code.vegaprotocol.io/vega/types/num"
+)
+
+type ERC20Cmd struct {
+	config.RootPathFlag
+	config.PassphraseFlag
+
+	AddSigner    ERC20AddSignerCmd    `command:"add_signer" description:"Create signature to add a new signer to the erc20 bridge"`
+	RemoveSigner ERC20RemoveSignerCmd `command:"remove_signer" description:"Create signature to remove a signer from the erc20 bridge"`
+	SetThreshold ERC20SetThresholdCmd `command:"set_threshold" description:"Create signature to change the threshold of required signature to apply changes to the bridge"`
+}
+
+var erc20Cmd *ERC20Cmd
+
+func ERC20() *ERC20Cmd {
+	root := config.NewRootPathFlag()
+	erc20Cmd = &ERC20Cmd{
+		RootPathFlag: root,
+		AddSigner: ERC20AddSignerCmd{
+			Config: nodewallet.NewDefaultConfig(),
+		},
+		RemoveSigner: ERC20RemoveSignerCmd{
+			Config: nodewallet.NewDefaultConfig(),
+		},
+		SetThreshold: ERC20SetThresholdCmd{
+			Config: nodewallet.NewDefaultConfig(),
+		},
+	}
+
+	return erc20Cmd
+}
+
+type ERC20AddSignerCmd struct {
+	Config nodewallet.Config
+
+	NewSigner string `long:"new-signer" required:"true" description:"Ethereum address of the new signer"`
+	Submitter string `long:"submitter" required:"true" description:"Ethereum address of the submitter of the transaction"`
+	Nonce     string `long:"nonce" required:"true" description:"An nonce for this signature"`
+}
+
+func (opts *ERC20AddSignerCmd) Execute(_ []string) error {
+	log := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
+	defer log.AtExit()
+
+	if ok, err := vgfs.PathExists(erc20Cmd.RootPath); !ok {
+		return fmt.Errorf("invalid root directory path: %w", err)
+	}
+
+	pass, err := erc20Cmd.PassphraseFile.Get("node wallet")
+	if err != nil {
+		return err
+	}
+
+	conf, err := config.Read(erc20Cmd.RootPath)
+	if err != nil {
+		return err
+	}
+	opts.Config = conf.NodeWallet
+
+	nw, err := nodewallet.New(log, conf.NodeWallet, pass, nil, erc20Cmd.RootPath)
+	if err != nil {
+		return err
+	}
+
+	w, ok := nw.Get(nodewallet.Blockchain("ethereum"))
+	if !ok {
+		return errors.New("no ethereum wallet configured")
+	}
+
+	nonce, overflowed := num.UintFromString(opts.Nonce, 10)
+	if overflowed {
+		return errors.New("invalid nonce, needs to be base 10")
+	}
+
+	multiSigControl := bridges.NewERC20MultiSigControl(w)
+	_, signature, err := multiSigControl.AddSigner(
+		opts.NewSigner, opts.Submitter, nonce,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to generate signature: %w", err)
+	}
+
+	fmt.Printf("0x%v\n", hex.EncodeToString(signature))
+	return nil
+}
+
+type ERC20RemoveSignerCmd struct {
+	Config    nodewallet.Config
+	OldSigner string `long:"old-signer" required:"true" description:"Ethereum address of signer to remove"`
+	Submitter string `long:"submitter" required:"true" description:"Ethereum address of the submitter of the transaction"`
+	Nonce     string `long:"nonce" required:"true" description:"An nonce for this signature"`
+}
+
+func (opts *ERC20RemoveSignerCmd) Execute(_ []string) error {
+	log := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
+	defer log.AtExit()
+
+	if ok, err := vgfs.PathExists(erc20Cmd.RootPath); !ok {
+		return fmt.Errorf("invalid root directory path: %w", err)
+	}
+
+	pass, err := erc20Cmd.PassphraseFile.Get("node wallet")
+	if err != nil {
+		return err
+	}
+
+	conf, err := config.Read(erc20Cmd.RootPath)
+	if err != nil {
+		return err
+	}
+	opts.Config = conf.NodeWallet
+
+	nw, err := nodewallet.New(log, conf.NodeWallet, pass, nil, erc20Cmd.RootPath)
+	if err != nil {
+		return err
+	}
+
+	w, ok := nw.Get(nodewallet.Blockchain("ethereum"))
+	if !ok {
+		return errors.New("no ethereum wallet configured")
+	}
+
+	nonce, overflowed := num.UintFromString(opts.Nonce, 10)
+	if overflowed {
+		return errors.New("invalid nonce, needs to be base 10")
+	}
+
+	multiSigControl := bridges.NewERC20MultiSigControl(w)
+	_, signature, err := multiSigControl.RemoveSigner(
+		opts.OldSigner, opts.Submitter, nonce,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to generate signature: %w", err)
+	}
+
+	fmt.Printf("0x%v\n", hex.EncodeToString(signature))
+	return nil
+}
+
+type ERC20SetThresholdCmd struct {
+	Config       nodewallet.Config
+	NewThreshold uint16 `long:"new-threshold" required:"true" description:"The new threshold to be used on the bridge"`
+	Submitter    string `long:"submitter" required:"true" description:"Ethereum address of the submitter of the transaction"`
+	Nonce        string `long:"nonce" required:"true" description:"An nonce for this signature"`
+}
+
+func (opts *ERC20SetThresholdCmd) Execute(_ []string) error {
+	log := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
+	defer log.AtExit()
+
+	if opts.NewThreshold == 0 || opts.NewThreshold > 1000 {
+		return fmt.Errorf("invalid new threshold, required to be > 0 and <= 1000, got %d", opts.NewThreshold)
+	}
+
+	if ok, err := vgfs.PathExists(erc20Cmd.RootPath); !ok {
+		return fmt.Errorf("invalid root directory path: %w", err)
+	}
+
+	pass, err := erc20Cmd.PassphraseFile.Get("node wallet")
+	if err != nil {
+		return err
+	}
+
+	conf, err := config.Read(erc20Cmd.RootPath)
+	if err != nil {
+		return err
+	}
+	opts.Config = conf.NodeWallet
+
+	nw, err := nodewallet.New(log, conf.NodeWallet, pass, nil, erc20Cmd.RootPath)
+	if err != nil {
+		return err
+	}
+
+	w, ok := nw.Get(nodewallet.Blockchain("ethereum"))
+	if !ok {
+		return errors.New("no ethereum wallet configured")
+	}
+
+	nonce, overflowed := num.UintFromString(opts.Nonce, 10)
+	if overflowed {
+		return errors.New("invalid nonce, needs to be base 10")
+	}
+
+	multiSigControl := bridges.NewERC20MultiSigControl(w)
+	_, signature, err := multiSigControl.SetThreshold(
+		opts.NewThreshold, opts.Submitter, nonce,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to generate signature: %w", err)
+	}
+
+	fmt.Printf("0x%v\n", hex.EncodeToString(signature))
+	return nil
+}

--- a/cmd/vega/bridge/erc20.go
+++ b/cmd/vega/bridge/erc20.go
@@ -47,7 +47,7 @@ type ERC20AddSignerCmd struct {
 
 	NewSigner string `long:"new-signer" required:"true" description:"Ethereum address of the new signer"`
 	Submitter string `long:"submitter" required:"true" description:"Ethereum address of the submitter of the transaction"`
-	Nonce     string `long:"nonce" required:"true" description:"An nonce for this signature"`
+	Nonce     string `long:"nonce" required:"true" description:"A nonce for this signature"`
 }
 
 func (opts *ERC20AddSignerCmd) Execute(_ []string) error {
@@ -100,7 +100,7 @@ type ERC20RemoveSignerCmd struct {
 	Config    nodewallet.Config
 	OldSigner string `long:"old-signer" required:"true" description:"Ethereum address of signer to remove"`
 	Submitter string `long:"submitter" required:"true" description:"Ethereum address of the submitter of the transaction"`
-	Nonce     string `long:"nonce" required:"true" description:"An nonce for this signature"`
+	Nonce     string `long:"nonce" required:"true" description:"A nonce for this signature"`
 }
 
 func (opts *ERC20RemoveSignerCmd) Execute(_ []string) error {
@@ -153,7 +153,7 @@ type ERC20SetThresholdCmd struct {
 	Config       nodewallet.Config
 	NewThreshold uint16 `long:"new-threshold" required:"true" description:"The new threshold to be used on the bridge"`
 	Submitter    string `long:"submitter" required:"true" description:"Ethereum address of the submitter of the transaction"`
-	Nonce        string `long:"nonce" required:"true" description:"An nonce for this signature"`
+	Nonce        string `long:"nonce" required:"true" description:"A nonce for this signature"`
 }
 
 func (opts *ERC20SetThresholdCmd) Execute(_ []string) error {
@@ -191,7 +191,7 @@ func (opts *ERC20SetThresholdCmd) Execute(_ []string) error {
 
 	nonce, overflowed := num.UintFromString(opts.Nonce, 10)
 	if overflowed {
-		return errors.New("invalid nonce, needs to be base 10")
+		return errors.New("invalid nonce, needs to be base 10 and not overflow")
 	}
 
 	multiSigControl := bridges.NewERC20MultiSigControl(w)

--- a/cmd/vega/main.go
+++ b/cmd/vega/main.go
@@ -69,6 +69,7 @@ func Main(ctx context.Context) error {
 		Checkpoint,
 		Query,
 		Command,
+		Bridge,
 	); err != nil {
 		fmt.Printf("%+v\n", err)
 		return err


### PR DESCRIPTION
This pull request implements the validators signature for the following functionnalities of the multi sig control:
- add_signer
- remove_signer
- set_threshold

It also provide a simple command line interface so the validators can generate signature using the node ethereum address:
```
vega bridge erc20 add_signer --submitter="0x1FaA74E181092A97Fecc923015293ce57eE1208A" \
                             --new-signer="0xE20c747a7389B7De2c595658277132f188A074EE" \
                             --nonce="123456789"
```

close #4036 