### PR TITLE
Add some logging + height/version handling fixes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -100,3 +100,4 @@ vegawallet
 whitepaper
 XDG
 xor
+cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 - [4395](https://github.com/vegaprotocol/vega/pull/4395) - Fix drone pipeline
 - [4398](https://github.com/vegaprotocol/vega/pull/4398) - Fix to set proper status on withdrawal errors
 - [4421](https://github.com/vegaprotocol/vega/issues/4421) - Fix to missing pending rewards in LNL checkpoint
+- [4419](https://github.com/vegaprotocol/vega/pull/4419) - Fix snapshot cleanup, improve logging when specified block height could not be reloaded.
+
 
 ## 0.45.5
 *2021-11-16*

--- a/execution/engine_snapshot.go
+++ b/execution/engine_snapshot.go
@@ -13,11 +13,15 @@ import (
 var marketsKey = (&types.PayloadExecutionMarkets{}).Key()
 
 func (e *Engine) marketsStates() ([]*types.ExecMarket, []types.StateProvider, error) {
-	if len(e.marketsCpy) == 0 {
+	mkts := len(e.marketsCpy)
+	if mkts == 0 {
 		return nil, nil, nil
 	}
-	mks := make([]*types.ExecMarket, 0, len(e.marketsCpy))
-	e.marketsStateProviders = make([]types.StateProvider, 0, (len(e.marketsCpy)-len(e.previouslySnapshottedMarkets))*4)
+	mks := make([]*types.ExecMarket, 0, mkts)
+	if prev := len(e.previouslySnapshottedMarkets); prev < mkts {
+		mkts -= prev
+	}
+	e.marketsStateProviders = make([]types.StateProvider, 0, mkts*4)
 	for _, m := range e.marketsCpy {
 		mks = append(mks, m.getState())
 


### PR DESCRIPTION
Add logging of max and min heights found in store, remove old versions when saving past cap, default number of versions to 1, to avoid issues with invalid config values like -1 or 0.

Fixes #4419 