### PR TITLE
Making LNL easier to test

### DIFF
--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -104,6 +104,6 @@ func defaultNetParams() map[string]value {
 		// network checkpoint parameters
 		NetworkCheckpointMarketFreezeDate:              NewTime().Mutable(true).MustUpdate("never"),
 		NetworkCheckpointNetworkEOLDate:                NewTime().Mutable(true).MustUpdate("never"),
-		NetworkCheckpointTimeElapsedBetweenCheckpoints: NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("1h"),
+		NetworkCheckpointTimeElapsedBetweenCheckpoints: NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("1m"),
 	}
 }

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -324,11 +324,12 @@ func (app *App) OnCommit() (resp tmtypes.ResponseCommit) {
 }
 
 func (app *App) handleCheckpoint(snap *types.Snapshot) error {
+	now := time.Now()
 	f, err := os.Create(
 		filepath.Join(
 			app.cfg.CheckpointsPath,
 			fmt.Sprintf(
-				"%s-%s.cp", app.cBlock, hex.EncodeToString(snap.Hash),
+				"%s-%s-%s.cp", now.Format("20060102150405"), app.cBlock, hex.EncodeToString(snap.Hash),
 			),
 		),
 	)


### PR DESCRIPTION
After catching up with @fkondej, we agreed to prefix checkpoint files with a YmdHms time, and set default checkpoint interval to 1m to make automated testing easier