### PR TITLE
4261 snapshot stake verifier

### DIFF
--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -369,7 +369,8 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 		panic(err)
 	}
 	// @TODO register StateProviders with snapshot engine:
-	l.snapshot.AddProviders(l.checkpoint, l.collateral, l.governance, l.delegation, l.netParams, l.epochService, l.assets, l.banking, l.notary, l.spam, l.rewards, l.stakingAccounts)
+	l.snapshot.AddProviders(l.checkpoint, l.collateral, l.governance, l.delegation, l.netParams, l.epochService, l.assets, l.banking,
+		l.notary, l.spam, l.rewards, l.stakingAccounts, l.stakeVerifier, l.limits)
 	// these haven't been implemented yet. Replay protection will require some trickery.
 	// l.snapshot.AddProviders(l.executionEngine)
 

--- a/limits/snapshot.go
+++ b/limits/snapshot.go
@@ -1,6 +1,8 @@
 package limits
 
 import (
+	"context"
+
 	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/types"
 
@@ -67,7 +69,7 @@ func (e *Engine) Namespace() types.SnapshotNamespace {
 }
 
 func (e *Engine) Keys() []string {
-	return []string{allKey}
+	return hashKeys
 }
 
 func (e *Engine) GetHash(k string) ([]byte, error) {
@@ -80,28 +82,16 @@ func (e *Engine) GetState(k string) ([]byte, error) {
 	return data, err
 }
 
-func (e *Engine) Snapshot() (map[string][]byte, error) {
-	r := make(map[string][]byte, len(hashKeys))
-	for _, k := range hashKeys {
-		state, err := e.GetState(k)
-		if err != nil {
-			return nil, err
-		}
-		r[k] = state
-	}
-	return r, nil
-}
-
-func (e *Engine) LoadState(payload *types.Payload) error {
+func (e *Engine) LoadState(_ context.Context, payload *types.Payload) ([]types.StateProvider, error) {
 	if e.Namespace() != payload.Data.Namespace() {
-		return types.ErrInvalidSnapshotNamespace
+		return nil, types.ErrInvalidSnapshotNamespace
 	}
 
 	switch pl := payload.Data.(type) {
 	case *types.PayloadLimitState:
-		return e.restoreLimits(pl.LimitState)
+		return nil, e.restoreLimits(pl.LimitState)
 	default:
-		return types.ErrUnknownSnapshotType
+		return nil, types.ErrUnknownSnapshotType
 	}
 }
 

--- a/limits/snapshot_test.go
+++ b/limits/snapshot_test.go
@@ -28,7 +28,7 @@ func TestLimitSnapshotEmpty(t *testing.T) {
 func TestLimitSnapshotWrongPayLoad(t *testing.T) {
 	l := getLimitsTest()
 	snap := &types.Payload{Data: &types.PayloadEpoch{}}
-	err := l.LoadState(snap)
+	_, err := l.LoadState(context.Background(), snap)
 	assert.ErrorIs(t, types.ErrInvalidSnapshotNamespace, err)
 }
 
@@ -48,6 +48,7 @@ func TestLimitSnapshotGenesisState(t *testing.T) {
 }
 
 func TestLimitSnapshotBlockCount(t *testing.T) {
+	ctx := context.Background()
 	gs := &limits.GenesisState{
 		BootstrapBlockCount: 1,
 	}
@@ -58,7 +59,7 @@ func TestLimitSnapshotBlockCount(t *testing.T) {
 	require.Nil(t, err)
 
 	// increase block count and hash should change
-	lmt.OnTick(context.Background(), time.Unix(3000, 0))
+	lmt.OnTick(ctx, time.Unix(3000, 0))
 	require.False(t, lmt.BootstrapFinished())
 
 	h2, err := lmt.GetHash(allKey)
@@ -76,7 +77,7 @@ func TestLimitSnapshotBlockCount(t *testing.T) {
 	// be counting the expected steps for boostrapping to have finished
 	snapLmt := getLimitsTest()
 	snapLmt.loadGenesisState(t, gs)
-	err = snapLmt.LoadState(types.PayloadFromProto(snap))
+	_, err = snapLmt.LoadState(ctx, types.PayloadFromProto(snap))
 	require.Nil(t, err)
 	require.False(t, snapLmt.BootstrapFinished())
 
@@ -85,6 +86,7 @@ func TestLimitSnapshotBlockCount(t *testing.T) {
 }
 
 func TestLimitSnapshotBootstrapFinished(t *testing.T) {
+	ctx := context.Background()
 	gs := &limits.GenesisState{
 		BootstrapBlockCount:  0,
 		ProposeMarketEnabled: true,
@@ -94,7 +96,7 @@ func TestLimitSnapshotBootstrapFinished(t *testing.T) {
 	lmt.loadGenesisState(t, gs)
 
 	// Tick to get out of bootstrapping
-	lmt.OnTick(context.Background(), time.Unix(3000, 0))
+	lmt.OnTick(ctx, time.Unix(3000, 0))
 	require.True(t, lmt.CanProposeAsset())
 	require.True(t, lmt.CanProposeMarket())
 	require.True(t, lmt.BootstrapFinished())
@@ -109,7 +111,7 @@ func TestLimitSnapshotBootstrapFinished(t *testing.T) {
 	// Load state into new engine and check all the flags have returned
 	snapLmt := getLimitsTest()
 	snapLmt.loadGenesisState(t, gs)
-	err = snapLmt.LoadState(types.PayloadFromProto(snap))
+	_, err = snapLmt.LoadState(ctx, types.PayloadFromProto(snap))
 	require.Nil(t, err)
 	require.True(t, lmt.CanProposeAsset())
 	require.True(t, lmt.CanProposeMarket())

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -101,6 +101,7 @@ var nodeOrder = []types.SnapshotNamespace{
 	types.PositionsSnapshot, // again, needs a market
 	types.EpochSnapshot,
 	types.StakingSnapshot,
+	types.StakeVerifierSnapshot,
 	types.SpamSnapshot,
 	types.LimitSnapshot,
 	types.ReplayProtectionSnapshot,

--- a/staking/mocks/witness_mock.go
+++ b/staking/mocks/witness_mock.go
@@ -34,6 +34,20 @@ func (m *MockWitness) EXPECT() *MockWitnessMockRecorder {
 	return m.recorder
 }
 
+// RestoreResource mocks base method
+func (m *MockWitness) RestoreResource(arg0 validators.Resource, arg1 func(interface{}, bool)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreResource", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreResource indicates an expected call of RestoreResource
+func (mr *MockWitnessMockRecorder) RestoreResource(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreResource", reflect.TypeOf((*MockWitness)(nil).RestoreResource), arg0, arg1)
+}
+
 // StartCheck mocks base method
 func (m *MockWitness) StartCheck(arg0 validators.Resource, arg1 func(interface{}, bool), arg2 time.Time) error {
 	m.ctrl.T.Helper()

--- a/staking/stake_verifier_snapshot.go
+++ b/staking/stake_verifier_snapshot.go
@@ -1,0 +1,148 @@
+package staking
+
+import (
+	"context"
+
+	"code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/types"
+
+	"github.com/golang/protobuf/proto"
+)
+
+var (
+	depositedKey = (&types.PayloadStakeVerifierDeposited{}).Key()
+	removedKey   = (&types.PayloadStakeVerifierRemoved{}).Key()
+
+	hashKeys = []string{
+		depositedKey,
+		removedKey,
+	}
+)
+
+type stakeVerifierSnapshotState struct {
+	hash       map[string][]byte
+	serialised map[string][]byte
+	changed    map[string]bool
+}
+
+func (s *StakeVerifier) serialisePendingSD() ([]byte, error) {
+	deposited := make([]*types.StakeDeposited, 0, len(s.pendingSDs))
+
+	for _, p := range s.pendingSDs {
+		deposited = append(deposited, p.StakeDeposited)
+	}
+
+	pl := types.Payload{
+		Data: &types.PayloadStakeVerifierDeposited{
+			StakeVerifierDeposited: deposited,
+		},
+	}
+	return proto.Marshal(pl.IntoProto())
+}
+
+func (s *StakeVerifier) serialisePendingSR() ([]byte, error) {
+	removed := make([]*types.StakeRemoved, 0, len(s.pendingSRs))
+
+	for _, p := range s.pendingSRs {
+		removed = append(removed, p.StakeRemoved)
+	}
+
+	pl := types.Payload{
+		Data: &types.PayloadStakeVerifierRemoved{
+			StakeVerifierRemoved: removed,
+		},
+	}
+	return proto.Marshal(pl.IntoProto())
+}
+
+// get the serialised form and hash of the given key.
+func (s *StakeVerifier) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	if _, ok := s.keyToSerialiser[k]; !ok {
+		return nil, nil, types.ErrSnapshotKeyDoesNotExist
+	}
+
+	if !s.svss.changed[k] {
+		return s.svss.serialised[k], s.svss.hash[k], nil
+	}
+
+	data, err := s.keyToSerialiser[k]()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hash := crypto.Hash(data)
+	s.svss.serialised[k] = data
+	s.svss.hash[k] = hash
+	s.svss.changed[k] = false
+	return data, hash, nil
+}
+
+func (s *StakeVerifier) Namespace() types.SnapshotNamespace {
+	return types.StakeVerifierSnapshot
+}
+
+func (s *StakeVerifier) Keys() []string {
+	return hashKeys
+}
+
+func (s *StakeVerifier) GetHash(k string) ([]byte, error) {
+	_, hash, err := s.getSerialisedAndHash(k)
+	return hash, err
+}
+
+func (s *StakeVerifier) GetState(k string) ([]byte, error) {
+	data, _, err := s.getSerialisedAndHash(k)
+	return data, err
+}
+
+func (s *StakeVerifier) LoadState(ctx context.Context, payload *types.Payload) ([]types.StateProvider, error) {
+	if s.Namespace() != payload.Data.Namespace() {
+		return nil, types.ErrInvalidSnapshotNamespace
+	}
+
+	switch pl := payload.Data.(type) {
+	case *types.PayloadStakeVerifierDeposited:
+		return nil, s.restorePendingSD(ctx, pl.StakeVerifierDeposited)
+	case *types.PayloadStakeVerifierRemoved:
+		return nil, s.restorePendingSR(ctx, pl.StakeVerifierRemoved)
+	default:
+		return nil, types.ErrUnknownSnapshotType
+	}
+}
+
+func (s *StakeVerifier) restorePendingSD(ctx context.Context, deposited []*types.StakeDeposited) error {
+	s.pendingSDs = make([]*pendingSD, 0, len(deposited))
+
+	for _, d := range deposited {
+		s.ensureNotDuplicate(d.ID, d.Hash())
+
+		pending := &pendingSD{
+			StakeDeposited: d,
+			check:          func() error { return s.ocv.CheckStakeDeposited(d) },
+		}
+
+		s.pendingSDs = append(s.pendingSDs, pending)
+		s.witness.RestoreResource(pending, s.onEventVerified)
+	}
+	s.svss.changed[depositedKey] = true
+	return nil
+}
+
+func (s *StakeVerifier) restorePendingSR(ctx context.Context, removed []*types.StakeRemoved) error {
+	s.pendingSRs = make([]*pendingSR, 0, len(removed))
+
+	for _, r := range removed {
+		s.ensureNotDuplicate(r.ID, r.Hash())
+
+		pending := &pendingSR{
+			StakeRemoved: r,
+			check:        func() error { return s.ocv.CheckStakeRemoved(r) },
+		}
+
+		s.pendingSRs = append(s.pendingSRs, pending)
+		s.witness.RestoreResource(pending, s.onEventVerified)
+	}
+
+	s.svss.changed[removedKey] = true
+	return nil
+}

--- a/staking/stake_verifier_snapshot.go
+++ b/staking/stake_verifier_snapshot.go
@@ -114,7 +114,10 @@ func (s *StakeVerifier) restorePendingSD(ctx context.Context, deposited []*types
 	s.pendingSDs = make([]*pendingSD, 0, len(deposited))
 
 	for _, d := range deposited {
-		s.ensureNotDuplicate(d.ID, d.Hash())
+		// this populates the id/hash structs
+		if !s.ensureNotDuplicate(d.ID, d.Hash()) {
+			s.log.Panic("pendingSD's unexpectedly pre-populated when restoring from snapshot")
+		}
 
 		pending := &pendingSD{
 			StakeDeposited: d,
@@ -132,7 +135,10 @@ func (s *StakeVerifier) restorePendingSR(ctx context.Context, removed []*types.S
 	s.pendingSRs = make([]*pendingSR, 0, len(removed))
 
 	for _, r := range removed {
-		s.ensureNotDuplicate(r.ID, r.Hash())
+		// this populates the id/hash structs
+		if !s.ensureNotDuplicate(r.ID, r.Hash()) {
+			s.log.Panic("pendingSR's unexpectedly pre-populated when restoring from snapshot")
+		}
 
 		pending := &pendingSR{
 			StakeRemoved: r,

--- a/staking/stake_verifier_snapshot_test.go
+++ b/staking/stake_verifier_snapshot_test.go
@@ -1,0 +1,135 @@
+package staking_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	snapshot "code.vegaprotocol.io/protos/vega/snapshot/v1"
+	"code.vegaprotocol.io/vega/staking"
+	"code.vegaprotocol.io/vega/types"
+	"code.vegaprotocol.io/vega/types/num"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	depositedKey = (&types.PayloadStakeVerifierDeposited{}).Key()
+	removedKey   = (&types.PayloadStakeVerifierRemoved{}).Key()
+)
+
+func TestSVSnapshotEmpty(t *testing.T) {
+	sv := getStakeVerifierTest(t)
+	defer sv.ctrl.Finish()
+
+	assert.Equal(t, 2, len(sv.Keys()))
+
+	h, err := sv.GetHash(depositedKey)
+	require.Nil(t, err)
+	require.NotNil(t, h)
+
+	h, err = sv.GetHash(removedKey)
+	require.Nil(t, err)
+	require.NotNil(t, h)
+}
+
+func TestSVSnapshotDeposited(t *testing.T) {
+	key := depositedKey
+	ctx := context.Background()
+	sv := getStakeVerifierTest(t)
+	defer sv.ctrl.Finish()
+
+	sv.broker.EXPECT().Send(gomock.Any()).Times(1)
+	sv.witness.EXPECT().StartCheck(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+
+	h1, err := sv.GetHash(key)
+	require.Nil(t, err)
+	require.NotNil(t, h1)
+
+	event := &types.StakeDeposited{
+		BlockNumber:     42,
+		LogIndex:        1789,
+		TxID:            "somehash",
+		ID:              "someid",
+		VegaPubKey:      "somepubkey",
+		EthereumAddress: "0xnothex",
+		Amount:          num.NewUint(1000),
+		BlockTime:       100000,
+	}
+
+	err = sv.ProcessStakeDeposited(ctx, event)
+	require.Nil(t, err)
+
+	h2, err := sv.GetHash(key)
+	require.Nil(t, err)
+	require.False(t, bytes.Equal(h1, h2))
+
+	state, err := sv.GetState(key)
+	require.Nil(t, err)
+
+	snap := &snapshot.Payload{}
+	err = proto.Unmarshal(state, snap)
+	require.Nil(t, err)
+
+	// Restore into new things
+	snapSV := getStakeVerifierTest(t)
+	defer snapSV.ctrl.Finish()
+	snapSV.witness.EXPECT().RestoreResource(gomock.Any(), gomock.Any()).Times(1)
+
+	_, err = snapSV.LoadState(ctx, types.PayloadFromProto(snap))
+	require.Nil(t, err)
+	// Check its there by adding it again and checking for duplication error
+	require.ErrorIs(t, staking.ErrDuplicatedStakeDepositedEvent, snapSV.ProcessStakeDeposited(ctx, event))
+}
+
+func TestSVSnapshotRemoved(t *testing.T) {
+	key := removedKey
+	ctx := context.Background()
+	sv := getStakeVerifierTest(t)
+	defer sv.ctrl.Finish()
+
+	sv.broker.EXPECT().Send(gomock.Any()).Times(1)
+	sv.witness.EXPECT().StartCheck(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+
+	h1, err := sv.GetHash(key)
+	require.Nil(t, err)
+	require.NotNil(t, h1)
+
+	event := &types.StakeRemoved{
+		BlockNumber:     42,
+		LogIndex:        1789,
+		TxID:            "somehash",
+		ID:              "someid",
+		VegaPubKey:      "somepubkey",
+		EthereumAddress: "0xnothex",
+		Amount:          num.NewUint(1000),
+		BlockTime:       100000,
+	}
+
+	err = sv.ProcessStakeRemoved(ctx, event)
+	require.Nil(t, err)
+
+	h2, err := sv.GetHash(key)
+	require.Nil(t, err)
+	require.False(t, bytes.Equal(h1, h2))
+
+	state, err := sv.GetState(key)
+	require.Nil(t, err)
+
+	snap := &snapshot.Payload{}
+	err = proto.Unmarshal(state, snap)
+	require.Nil(t, err)
+
+	// Restore into new things
+	snapSV := getStakeVerifierTest(t)
+	defer snapSV.ctrl.Finish()
+	snapSV.witness.EXPECT().RestoreResource(gomock.Any(), gomock.Any()).Times(1)
+
+	_, err = snapSV.LoadState(ctx, types.PayloadFromProto(snap))
+	require.Nil(t, err)
+	// Check its there by adding it again and checking for duplication error
+	require.ErrorIs(t, staking.ErrDuplicatedStakeRemovedEvent, snapSV.ProcessStakeRemoved(ctx, event))
+}

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -46,6 +46,7 @@ const (
 	SpamSnapshot             SnapshotNamespace = "spam"
 	LimitSnapshot            SnapshotNamespace = "limits"
 	NotarySnapshot           SnapshotNamespace = "notary"
+	StakeVerifierSnapshot    SnapshotNamespace = "stakeverifier"
 	ReplayProtectionSnapshot SnapshotNamespace = "replay"
 	EventForwarderSnapshot   SnapshotNamespace = "eventforwarder"
 	WitnessSnapshot          SnapshotNamespace = "witness"


### PR DESCRIPTION
closes #4261 

This PR implements snapshotting of the stake-verfier. While I was there, I also added the limits engine as a stateprovider to the snapshot engine since it was missing.