### PR TITLE
Feature/4285 smoother checkpoints handling

### DIFF
--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -219,9 +219,13 @@ func (e *Engine) Load(ctx context.Context, cpt *types.CheckpointState) error {
 			logging.Int("hash-diff", hashDiff),
 		)
 	}
-	if e.loadHash == nil || !bytes.Equal(e.loadHash, cpt.Hash) {
-		return nil
+	if e.loadHash == nil {
+		return errors.New("no checkpoint expected to be restored")
 	}
+	if !bytes.Equal(e.loadHash, cpt.Hash) {
+		return fmt.Errorf("incompatible hashes, received(%v), expected(%v)", hex.EncodeToString(cpt.Hash), hex.EncodeToString(e.loadHash))
+	}
+
 	// we found the checkpoint we need to load, set value to nil
 	// either the checkpoint was loaded successfully, or it wasn't
 	// if this fails, the node goes down

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -14,8 +14,10 @@ import (
 )
 
 var (
-	ErrUnknownCheckpointName      = errors.New("component for checkpoint not registered")
-	ErrComponentWithDuplicateName = errors.New("multiple components with the same name")
+	ErrUnknownCheckpointName            = errors.New("component for checkpoint not registered")
+	ErrComponentWithDuplicateName       = errors.New("multiple components with the same name")
+	ErrNoCheckpointExpectedToBeRestored = errors.New("no checkpoint expected to be restored")
+	ErrIncompatibleHashes               = errors.New("incompatible hashes")
 
 	cpOrder = []types.CheckpointName{
 		types.AssetsCheckpoint,     // assets are required for collateral to work, and the vote asset needs to be restored
@@ -220,10 +222,10 @@ func (e *Engine) Load(ctx context.Context, cpt *types.CheckpointState) error {
 		)
 	}
 	if e.loadHash == nil {
-		return errors.New("no checkpoint expected to be restored")
+		return ErrNoCheckpointExpectedToBeRestored
 	}
 	if !bytes.Equal(e.loadHash, cpt.Hash) {
-		return fmt.Errorf("incompatible hashes, received(%v), expected(%v)", hex.EncodeToString(cpt.Hash), hex.EncodeToString(e.loadHash))
+		return fmt.Errorf("received(%v), expected(%v): %w", hex.EncodeToString(cpt.Hash), hex.EncodeToString(e.loadHash), ErrIncompatibleHashes)
 	}
 
 	// we found the checkpoint we need to load, set value to nil

--- a/checkpoint/engine_test.go
+++ b/checkpoint/engine_test.go
@@ -547,7 +547,7 @@ func testLoadGenesisHashOnlyOnce(t *testing.T) {
 	raw, err := eng.Checkpoint(ctx, time.Now())
 	require.NoError(t, err)
 	// calling load with this checkpoint now is a noop
-	require.NoError(t, eng.Load(ctx, raw))
+	require.Error(t, eng.Load(ctx, raw))
 	// pretend like the genesis block specified this hash to restore
 	set := genesis{
 		CP: &checkpoint.GenesisState{
@@ -563,7 +563,7 @@ func testLoadGenesisHashOnlyOnce(t *testing.T) {
 	// set up the engine to accept that hash
 	require.NoError(t, eng.UponGenesis(ctx, different))
 	// this doesn´t  call "load" on the components
-	require.NoError(t, eng.Load(ctx, raw))
+	require.Error(t, eng.Load(ctx, raw))
 	// now set the engine to accept the hash of the data we want to load
 	require.NoError(t, eng.UponGenesis(ctx, gen))
 	// now we do expect the calls to be made, but only once
@@ -572,7 +572,7 @@ func testLoadGenesisHashOnlyOnce(t *testing.T) {
 	}
 	require.NoError(t, eng.Load(ctx, raw))
 	// subsequent calls to load this checkpoint do nothing
-	require.NoError(t, eng.Load(ctx, raw))
+	require.Error(t, eng.Load(ctx, raw))
 }
 
 func testLoadAssets(t *testing.T) {
@@ -603,7 +603,7 @@ func testLoadAssets(t *testing.T) {
 	raw, err := eng.Checkpoint(ctx, time.Now())
 	require.NoError(t, err)
 	// calling load with this checkpoint now is a noop
-	require.NoError(t, eng.Load(ctx, raw))
+	require.Error(t, eng.Load(ctx, raw))
 	// pretend like the genesis block specified this hash to restore
 	set := genesis{
 		CP: &checkpoint.GenesisState{
@@ -629,7 +629,7 @@ func testLoadAssets(t *testing.T) {
 	collateral.EXPECT().EnableAsset(ctx, enabled).Times(1).Return(nil)
 	require.NoError(t, eng.Load(ctx, raw))
 	// subsequent calls to load this checkpoint do nothing
-	require.NoError(t, eng.Load(ctx, raw))
+	require.Error(t, eng.Load(ctx, raw))
 }
 
 type wrappedMock struct {

--- a/cmd/vega/checkpoint.go
+++ b/cmd/vega/checkpoint.go
@@ -73,10 +73,11 @@ func (c *checkpointRestore) Execute(_ []string) error {
 	cmd := &commandspb.RestoreSnapshot{
 		Data: cpData,
 	}
+
 	ch := make(chan error)
-	commander.Command(context.Background(), txn.CheckpointRestoreCommand, cmd, func(ok bool) {
-		if !ok {
-			ch <- fmt.Errorf("failed to send restore command")
+	commander.CommandSync(context.Background(), txn.CheckpointRestoreCommand, cmd, func(err error) {
+		if err != nil {
+			ch <- fmt.Errorf("failed to send restore command: %v", err)
 		}
 		close(ch)
 	})
@@ -107,7 +108,7 @@ func getNodeWalletCommander(log *logging.Logger) (*nodewallets.Commander, error)
 		return nil, fmt.Errorf("couldn't initialise ABCI client: %w", err)
 	}
 
-	commander, err := nodewallets.NewCommander(log, nil, vegaWallet, statistics)
+	commander, err := nodewallets.NewCommander(cfg.NodeWallet, log, nil, vegaWallet, statistics)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't initialise node wallet commander: %w", err)
 	}

--- a/cmd/vega/checkpoint.go
+++ b/cmd/vega/checkpoint.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
+	"strconv"
+	"time"
 
+	api "code.vegaprotocol.io/protos/vega/api/v1"
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
 	vgfs "code.vegaprotocol.io/shared/libs/fs"
 	"code.vegaprotocol.io/shared/paths"
@@ -13,10 +17,10 @@ import (
 	"code.vegaprotocol.io/vega/config"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/nodewallets"
-	"code.vegaprotocol.io/vega/stats"
 	"code.vegaprotocol.io/vega/txn"
 
 	"github.com/jessevdk/go-flags"
+	"google.golang.org/grpc"
 )
 
 type CheckpointCmd struct {
@@ -65,10 +69,11 @@ func (c *checkpointRestore) Execute(_ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read checkpoint file: %w", err)
 	}
-	commander, err := getNodeWalletCommander(log)
+	commander, cfunc, err := getNodeWalletCommander(log)
 	if err != nil {
 		return fmt.Errorf("failed to get commander: %w", err)
 	}
+	defer cfunc()
 
 	cmd := &commandspb.RestoreSnapshot{
 		Data: cpData,
@@ -84,35 +89,64 @@ func (c *checkpointRestore) Execute(_ []string) error {
 	return <-ch
 }
 
-func getNodeWalletCommander(log *logging.Logger) (*nodewallets.Commander, error) {
+func getNodeWalletCommander(log *logging.Logger) (*nodewallets.Commander, context.CancelFunc, error) {
 	vegaPaths := paths.New(checkpointCmd.VegaHome)
 
 	_, cfg, err := config.EnsureNodeConfig(vegaPaths)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	registryPass, err := checkpointCmd.PassphraseFile.Get("node wallet", false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	vegaWallet, err := nodewallets.GetVegaWallet(vegaPaths, registryPass)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get Vega node wallet: %w", err)
+		return nil, nil, fmt.Errorf("couldn't get Vega node wallet: %w", err)
 	}
 
-	statistics := stats.New(log, cfg.Stats, CLIVersion, CLIVersionHash)
 	abciClient, err := abci.NewClient(cfg.Blockchain.Tendermint.ClientAddr)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't initialise ABCI client: %w", err)
+		return nil, nil, fmt.Errorf("couldn't initialise ABCI client: %w", err)
 	}
 
-	commander, err := nodewallets.NewCommander(cfg.NodeWallet, log, nil, vegaWallet, statistics)
+	coreClient, err := getCoreClient(
+		net.JoinHostPort(cfg.API.IP, strconv.Itoa(cfg.API.Port)))
 	if err != nil {
-		return nil, fmt.Errorf("couldn't initialise node wallet commander: %w", err)
+		return nil, nil, fmt.Errorf("couldn't connect to node: %w", err)
+	}
+
+	ctx, cancel := timeoutContext()
+	resp, err := coreClient.LastBlockHeight(ctx, &api.LastBlockHeightRequest{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't get last block height: %w", err)
+	}
+
+	commander, err := nodewallets.NewCommander(cfg.NodeWallet, log, nil, vegaWallet, heightProvider(resp.Height))
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't initialise node wallet commander: %w", err)
 	}
 
 	commander.SetChain(blockchain.NewClient(abciClient))
-	return commander, nil
+	return commander, cancel, nil
+}
+
+type heightProvider uint64
+
+func (h heightProvider) Height() uint64 {
+	return uint64(h)
+}
+
+func getCoreClient(address string) (api.CoreServiceClient, error) {
+	tdconn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	return api.NewCoreServiceClient(tdconn), nil
+}
+
+func timeoutContext() (context.Context, func()) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
 }

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -313,7 +313,7 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 	)
 
 	// we cannot pass the Chain dependency here (that's set by the blockchain)
-	commander, err := nodewallets.NewCommander(l.Log, nil, l.nodeWallets.Vega, l.stats)
+	commander, err := nodewallets.NewCommander(l.conf.NodeWallet, l.Log, nil, l.nodeWallets.Vega, l.stats)
 	if err != nil {
 		return err
 	}

--- a/cmd/vegabenchmark/mocks/commander_mock.go
+++ b/cmd/vegabenchmark/mocks/commander_mock.go
@@ -36,7 +36,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(bool)) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3)
 }

--- a/cmd/vegabenchmark/mocks/interface.go
+++ b/cmd/vegabenchmark/mocks/interface.go
@@ -69,7 +69,7 @@ type OracleAdaptors interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination commander_mock.go -package mocks code.vegaprotocol.io/vega/cmd/vegabenchmark/mocks Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(bool))
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error))
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination governance_engine_mock.go -package mocks code.vegaprotocol.io/vega/cmd/vegabenchmark/mocks GovernanceEngine

--- a/evtforward/evtforward.go
+++ b/evtforward/evtforward.go
@@ -34,7 +34,7 @@ type TimeService interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/evtforward Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(bool))
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error))
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/validator_topology_mock.go -package mocks code.vegaprotocol.io/vega/evtforward ValidatorTopology

--- a/evtforward/mocks/commander_mock.go
+++ b/evtforward/mocks/commander_mock.go
@@ -36,7 +36,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(bool)) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3)
 }

--- a/nodewallets/commander.go
+++ b/nodewallets/commander.go
@@ -40,8 +40,9 @@ type Commander struct {
 // NewCommander - used to sign and send transaction from core
 // e.g. NodeRegistration, NodeVote
 // chain argument can't be passed in cmd package, but is used for tests.
-func NewCommander(log *logging.Logger, bc Chain, w *vega.Wallet, bstats BlockchainStats) (*Commander, error) {
+func NewCommander(cfg Config, log *logging.Logger, bc Chain, w *vega.Wallet, bstats BlockchainStats) (*Commander, error) {
 	log = log.Named(commanderNamedLogger)
+	log.SetLevel(cfg.Level.Get())
 	return &Commander{
 		log:    log,
 		bc:     bc,
@@ -56,7 +57,15 @@ func (c *Commander) SetChain(bc *blockchain.Client) {
 }
 
 // Command - send command to chain.
-func (c *Commander) Command(_ context.Context, cmd txn.Command, payload proto.Message, done func(bool)) {
+func (c *Commander) Command(ctx context.Context, cmd txn.Command, payload proto.Message, done func(error)) {
+	c.command(ctx, cmd, payload, done, api.SubmitTransactionRequest_TYPE_ASYNC)
+}
+
+func (c *Commander) CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, done func(error)) {
+	c.command(ctx, cmd, payload, done, api.SubmitTransactionRequest_TYPE_SYNC)
+}
+
+func (c *Commander) command(_ context.Context, cmd txn.Command, payload proto.Message, done func(error), ty api.SubmitTransactionRequest_Type) {
 	if c.bc == nil {
 		panic("commander was instantiating without chain")
 	}
@@ -78,16 +87,16 @@ func (c *Commander) Command(_ context.Context, cmd txn.Command, payload proto.Me
 		}
 
 		tx := commands.NewTransaction(c.wallet.PubKey().Hex(), marshalledData, signature)
-		err = c.bc.SubmitTransactionV2(ctx, tx, api.SubmitTransactionRequest_TYPE_ASYNC)
+		err = c.bc.SubmitTransactionV2(ctx, tx, ty)
 		if err != nil {
 			// this can happen as network dependent
-			c.log.Error("could not send transaction to tendermint",
+			c.log.Debug("could not send transaction to tendermint",
 				logging.Error(err),
 				logging.String("tx", payload.String()))
 		}
 
 		if done != nil {
-			done(err == nil)
+			done(err)
 		}
 	}()
 }

--- a/nodewallets/commander.go
+++ b/nodewallets/commander.go
@@ -43,6 +43,7 @@ type Commander struct {
 func NewCommander(cfg Config, log *logging.Logger, bc Chain, w *vega.Wallet, bstats BlockchainStats) (*Commander, error) {
 	log = log.Named(commanderNamedLogger)
 	log.SetLevel(cfg.Level.Get())
+
 	return &Commander{
 		log:    log,
 		bc:     bc,

--- a/nodewallets/commander_test.go
+++ b/nodewallets/commander_test.go
@@ -47,7 +47,8 @@ func getTestCommander(t *testing.T) *testCommander {
 	require.NoError(t, err)
 	require.NotNil(t, wallet)
 
-	cmd, err := nodewallets.NewCommander(logging.NewTestLogger(), chain, wallet, bstats)
+	cmd, err := nodewallets.NewCommander(
+		nodewallets.NewDefaultConfig(), logging.NewTestLogger(), chain, wallet, bstats)
 	require.NoError(t, err)
 
 	return &testCommander{
@@ -88,11 +89,11 @@ func testSignedCommandSuccess(t *testing.T) {
 	commander.chain.EXPECT().SubmitTransactionV2(
 		gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
-	ok := make(chan bool)
-	commander.Command(ctx, cmd, payload, func(b bool) {
-		ok <- b
+	ok := make(chan error)
+	commander.Command(ctx, cmd, payload, func(err error) {
+		ok <- err
 	})
-	assert.True(t, <-ok)
+	assert.NoError(t, <-ok)
 }
 
 func testSignedCommandFailure(t *testing.T) {
@@ -110,11 +111,11 @@ func testSignedCommandFailure(t *testing.T) {
 	commander.chain.EXPECT().SubmitTransactionV2(
 		gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(errors.New("bad bad"))
 
-	ok := make(chan bool)
-	commander.Command(ctx, cmd, payload, func(b bool) {
-		ok <- b
+	ok := make(chan error)
+	commander.Command(ctx, cmd, payload, func(err error) {
+		ok <- err
 	})
-	assert.False(t, <-ok)
+	assert.Error(t, <-ok)
 }
 
 func (t *testCommander) Finish() {

--- a/notary/mocks/commander_mock.go
+++ b/notary/mocks/commander_mock.go
@@ -36,7 +36,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(bool)) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3)
 }

--- a/notary/notary.go
+++ b/notary/notary.go
@@ -40,7 +40,7 @@ type Broker interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/processor Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(bool))
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error))
 }
 
 // Notary will aggregate all signatures of a node for

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -15,6 +15,7 @@ import (
 	"code.vegaprotocol.io/shared/paths"
 
 	"code.vegaprotocol.io/vega/blockchain/abci"
+	"code.vegaprotocol.io/vega/checkpoint"
 	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/genesis"
@@ -1097,7 +1098,7 @@ func (app *App) DeliverReloadCheckpoint(ctx context.Context, tx abci.Tx) (err er
 	ctx = vgcontext.WithBlockHeight(ctx, bh)
 	app.blockCtx = ctx
 	err = app.checkpoint.Load(ctx, cpt)
-	if err != nil && err != types.ErrCheckpointStateInvalid && err != types.ErrCheckpointHashIncorrect {
+	if err != nil && err != types.ErrCheckpointStateInvalid && err != types.ErrCheckpointHashIncorrect && !errors.Is(err, checkpoint.ErrNoCheckpointExpectedToBeRestored) && !errors.Is(err, checkpoint.ErrIncompatibleHashes) {
 		app.log.Panic("Failed to restore checkpoint", logging.Error(err))
 	}
 	// set flag in case the CP has been reloaded

--- a/processor/mocks/checkpoint_mock.go
+++ b/processor/mocks/checkpoint_mock.go
@@ -92,3 +92,17 @@ func (mr *MockCheckpointMockRecorder) Load(arg0, arg1 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockCheckpoint)(nil).Load), arg0, arg1)
 }
+
+// ValidateCheckpoint mocks base method
+func (m *MockCheckpoint) ValidateCheckpoint(arg0 *types.CheckpointState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateCheckpoint", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateCheckpoint indicates an expected call of ValidateCheckpoint
+func (mr *MockCheckpointMockRecorder) ValidateCheckpoint(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCheckpoint", reflect.TypeOf((*MockCheckpoint)(nil).ValidateCheckpoint), arg0)
+}

--- a/processor/mocks/commander_mock.go
+++ b/processor/mocks/commander_mock.go
@@ -36,7 +36,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(bool)) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3)
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -117,7 +117,7 @@ type Assets interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/processor Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(bool))
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error))
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/validator_topology_mock.go -package mocks code.vegaprotocol.io/vega/processor ValidatorTopology

--- a/stats/blockchain.go
+++ b/stats/blockchain.go
@@ -76,6 +76,10 @@ func (b *Blockchain) IncHeight() {
 	b.height++
 }
 
+func (b *Blockchain) SetHeight(height uint64) {
+	b.height = height
+}
+
 // AverageTxSizeBytes return the average size in bytes of the
 // transaction sent to vega.
 func (b *Blockchain) AverageTxSizeBytes() uint64 {

--- a/validators/mocks/commander_mock.go
+++ b/validators/mocks/commander_mock.go
@@ -36,7 +36,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(bool)) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
Combine 2 issues.

Add better logs and errors handling / display for when trying to get a checkpoint in both from the command line and the core side of things
Also fix the checkpoint command to use the proper block height.

But also allow use to submit a checkpoint during the bootstraping period. This is not executed until the bootstraping period is finished.


close #4282 
close #4285  