### PR TITLE
fix filename for checkpoints

### DIFF
--- a/processor/abci.go
+++ b/processor/abci.go
@@ -452,7 +452,8 @@ func (app *App) OnCommit() (resp tmtypes.ResponseCommit) {
 
 func (app *App) handleCheckpoint(cpt *types.CheckpointState) error {
 	now := time.Now()
-	cpFileName := fmt.Sprintf("%s-%s-%s.cp", now.Format("20060102150405"), app.cBlock, hex.EncodeToString(cpt.Hash))
+	height, _ := vgcontext.BlockHeightFromContext(app.blockCtx)
+	cpFileName := fmt.Sprintf("%s-%d-%s.cp", now.Format("20060102150405"), height, hex.EncodeToString(cpt.Hash))
 	cpFilePath, err := app.vegaPaths.StatePathFor(filepath.Join(paths.CheckpointStateHome, cpFileName))
 	if err != nil {
 		return fmt.Errorf("couldn't get path for checkpoint file: %w", err)

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -451,7 +451,7 @@ func (app *App) OnCommit() (resp tmtypes.ResponseCommit) {
 }
 
 func (app *App) handleCheckpoint(cpt *types.CheckpointState) error {
-	now := time.Now()
+	now := app.currentTimestamp
 	height, _ := vgcontext.BlockHeightFromContext(app.blockCtx)
 	cpFileName := fmt.Sprintf("%s-%d-%s.cp", now.Format("20060102150405"), height, hex.EncodeToString(cpt.Hash))
 	cpFilePath, err := app.vegaPaths.StatePathFor(filepath.Join(paths.CheckpointStateHome, cpFileName))


### PR DESCRIPTION
Use the block height instead of block hash in the checkpoint filename.