### PR TITLE
dedup event sent when creating the reward pool + fix owner

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -2360,12 +2360,11 @@ func (e *Engine) CreateOrGetAssetRewardPoolAccount(ctx context.Context, asset st
 			Asset:    asset,
 			MarketID: noMarket,
 			Balance:  num.Zero(),
-			Owner:    "",
+			Owner:    systemOwner,
 			Type:     types.AccountTypeGlobalReward,
 		}
 		e.accs[accountID] = &acc
 		e.addAccountToHashableSlice(&acc)
-		e.broker.Send(events.NewAccountEvent(ctx, acc))
 		e.broker.Send(events.NewAccountEvent(ctx, acc))
 	}
 	return accountID, nil

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -144,7 +144,7 @@ func testTransferRewardsSuccess(t *testing.T) {
 	eng := getTestEngine(t, "test-market")
 	defer eng.Finish()
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(2)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(1)
 	rewardAccID, _ := eng.CreateOrGetAssetRewardPoolAccount(context.Background(), "ETH")
 
 	eng.broker.EXPECT().Send(gomock.Any()).Times(1)


### PR DESCRIPTION
Reward pool owner is systemOwner.
Do not send event twice when reward pool is created