### PR TITLE
Experiment at removing the snapshotting details from the engine

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -156,7 +156,7 @@ type Market struct {
 	matching           *matching.CachedOrderBook
 	tradableInstrument *markets.TradableInstrument
 	risk               *risk.Engine
-	position           *positions.Engine
+	position           *positions.SnapshotEngine
 	settlement         *settlement.Engine
 	fee                *fee.Engine
 	liquidity          *liquidity.SnapshotEngine
@@ -276,7 +276,7 @@ func NewMarket(
 		mkt.ID,
 		broker,
 	)
-	positionEngine := positions.New(log, positionConfig, mkt.ID)
+	positionEngine := positions.NewSnapshotEngine(log, positionConfig, mkt.ID)
 
 	feeEngine, err := fee.New(log, feeConfig, *mkt.Fees, asset)
 	if err != nil {

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -302,14 +302,6 @@ func getTestEngine(t *testing.T) *positions.SnapshotEngine {
 	)
 }
 
-func getTestSnapshotEngine(t *testing.T) *positions.SnapshotEngine {
-	t.Helper()
-	return positions.NewSnapshotEngine(
-		logging.NewTestLogger(), positions.NewDefaultConfig(),
-		"test_market",
-	)
-}
-
 func TestGetOpenInterestGivenTrades(t *testing.T) {
 	// A, B represents partys who already have positions
 	// C, D represents partys who don't have positions (but there are entries in "trades" array that contain their trades)

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -294,9 +294,17 @@ func testUnregisterOrderUnsuccessful(t *testing.T) {
 	})
 }
 
-func getTestEngine(t *testing.T) *positions.Engine {
+func getTestEngine(t *testing.T) *positions.SnapshotEngine {
 	t.Helper()
-	return positions.New(
+	return positions.NewSnapshotEngine(
+		logging.NewTestLogger(), positions.NewDefaultConfig(),
+		"test_market",
+	)
+}
+
+func getTestSnapshotEngine(t *testing.T) *positions.SnapshotEngine {
+	t.Helper()
+	return positions.NewSnapshotEngine(
 		logging.NewTestLogger(), positions.NewDefaultConfig(),
 		"test_market",
 	)
@@ -583,7 +591,7 @@ func TestHash(t *testing.T) {
 	}
 }
 
-func registerOrder(e *positions.Engine, side types.Side, party string, price *num.Uint, size uint64) {
+func registerOrder(e *positions.SnapshotEngine, side types.Side, party string, price *num.Uint, size uint64) {
 	e.RegisterOrder(&types.Order{
 		Party:     party,
 		Side:      side,

--- a/positions/snapshot_test.go
+++ b/positions/snapshot_test.go
@@ -67,7 +67,7 @@ func fillTestPositions(e *positions.SnapshotEngine) {
 }
 
 func TestSnapshotSaveAndLoad(t *testing.T) {
-	engine := getTestSnapshotEngine(t)
+	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()

--- a/positions/snapshot_test.go
+++ b/positions/snapshot_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func fillTestPositions(e *positions.Engine) {
+func fillTestPositions(e *positions.SnapshotEngine) {
 	orders := []types.Order{
 		{
 			Party:     "test_party_1",
@@ -67,7 +67,7 @@ func fillTestPositions(e *positions.Engine) {
 }
 
 func TestSnapshotSaveAndLoad(t *testing.T) {
-	engine := getTestEngine(t)
+	engine := getTestSnapshotEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()


### PR DESCRIPTION
This is just an experiment a trying to separate a tiny bit more the implementation of the snapshotting from the implementation of the engine itself. It doesn't bring much but would reduce code shared in the engine used only for snapshot.

Also the position engine wasn't chosen because of the actual implementation, the snasphoting code is actutally minimal in there. 

Also deterministic serialization of the protos is used (compatible only in go, and not accross version, but assuming we controle this...)

Also I'm not sure it's applicable in every situation.

Just looking to open discussion about this.

The drawbacks I can see is the overhead due to the indirection, but not sure it would be so bad. Also In more complex engine that would eventually stops us from doing fine grained snapshots most likely.

close #4339  