### PR TITLE
catch ERC20 assets in genesis file when nullchain and error appropria…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [4500](https://github.com/vegaprotocol/vega/pull/4500) - Set minimum power to tendermint consensus power for validator
 - [4504](https://github.com/vegaprotocol/vega/pull/4504) - Prevent premature ending of an epoch when loading from a checkpoint within the same epoch of taking it. 
 - [4505](https://github.com/vegaprotocol/vega/pull/4506) - Wire `net params` to time service to flush pending updates
-- [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the nullchain with an ERC20 asset
+- [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the null-blockchain with an ERC20 asset
 - [4516](https://github.com/vegaprotocol/vega/pull/4516) - Fix release number title typo - 0.46.1 > 0.46.2 
 
 ## 0.47.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [4500](https://github.com/vegaprotocol/vega/pull/4500) - Set minimum power to tendermint consensus power for validator
 - [4504](https://github.com/vegaprotocol/vega/pull/4504) - Prevent premature ending of an epoch when loading from a checkpoint within the same epoch of taking it. 
 - [4505](https://github.com/vegaprotocol/vega/pull/4506) - Wire `net params` to time service to flush pending updates
+- [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the nullchain with an ERC20 asset
 - [4516](https://github.com/vegaprotocol/vega/pull/4516) - Fix release number title typo - 0.46.1 > 0.46.2 
 
 ## 0.47.0

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -17,7 +17,6 @@ var (
 	ErrAssetInvalid       = errors.New("asset invalid")
 	ErrAssetDoesNotExist  = errors.New("asset does not exist")
 	ErrUnknownAssetSource = errors.New("unknown asset source")
-	ErrEthClientMissing   = errors.New("eth client is missing")
 )
 
 // TimeService ...
@@ -122,10 +121,6 @@ func (s *Service) assetFromDetails(assetID string, assetDetails *types.AssetDeta
 			builtin.New(assetID, assetDetails),
 		}, nil
 	case *types.AssetDetailsErc20:
-		if s.ethClient == nil {
-			// likely trying to do something with an ERC20 asset when using a null chain provider
-			return nil, ErrEthClientMissing
-		}
 		asset, err := erc20.New(assetID, assetDetails, s.nodeWallets.Ethereum, s.ethClient)
 		if err != nil {
 			return nil, err

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -53,7 +53,7 @@ import (
 
 var (
 	ErrUnknownChainProvider    = errors.New("unknown chain provider")
-	ErrERC20AssetWithNullChain = errors.New("cannot use ERC20 with nullchain")
+	ErrERC20AssetWithNullChain = errors.New("cannot use ERC20 asset with nullchain")
 )
 
 func (l *NodeCommand) persistentPre(args []string) (err error) {

--- a/cmd/vega/node/node_pre.go
+++ b/cmd/vega/node/node_pre.go
@@ -51,7 +51,10 @@ import (
 	tmtypes "github.com/tendermint/tendermint/abci/types"
 )
 
-var ErrUnknownChainProvider = errors.New("unknown chain provider")
+var (
+	ErrUnknownChainProvider    = errors.New("unknown chain provider")
+	ErrERC20AssetWithNullChain = errors.New("cannot use ERC20 with nullchain")
+)
 
 func (l *NodeCommand) persistentPre(args []string) (err error) {
 	// this shouldn't happen...
@@ -153,6 +156,10 @@ func (l *NodeCommand) loadAsset(ctx context.Context, id string, v *proto.AssetDe
 	asset, err := l.assets.Get(aid)
 	if err != nil {
 		return fmt.Errorf("unable to get asset %v", err)
+	}
+
+	if l.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain && asset.IsERC20() {
+		return ErrERC20AssetWithNullChain
 	}
 
 	// just a simple backoff here


### PR DESCRIPTION
closes #4520 

Vega running with the nullchain cannot use ERC20 assets because it, intentionally, does not dial into the ethereum chain. What I had before didn't seem to work due to golang "interface with a null behind it is not the same a a nil value". So I've switched to something a bit more explicit.