### PR TITLE
fix oracle specs missing id in integration test

### DIFF
--- a/integration/steps/the_oracle_spec.go
+++ b/integration/steps/the_oracle_spec.go
@@ -1,24 +1,13 @@
 package steps
 
 import (
-	"math/rand"
-
 	"github.com/cucumber/godog"
 
 	types "code.vegaprotocol.io/protos/vega"
 	oraclesv1 "code.vegaprotocol.io/protos/vega/oracles/v1"
+	vgrand "code.vegaprotocol.io/shared/libs/rand"
 	"code.vegaprotocol.io/vega/integration/steps/market"
 )
-
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-func RandStringBytesRmndr(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
-	}
-	return string(b)
-}
 
 func TheOracleSpec(config *market.Config, name string, specType string, rawPubKeys string, table *godog.Table) error {
 	pubKeys := StrSlice(rawPubKeys, ",")
@@ -49,7 +38,7 @@ func TheOracleSpec(config *market.Config, name string, specType string, rawPubKe
 		name,
 		specType,
 		&oraclesv1.OracleSpec{
-			Id:      RandStringBytesRmndr(10),
+			Id:      vgrand.RandomStr(10),
 			PubKeys: pubKeys,
 			Filters: filters,
 		},

--- a/integration/steps/the_oracle_spec.go
+++ b/integration/steps/the_oracle_spec.go
@@ -1,12 +1,24 @@
 package steps
 
 import (
+	"math/rand"
+
 	"github.com/cucumber/godog"
 
 	types "code.vegaprotocol.io/protos/vega"
 	oraclesv1 "code.vegaprotocol.io/protos/vega/oracles/v1"
 	"code.vegaprotocol.io/vega/integration/steps/market"
 )
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandStringBytesRmndr(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+	}
+	return string(b)
+}
 
 func TheOracleSpec(config *market.Config, name string, specType string, rawPubKeys string, table *godog.Table) error {
 	pubKeys := StrSlice(rawPubKeys, ",")
@@ -37,6 +49,7 @@ func TheOracleSpec(config *market.Config, name string, specType string, rawPubKe
 		name,
 		specType,
 		&oraclesv1.OracleSpec{
+			Id:      RandStringBytesRmndr(10),
 			PubKeys: pubKeys,
 			Filters: filters,
 		},


### PR DESCRIPTION
close #4187 

this is fixing a bug in integration tests setting up more than 2 oracle specs. The issue is that when more than 2 oracle specs are being set up in code (as opposed to reading the json default config) they are not given an id and therefore are overwriting each other. 
