### PR TITLE
Bug fix: Rewards payout with delay 

### DIFF
--- a/rewards/engine.go
+++ b/rewards/engine.go
@@ -271,6 +271,18 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 	}
 }
 
+func (e *Engine) calcTotalPendingPayout(accountID string) *num.Uint {
+	totalPendingForRS := num.Zero()
+	for _, payouts := range e.pendingPayouts {
+		for _, po := range payouts {
+			if po.fromAccount == accountID {
+				totalPendingForRS.AddSum(po.totalReward)
+			}
+		}
+	}
+	return totalPendingForRS
+}
+
 // process rewards when needed
 func (e *Engine) processRewards(ctx context.Context, rewardScheme *types.RewardScheme, epoch types.Epoch, _ time.Time) {
 	// get the reward pool accounts for the reward scheme
@@ -282,6 +294,13 @@ func (e *Engine) processRewards(ctx context.Context, rewardScheme *types.RewardS
 		}
 
 		rewardAccountBalance := account.Balance
+
+		// account for pending payouts
+		totalPendingPayouts := e.calcTotalPendingPayout(account.ID)
+		if rewardAccountBalance.LT(totalPendingPayouts) {
+			e.log.Panic("insufficient balance in reward account to cover for pending payouts", logging.String("rewardAccountBalance", rewardAccountBalance.String()), logging.String("totalPendingPayouts", totalPendingPayouts.String()))
+		}
+		rewardAccountBalance = num.Zero().Sub(rewardAccountBalance, totalPendingPayouts)
 
 		// get how much reward needs to be distributed based on the current balance and the reward scheme
 		rewardAmt, err := rewardScheme.GetReward(rewardAccountBalance, epoch)
@@ -299,8 +318,9 @@ func (e *Engine) processRewards(ctx context.Context, rewardScheme *types.RewardS
 		payoutEvents := map[string]*events.RewardPayout{}
 		parties := []string{}
 		for party, amount := range po.partyToAmount {
-			proportion, _ := amount.ToDecimal().Div(po.totalReward.ToDecimal()).Float64()
-			payoutEvents[party] = events.NewRewardPayout(ctx, po.timestamp, party, po.epochSeq, po.asset, amount, proportion)
+			proportion := amount.ToDecimal().Div(po.totalReward.ToDecimal())
+			pct, _ := proportion.Mul(num.DecimalFromInt64(100)).Float64()
+			payoutEvents[party] = events.NewRewardPayout(ctx, po.timestamp, party, po.epochSeq, po.asset, amount, pct)
 			parties = append(parties, party)
 		}
 		sort.Strings(parties)

--- a/rewards/engine_test.go
+++ b/rewards/engine_test.go
@@ -36,6 +36,59 @@ func Test(t *testing.T) {
 	t.Run("Process epoch end to calculate payout with no delay - rewards are distributed successfully", testOnEpochEndNoPayoutDelay)
 	t.Run("Process pending payouts on time update - time for payout hasn't come yet so no payouts sent", testOnChainTimeUpdateNoPayoutsToSend)
 	t.Run("Reward snapshot round trip with delayed payout", testRewardSnapshotRoundTrip)
+	t.Run("Calculate rewards with delays such that pending payouts pile and are accounted for reward amount available for next round next rounds before being distributed", testMultipleEpochsWithPendingPayouts)
+}
+
+func testMultipleEpochsWithPendingPayouts(t *testing.T) {
+	testEngine := getEngine(t)
+	engine := testEngine.engine
+	engine.registerStakingAndDelegationRewardScheme()
+	engine.UpdatePayoutFractionForStakingRewardScheme(context.Background(), 1.0)
+	engine.UpdateDelegatorShareForStakingRewardScheme(context.Background(), 0.3)
+	engine.UpdateMinimumValidatorStakeForStakingRewardScheme(context.Background(), num.NewDecimalFromFloat(0))
+	engine.UpdateAssetForStakingAndDelegationRewardScheme(context.Background(), "ETH")
+	engine.UpdateCompetitionLevelForStakingRewardScheme(context.Background(), 1.1)
+	engine.UpdateMaxPayoutPerEpochStakeForStakingRewardScheme(context.Background(), num.NewDecimalFromFloat(1000000000))
+
+	rs := engine.rewardSchemes[stakingAndDelegationSchemeID]
+
+	//setup delay
+	rs.PayoutDelay = 120 * time.Second
+	rs.PayoutFraction = 0.5
+
+	//setup reward account balance
+	err := testEngine.collateral.IncrementBalance(context.Background(), rs.RewardPoolAccountIDs[0], num.NewUint(1000000))
+	require.Nil(t, err)
+
+	// there is remaining 1000000 to distribute as payout
+	now := time.Now()
+	epoch1 := types.Epoch{StartTime: now, EndTime: now, Seq: 1}
+	testEngine.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
+	testEngine.delegation.EXPECT().ProcessEpochDelegations(gomock.Any(), gomock.Any()).Return(testEngine.validatorData)
+	engine.OnEpochEnd(context.Background(), epoch1)
+
+	// at this point there should be a payout pending
+	require.Equal(t, 1, len(engine.pendingPayouts))
+	require.Equal(t, num.NewUint(499999), engine.pendingPayouts[now.Add(rs.PayoutDelay)][0].totalReward)
+	require.Equal(t, num.NewUint(499999), engine.calcTotalPendingPayout(rs.RewardPoolAccountIDs[0]))
+
+	// now add reward for epoch 2
+	now2 := now.Add(10 * time.Second)
+	epoch2 := types.Epoch{StartTime: now2, EndTime: now2, Seq: 2}
+	testEngine.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
+	testEngine.delegation.EXPECT().ProcessEpochDelegations(gomock.Any(), gomock.Any()).Return(testEngine.validatorData)
+	engine.OnEpochEnd(context.Background(), epoch2)
+
+	// at this point there should be a payout pending
+	require.Equal(t, 2, len(engine.pendingPayouts))
+	require.Equal(t, num.NewUint(249999), engine.pendingPayouts[now2.Add(rs.PayoutDelay)][0].totalReward)
+	require.Equal(t, num.NewUint(749998), engine.calcTotalPendingPayout(rs.RewardPoolAccountIDs[0]))
+
+	// run to the end of delay to have payouts distributed
+
+	now3 := now2.Add(121 * time.Second)
+	engine.onChainTimeUpdate(context.Background(), now3)
+	require.Equal(t, num.Zero(), engine.calcTotalPendingPayout(rs.RewardPoolAccountIDs[0]))
 }
 
 func testRewardSnapshotRoundTrip(t *testing.T) {
@@ -53,6 +106,7 @@ func testRewardSnapshotRoundTrip(t *testing.T) {
 
 	//setup delay
 	rs.PayoutDelay = 120 * time.Second
+	rs.PayoutFraction = 0.1
 
 	//setup reward account balance
 	err := testEngine.collateral.IncrementBalance(context.Background(), rs.RewardPoolAccountIDs[0], num.NewUint(1000000))
@@ -365,6 +419,10 @@ func testOnEpochEndFullPayoutWithPayoutDelay(t *testing.T) {
 	testEngine.delegation.EXPECT().ProcessEpochDelegations(gomock.Any(), gomock.Any()).Return(testEngine.validatorData)
 	engine.OnEpochEnd(context.Background(), epoch)
 
+	// advance to the end of the delay for the second reward + topup the balance of the reward account to be 1M again
+	err = testEngine.collateral.IncrementBalance(context.Background(), rs.RewardPoolAccountIDs[0], num.NewUint(999999))
+	require.Nil(t, err)
+
 	// setup party accounts
 	testEngine.collateral.CreatePartyGeneralAccount(context.Background(), "party1", "ETH")
 	testEngine.collateral.CreatePartyGeneralAccount(context.Background(), "party2", "ETH")
@@ -397,10 +455,6 @@ func testOnEpochEndFullPayoutWithPayoutDelay(t *testing.T) {
 	require.Equal(t, num.NewUint(140000), node1Acc.Balance)
 	require.Equal(t, num.NewUint(400000), node2Acc.Balance)
 	require.Equal(t, num.NewUint(331428), node3Acc.Balance)
-
-	// advance to the end of the delay for the second reward + topup the balance of the reward account to be 1M again
-	err = testEngine.collateral.IncrementBalance(context.Background(), rs.RewardPoolAccountIDs[0], num.NewUint(999999))
-	require.Nil(t, err)
 
 	engine.onChainTimeUpdate(context.Background(), epoch2.EndTime.Add(rs.PayoutDelay))
 


### PR DESCRIPTION
close #4194 #4193 

Last week we changed reward calculation such that the calculation is made immediately and the payout may be delayed - in such case the pending reward amounts need to be account for when using the reward balance. 

Another minor fix included is that reward events have percentageOfTotalReward which should be percent but is actually ratio.  