### PR TITLE
unwrap the timestamps in reward payout event

### DIFF
--- a/events/reward_payout.go
+++ b/events/reward_payout.go
@@ -73,5 +73,6 @@ func RewardPayoutEventFromStream(ctx context.Context, be *eventspb.BusEvent) *Re
 		Asset:                   rp.Asset,
 		PercentageOfTotalReward: rp.PercentOfTotalReward,
 		Amount:                  amount,
+		Timestamp:               rp.Timestamp,
 	}
 }


### PR DESCRIPTION
close #4329.  