### PR TITLE
Read config from path, instead of using default

### DIFF
--- a/cmd/vega/checkpoint.go
+++ b/cmd/vega/checkpoint.go
@@ -82,7 +82,10 @@ func (c *checkpointRestore) Execute(args []string) error {
 }
 
 func (c checkpointRestore) getCommander(log *logging.Logger) (*nodewallet.Commander, error) {
-	cfg := config.NewDefaultConfig(checkpointCmd.RootPath)
+	cfg, err := config.Read(checkpointCmd.RootPath)
+	if err != nil {
+		return nil, err
+	}
 	nwConf := cfg.NodeWallet
 	// instantiate the ETHClient
 	ethclt, err := ethclient.Dial(nwConf.ETH.Address)


### PR DESCRIPTION
checkpoint command should use the config from disk, not hard-coded defaults