### PR TITLE
fix non deterministic test by using same idGenerator

### DIFF
--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -40,23 +40,21 @@ func eq(t *testing.T, x interface{}) eqMatcher {
 }
 
 type testEngine struct {
-	ctrl     *gomock.Controller
-	marketID string
-	broker   *bmock.MockBroker
-	// idGen        *mocks.MockIDGen
+	ctrl         *gomock.Controller
+	marketID     string
+	broker       *bmock.MockBroker
 	riskModel    *mocks.MockRiskModel
 	priceMonitor *mocks.MockPriceMonitor
 	engine       *liquidity.SnapshotEngine
+	idGen        *idGenStub
 }
 
-func newTestEngine(t *testing.T, now time.Time) *testEngine {
+func newTestEngineWithIDGen(t *testing.T, now time.Time, idGen *idGenStub) *testEngine {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 
 	log := logging.NewTestLogger()
 	broker := bmock.NewMockBroker(ctrl)
-	// idGen := mocks.NewMockIDGen(ctrl)
-	idGen := &idGenStub{}
 	risk := mocks.NewMockRiskModel(ctrl)
 	monitor := mocks.NewMockPriceMonitor(ctrl)
 	market := "market-id"
@@ -70,14 +68,20 @@ func newTestEngine(t *testing.T, now time.Time) *testEngine {
 	engine.OnChainTimeUpdate(context.Background(), now)
 
 	return &testEngine{
-		ctrl:     ctrl,
-		marketID: market,
-		broker:   broker,
-		// idGen:        idGen,
+		ctrl:         ctrl,
+		marketID:     market,
+		broker:       broker,
+		idGen:        idGen,
 		riskModel:    risk,
 		priceMonitor: monitor,
 		engine:       engine,
 	}
+}
+
+func newTestEngine(t *testing.T, now time.Time) *testEngine {
+	t.Helper()
+	idGen := &idGenStub{}
+	return newTestEngineWithIDGen(t, now, idGen)
 }
 
 func TestSubmissions(t *testing.T) {

--- a/liquidity/snapshot_test.go
+++ b/liquidity/snapshot_test.go
@@ -27,8 +27,8 @@ func TestSnapshotRoundTrip(t *testing.T) {
 		market = "market-id"
 		ctx    = context.Background()
 		e1     = newTestEngine(t, initialTime)
-		e2     = newTestEngine(t, initialTime)
-		e3     = newTestEngine(t, initialTime)
+		e2     = newTestEngineWithIDGen(t, initialTime, e1.idGen)
+		e3     = newTestEngineWithIDGen(t, initialTime, e1.idGen)
 	)
 
 	e1.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -126,10 +126,10 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 	expectedHashes2 := map[string]string{
 		"parameters:market-id":             "b5eec91c297baf1f06830350dbcb37d79937561ae605d2304eb12680e443775c",
-		"partiesLiquidityOrders:market-id": "4f70bcae9080f9c4879db76c814cb1d1e538501a565a459114bbf7f6db8ccd9b",
+		"partiesLiquidityOrders:market-id": "c76075385924d7207d9002d2f9855c089f1c409c7e6e235d5b0ddc4a84bc7fc4",
 		"partiesOrders:market-id":          "f9cb31b1c4c8df91f6a348d43978c302c8887336107c265259bc74fdddf00e19",
 		"pendingProvisions:market-id":      "627ef55af7f36bea0d09b0081b85d66531a01df060d8e9447e17049a4e152b12",
-		"provisions:market-id":             "89bcde9a9715401764cf27403e3585126c9321a477e54c28d84b74f95fb78189",
+		"provisions:market-id":             "56319a9f75b8f0a5eb53afb0a6cfd2286e6a8168fd28cbbbd0855b47cdde94b9",
 	}
 
 	lp3 := &types.LiquidityProvisionSubmission{


### PR DESCRIPTION
A test wasn't generating always the same hash due to the engines using different idGenerator. This is fixed, running go test -run=TestSnapshotRoundTrip -count=1000 ./liquidity gives no consistent results.

close #4342  