### PR TITLE
Make sure chain id is in context when processing checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@
 - [4455](https://github.com/vegaprotocol/vega/pull/4455) - Introduce API to allow time-forwarding in the null-blockchain
 
 ### 🐛 Fixes
+
 - [4435](https://github.com/vegaprotocol/vega/pull/4435) - Fix non determinism in deposits snapshot
 - [4418](https://github.com/vegaprotocol/vega/pull/4418) - Add some logging + height/version handling fixes
-
+- [4461](https://github.com/vegaprotocol/vega/pull/4461) - Fix problem where chain id was not present on event bus during checkpoint loading
 
 ## 0.46.1
 *2021-11-24*

--- a/netparams/checkpoint.go
+++ b/netparams/checkpoint.go
@@ -38,7 +38,7 @@ func (s *Store) Checkpoint() ([]byte, error) {
 	return proto.Marshal(&params)
 }
 
-func (s *Store) Load(_ context.Context, data []byte) error {
+func (s *Store) Load(ctx context.Context, data []byte) error {
 	params := &snapshot.NetParams{}
 	if err := proto.Unmarshal(data, params); err != nil {
 		return err
@@ -47,7 +47,7 @@ func (s *Store) Load(_ context.Context, data []byte) error {
 	for _, param := range params.Params {
 		np[param.Key] = param.Value
 	}
-	if err := s.updateBatch(context.Background(), np); err != nil {
+	if err := s.updateBatch(ctx, np); err != nil {
 		return err
 	}
 	return nil

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -1184,9 +1184,22 @@ func (app *App) DeliverReloadCheckpoint(ctx context.Context, tx abci.Tx) (err er
 	if err != nil {
 		app.log.Panic("Failed to get blockheight from checkpoint", logging.Error(err))
 	}
-	// ensure block height is set
+	// ensure block height and chain id are set
+	cid, err := vgcontext.ChainIDFromContext(app.chainCtx)
+	if err != nil {
+		app.log.Panic("Failed to get chain id", logging.Error(err))
+	}
+
 	ctx = vgcontext.WithBlockHeight(ctx, bh)
+	ctx = vgcontext.WithChainID(ctx, cid)
 	app.blockCtx = ctx
+	//
+	// app.chainCtx = vgcontext.WithChainID(context.Background(), req.ChainId)
+	// ctx := vgcontext.WithBlockHeight(app.chainCtx, 0)
+	// ctx = vgcontext.WithTraceID(ctx, hash)
+	// app.blockCtx = ctx
+
+	//
 	err = app.checkpoint.Load(ctx, cpt)
 	if err != nil && err != types.ErrCheckpointStateInvalid && err != types.ErrCheckpointHashIncorrect && !errors.Is(err, checkpoint.ErrNoCheckpointExpectedToBeRestored) && !errors.Is(err, checkpoint.ErrIncompatibleHashes) {
 		app.log.Panic("Failed to restore checkpoint", logging.Error(err))

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -1193,13 +1193,6 @@ func (app *App) DeliverReloadCheckpoint(ctx context.Context, tx abci.Tx) (err er
 	ctx = vgcontext.WithBlockHeight(ctx, bh)
 	ctx = vgcontext.WithChainID(ctx, cid)
 	app.blockCtx = ctx
-	//
-	// app.chainCtx = vgcontext.WithChainID(context.Background(), req.ChainId)
-	// ctx := vgcontext.WithBlockHeight(app.chainCtx, 0)
-	// ctx = vgcontext.WithTraceID(ctx, hash)
-	// app.blockCtx = ctx
-
-	//
 	err = app.checkpoint.Load(ctx, cpt)
 	if err != nil && err != types.ErrCheckpointStateInvalid && err != types.ErrCheckpointHashIncorrect && !errors.Is(err, checkpoint.ErrNoCheckpointExpectedToBeRestored) && !errors.Is(err, checkpoint.ErrIncompatibleHashes) {
 		app.log.Panic("Failed to restore checkpoint", logging.Error(err))


### PR DESCRIPTION
Closes #4457 

The chainid was not being included in events generated by checkpoint restore transactions, this fixes that and along with it should allow the LNL tests to pass.