### PR TITLE
Extend integration tests with global check for net deposits

### DIFF
--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -553,7 +553,7 @@ func (e *Engine) FinalSettlement(ctx context.Context, marketID string, transfers
 
 		for _, bal := range res.Balances {
 			amountCollected.AddSum(bal.Balance)
-			if err := e.UpdateBalance(ctx, bal.Account.ID, bal.Balance); err != nil {
+			if err := e.IncrementBalance(ctx, bal.Account.ID, bal.Balance); err != nil {
 				e.log.Error(
 					"Could not update the target account in transfer",
 					logging.String("account-id", bal.Account.ID),
@@ -650,7 +650,7 @@ func (e *Engine) FinalSettlement(ctx context.Context, marketID string, transfers
 
 		// update the to accounts now
 		for _, bal := range res.Balances {
-			if err := e.UpdateBalance(ctx, bal.Account.ID, bal.Balance); err != nil {
+			if err := e.IncrementBalance(ctx, bal.Account.ID, bal.Balance); err != nil {
 				e.log.Error(
 					"Could not update the target account in transfer",
 					logging.String("account-id", bal.Account.ID),

--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -120,9 +120,11 @@ type Engine struct {
 
 // New instantiate a new delegation engine.
 func New(log *logging.Logger, config Config, broker Broker, topology ValidatorTopology, stakingAccounts StakingAccounts, epochEngine EpochEngine, ts TimeService) *Engine {
+	log = log.Named(namedLogger)
+	log.SetLevel(config.Level.Get())
 	e := &Engine{
 		config:               config,
-		log:                  log.Named(namedLogger),
+		log:                  log,
 		broker:               broker,
 		topology:             topology,
 		stakingAccounts:      stakingAccounts,

--- a/integration/features/insurance_pool/verified-loss-socialization-case4.feature
+++ b/integration/features/insurance_pool/verified-loss-socialization-case4.feature
@@ -7,7 +7,7 @@ Feature: Test loss socialization case 4
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 1     |
-      
+
   Scenario: case 4 from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
 # setup accounts
     Given the initial insurance pool balance is "2900" for the markets:
@@ -15,12 +15,12 @@ Feature: Test loss socialization case 4
       | party           | asset | amount    |
       | sellSideProvider | BTC   | 100000000 |
       | buySideProvider  | BTC   | 100000000 |
-      | party1          | BTC   | 2000      |
-      | party2          | BTC   | 10000     |
-      | party3          | BTC   | 3000      |
-      | party4          | BTC   | 10000     |
-      | party5          | BTC   | 100000000 |
-      | party6          | BTC   | 100000000 |
+      | party1           | BTC   | 2000      |
+      | party2           | BTC   | 10000     |
+      | party3           | BTC   | 3000      |
+      | party4           | BTC   | 10000     |
+      | party5           | BTC   | 100000000 |
+      | party6           | BTC   | 100000000 |
       | aux1             | BTC   | 100000000 |
       | aux2             | BTC   | 100000000 |
 

--- a/integration/features/settlement/settlement_at_expiry.feature
+++ b/integration/features/settlement/settlement_at_expiry.feature
@@ -9,7 +9,7 @@ Feature: Test settlement at expiry
 
     And the oracle spec for trading termination filtering data from "0xCAFECAFE" named "ethDec20Oracle":
       | property           | type           | binding              |
-      | trading.terminated | TYPE_BOOLEAN   | trading termination  |  
+      | trading.terminated | TYPE_BOOLEAN   | trading termination  |
 
     And the markets:
       | id        | quote name | asset | maturity date        | risk model                  | margin calculator         | auction duration | fees         | price monitoring | oracle config          |
@@ -124,7 +124,7 @@ Feature: Test settlement at expiry
       | party1 | ETH/DEC19 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | ref-1     | OrderError: Invalid Market ID |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general |
-      | party1 | ETH   | ETH/DEC19 | 0      | 11676   |
+      | party1 | ETH   | ETH/DEC19 | 0      | 11916   |
       | party2 | ETH   | ETH/DEC19 | 0      | 42      |
       | party3 | ETH   | ETH/DEC19 | 0      | 4042    |
     # And the cumulated balance for all accounts should be worth "100214513"
@@ -194,8 +194,8 @@ Scenario: Settlement happened when market is being closed - no loss socialisatio
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general |
-      | party1 | ETH   | ETH/DEC19 | 0      | 11676   |
-      | party2 | ETH   | ETH/DEC19 | 0      | 0      |
+      | party1 | ETH   | ETH/DEC19 | 0      | 11916   |
+      | party2 | ETH   | ETH/DEC19 | 0      | 0       |
     # And the cumulated balance for all accounts should be worth "100214513"
     And the insurance pool balance should be "0" for the market "ETH/DEC19"
     # 916 were taken from the insurance pool to cover the losses of party 2, the remaining is split between global and the other market
@@ -263,7 +263,7 @@ Scenario: Settlement happened when market is being closed - loss socialisation i
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general |
-      | party1 | ETH   | ETH/DEC19 | 0      | 11399   |
+      | party1 | ETH   | ETH/DEC19 | 0      | 11639   |
       | party2 | ETH   | ETH/DEC19 | 0      | 0       |
     # And the cumulated balance for all accounts should be worth "100214513"
     And the insurance pool balance should be "0" for the market "ETH/DEC19"

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -69,6 +69,17 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		}
 	})
 
+	s.AfterScenario(func(s *godog.Scenario, err error) {
+		if err != nil {
+			return
+		}
+
+		berr := steps.TheCumulatedBalanceForAllAccountsShouldBeWorth(execsetup.broker, execsetup.netDeposits.String())
+		if berr != nil {
+			reporter.Fatalf("\n\nError at scenario end (testing net deposits/withdrawals against cumulated balance for all accounts): %v\n\n", berr)
+		}
+	})
+
 	// delegation/validator steps
 	s.Step(`the validators:$`, func(table *godog.Table) error {
 		return steps.TheValidators(execsetup.topology, execsetup.stakingAccount, execsetup.delegationEngine, table)
@@ -167,7 +178,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		return steps.PartiesPlaceTheFollowingPeggedOrders(execsetup.executionEngine, table)
 	})
 	s.Step(`^the parties deposit on asset's general account the following amount:$`, func(table *godog.Table) error {
-		return steps.PartiesDepositTheFollowingAssets(execsetup.collateralEngine, execsetup.broker, table)
+		return steps.PartiesDepositTheFollowingAssets(execsetup.collateralEngine, execsetup.broker, execsetup.netDeposits, table)
 	})
 	s.Step(`^the parties deposit on staking account the following amount:$`, func(table *godog.Table) error {
 		return steps.PartiesTransferToStakingAccount(execsetup.stakingAccount, execsetup.broker, table, "")
@@ -177,7 +188,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	})
 
 	s.Step(`^the parties withdraw the following assets:$`, func(table *godog.Table) error {
-		return steps.PartiesWithdrawTheFollowingAssets(execsetup.collateralEngine, table)
+		return steps.PartiesWithdrawTheFollowingAssets(execsetup.collateralEngine, execsetup.netDeposits, table)
 	})
 	s.Step(`^the parties place the following orders:$`, func(table *godog.Table) error {
 		return steps.PartiesPlaceTheFollowingOrders(execsetup.executionEngine, table)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -92,7 +92,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		return steps.ValidatorsShouldHaveTheFollowingScores(execsetup.broker, table, epoch)
 	})
 	s.Step(`^the global reward account gets the following deposits:$`, func(table *godog.Table) error {
-		return steps.DepositToRewardAccount(execsetup.collateralEngine, table)
+		return steps.DepositToRewardAccount(execsetup.collateralEngine, table, execsetup.netDeposits)
 	})
 
 	s.Step(`^the parties receive the following reward for epoch (\d+):$`, func(epoch string, table *godog.Table) error {
@@ -140,6 +140,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 			if err := execsetup.collateralEngine.IncrementBalance(context.Background(), marketInsuranceAccount.ID, amount); err != nil {
 				return err
 			}
+			// add to the net deposits
+			execsetup.netDeposits.Add(execsetup.netDeposits, amount)
 		}
 		return nil
 	})

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -68,7 +68,7 @@ type executionTestSetup struct {
 
 	netParams *netparams.Store
 
-	//keep track of net deposits/withdrawals (ignores asset type)
+	// keep track of net deposits/withdrawals (ignores asset type)
 	netDeposits *num.Uint
 }
 

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"code.vegaprotocol.io/vega/epochtime"
 	"code.vegaprotocol.io/vega/execution"
 	"code.vegaprotocol.io/vega/rewards"
+	"code.vegaprotocol.io/vega/types/num"
 
 	"code.vegaprotocol.io/vega/integration/helpers"
 	"code.vegaprotocol.io/vega/integration/steps/market"
@@ -66,6 +67,9 @@ type executionTestSetup struct {
 	block *helpers.Block
 
 	netParams *netparams.Store
+
+	//keep track of net deposits/withdrawals (ignores asset type)
+	netDeposits *num.Uint
 }
 
 func newExecutionTestSetup() *executionTestSetup {
@@ -127,6 +131,8 @@ func newExecutionTestSetup() *executionTestSetup {
 	if err := execsetup.registerNetParamsCallbacks(); err != nil {
 		panic(err)
 	}
+
+	execsetup.netDeposits = num.Zero()
 
 	return execsetup
 }

--- a/integration/steps/deposit_to_reward_account.go
+++ b/integration/steps/deposit_to_reward_account.go
@@ -12,12 +12,14 @@ import (
 func DepositToRewardAccount(
 	collateralEngine *collateral.Engine,
 	table *godog.Table,
+	netDeposits *num.Uint,
 ) error {
 	for _, r := range parseRewardDepositTable(table) {
 		row := rewardDeposit{row: r}
 
 		rewardAccount, _ := collateralEngine.GetGlobalRewardAccount(row.Asset())
 		collateralEngine.IncrementBalance(context.Background(), rewardAccount.ID, row.Amount())
+		netDeposits.Add(netDeposits, row.Amount())
 	}
 	return nil
 }

--- a/integration/steps/parties_deposit_assets.go
+++ b/integration/steps/parties_deposit_assets.go
@@ -14,17 +14,19 @@ import (
 func PartiesDepositTheFollowingAssets(
 	collateralEngine *collateral.Engine,
 	broker *stubs.BrokerStub,
+	netDeposits *num.Uint,
 	table *godog.Table,
 ) error {
 	ctx := context.Background()
 
 	for _, r := range parseDepositAssetTable(table) {
 		row := depositAssetRow{row: r}
+		amount := row.Amount()
 		_, err := collateralEngine.Deposit(
 			ctx,
 			row.Party(),
 			row.Asset(),
-			row.Amount(),
+			amount,
 		)
 		if err := checkExpectedError(row, err); err != nil {
 			return err
@@ -34,6 +36,7 @@ func PartiesDepositTheFollowingAssets(
 		if err != nil {
 			return errNoGeneralAccountForParty(row, err)
 		}
+		netDeposits.Add(netDeposits, amount)
 	}
 	return nil
 }

--- a/integration/steps/parties_withdraw_the_following_assets.go
+++ b/integration/steps/parties_withdraw_the_following_assets.go
@@ -11,15 +11,17 @@ import (
 
 func PartiesWithdrawTheFollowingAssets(
 	collateral *collateral.Engine,
+	netDeposits *num.Uint,
 	table *godog.Table,
 ) error {
 	for _, r := range parseWithdrawAssetTable(table) {
 		row := withdrawAssetRow{row: r}
-
-		_, err := collateral.Withdraw(context.Background(), row.Party(), row.Asset(), row.Amount())
+		amount := row.Amount()
+		_, err := collateral.Withdraw(context.Background(), row.Party(), row.Asset(), amount)
 		if err := checkExpectedError(row, err); err != nil {
 			return err
 		}
+		netDeposits = netDeposits.Sub(netDeposits, amount)
 	}
 	return nil
 }


### PR DESCRIPTION
After scenario gets executed check if net deposits/withdrawals equal the cumulated accounts balances.

This is a fundamental thing to get right: at every point in time sum of all accounts within the protocol must be equal the net deposits/withdrawals carried out by parties - therefore I'd like it to be tested in the background after each scenario. 

This is a naive way of checking it (we don't differentiate between assets), which may be extended if we modify `steps.TheCumulatedBalanceForAllAccountsShouldBeWorth(...)` to distinguish between different assets.

Blocked by: #4304 

Closes #4318
closes #4304  