### PR TITLE
4449 nullchain without eth chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [4434](https://github.com/vegaprotocol/vega/pull/4434) - Add free form governance net parameters to `allKeys` map
 - [4436](https://github.com/vegaprotocol/vega/pull/4436) - Add ability for the null-blockchain to deliver transactions
 - [4455](https://github.com/vegaprotocol/vega/pull/4455) - Introduce API to allow time-forwarding in the null-blockchain
+- [4463](https://github.com/vegaprotocol/vega/pull/4463) - Remove the need for an Ethereum connection when using the null-blockchain
 
 ### 🐛 Fixes
 

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -17,6 +17,7 @@ var (
 	ErrAssetInvalid       = errors.New("asset invalid")
 	ErrAssetDoesNotExist  = errors.New("asset does not exist")
 	ErrUnknownAssetSource = errors.New("unknown asset source")
+	ErrEthClientMissing   = errors.New("eth client is missing")
 )
 
 // TimeService ...
@@ -121,6 +122,10 @@ func (s *Service) assetFromDetails(assetID string, assetDetails *types.AssetDeta
 			builtin.New(assetID, assetDetails),
 		}, nil
 	case *types.AssetDetailsErc20:
+		if s.ethClient == nil {
+			// likely trying to do something with an ERC20 asset when using a null chain provider
+			return nil, ErrEthClientMissing
+		}
 		asset, err := erc20.New(assetID, assetDetails, s.nodeWallets.Ethereum, s.ethClient)
 		if err != nil {
 			return nil, err

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -83,6 +83,6 @@ func NewDefaultNullChainConfig() NullChainConfig {
 		BlockDuration:        encoding.Duration{Duration: time.Second},
 		TransactionsPerBlock: 10,
 		IP:                   "localhost",
-		Port:                 3009,
+		Port:                 3101,
 	}
 }

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -7,6 +7,11 @@ import (
 	"code.vegaprotocol.io/vega/logging"
 )
 
+const (
+	ProviderNullChain  = "nullchain"
+	ProviderTendermint = "tendermint"
+)
+
 // Config represent the configuration of the blockchain package.
 type Config struct {
 	Level               encoding.LogLevel `long:"log-level"`
@@ -27,7 +32,7 @@ func NewDefaultConfig() Config {
 		Level:               encoding.LogLevel{Level: logging.InfoLevel},
 		LogOrderSubmitDebug: true,
 		LogTimeDebug:        true,
-		ChainProvider:       "tendermint",
+		ChainProvider:       ProviderTendermint,
 		Tendermint:          NewDefaultTendermintConfig(),
 		Null:                NewDefaultNullChainConfig(),
 	}

--- a/blockchain/nullchain/README.md
+++ b/blockchain/nullchain/README.md
@@ -17,7 +17,7 @@ Providing the following options when running `vega node`, or by setting them in 
 `PATH_TO_TM_GENESIS_FILE` is required and can be a normal `genesis.json` that would be used with Tendermint. The Null-blockchain requires it to be able to parse and send the `app_state` to `InitChain`. Also if `genesis_time` is set it will be used as the initial frozen time of the chain, otherwise it will be set to `time.Now()`. 
 
 
-## Moving time forward
+## Moving Time Forward
 
 There are two ways in which time can be moved forward. The first is by submitting a number of transactions equal to `transactions-per-block`. Once this threshold is hit the submitted transactions will be processed, and `vegatime` will be incremented by
 `block-duration`.
@@ -26,11 +26,20 @@ The other is by using an exposed HTTP endpoint to specify either a duration, or 
 
 ```
 # By duration
-curl -X POST -d "{\"forward\": \"1s\"}" http://localhost:3101/api/v1/forwardtime
+curl -X POST -d "{\"forward\": \"10s\"}" http://localhost:3101/api/v1/forwardtime
 
 
 # By datetime
-curl -X POST -d "{\"timeforward\": \"2021-11-25T14:14:00Z\"}" http://localhost:3101/api/v1/timeforward
+curl -X POST -d "{\"forward\": \"2021-11-25T14:14:00Z\"}" http://localhost:3101/api/v1/forwardtime
 ```
 
 Moving time forward will create empty blocks until the target time is reached. Any pending transactions will be processed in the first block. If the target time is such that it does not move ahead by a multiple of `block-duration` then time will be snapped backwards to the block last ended, and `vegatime` could be less than the target time. 
+
+## Depositing Funds and Staking
+
+The Null-Blockchain is made to work with as few external dependencies as possible and so does not dial into the Ethereum chain. This means that all assets being used must be built-in assets, and not ERC20. Funds can be deposited into the system using the faucet (See `vega faucet --help`).
+
+To be able to be able to flex goverance the null-blockchain will need to be able to pretend that a party has staked to allow voting and proposals to work. This is done with a mock up a staking account that loops itself into the collateral engine. To be able to simulate staking the faucet can be used to deposit the built-in asset `VOTE` into a party's general account in the collateral engine. This general account balance for `VOTE` is then sneakily looped into governance as if it were a staked balance.
+
+
+

--- a/blockchain/nullchain/README.md
+++ b/blockchain/nullchain/README.md
@@ -26,10 +26,11 @@ The other is by using an exposed HTTP endpoint to specify either a duration, or 
 
 ```
 # By duration
-curl -X POST -d "{\"forward\": \"10s\"}" http://localhost:3009/api/v1/forwardtime
+curl -X POST -d "{\"forward\": \"1s\"}" http://localhost:3101/api/v1/forwardtime
+
 
 # By datetime
-curl -X POST -d "{\"timeforward\": \"2021-11-25T14:14:00Z\"}" http://localhost:3009/api/v1/timeforward
+curl -X POST -d "{\"timeforward\": \"2021-11-25T14:14:00Z\"}" http://localhost:3101/api/v1/timeforward
 ```
 
 Moving time forward will create empty blocks until the target time is reached. Any pending transactions will be processed in the first block. If the target time is such that it does not move ahead by a multiple of `block-duration` then time will be snapped backwards to the block last ended, and `vegatime` could be less than the target time. 

--- a/blockchain/nullchain/nullchain_test.go
+++ b/blockchain/nullchain/nullchain_test.go
@@ -59,7 +59,7 @@ func testTransactionsCreateBlock(t *testing.T) {
 
 	// Expected BeginBlock to be called with time shuffled forward by a block
 	now, _ := testChain.chain.GetGenesisTime(ctx)
-	r := abci.RequestBeginBlock{Header: types.Header{Time: now.Add(time.Second)}}
+	r := abci.RequestBeginBlock{Header: types.Header{Time: now.Add(time.Second), ChainID: chainID, Height: 2}}
 
 	// One round of block processing calls
 	testChain.app.EXPECT().BeginBlock(r).Times(1)
@@ -199,7 +199,7 @@ func getTestNullChain(t *testing.T, txnPerBlock uint64, d time.Duration) *testNu
 
 func newGenesisFile(t *testing.T) string {
 	t.Helper()
-	data := fmt.Sprintf("{ \"genesis_time\": \"%s\",\"chain_id\": \"%s\", \"appstate\": { \"stuff\": \"stuff\" }}", genesisTime, chainID)
+	data := fmt.Sprintf("{ \"genesis_time\": \"%s\",\"chain_id\": \"%s\", \"app_state\": { \"validators\": {}}}", genesisTime, chainID)
 
 	filePath := filepath.Join(t.TempDir(), "genesis.json")
 	if err := vgfs.WriteFile(filePath, []byte(data)); err != nil {

--- a/blockchain/nullchain/server.go
+++ b/blockchain/nullchain/server.go
@@ -83,5 +83,4 @@ func (n *NullBlockchain) handleForwardTime(w http.ResponseWriter, r *http.Reques
 
 	// Do the dance
 	n.ForwardTime(d)
-	w.WriteHeader(http.StatusOK)
 }

--- a/blockchain/nullchain/server.go
+++ b/blockchain/nullchain/server.go
@@ -13,6 +13,10 @@ import (
 var ErrInvalidRequest = errors.New("invalid request")
 
 func (n *NullBlockchain) Stop() {
+	if n.srv == nil {
+		return
+	}
+
 	n.log.Info("Stopping nullchain server")
 	if err := n.srv.Shutdown(context.Background()); err != nil {
 		n.log.Warn("failed to shutdown")

--- a/blockchain/nullchain/staking_loop.go
+++ b/blockchain/nullchain/staking_loop.go
@@ -25,6 +25,8 @@ type StakingLoop struct {
 	stakingAsset string
 }
 
+// NewStakingLoop return a type that can "mock" a StakingAccount by instead reading deposited amounts
+// from the collateral engine. Used by the null-blockchain to remove the need for an Ethereum connection.
 func NewStakingLoop(col Collateral, assets Assets) *StakingLoop {
 	return &StakingLoop{
 		col:          col,
@@ -44,17 +46,13 @@ func (s *StakingLoop) GetAvailableBalance(party string) (*num.Uint, error) {
 func (s *StakingLoop) GetAvailableBalanceInRange(party string, from, to time.Time) (*num.Uint, error) {
 	// We're just going to have to say we have no notion of time range and whatever is has be deposited by the faucet
 	// has always been there.
-	balance, err := s.GetAvailableBalance(party)
-	if err != nil {
-		return nil, err
-	}
-	return balance, nil
+	return s.GetAvailableBalance(party)
 }
 
 func (s *StakingLoop) GetStakingAssetTotalSupply() *num.Uint {
 	asset, err := s.assets.Get(s.stakingAsset)
 	if err != nil {
-		return nil // its really should exist
+		return nil
 	}
 	return asset.Type().GetAssetTotalSupply()
 }

--- a/blockchain/nullchain/staking_loop.go
+++ b/blockchain/nullchain/staking_loop.go
@@ -1,0 +1,60 @@
+package nullchain
+
+import (
+	"time"
+
+	"code.vegaprotocol.io/vega/assets"
+	"code.vegaprotocol.io/vega/types"
+	"code.vegaprotocol.io/vega/types/num"
+)
+
+type Collateral interface {
+	GetPartyGeneralAccount(party, asset string) (*types.Account, error)
+}
+
+type Assets interface {
+	Get(assetID string) (*assets.Asset, error)
+}
+
+type StakingLoop struct {
+	col    Collateral
+	assets Assets
+
+	// The built-in asset which when deposited into the collateral is to be used to pretend that is was
+	// staked on the bridge
+	stakingAsset string
+}
+
+func NewStakingLoop(col Collateral, assets Assets) *StakingLoop {
+	return &StakingLoop{
+		col:          col,
+		assets:       assets,
+		stakingAsset: "VOTE",
+	}
+}
+
+func (s *StakingLoop) GetAvailableBalance(party string) (*num.Uint, error) {
+	acc, err := s.col.GetPartyGeneralAccount(party, s.stakingAsset)
+	if err != nil {
+		return nil, err
+	}
+	return acc.Balance.Clone(), nil
+}
+
+func (s *StakingLoop) GetAvailableBalanceInRange(party string, from, to time.Time) (*num.Uint, error) {
+	// We're just going to have to say we have no notion of time range and whatever is has be deposited by the faucet
+	// has always been there.
+	balance, err := s.GetAvailableBalance(party)
+	if err != nil {
+		return nil, err
+	}
+	return balance, nil
+}
+
+func (s *StakingLoop) GetStakingAssetTotalSupply() *num.Uint {
+	asset, err := s.assets.Get(s.stakingAsset)
+	if err != nil {
+		return nil // its really should exist
+	}
+	return asset.Type().GetAssetTotalSupply()
+}

--- a/client/eth/client.go
+++ b/client/eth/client.go
@@ -45,6 +45,9 @@ func Dial(ctx context.Context, rawURL string) (*Client, error) {
 }
 
 func (c *Client) OnEthereumConfigUpdate(ctx context.Context, v interface{}) error {
+	if c == nil {
+		return nil
+	}
 	ecfg, ok := v.(*types.EthereumConfig)
 	if !ok {
 		return errors.New("invalid types for Ethereum config")

--- a/cmd/vega/node/node.go
+++ b/cmd/vega/node/node.go
@@ -215,13 +215,3 @@ func waitSig(ctx context.Context, log *logging.Logger) {
 		// nothing to do
 	}
 }
-
-func flagProvided(flag string) bool {
-	for _, v := range os.Args[1:] {
-		if v == flag {
-			return true
-		}
-	}
-
-	return false
-}

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -351,6 +351,7 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 	l.stakingAccounts, l.stakeVerifier = staking.New(
 		l.Log, l.conf.Staking, l.broker, l.timeService, l.witness, l.ethClient, l.netParams,
 	)
+	l.epochService = epochtime.NewService(l.Log, l.conf.Epoch, l.timeService, l.broker)
 
 	if l.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
 
@@ -362,8 +363,6 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 		l.governance = governance.NewEngine(l.Log, l.conf.Governance, l.stakingAccounts, l.broker, l.assets, l.witness, l.netParams, now)
 		l.delegation = delegation.New(l.Log, delegation.NewDefaultConfig(), l.broker, l.topology, l.stakingAccounts, l.epochService, l.timeService)
 	}
-
-	l.epochService = epochtime.NewService(l.Log, l.conf.Epoch, l.timeService, l.broker)
 
 	l.netParams.Watch(
 		netparams.WatchParam{

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -354,7 +354,6 @@ func (l *NodeCommand) preRun(_ []string) (err error) {
 	l.epochService = epochtime.NewService(l.Log, l.conf.Epoch, l.timeService, l.broker)
 
 	if l.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
-
 		// Use staking-loop to pretend a dummy builtin asssets deposited with the faucet was staked
 		stakingLoop := nullchain.NewStakingLoop(l.collateral, l.assets)
 		l.governance = governance.NewEngine(l.Log, l.conf.Governance, stakingLoop, l.broker, l.assets, l.witness, l.netParams, now)


### PR DESCRIPTION
closes #4449 

When using the nullchain we no longer dial to the Ethereum chain. Staking accounts are mocked by instead reading the balance from the general account in the collateral engine for a built-int asset with a particular name. See the README for more details.

There are also some other misc. fixes.