### PR TITLE
Remove deposits once they have been finalised + fix sorting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [4515](https://github.com/vegaprotocol/vega/pull/4515) - Set log level in snapshot engine
 - [4522](https://github.com/vegaprotocol/vega/pull/4522) - Set transfer responses event when paying rewards
 - [4566](https://github.com/vegaprotocol/vega/pull/4566) - Withdrawal fails should return a status rejected rather than cancelled
+- [4582](https://github.com/vegaprotocol/vega/pull/4582) - Deposits stayed in memory indefinitely, and withdrawal keys were not being sorted to ensure determinism.
 
 ## 0.47.4
 *2022-01-05*

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -259,6 +259,7 @@ func (e *Engine) getWithdrawalFromRef(ref *big.Int) (*types.Withdrawal, error) {
 	for k := range e.withdrawals {
 		withdrawalsK = append(withdrawalsK, k)
 	}
+	sort.Strings(withdrawalsK)
 
 	for _, k := range withdrawalsK {
 		v := e.withdrawals[k]
@@ -303,7 +304,11 @@ func (e *Engine) finalizeAssetList(ctx context.Context, assetID string) error {
 }
 
 func (e *Engine) finalizeDeposit(ctx context.Context, d *types.Deposit) error {
-	defer func() { e.broker.Send(events.NewDepositEvent(ctx, *d)) }()
+	defer func() {
+		e.broker.Send(events.NewDepositEvent(ctx, *d))
+		// whatever happens, the deposit is in its final state (cancelled or finalized)
+		delete(e.deposits, d.ID)
+	}()
 	res, err := e.col.Deposit(ctx, d.PartyID, d.Asset, d.Amount)
 	if err != nil {
 		d.Status = types.DepositStatusCancelled
@@ -319,8 +324,11 @@ func (e *Engine) finalizeDeposit(ctx context.Context, d *types.Deposit) error {
 
 func (e *Engine) finalizeWithdraw(
 	ctx context.Context, w *types.Withdrawal) error {
-	// always send the withdrawal event
-	defer func() { e.broker.Send(events.NewWithdrawalEvent(ctx, *w)) }()
+	// always send the withdrawal event, don't delete it from the map because we
+	// may still receive events
+	defer func() {
+		e.broker.Send(events.NewWithdrawalEvent(ctx, *w))
+	}()
 
 	res, err := e.col.Withdraw(ctx, w.PartyID, w.Asset, w.Amount.Clone())
 	if err != nil {


### PR DESCRIPTION
Closes #4582 

Turns out the events were being sent out correctly.

Withdrawals are a bit trickier to remove outright, as we rely on that map to defend against duplicate events we may receive.
There was an issue where we didn't sort the keys to ensure determinism.