### PR TITLE
4411 null blockchain transations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [4392](https://github.com/vegaprotocol/vega/pull/4392) - Update `GETTING_STARTED.md` documentation
 - [4391](https://github.com/vegaprotocol/vega/pull/4391) - Refactor delegation
 - [4423](https://github.com/vegaprotocol/vega/pull/4423) - Add CLI options to start node with a null-blockchain
+- [4436](https://github.com/vegaprotocol/vega/pull/4436) - Add ability for the null-blockchain to deliver transactions
 - [4400](https://github.com/vegaprotocol/vega/pull/4400) - Add transaction hash to `SubmitTransactionResponse`
 - [4394](https://github.com/vegaprotocol/vega/pull/4394) - Add step to clear all events in integration tests
 - [4403](https://github.com/vegaprotocol/vega/pull/4403) - Fully remove expiry from withdrawals #4403

--- a/blockchain/client.go
+++ b/blockchain/client.go
@@ -124,7 +124,6 @@ func (c *Client) Health() (*tmctypes.ResultHealth, error) {
 func (c *Client) GenesisValidators() ([]*tmtypes.Validator, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-
 	return c.clt.GenesisValidators(ctx)
 }
 

--- a/blockchain/nullchain/mocks/application_service_mock.go
+++ b/blockchain/nullchain/mocks/application_service_mock.go
@@ -33,6 +33,62 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
 }
 
+// BeginBlock mocks base method
+func (m *MockApplicationService) BeginBlock(arg0 types.RequestBeginBlock) types.ResponseBeginBlock {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BeginBlock", arg0)
+	ret0, _ := ret[0].(types.ResponseBeginBlock)
+	return ret0
+}
+
+// BeginBlock indicates an expected call of BeginBlock
+func (mr *MockApplicationServiceMockRecorder) BeginBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginBlock", reflect.TypeOf((*MockApplicationService)(nil).BeginBlock), arg0)
+}
+
+// Commit mocks base method
+func (m *MockApplicationService) Commit() types.ResponseCommit {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Commit")
+	ret0, _ := ret[0].(types.ResponseCommit)
+	return ret0
+}
+
+// Commit indicates an expected call of Commit
+func (mr *MockApplicationServiceMockRecorder) Commit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockApplicationService)(nil).Commit))
+}
+
+// DeliverTx mocks base method
+func (m *MockApplicationService) DeliverTx(arg0 types.RequestDeliverTx) types.ResponseDeliverTx {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeliverTx", arg0)
+	ret0, _ := ret[0].(types.ResponseDeliverTx)
+	return ret0
+}
+
+// DeliverTx indicates an expected call of DeliverTx
+func (mr *MockApplicationServiceMockRecorder) DeliverTx(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeliverTx", reflect.TypeOf((*MockApplicationService)(nil).DeliverTx), arg0)
+}
+
+// EndBlock mocks base method
+func (m *MockApplicationService) EndBlock(arg0 types.RequestEndBlock) types.ResponseEndBlock {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EndBlock", arg0)
+	ret0, _ := ret[0].(types.ResponseEndBlock)
+	return ret0
+}
+
+// EndBlock indicates an expected call of EndBlock
+func (mr *MockApplicationServiceMockRecorder) EndBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndBlock", reflect.TypeOf((*MockApplicationService)(nil).EndBlock), arg0)
+}
+
 // InitChain mocks base method
 func (m *MockApplicationService) InitChain(arg0 types.RequestInitChain) types.ResponseInitChain {
 	m.ctrl.T.Helper()

--- a/blockchain/nullchain/nullchain.go
+++ b/blockchain/nullchain/nullchain.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	ErrNotImplemented      = errors.New("not implemeneted for nullblockchain")
-	ErrGenesisFileRequired = errors.New("--blockchain.nullchain.genesis-file  is required")
+	ErrNotImplemented      = errors.New("not implemented for nullblockchain")
+	ErrGenesisFileRequired = errors.New("--blockchain.nullchain.genesis-file is required")
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/application_service_mock.go -package mocks code.vegaprotocol.io/vega/blockchain/nullchain ApplicationService

--- a/blockchain/nullchain/nullchain_test.go
+++ b/blockchain/nullchain/nullchain_test.go
@@ -1,0 +1,125 @@
+package nullchain_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	vgfs "code.vegaprotocol.io/shared/libs/fs"
+	vgrand "code.vegaprotocol.io/shared/libs/rand"
+
+	"code.vegaprotocol.io/vega/blockchain/nullchain"
+	"code.vegaprotocol.io/vega/blockchain/nullchain/mocks"
+	"code.vegaprotocol.io/vega/config/encoding"
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestNullChain(t *testing.T) {
+	t.Run("test Nullchain Start", testNullChainStart)
+	t.Run("test transactions create block", testTransactionsCreateBlock)
+	t.Run("test timeforwarding creates blocks", testTimeForwardingCreatesBlocks)
+}
+
+func testNullChainStart(t *testing.T) {
+	testChain := getTestNullChain(t, 10, 2*time.Second)
+	defer testChain.ctrl.Finish()
+
+	testChain.app.EXPECT().InitChain(gomock.Any()).Times(1)
+	testChain.app.EXPECT().BeginBlock(gomock.Any()).Times(1)
+
+	testChain.chain.Start()
+}
+
+func testTimeForwardingCreatesBlocks(t *testing.T) {
+	ctx := context.Background()
+	testChain := getTestNullChain(t, 10, 2*time.Second)
+	defer testChain.ctrl.Finish()
+
+	// 10 blocks and a second (we should snap back to 20 blocks)
+	step := 21 * time.Second
+	now, _ := testChain.chain.GetGenesisTime(ctx)
+	beginBlockTime := now
+
+	// Fill in a partial blocks worth of transactions
+	testChain.chain.SendTransactionSync(ctx, []byte(vgrand.RandomStr(5)))
+	testChain.chain.SendTransactionAsync(ctx, []byte(vgrand.RandomStr(5)))
+	testChain.chain.SendTransactionSync(ctx, []byte(vgrand.RandomStr(5)))
+
+	// One round of block processing calls
+	testChain.app.EXPECT().BeginBlock(gomock.Any()).Times(10).Do(func(r abci.RequestBeginBlock) {
+		beginBlockTime = r.Header.Time
+	})
+	testChain.app.EXPECT().EndBlock(gomock.Any()).Times(10)
+	testChain.app.EXPECT().Commit().Times(10)
+	testChain.app.EXPECT().DeliverTx(gomock.Any()).Times(3)
+
+	testChain.chain.ForwardTime(step)
+
+	assert.True(t, beginBlockTime.Equal(now.Add(20*time.Second)))
+}
+
+func testTransactionsCreateBlock(t *testing.T) {
+	ctx := context.Background()
+	testChain := getTestNullChain(t, 2, time.Second)
+	defer testChain.ctrl.Finish()
+
+	// Expected BeginBlock to be called with time shuffled forward by a block
+	now, _ := testChain.chain.GetGenesisTime(ctx)
+	r := abci.RequestBeginBlock{Header: types.Header{Time: now.Add(time.Second)}}
+
+	// One round of block processing calls
+	testChain.app.EXPECT().BeginBlock(r).Times(1)
+	testChain.app.EXPECT().EndBlock(gomock.Any()).Times(1)
+	testChain.app.EXPECT().Commit().Times(1)
+
+	// Expect only two of the three transactions to be delivered
+	testChain.app.EXPECT().DeliverTx(gomock.Any()).Times(2)
+
+	// Send in three transactions, two gets delivered in the block, one left over
+	testChain.chain.SendTransactionSync(ctx, []byte(vgrand.RandomStr(5)))
+	testChain.chain.SendTransactionSync(ctx, []byte(vgrand.RandomStr(5)))
+	testChain.chain.SendTransactionSync(ctx, []byte(vgrand.RandomStr(5)))
+}
+
+type testNullBlockChain struct {
+	chain *nullchain.NullBlockchain
+	ctrl  *gomock.Controller
+	app   *mocks.MockApplicationService
+}
+
+func getTestNullChain(t *testing.T, txnPerBlock uint64, d time.Duration) *testNullBlockChain {
+	ctrl := gomock.NewController(t)
+
+	app := mocks.NewMockApplicationService(ctrl)
+
+	cfg := nullchain.NewDefaultConfig()
+	cfg.GenesisFile = newGenesisFile(t)
+	cfg.BlockDuration = encoding.Duration{Duration: d}
+	cfg.TransactionsPerBlock = txnPerBlock
+
+	n := nullchain.NewClient(logging.NewTestLogger(), cfg, app)
+	require.NotNil(t, n)
+
+	return &testNullBlockChain{
+		chain: n,
+		ctrl:  ctrl,
+		app:   app,
+	}
+}
+
+func newGenesisFile(t *testing.T) string {
+	t.Helper()
+	data := "{ \"appstate\": { \"stuff\": \"stuff\" }}"
+
+	filePath := filepath.Join(t.TempDir(), "genesis.json")
+	if err := vgfs.WriteFile(filePath, []byte(data)); err != nil {
+		t.Fatalf("couldn't write file: %v", err)
+	}
+	return filePath
+}

--- a/cmd/vega/node/node.go
+++ b/cmd/vega/node/node.go
@@ -188,10 +188,12 @@ func (l *NodeCommand) runNode(args []string) error {
 	metrics.Start(l.conf.Metrics)
 
 	// some clients need to start after the rpc-server is up
-	l.blockchainClient.Start()
+	err := l.blockchainClient.Start()
 
-	l.Log.Info("Vega startup complete")
-	waitSig(l.ctx, l.Log)
+	if err == nil {
+		l.Log.Info("Vega startup complete")
+		waitSig(l.ctx, l.Log)
+	}
 
 	// Clean up and close resources
 	grpcServer.Stop()
@@ -199,7 +201,7 @@ func (l *NodeCommand) runNode(args []string) error {
 	statusChecker.Stop()
 	proxyServer.Stop()
 
-	return nil
+	return err
 }
 
 // waitSig will wait for a sigterm or sigint interrupt.


### PR DESCRIPTION
closes #4411 

When using the nullchain, you can now send in transactions which get collected up into a blocks worth, and then trivially delivered into core. Time gets shuffled forwards whenever a block gets full. 

I have also implemented the time forwarding logic which is invoked by calling `ForwardTime`. This will eventually be wired up to some externally callable API. Thats to come in the next ticket.