### PR TITLE
prevent overflow when party has pending undelegation and later dissoc…

### DIFF
--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -662,7 +662,11 @@ func (e *Engine) getNextEpochBalanceEvent(ctx context.Context, party, nodeID str
 		}
 	}
 
-	amt := num.Zero().Sub(num.Sum(delegatedToNode, pendingDelegated), pendingUndelegated)
+	potentialDelegationForNextEpoch := num.Sum(delegatedToNode, pendingDelegated)
+	amt := num.Zero()
+	if potentialDelegationForNextEpoch.GT(pendingUndelegated) {
+		amt = num.Zero().Sub(potentialDelegationForNextEpoch, pendingUndelegated)
+	}
 	return events.NewDelegationBalance(ctx, party, nodeID, amt, num.NewUint(seq+1).String())
 }
 

--- a/integration/features/delegation/reconciliation.feature
+++ b/integration/features/delegation/reconciliation.feature
@@ -134,6 +134,10 @@ Feature: Staking & Delegation
   Scenario: Party dissociation gets reconciled during the epoch incrementally
     Description: A party with delegation dissociates some tokens in multiple withdrawals which causes their whole delegation to be undone within 30 seconds and reflected before the epoch ends
    
+    Given the parties submit the following undelegations:
+    | party  | node id  | amount |  when         |
+    | party1 |  node1   |  100   |  end of epoch |      
+
     #epoch 1 withdraw 100 
     Given the parties withdraw from staking account the following amount:  
     | party  | asset  | amount |


### PR DESCRIPTION
…iates such that balance is 0

the scenario is the following (as implemented in the reconcile feature test:
epoch 0: party associates 100 tokens with VEGA
epoch 0: party nominates 100 to node 1
epoch 1: party requests to un-nominate 100 from node 1
epoch 1: party dissociates 100 VEGA 

as the request to un-nominate is not cancelled, to prevent the balance for epoch 2 to be negative (overflow) until the request is processed at the end of the epoch - we need to make the balance the max(0, delegated + pending delegation - pending undelegated)

close #4259 