### PR TITLE
Do not fail when enabling assets multiple times

### DIFF
--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -244,9 +244,9 @@ func (e *Engine) Load(ctx context.Context, snap *types.Snapshot) error {
 		if !doneCollat {
 			if cc, ok := c.(CollateralState); ok {
 				for _, a := range assets {
-					if err := cc.EnableAsset(ctx, *a); err != nil {
-						return err
-					}
+					// ignore this error, if the asset is already enabled, that's fine
+					// we can carry on as though nothing happened
+					_ = cc.EnableAsset(ctx, *a)
 				}
 				doneCollat = true
 			}

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -246,7 +246,12 @@ func (e *Engine) Load(ctx context.Context, snap *types.Snapshot) error {
 				for _, a := range assets {
 					// ignore this error, if the asset is already enabled, that's fine
 					// we can carry on as though nothing happened
-					_ = cc.EnableAsset(ctx, *a)
+					if err := cc.EnableAsset(ctx, *a); err != nil {
+						e.log.Debug("Asset already enabled",
+							logging.String("asset-id", a.ID),
+							logging.Error(err),
+						)
+					}
 				}
 				doneCollat = true
 			}


### PR DESCRIPTION
Network params and assets both contain the token asset. When reloading a checkpoint, we may enable the same asset twice. This used to result in a panic (failed to restore checkpoint), but it shouldn't.

Checkpoint reloading should ignore this error. We're not checking for the specific error now, because `collateral.EnableAsset` only ever returns the `ErrAssetAlreadyEnabled` error

Closes #4089 