### PR TITLE
OneOff transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [4588](https://github.com/vegaprotocol/vega/pull/4588) - Add `--update` and `--replace` flags on `vega genesis new validator`
 - [4508](https://github.com/vegaprotocol/vega/pull/4508) - Disallow negative offset for pegged orders
 - [4522](https://github.com/vegaprotocol/vega/pull/4522) - Add `--network-url` option to `vega tm`
+- [4580](https://github.com/vegaprotocol/vega/pull/4580) - Add transfer command support (one off transfers)
 
 ### 🐛 Fixes
 - [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the null-blockchain with an ERC20 asset
@@ -45,7 +46,7 @@
 - [4566](https://github.com/vegaprotocol/vega/pull/4566) - Withdrawal fails should return a status rejected rather than cancelled
 - [4582](https://github.com/vegaprotocol/vega/pull/4582) - Deposits stayed in memory indefinitely, and withdrawal keys were not being sorted to ensure determinism.
 - [4588](https://github.com/vegaprotocol/vega/pull/4588) - Fail when missing tendermint home and public key in `nodewallet import` command
-- [4617](https://github.com/vegaprotocol/vega/pull/4617) - Bug fix for incorrectly reporting auto delegation 
+- [4617](https://github.com/vegaprotocol/vega/pull/4617) - Bug fix for incorrectly reporting auto delegation
 ## 0.47.4
 *2022-01-05*
 

--- a/banking/checkpoint.go
+++ b/banking/checkpoint.go
@@ -1,0 +1,63 @@
+package banking
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	checkpoint "code.vegaprotocol.io/protos/vega/checkpoint/v1"
+	"code.vegaprotocol.io/vega/types"
+	"github.com/golang/protobuf/proto"
+)
+
+func (e *Engine) Name() types.CheckpointName {
+	return types.BankingCheckpoint
+}
+
+func (e *Engine) Checkpoint() ([]byte, error) {
+	msg := &checkpoint.Banking{
+		TransfersAtTime: e.getScheduledTransfers(),
+	}
+	ret, err := proto.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (e *Engine) Load(ctx context.Context, data []byte) error {
+	b := checkpoint.Banking{}
+	if err := proto.Unmarshal(data, &b); err != nil {
+		return err
+	}
+
+	for _, v := range b.TransfersAtTime {
+		transfers := make([]scheduledTransfer, 0, len(v.Transfers))
+		for _, v := range v.Transfers {
+			transfer, err := scheduledTransferFromProto(v)
+			if err != nil {
+				return err
+			}
+			transfers = append(transfers, transfer)
+		}
+		e.scheduledTransfers[time.Unix(v.DeliverOn, 0)] = transfers
+	}
+	return nil
+}
+
+func (e *Engine) getScheduledTransfers() []*checkpoint.ScheduledTransferAtTime {
+	out := []*checkpoint.ScheduledTransferAtTime{}
+
+	for k, v := range e.scheduledTransfers {
+		transfers := make([]*checkpoint.ScheduledTransfer, 0, len(v))
+		for _, v := range v {
+			transfers = append(transfers, v.ToProto())
+		}
+
+		out = append(out, &checkpoint.ScheduledTransferAtTime{DeliverOn: k.Unix(), Transfers: transfers})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].DeliverOn < out[j].DeliverOn })
+
+	return out
+}

--- a/banking/checkpoint.go
+++ b/banking/checkpoint.go
@@ -65,7 +65,7 @@ func (e *Engine) getScheduledTransfers() []*checkpoint.ScheduledTransferAtTime {
 		out = append(out, &checkpoint.ScheduledTransferAtTime{DeliverOn: k.Unix(), Transfers: transfers})
 	}
 
-	sort.Slice(out, func(i, j int) bool { return out[i].DeliverOn < out[j].DeliverOn })
+	sort.SliceStable(out, func(i, j int) bool { return out[i].DeliverOn < out[j].DeliverOn })
 
 	return out
 }

--- a/banking/checkpoint_test.go
+++ b/banking/checkpoint_test.go
@@ -97,6 +97,7 @@ func testSimpledScheduledTransfer(t *testing.T) {
 	defer e2.ctrl.Finish()
 
 	// load the checkpoint
+	e2.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
 	assert.NoError(t, e2.Load(ctx, checkp))
 
 	// then trigger the time update, and see the transfer

--- a/banking/checkpoint_test.go
+++ b/banking/checkpoint_test.go
@@ -16,7 +16,6 @@ func TestCheckpoint(t *testing.T) {
 }
 
 func testSimpledScheduledTransfer(t *testing.T) {
-
 	e := getTestEngine(t)
 	defer e.ctrl.Finish()
 
@@ -85,7 +84,7 @@ func testSimpledScheduledTransfer(t *testing.T) {
 			return nil, nil
 		})
 
-	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	e.broker.EXPECT().Send(gomock.Any()).Times(2)
 
 	assert.NoError(t, e.TransferFunds(ctx, transfer))
 
@@ -129,6 +128,6 @@ func testSimpledScheduledTransfer(t *testing.T) {
 			return nil, nil
 		})
 
+	e2.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
 	e2.OnTick(context.Background(), time.Unix(12, 0))
-
 }

--- a/banking/checkpoint_test.go
+++ b/banking/checkpoint_test.go
@@ -1,0 +1,134 @@
+package banking_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/types"
+	"code.vegaprotocol.io/vega/types/num"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpoint(t *testing.T) {
+	t.Run("test simple scheduled transfer", testSimpledScheduledTransfer)
+}
+
+func testSimpledScheduledTransfer(t *testing.T) {
+
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	// let's do a massive fee, easy to test
+	e.OnTransferFeeFactorUpdate(context.Background(), num.NewDecimalFromFloat(1))
+	e.OnTick(context.Background(), time.Unix(10, 0))
+
+	deliverOn := time.Unix(12, 0)
+	ctx := context.Background()
+	transfer := &types.TransferFunds{
+		Kind: types.TransferCommandKindOneOff,
+		OneOff: &types.OneOffTransfer{
+			TransferBase: &types.TransferBase{
+				From:            "from",
+				FromAccountType: types.AccountTypeGeneral,
+				To:              "to",
+				ToAccountType:   types.AccountTypeGlobalReward,
+				Asset:           "eth",
+				Amount:          num.NewUint(10),
+				Reference:       "someref",
+			},
+			DeliverOn: &deliverOn,
+		},
+	}
+
+	fromAcc := types.Account{
+		Balance: num.NewUint(100),
+	}
+
+	// asset exists
+	e.assets.EXPECT().Get(gomock.Any()).Times(1).Return(nil, nil)
+	e.col.EXPECT().GetPartyGeneralAccount(gomock.Any(), gomock.Any()).Times(1).Return(&fromAcc, nil)
+
+	// assert the calculation of fees and transfer request are correct
+	e.col.EXPECT().TransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context,
+			transfers []*types.Transfer,
+			accountTypes []types.AccountType,
+			references []string,
+			feeTransfers []*types.Transfer,
+			feeTransfersAccountTypes []types.AccountType,
+		) ([]*types.TransferResponse, error,
+		) {
+			t.Run("ensure transfers are correct", func(t *testing.T) {
+				// transfer is done fully instantly, we should have 2 transfer
+				assert.Len(t, transfers, 1)
+				assert.Equal(t, transfers[0].Owner, "from")
+				assert.Equal(t, transfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[0].Amount.Asset, "eth")
+
+				// 2 account types too
+				assert.Len(t, accountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+			})
+
+			t.Run("ensure fee transfers are correct", func(t *testing.T) {
+				assert.Len(t, feeTransfers, 1)
+				assert.Equal(t, feeTransfers[0].Owner, "from")
+				assert.Equal(t, feeTransfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, feeTransfers[0].Amount.Asset, "eth")
+
+				// then the fees account types
+				assert.Len(t, feeTransfersAccountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+			})
+			return nil, nil
+		})
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+
+	assert.NoError(t, e.TransferFunds(ctx, transfer))
+
+	checkp, err := e.Checkpoint()
+	assert.NoError(t, err)
+
+	// now second step, we start a new engine, and load the checkpoint
+
+	e2 := getTestEngine(t)
+	defer e2.ctrl.Finish()
+
+	// load the checkpoint
+	assert.NoError(t, e2.Load(ctx, checkp))
+
+	// then trigger the time update, and see the transfer
+	// assert the calculation of fees and transfer request are correct
+	e2.broker.EXPECT().Send(gomock.Any()).Times(1)
+	e2.col.EXPECT().TransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context,
+			transfers []*types.Transfer,
+			accountTypes []types.AccountType,
+			references []string,
+			feeTransfers []*types.Transfer,
+			feeTransfersAccountTypes []types.AccountType,
+		) ([]*types.TransferResponse, error,
+		) {
+			t.Run("ensure transfers are correct", func(t *testing.T) {
+				// transfer is done fully instantly, we should have 2 transfer
+				assert.Equal(t, transfers[0].Owner, "to")
+				assert.Equal(t, transfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[0].Amount.Asset, "eth")
+
+				// 1 account types too
+				assert.Len(t, accountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGlobalReward)
+			})
+
+			t.Run("ensure fee transfers are correct", func(t *testing.T) {
+				assert.Len(t, feeTransfers, 0)
+			})
+			return nil, nil
+		})
+
+	e2.OnTick(context.Background(), time.Unix(12, 0))
+
+}

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -33,7 +33,6 @@ var (
 	ErrInvalidWithdrawalState                     = errors.New("invalid withdrawal state")
 	ErrNotMatchingWithdrawalForReference          = errors.New("invalid reference for withdrawal chain event")
 	ErrWithdrawalNotReady                         = errors.New("withdrawal not ready")
-	ErrCannotTransferZeroFunds                    = errors.New("cannot transfer zero funds")
 	ErrNoGeneralAccountForAsset                   = errors.New("no general account for asset")
 	ErrNotEnoughFundsToTransfer                   = errors.New("not enough funds to transfer")
 )
@@ -168,6 +167,7 @@ func New(
 		},
 		keyToSerialiser:    map[string]func() ([]byte, error){},
 		scheduledTransfers: map[time.Time][]scheduledTransfer{},
+		transferFeeFactor:  num.DecimalZero(),
 	}
 
 	e.keyToSerialiser[withdrawalsKey] = e.serialiseWithdrawals

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -90,6 +90,7 @@ type Topology interface {
 // Broker - the event bus.
 type Broker interface {
 	Send(e events.Event)
+	SendBatch(evts []events.Event)
 }
 
 const (

--- a/banking/mocks/collateral_mock.go
+++ b/banking/mocks/collateral_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	vega "code.vegaprotocol.io/protos/vega"
 	types "code.vegaprotocol.io/vega/types"
 	num "code.vegaprotocol.io/vega/types/num"
 	context "context"
@@ -33,6 +34,21 @@ func NewMockCollateral(ctrl *gomock.Controller) *MockCollateral {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCollateral) EXPECT() *MockCollateralMockRecorder {
 	return m.recorder
+}
+
+// CreatePartyGeneralAccount mocks base method
+func (m *MockCollateral) CreatePartyGeneralAccount(arg0 context.Context, arg1, arg2 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePartyGeneralAccount", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePartyGeneralAccount indicates an expected call of CreatePartyGeneralAccount
+func (mr *MockCollateralMockRecorder) CreatePartyGeneralAccount(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePartyGeneralAccount", reflect.TypeOf((*MockCollateral)(nil).CreatePartyGeneralAccount), arg0, arg1, arg2)
 }
 
 // Deposit mocks base method
@@ -77,6 +93,21 @@ func (m *MockCollateral) GetPartyGeneralAccount(arg0, arg1 string) (*types.Accou
 func (mr *MockCollateralMockRecorder) GetPartyGeneralAccount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPartyGeneralAccount", reflect.TypeOf((*MockCollateral)(nil).GetPartyGeneralAccount), arg0, arg1)
+}
+
+// TransferFunds mocks base method
+func (m *MockCollateral) TransferFunds(arg0 context.Context, arg1 []*types.Transfer, arg2 []vega.AccountType, arg3 []string, arg4 []*types.Transfer, arg5 []vega.AccountType) ([]*types.TransferResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransferFunds", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].([]*types.TransferResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransferFunds indicates an expected call of TransferFunds
+func (mr *MockCollateralMockRecorder) TransferFunds(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferFunds", reflect.TypeOf((*MockCollateral)(nil).TransferFunds), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Withdraw mocks base method

--- a/banking/mocks/collateral_mock.go
+++ b/banking/mocks/collateral_mock.go
@@ -36,21 +36,6 @@ func (m *MockCollateral) EXPECT() *MockCollateralMockRecorder {
 	return m.recorder
 }
 
-// CreatePartyGeneralAccount mocks base method
-func (m *MockCollateral) CreatePartyGeneralAccount(arg0 context.Context, arg1, arg2 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePartyGeneralAccount", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreatePartyGeneralAccount indicates an expected call of CreatePartyGeneralAccount
-func (mr *MockCollateralMockRecorder) CreatePartyGeneralAccount(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePartyGeneralAccount", reflect.TypeOf((*MockCollateral)(nil).CreatePartyGeneralAccount), arg0, arg1, arg2)
-}
-
 // Deposit mocks base method
 func (m *MockCollateral) Deposit(arg0 context.Context, arg1, arg2 string, arg3 *num.Uint) (*types.TransferResponse, error) {
 	m.ctrl.T.Helper()

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -13,9 +13,7 @@ import (
 	"code.vegaprotocol.io/vega/types/num"
 )
 
-var (
-	ErrUnsupportedTransferKind = errors.New("unsupported transfer kind")
-)
+var ErrUnsupportedTransferKind = errors.New("unsupported transfer kind")
 
 type scheduledTransfer struct {
 	transfer    *types.Transfer
@@ -179,11 +177,11 @@ type timesToTransfers struct {
 }
 
 func (e *Engine) distributeScheduledTransfers(ctx context.Context) error {
-	var ttfs = []timesToTransfers{}
+	ttfs := []timesToTransfers{}
 
 	// iterate over those scheduled transfers to sort them by time
 	for k, v := range e.scheduledTransfers {
-		if k.Before(e.currentTime) {
+		if e.currentTime.After(k) || e.currentTime.Equal(k) {
 			ttfs = append(ttfs, timesToTransfers{k, v})
 			delete(e.scheduledTransfers, k)
 		}
@@ -244,5 +242,5 @@ func (e *Engine) recurringTransfer(
 	ctx context.Context,
 	transfer *types.RecurringTransfer,
 ) error {
-	return nil
+	return errors.New("unimplemented")
 }

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -223,7 +223,7 @@ func (e *Engine) distributeScheduledTransfers(ctx context.Context) error {
 
 	// iterate over those scheduled transfers to sort them by time
 	for k, v := range e.scheduledTransfers {
-		if e.currentTime.After(k) || e.currentTime.Equal(k) {
+		if !e.currentTime.Before(k) {
 			ttfs = append(ttfs, timesToTransfers{k, v})
 			delete(e.scheduledTransfers, k)
 		}

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	checkpoint "code.vegaprotocol.io/protos/vega/checkpoint/v1"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
@@ -19,6 +20,27 @@ type scheduledTransfer struct {
 	transfer    *types.Transfer
 	accountType types.AccountType
 	reference   string
+}
+
+func (s *scheduledTransfer) ToProto() *checkpoint.ScheduledTransfer {
+	return &checkpoint.ScheduledTransfer{
+		Transfer:    s.transfer.IntoProto(),
+		AccountType: s.accountType,
+		Reference:   s.reference,
+	}
+}
+
+func scheduledTransferFromProto(p *checkpoint.ScheduledTransfer) (scheduledTransfer, error) {
+	transfer, err := types.TransferFromProto(p.Transfer)
+	if err != nil {
+		return scheduledTransfer{}, err
+	}
+
+	return scheduledTransfer{
+		transfer:    transfer,
+		accountType: p.AccountType,
+		reference:   p.Reference,
+	}, nil
 }
 
 func (e *Engine) OnTransferFeeFactorUpdate(ctx context.Context, f num.Decimal) error {

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -232,7 +232,7 @@ func (e *Engine) distributeScheduledTransfers(ctx context.Context) error {
 
 	// sort slice by time.
 	// no need to sort transfers they are going out as first in first out.
-	sort.Slice(ttfs, func(i, j int) bool {
+	sort.SliceStable(ttfs, func(i, j int) bool {
 		return ttfs[i].deliverOn.Before(ttfs[j].deliverOn)
 	})
 

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -171,7 +171,7 @@ func (e *Engine) ensureFeeForTransferFunds(
 	// now we get the total amount and ensure we have enough funds
 	// if the source account
 	var (
-		totalAmount = num.Zero().Add(feeAmount, amount)
+		totalAmount = num.Sum(feeAmount, amount)
 		account     *types.Account
 		err         error
 	)
@@ -210,7 +210,7 @@ func (e *Engine) ensureFeeForTransferFunds(
 			Asset:  asset,
 		},
 		Type:      types.TransferTypeInfrastructureFeePay,
-		MinAmount: feeAmount.Clone(),
+		MinAmount: feeAmount,
 	}, nil
 }
 

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -1,0 +1,225 @@
+package banking
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/types"
+	"code.vegaprotocol.io/vega/types/num"
+)
+
+type scheduledTransfer struct {
+	transfer    *types.Transfer
+	accountType types.AccountType
+	reference   string
+}
+
+func (e *Engine) TransferFunds(
+	ctx context.Context,
+	from, to, asset string,
+	fromAccountType, toAccountType types.AccountType,
+	amount *num.Uint,
+	reference string,
+	deliverOn *time.Time,
+) error {
+	// ensure asset exists
+	if _, err := e.assets.Get(asset); err != nil {
+		e.log.Debug("cannot transfer funds, invalid asset", logging.Error(err))
+		return fmt.Errorf("could not transfer funds: %w", err)
+	}
+
+	// ensure amount makes senses
+	if amount.IsZero() {
+		return ErrCannotTransferZeroFunds
+	}
+
+	if fromAccountType != types.AccountTypeGeneral {
+		return fmt.Errorf("unsupported from account type: %v", fromAccountType)
+	}
+
+	if toAccountType != types.AccountTypeGeneral && toAccountType != types.AccountTypeGlobalReward {
+		return fmt.Errorf("unsupported to account type: %v", toAccountType)
+	}
+
+	// ensure the party have enough funds for both the
+	// amount and the fee for the transfer
+	feeTransfer, err := e.ensureFeeForTransferFunds(
+		amount, from, asset, fromAccountType)
+	if err != nil {
+		return fmt.Errorf("could not pay the fee for transfer: %w", err)
+	}
+	feeTransferAccountType := []types.AccountType{fromAccountType}
+
+	// build the transfers
+	transfers := []*types.Transfer{
+		{
+			Owner: from,
+			Amount: &types.FinancialAmount{
+				Amount: amount.Clone(),
+				Asset:  asset,
+			},
+			Type:      types.TransferTypeTransferFundsSend,
+			MinAmount: amount.Clone(),
+		},
+	}
+	toTransfer := &types.Transfer{
+		Owner: to,
+		Amount: &types.FinancialAmount{
+			Amount: amount.Clone(),
+			Asset:  asset,
+		},
+		Type:      types.TransferTypeTransferFundsDistribute,
+		MinAmount: amount.Clone(),
+	}
+
+	// build account types and references
+	accountTypes := []types.AccountType{fromAccountType}
+	references := []string{reference}
+
+	// does the transfer needs to be finalized now?
+	if deliverOn != nil && deliverOn.Before(e.currentTime) {
+		transfers = append(transfers, toTransfer)
+		accountTypes = append(accountTypes, toAccountType)
+		references = append(references, reference)
+	} else {
+		// schedule the transfer
+		e.scheduleTransfer(toTransfer, toAccountType, reference, *deliverOn)
+	}
+
+	// process the transfer
+	tresps, err := e.col.TransferFunds(
+		ctx, transfers, accountTypes, references, []*types.Transfer{feeTransfer}, feeTransferAccountType,
+	)
+	if err != nil {
+		return err
+	}
+
+	e.broker.Send(events.NewTransferResponse(ctx, tresps))
+
+	return nil
+}
+
+func (e *Engine) ensureFeeForTransferFunds(
+	amount *num.Uint,
+	from, asset string,
+	fromAccountType types.AccountType,
+) (*types.Transfer, error) {
+	// first we calculate the fee
+	feeAmount, _ := num.UintFromDecimal(amount.ToDecimal().Mul(e.transferFeeFactor))
+
+	// now we get the total amount and ensure we have enough funds
+	// if the source account
+	var (
+		totalAmount = num.Zero().Add(feeAmount, amount)
+		account     *types.Account
+		err         error
+	)
+	switch fromAccountType {
+	case types.AccountTypeGeneral:
+		account, err = e.col.GetPartyGeneralAccount(from, asset)
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		e.log.Panic("from account not supported",
+			logging.String("account-type", fromAccountType.String()),
+			logging.String("asset", asset),
+			logging.String("from", from),
+		)
+	}
+
+	if account.Balance.LT(totalAmount) {
+		e.log.Debug("not enough funds to transfer",
+			logging.BigUint("amount", amount),
+			logging.BigUint("fee", feeAmount),
+			logging.BigUint("total-amount", totalAmount),
+			logging.BigUint("account-balance", account.Balance),
+			logging.String("account-type", fromAccountType.String()),
+			logging.String("asset", asset),
+			logging.String("from", from),
+		)
+		return nil, ErrNotEnoughFundsToTransfer
+	}
+
+	return &types.Transfer{
+		Owner: from,
+		Amount: &types.FinancialAmount{
+			Amount: feeAmount.Clone(),
+			Asset:  asset,
+		},
+		Type:      types.TransferTypeInfrastructureFeePay,
+		MinAmount: feeAmount.Clone(),
+	}, nil
+}
+
+type timesToTransfers struct {
+	deliverOn time.Time
+	transfer  []scheduledTransfer
+}
+
+func (e *Engine) distributeScheduledTransfers(ctx context.Context) error {
+	var ttfs = []timesToTransfers{}
+
+	// iterate over those scheduled transfers to sort them by time
+	for k, v := range e.scheduledTransfers {
+		if k.Before(e.currentTime) {
+			ttfs = append(ttfs, timesToTransfers{k, v})
+			delete(e.scheduledTransfers, k)
+		}
+	}
+
+	// sort slice by time.
+	// no need to sort transfers they are going out as first in first out.
+	sort.Slice(ttfs, func(i, j int) bool {
+		return ttfs[i].deliverOn.Before(ttfs[j].deliverOn)
+	})
+
+	transfers := []*types.Transfer{}
+	accountTypes := []types.AccountType{}
+	references := []string{}
+	for _, v := range ttfs {
+		for _, t := range v.transfer {
+			transfers = append(transfers, t.transfer)
+			accountTypes = append(accountTypes, t.accountType)
+			references = append(references, t.reference)
+		}
+	}
+
+	if len(transfers) <= 0 {
+		// nothing to do yeay
+		return nil
+	}
+
+	tresps, err := e.col.TransferFunds(
+		ctx, transfers, accountTypes, references, nil, nil, // no fees required there, they've been paid already
+	)
+	if err != nil {
+		return err
+	}
+
+	e.broker.Send(events.NewTransferResponse(ctx, tresps))
+
+	return nil
+}
+
+func (e *Engine) scheduleTransfer(
+	t *types.Transfer, ty types.AccountType, reference string, deliverOn time.Time,
+) {
+	sts, ok := e.scheduledTransfers[deliverOn]
+	if !ok {
+		e.scheduledTransfers[deliverOn] = []scheduledTransfer{}
+		sts = e.scheduledTransfers[deliverOn]
+	}
+
+	sts = append(sts, scheduledTransfer{
+		transfer:    t,
+		accountType: ty,
+		reference:   reference,
+	})
+	e.scheduledTransfers[deliverOn] = sts
+}

--- a/banking/transfers.go
+++ b/banking/transfers.go
@@ -103,8 +103,7 @@ func (e *Engine) oneOffTransfer(
 	references := []string{transfer.Reference}
 
 	// does the transfer needs to be finalized now?
-	if transfer.DeliverOn == nil ||
-		(transfer.DeliverOn != nil && transfer.DeliverOn.Before(e.currentTime)) {
+	if transfer.DeliverOn == nil || transfer.DeliverOn.Before(e.currentTime) {
 		transfers = append(transfers, toTransfer)
 		accountTypes = append(accountTypes, transfer.ToAccountType)
 		references = append(references, transfer.Reference)

--- a/banking/transfers_test.go
+++ b/banking/transfers_test.go
@@ -64,6 +64,7 @@ func testOneOffTransferNotEnoughFundsToTransfer(t *testing.T) {
 	// asset exists
 	e.assets.EXPECT().Get(gomock.Any()).Times(1).Return(nil, nil)
 	e.col.EXPECT().GetPartyGeneralAccount(gomock.Any(), gomock.Any()).Times(1).Return(&fromAcc, nil)
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
 
 	assert.EqualError(t,
 		e.TransferFunds(ctx, transfer),
@@ -97,6 +98,7 @@ func testOneOffTransferInvalidTransfers(t *testing.T) {
 	var baseCpy types.TransferBase
 
 	t.Run("invalid from account", func(t *testing.T) {
+		e.broker.EXPECT().Send(gomock.Any()).Times(1)
 		baseCpy := transferBase
 		transfer.OneOff.TransferBase = &baseCpy
 		transfer.OneOff.From = ""
@@ -107,6 +109,7 @@ func testOneOffTransferInvalidTransfers(t *testing.T) {
 	})
 
 	t.Run("invalid to account", func(t *testing.T) {
+		e.broker.EXPECT().Send(gomock.Any()).Times(1)
 		baseCpy = transferBase
 		transfer.OneOff.TransferBase = &baseCpy
 		transfer.OneOff.To = ""
@@ -117,6 +120,7 @@ func testOneOffTransferInvalidTransfers(t *testing.T) {
 	})
 
 	t.Run("unsupported from account type", func(t *testing.T) {
+		e.broker.EXPECT().Send(gomock.Any()).Times(1)
 		baseCpy = transferBase
 		transfer.OneOff.TransferBase = &baseCpy
 		transfer.OneOff.FromAccountType = types.AccountTypeBond
@@ -127,6 +131,7 @@ func testOneOffTransferInvalidTransfers(t *testing.T) {
 	})
 
 	t.Run("unsuported to account type", func(t *testing.T) {
+		e.broker.EXPECT().Send(gomock.Any()).Times(1)
 		baseCpy = transferBase
 		transfer.OneOff.TransferBase = &baseCpy
 		transfer.OneOff.ToAccountType = types.AccountTypeBond
@@ -137,6 +142,7 @@ func testOneOffTransferInvalidTransfers(t *testing.T) {
 	})
 
 	t.Run("zero funds transfer", func(t *testing.T) {
+		e.broker.EXPECT().Send(gomock.Any()).Times(1)
 		baseCpy = transferBase
 		transfer.OneOff.TransferBase = &baseCpy
 		transfer.OneOff.Amount = num.Zero()
@@ -217,7 +223,7 @@ func testValidOneOffTransfer(t *testing.T) {
 			return nil, nil
 		})
 
-	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	e.broker.EXPECT().Send(gomock.Any()).Times(2)
 
 	assert.NoError(t, e.TransferFunds(ctx, transfer))
 }
@@ -295,7 +301,7 @@ func testValidOneOffTransferWithDeliverOnInThePastStraightAway(t *testing.T) {
 			return nil, nil
 		})
 
-	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	e.broker.EXPECT().Send(gomock.Any()).Times(2)
 
 	assert.NoError(t, e.TransferFunds(ctx, transfer))
 }
@@ -369,7 +375,7 @@ func testValidOneOffTransferWithDeliverOn(t *testing.T) {
 			return nil, nil
 		})
 
-	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	e.broker.EXPECT().Send(gomock.Any()).Times(2)
 
 	assert.NoError(t, e.TransferFunds(ctx, transfer))
 
@@ -406,5 +412,6 @@ func testValidOneOffTransferWithDeliverOn(t *testing.T) {
 			return nil, nil
 		})
 
+	e.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
 	e.OnTick(context.Background(), time.Unix(12, 0))
 }

--- a/banking/transfers_test.go
+++ b/banking/transfers_test.go
@@ -1,0 +1,410 @@
+package banking_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/banking"
+	"code.vegaprotocol.io/vega/types"
+	"code.vegaprotocol.io/vega/types/num"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransfers(t *testing.T) {
+	t.Run("invalid transfer kind", testInvalidTransferKind)
+	t.Run("onefoff not enough funds to transfer", testOneOffTransferNotEnoughFundsToTransfer)
+	t.Run("onefoff invalid transfers", testOneOffTransferInvalidTransfers)
+	t.Run("valid oneoff transfer", testValidOneOffTransfer)
+	t.Run("valid oneoff with deliverOn", testValidOneOffTransferWithDeliverOn)
+	t.Run("valid oneoff with deliverOn in the past is done straight away", testValidOneOffTransferWithDeliverOnInThePastStraightAway)
+}
+
+func testInvalidTransferKind(t *testing.T) {
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	ctx := context.Background()
+	transfer := &types.TransferFunds{
+		Kind: types.TransferCommandKind(-1),
+	}
+	assert.EqualError(t,
+		e.TransferFunds(ctx, transfer),
+		banking.ErrUnsupportedTransferKind.Error(),
+	)
+}
+
+func testOneOffTransferNotEnoughFundsToTransfer(t *testing.T) {
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	ctx := context.Background()
+	transfer := &types.TransferFunds{
+		Kind: types.TransferCommandKindOneOff,
+		OneOff: &types.OneOffTransfer{
+			TransferBase: &types.TransferBase{
+				From:            "from",
+				FromAccountType: types.AccountTypeGeneral,
+				To:              "to",
+				ToAccountType:   types.AccountTypeGeneral,
+				Asset:           "eth",
+				Amount:          num.NewUint(10),
+				Reference:       "someref",
+			},
+		},
+	}
+
+	fromAcc := types.Account{
+		Balance: num.NewUint(1),
+	}
+
+	// asset exists
+	e.assets.EXPECT().Get(gomock.Any()).Times(1).Return(nil, nil)
+	e.col.EXPECT().GetPartyGeneralAccount(gomock.Any(), gomock.Any()).Times(1).Return(&fromAcc, nil)
+
+	assert.EqualError(t,
+		e.TransferFunds(ctx, transfer),
+		fmt.Errorf("could not pay the fee for transfer: %w", banking.ErrNotEnoughFundsToTransfer).Error(),
+	)
+}
+
+func testOneOffTransferInvalidTransfers(t *testing.T) {
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	ctx := context.Background()
+	transfer := types.TransferFunds{
+		Kind:   types.TransferCommandKindOneOff,
+		OneOff: &types.OneOffTransfer{},
+	}
+
+	transferBase := types.TransferBase{
+		From:            "from",
+		FromAccountType: types.AccountTypeGeneral,
+		To:              "to",
+		ToAccountType:   types.AccountTypeGeneral,
+		Asset:           "eth",
+		Amount:          num.NewUint(10),
+		Reference:       "someref",
+	}
+
+	// asset exists
+	e.assets.EXPECT().Get(gomock.Any()).AnyTimes().Return(nil, nil)
+
+	var baseCpy types.TransferBase
+
+	t.Run("invalid from account", func(t *testing.T) {
+		baseCpy := transferBase
+		transfer.OneOff.TransferBase = &baseCpy
+		transfer.OneOff.From = ""
+		assert.EqualError(t,
+			e.TransferFunds(ctx, &transfer),
+			types.ErrInvalidFromAccount.Error(),
+		)
+	})
+
+	t.Run("invalid to account", func(t *testing.T) {
+		baseCpy = transferBase
+		transfer.OneOff.TransferBase = &baseCpy
+		transfer.OneOff.To = ""
+		assert.EqualError(t,
+			e.TransferFunds(ctx, &transfer),
+			types.ErrInvalidToAccount.Error(),
+		)
+	})
+
+	t.Run("unsupported from account type", func(t *testing.T) {
+		baseCpy = transferBase
+		transfer.OneOff.TransferBase = &baseCpy
+		transfer.OneOff.FromAccountType = types.AccountTypeBond
+		assert.EqualError(t,
+			e.TransferFunds(ctx, &transfer),
+			types.ErrUnsupportedFromAccountType.Error(),
+		)
+	})
+
+	t.Run("unsuported to account type", func(t *testing.T) {
+		baseCpy = transferBase
+		transfer.OneOff.TransferBase = &baseCpy
+		transfer.OneOff.ToAccountType = types.AccountTypeBond
+		assert.EqualError(t,
+			e.TransferFunds(ctx, &transfer),
+			types.ErrUnsupportedToAccountType.Error(),
+		)
+	})
+
+	t.Run("zero funds transfer", func(t *testing.T) {
+		baseCpy = transferBase
+		transfer.OneOff.TransferBase = &baseCpy
+		transfer.OneOff.Amount = num.Zero()
+		assert.EqualError(t,
+			e.TransferFunds(ctx, &transfer),
+			types.ErrCannotTransferZeroFunds.Error(),
+		)
+	})
+}
+
+func testValidOneOffTransfer(t *testing.T) {
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	// let's do a massive fee, easy to test
+	e.OnTransferFeeFactorUpdate(context.Background(), num.NewDecimalFromFloat(1))
+
+	ctx := context.Background()
+	transfer := &types.TransferFunds{
+		Kind: types.TransferCommandKindOneOff,
+		OneOff: &types.OneOffTransfer{
+			TransferBase: &types.TransferBase{
+				From:            "from",
+				FromAccountType: types.AccountTypeGeneral,
+				To:              "to",
+				ToAccountType:   types.AccountTypeGlobalReward,
+				Asset:           "eth",
+				Amount:          num.NewUint(10),
+				Reference:       "someref",
+			},
+		},
+	}
+
+	fromAcc := types.Account{
+		Balance: num.NewUint(100),
+	}
+
+	// asset exists
+	e.assets.EXPECT().Get(gomock.Any()).Times(1).Return(nil, nil)
+	e.col.EXPECT().GetPartyGeneralAccount(gomock.Any(), gomock.Any()).Times(1).Return(&fromAcc, nil)
+
+	// assert the calculation of fees and transfer request are correct
+	e.col.EXPECT().TransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context,
+			transfers []*types.Transfer,
+			accountTypes []types.AccountType,
+			references []string,
+			feeTransfers []*types.Transfer,
+			feeTransfersAccountTypes []types.AccountType,
+		) ([]*types.TransferResponse, error,
+		) {
+			t.Run("ensure transfers are correct", func(t *testing.T) {
+				// transfer is done fully instantly, we should have 2 transfer
+				assert.Len(t, transfers, 2)
+				assert.Equal(t, transfers[0].Owner, "from")
+				assert.Equal(t, transfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[0].Amount.Asset, "eth")
+				assert.Equal(t, transfers[1].Owner, "to")
+				assert.Equal(t, transfers[1].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[1].Amount.Asset, "eth")
+
+				// 2 account types too
+				assert.Len(t, accountTypes, 2)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+				assert.Equal(t, accountTypes[1], types.AccountTypeGlobalReward)
+			})
+
+			t.Run("ensure fee transfers are correct", func(t *testing.T) {
+				assert.Len(t, feeTransfers, 1)
+				assert.Equal(t, feeTransfers[0].Owner, "from")
+				assert.Equal(t, feeTransfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, feeTransfers[0].Amount.Asset, "eth")
+
+				// then the fees account types
+				assert.Len(t, feeTransfersAccountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+			})
+			return nil, nil
+		})
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+
+	assert.NoError(t, e.TransferFunds(ctx, transfer))
+}
+
+func testValidOneOffTransferWithDeliverOnInThePastStraightAway(t *testing.T) {
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	// let's do a massive fee, easy to test
+	e.OnTransferFeeFactorUpdate(context.Background(), num.NewDecimalFromFloat(1))
+	e.OnTick(context.Background(), time.Unix(10, 0))
+
+	deliverOn := time.Unix(9, 0)
+	ctx := context.Background()
+	transfer := &types.TransferFunds{
+		Kind: types.TransferCommandKindOneOff,
+		OneOff: &types.OneOffTransfer{
+			TransferBase: &types.TransferBase{
+				From:            "from",
+				FromAccountType: types.AccountTypeGeneral,
+				To:              "to",
+				ToAccountType:   types.AccountTypeGlobalReward,
+				Asset:           "eth",
+				Amount:          num.NewUint(10),
+				Reference:       "someref",
+			},
+			DeliverOn: &deliverOn,
+		},
+	}
+
+	fromAcc := types.Account{
+		Balance: num.NewUint(100),
+	}
+
+	// asset exists
+	e.assets.EXPECT().Get(gomock.Any()).Times(1).Return(nil, nil)
+	e.col.EXPECT().GetPartyGeneralAccount(gomock.Any(), gomock.Any()).Times(1).Return(&fromAcc, nil)
+
+	// assert the calculation of fees and transfer request are correct
+	e.col.EXPECT().TransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context,
+			transfers []*types.Transfer,
+			accountTypes []types.AccountType,
+			references []string,
+			feeTransfers []*types.Transfer,
+			feeTransfersAccountTypes []types.AccountType,
+		) ([]*types.TransferResponse, error,
+		) {
+			t.Run("ensure transfers are correct", func(t *testing.T) {
+				// transfer is done fully instantly, we should have 2 transfer
+				assert.Len(t, transfers, 2)
+				assert.Equal(t, transfers[0].Owner, "from")
+				assert.Equal(t, transfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[0].Amount.Asset, "eth")
+				assert.Equal(t, transfers[1].Owner, "to")
+				assert.Equal(t, transfers[1].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[1].Amount.Asset, "eth")
+
+				// 2 account types too
+				assert.Len(t, accountTypes, 2)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+				assert.Equal(t, accountTypes[1], types.AccountTypeGlobalReward)
+			})
+
+			t.Run("ensure fee transfers are correct", func(t *testing.T) {
+				assert.Len(t, feeTransfers, 1)
+				assert.Equal(t, feeTransfers[0].Owner, "from")
+				assert.Equal(t, feeTransfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, feeTransfers[0].Amount.Asset, "eth")
+
+				// then the fees account types
+				assert.Len(t, feeTransfersAccountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+			})
+			return nil, nil
+		})
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+
+	assert.NoError(t, e.TransferFunds(ctx, transfer))
+}
+
+func testValidOneOffTransferWithDeliverOn(t *testing.T) {
+	e := getTestEngine(t)
+	defer e.ctrl.Finish()
+
+	// let's do a massive fee, easy to test
+	e.OnTransferFeeFactorUpdate(context.Background(), num.NewDecimalFromFloat(1))
+	e.OnTick(context.Background(), time.Unix(10, 0))
+
+	deliverOn := time.Unix(12, 0)
+	ctx := context.Background()
+	transfer := &types.TransferFunds{
+		Kind: types.TransferCommandKindOneOff,
+		OneOff: &types.OneOffTransfer{
+			TransferBase: &types.TransferBase{
+				From:            "from",
+				FromAccountType: types.AccountTypeGeneral,
+				To:              "to",
+				ToAccountType:   types.AccountTypeGlobalReward,
+				Asset:           "eth",
+				Amount:          num.NewUint(10),
+				Reference:       "someref",
+			},
+			DeliverOn: &deliverOn,
+		},
+	}
+
+	fromAcc := types.Account{
+		Balance: num.NewUint(100),
+	}
+
+	// asset exists
+	e.assets.EXPECT().Get(gomock.Any()).Times(1).Return(nil, nil)
+	e.col.EXPECT().GetPartyGeneralAccount(gomock.Any(), gomock.Any()).Times(1).Return(&fromAcc, nil)
+
+	// assert the calculation of fees and transfer request are correct
+	e.col.EXPECT().TransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context,
+			transfers []*types.Transfer,
+			accountTypes []types.AccountType,
+			references []string,
+			feeTransfers []*types.Transfer,
+			feeTransfersAccountTypes []types.AccountType,
+		) ([]*types.TransferResponse, error,
+		) {
+			t.Run("ensure transfers are correct", func(t *testing.T) {
+				// transfer is done fully instantly, we should have 2 transfer
+				assert.Len(t, transfers, 1)
+				assert.Equal(t, transfers[0].Owner, "from")
+				assert.Equal(t, transfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[0].Amount.Asset, "eth")
+
+				// 2 account types too
+				assert.Len(t, accountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+			})
+
+			t.Run("ensure fee transfers are correct", func(t *testing.T) {
+				assert.Len(t, feeTransfers, 1)
+				assert.Equal(t, feeTransfers[0].Owner, "from")
+				assert.Equal(t, feeTransfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, feeTransfers[0].Amount.Asset, "eth")
+
+				// then the fees account types
+				assert.Len(t, feeTransfersAccountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGeneral)
+			})
+			return nil, nil
+		})
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+
+	assert.NoError(t, e.TransferFunds(ctx, transfer))
+
+	// nothing expected
+	e.OnTick(context.Background(), time.Unix(11, 0))
+
+	// now the funds are being paid
+
+	// assert the calculation of fees and transfer request are correct
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	e.col.EXPECT().TransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context,
+			transfers []*types.Transfer,
+			accountTypes []types.AccountType,
+			references []string,
+			feeTransfers []*types.Transfer,
+			feeTransfersAccountTypes []types.AccountType,
+		) ([]*types.TransferResponse, error,
+		) {
+			t.Run("ensure transfers are correct", func(t *testing.T) {
+				// transfer is done fully instantly, we should have 2 transfer
+				assert.Equal(t, transfers[0].Owner, "to")
+				assert.Equal(t, transfers[0].Amount.Amount, num.NewUint(10))
+				assert.Equal(t, transfers[0].Amount.Asset, "eth")
+
+				// 1 account types too
+				assert.Len(t, accountTypes, 1)
+				assert.Equal(t, accountTypes[0], types.AccountTypeGlobalReward)
+			})
+
+			t.Run("ensure fee transfers are correct", func(t *testing.T) {
+				assert.Len(t, feeTransfers, 0)
+			})
+			return nil, nil
+		})
+
+	e.OnTick(context.Background(), time.Unix(12, 0))
+}

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -28,6 +28,7 @@ var (
 		types.DelegationCheckpoint,     // so delegation sequence ID's make sense
 		types.PendingRewardsCheckpoint, // pending rewards can basically be reloaded any time
 		types.KeyRotationsCheckpoint,   // key rotations can be reloaded any time
+		types.BankingCheckpoint,        // key rotations can be reloaded any time
 	}
 )
 

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -28,7 +28,7 @@ var (
 		types.DelegationCheckpoint,     // so delegation sequence ID's make sense
 		types.PendingRewardsCheckpoint, // pending rewards can basically be reloaded any time
 		types.KeyRotationsCheckpoint,   // key rotations can be reloaded any time
-		types.BankingCheckpoint,        // key rotations can be reloaded any time
+		types.BankingCheckpoint,        // Banking checkpoint needs to be reload any time after collateral
 	}
 )
 

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -137,6 +137,10 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 	// setup rewards engine
 	n.rewards = rewards.New(n.Log, n.conf.Rewards, n.broker, n.delegation, n.epochService, n.collateral, n.timeService, n.topology)
 
+	n.notary = notary.NewWithSnapshot(
+		n.Log, n.conf.Notary, n.topology, n.broker, n.commander, n.timeService)
+	n.banking = banking.New(n.Log, n.conf.Banking, n.collateral, n.witness, n.timeService, n.assets, n.notary, n.broker, n.topology)
+
 	// checkpoint engine
 	n.checkpoint, err = checkpoint.New(n.Log, n.conf.Checkpoint, n.assets, n.collateral, n.governance, n.netParams, n.delegation, n.epochService, n.rewards, n.topology, n.banking)
 	if err != nil {
@@ -159,9 +163,6 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 		n.checkpoint.UponGenesis,
 	)
 
-	n.notary = notary.NewWithSnapshot(
-		n.Log, n.conf.Notary, n.topology, n.broker, n.commander, n.timeService)
-	n.banking = banking.New(n.Log, n.conf.Banking, n.collateral, n.witness, n.timeService, n.assets, n.notary, n.broker, n.topology)
 	n.spam = spam.New(n.Log, n.conf.Spam, n.epochService, n.stakingAccounts)
 	n.snapshot, err = snapshot.New(n.ctx, n.vegaPaths, n.conf.Snapshot, n.Log, n.timeService)
 	if err != nil {

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -440,6 +440,10 @@ func (n *NodeCommand) setupNetParameters() error {
 			Param:   netparams.FloatingPointUpdatesDuration,
 			Watcher: n.statevar.OnFloatingPointUpdatesDurationUpdate,
 		},
+		netparams.WatchParam{
+			Param:   netparams.TransferFeeFactor,
+			Watcher: n.banking.OnTransferFeeFactorUpdate,
+		},
 	)
 }
 

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -138,7 +138,7 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 	n.rewards = rewards.New(n.Log, n.conf.Rewards, n.broker, n.delegation, n.epochService, n.collateral, n.timeService, n.topology)
 
 	// checkpoint engine
-	n.checkpoint, err = checkpoint.New(n.Log, n.conf.Checkpoint, n.assets, n.collateral, n.governance, n.netParams, n.delegation, n.epochService, n.rewards, n.topology)
+	n.checkpoint, err = checkpoint.New(n.Log, n.conf.Checkpoint, n.assets, n.collateral, n.governance, n.netParams, n.delegation, n.epochService, n.rewards, n.topology, n.banking)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/vegabenchmark/mocks/broker_mock.go
+++ b/cmd/vegabenchmark/mocks/broker_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	broker "code.vegaprotocol.io/vega/broker"
 	events "code.vegaprotocol.io/vega/events"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -55,4 +56,46 @@ func (m *MockBroker) SendBatch(arg0 []events.Event) {
 func (mr *MockBrokerMockRecorder) SendBatch(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBatch", reflect.TypeOf((*MockBroker)(nil).SendBatch), arg0)
+}
+
+// Subscribe mocks base method
+func (m *MockBroker) Subscribe(arg0 broker.Subscriber) int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subscribe", arg0)
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Subscribe indicates an expected call of Subscribe
+func (mr *MockBrokerMockRecorder) Subscribe(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockBroker)(nil).Subscribe), arg0)
+}
+
+// SubscribeBatch mocks base method
+func (m *MockBroker) SubscribeBatch(arg0 ...broker.Subscriber) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "SubscribeBatch", varargs...)
+}
+
+// SubscribeBatch indicates an expected call of SubscribeBatch
+func (mr *MockBrokerMockRecorder) SubscribeBatch(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeBatch", reflect.TypeOf((*MockBroker)(nil).SubscribeBatch), arg0...)
+}
+
+// Unsubscribe mocks base method
+func (m *MockBroker) Unsubscribe(arg0 int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Unsubscribe", arg0)
+}
+
+// Unsubscribe indicates an expected call of Unsubscribe
+func (mr *MockBrokerMockRecorder) Unsubscribe(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MockBroker)(nil).Unsubscribe), arg0)
 }

--- a/cmd/vegabenchmark/mocks/interface.go
+++ b/cmd/vegabenchmark/mocks/interface.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
+	"code.vegaprotocol.io/vega/broker"
 	"code.vegaprotocol.io/vega/crypto"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/governance"
@@ -34,6 +35,9 @@ type Limits interface {
 type Broker interface {
 	Send(e events.Event)
 	SendBatch(e []events.Event)
+	Subscribe(s broker.Subscriber) int
+	SubscribeBatch(subs ...broker.Subscriber)
+	Unsubscribe(k int)
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination notary_mock.go -package mocks code.vegaprotocol.io/vega/cmd/vegabenchmark/mocks Notary

--- a/collateral/checkpoint.go
+++ b/collateral/checkpoint.go
@@ -35,12 +35,14 @@ func (e *Engine) Load(ctx context.Context, data []byte) error {
 	for _, balance := range msg.Balances {
 		ub, _ := num.UintFromString(balance.Balance, 10)
 		// for backward compatibility check both - after this is already out checkpoints will always have the type for global accounts
-		if balance.Party == systemOwner || balance.Party == systemOwner+types.AccountTypeGlobalReward.String() || balance.Party == systemOwner+types.AccountTypeFeesInfrastructure.String() {
+		if balance.Party == systemOwner || balance.Party == systemOwner+types.AccountTypeGlobalReward.String() || balance.Party == systemOwner+types.AccountTypeFeesInfrastructure.String() || balance.Party == systemOwner+types.AccountTypePendingTransfers.String() {
 			tp := types.AccountTypeGlobalInsurance
 			if balance.Party == systemOwner+types.AccountTypeGlobalReward.String() {
 				tp = types.AccountTypeGlobalReward
 			} else if balance.Party == systemOwner+types.AccountTypeFeesInfrastructure.String() {
 				tp = types.AccountTypeFeesInfrastructure
+			} else if balance.Party == systemOwner+types.AccountTypePendingTransfers.String() {
+				tp = types.AccountTypePendingTransfers
 			}
 
 			accID := e.accountID(noMarket, systemOwner, balance.Asset, tp)
@@ -71,10 +73,11 @@ func (e *Engine) getCheckpointBalances() []*checkpoint.AssetBalance {
 		}
 		switch acc.Type {
 		case types.AccountTypeMargin, types.AccountTypeGeneral, types.AccountTypeBond,
-			types.AccountTypeInsurance, types.AccountTypeGlobalInsurance, types.AccountTypeGlobalReward, types.AccountTypeFeesInfrastructure:
+			types.AccountTypeInsurance, types.AccountTypeGlobalInsurance, types.AccountTypeGlobalReward,
+			types.AccountTypeFeesInfrastructure, types.AccountTypePendingTransfers:
 			owner := acc.Owner
 			// handle reward accounts separately.
-			if owner == systemOwner && (acc.Type == types.AccountTypeGlobalReward || acc.Type == types.AccountTypeFeesInfrastructure) {
+			if owner == systemOwner && (acc.Type == types.AccountTypeGlobalReward || acc.Type == types.AccountTypeFeesInfrastructure || acc.Type == types.AccountTypePendingTransfers) {
 				owner = owner + acc.Type.String()
 			}
 

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1108,6 +1108,83 @@ func (e *Engine) RollbackMarginUpdateOnOrder(ctx context.Context, marketID strin
 	return res, nil
 }
 
+func (e *Engine) TransferFunds(
+	ctx context.Context,
+	transfers []*types.Transfer,
+	accountTypes []types.AccountType,
+	references []string,
+	feeTransfers []*types.Transfer,
+	feeTransfersAccountType []types.AccountType,
+) ([]*types.TransferResponse, error) {
+	if len(transfers) != len(accountTypes) || len(transfers) != len(references) {
+		e.log.Panic("not the same amount of transfers, accounts types and references to process",
+			logging.Int("transfers", len(transfers)),
+			logging.Int("accounts-types", len(accountTypes)),
+			logging.Int("reference", len(references)),
+		)
+	}
+
+	resps := make([]*types.TransferResponse, 0, len(transfers))
+	for i := range transfers {
+		req, err := e.getTransferFundsTransferRequest(
+			ctx, transfers[i], accountTypes[i], references[i])
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := e.getLedgerEntries(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range res.Transfers {
+			// increment the to account
+			if err := e.IncrementBalance(ctx, v.ToAccount, v.Amount); err != nil {
+				e.log.Error(
+					"Failed to increment balance for account",
+					logging.String("account-id", v.ToAccount),
+					logging.BigUint("amount", v.Amount),
+					logging.Error(err),
+				)
+			}
+		}
+
+		resps = append(resps, res)
+	}
+
+	if len(feeTransfers) > 0 {
+		for i := range feeTransfers {
+			req, err := e.getTransferFundsFeesTransferRequest(
+				ctx, feeTransfers[i], feeTransfersAccountType[i])
+			if err != nil {
+				return nil, err
+			}
+
+			res, err := e.getLedgerEntries(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, v := range res.Transfers {
+				// increment the to account
+				if err := e.IncrementBalance(ctx, v.ToAccount, v.Amount); err != nil {
+					e.log.Error(
+						"Failed to increment balance for account",
+						logging.String("account-id", v.ToAccount),
+						logging.BigUint("amount", v.Amount),
+						logging.Error(err),
+					)
+				}
+			}
+
+			resps = append(resps, res)
+		}
+	}
+
+	return resps, nil
+
+}
+
 // BondUpdate is to be used for any bond account transfers.
 // Update on new orders, updates on commitment changes, or on slashing.
 func (e *Engine) BondUpdate(ctx context.Context, market string, transfer *types.Transfer) (*types.TransferResponse, error) {
@@ -1348,6 +1425,137 @@ func (e *Engine) getBondTransferRequest(t *types.Transfer, market string) (*type
 	default:
 		return nil, errors.New("unsupported transfer type for bond account")
 	}
+}
+
+func (e *Engine) getTransferFundsTransferRequest(
+	ctx context.Context,
+	t *types.Transfer,
+	accountType types.AccountType,
+	reference string,
+) (*types.TransferRequest, error) {
+	var (
+		fromAcc, toAcc *types.Account
+		err            error
+	)
+	switch t.Type {
+	case types.TransferTypeTransferFundsSend:
+		// as of now only general account are supported.
+		// soon we'll have some kind of staking account lock as well.
+		switch accountType {
+		case types.AccountTypeGeneral:
+			fromAcc, err = e.GetPartyGeneralAccount(t.Owner, t.Amount.Asset)
+			if err != nil {
+				return nil, fmt.Errorf("account does not exists: %v, %v, %v",
+					accountType, t.Owner, t.Amount.Asset,
+				)
+			}
+
+		default:
+			return nil, fmt.Errorf("unsupported from account for TransferFunds: %v", accountType.String())
+		}
+
+	case types.TransferTypeTransferFundsDistribute:
+		// as of now we support only another general account or a reward
+		// pool
+		switch accountType {
+		// this account could not exists, we would need to create it then
+		case types.AccountTypeGeneral:
+			toAcc, err = e.GetPartyGeneralAccount(t.Owner, t.Amount.Asset)
+			if err != nil {
+				// account does not exists, let's just create it
+				id, err := e.CreatePartyGeneralAccount(ctx, t.Owner, t.Amount.Asset)
+				if err != nil {
+					return nil, err
+				}
+				toAcc, err = e.GetAccountByID(id)
+				if err != nil {
+					// shouldn't happen, we just created it...
+					return nil, err
+				}
+			}
+
+		// this could not exists as well, let's just create in this case
+		case types.AccountTypeGlobalReward:
+			id, err := e.CreateOrGetAssetRewardPoolAccount(ctx, t.Amount.Asset)
+			if err != nil {
+				return nil, err
+			}
+			toAcc, err = e.GetAccountByID(id)
+			if err != nil {
+				// shouldn't happen, we just created it...
+				return nil, err
+			}
+
+		default:
+			return nil, fmt.Errorf("unsupported to account for TransferFunds: %v", accountType.String())
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported transfer type for TransferFund: %v", t.Type.String())
+	}
+
+	// now we got all relevant accounts, we can build our request
+
+	return &types.TransferRequest{
+		FromAccount: []*types.Account{fromAcc},
+		ToAccount:   []*types.Account{toAcc},
+		Amount:      t.Amount.Amount.Clone(),
+		MinAmount:   t.Amount.Amount.Clone(),
+		Asset:       t.Amount.Asset,
+		Reference:   reference,
+	}, nil
+}
+
+func (e *Engine) getTransferFundsFeesTransferRequest(
+	ctx context.Context,
+	t *types.Transfer,
+	accountType types.AccountType,
+) (*types.TransferRequest, error) {
+	// only type supported here
+	if t.Type != types.TransferTypeInfrastructureFeeDistribute {
+		return nil, errors.New("only infrastructure fee distribute type supported")
+	}
+
+	var (
+		fromAcc, infra *types.Account
+		err            error
+	)
+
+	switch accountType {
+	case types.AccountTypeGeneral:
+		// as of now only general account are supported.
+		// soon we'll have some kind of staking account lock as well.
+		fromAcc, err = e.GetPartyGeneralAccount(t.Owner, t.Amount.Asset)
+		if err != nil {
+			return nil, fmt.Errorf("account does not exists: %v, %v, %v",
+				accountType, t.Owner, t.Amount.Asset,
+			)
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported from account for TransferFunds: %v", accountType.String())
+	}
+
+	infraID := e.accountID(noMarket, systemOwner, t.Amount.Asset, types.AccountTypeFeesInfrastructure)
+	if infra, err = e.GetAccountByID(infraID); err != nil {
+		// tha should never happened, if we got there, the
+		// asset exists and the infra fee therefore MUST exists
+		e.log.Panic("missing fee account",
+			logging.String("asset", t.Amount.Asset),
+			logging.String("id", infraID),
+			logging.Error(err),
+		)
+	}
+
+	// now we got all relevant accounts, we can build our request
+	return &types.TransferRequest{
+		FromAccount: []*types.Account{fromAcc},
+		ToAccount:   []*types.Account{infra},
+		Amount:      t.Amount.Amount.Clone(),
+		MinAmount:   t.Amount.Amount.Clone(),
+		Asset:       t.Amount.Asset,
+		Reference:   t.Type.String(),
+	}, nil
 }
 
 // getTransferRequest builds the request, and sets the required accounts based on the type of the Transfer argument.

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1182,7 +1182,6 @@ func (e *Engine) TransferFunds(
 	}
 
 	return resps, nil
-
 }
 
 // BondUpdate is to be used for any bond account transfers.

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -207,7 +207,7 @@ func (e *Engine) EnableAsset(ctx context.Context, asset types.Asset) error {
 	e.state.enableAsset(asset)
 	// then creat a new infrastructure fee account for the asset
 	// these are fee related account only
-	infraFeeID := e.accountID("", "", asset.ID, types.AccountTypeFeesInfrastructure)
+	infraFeeID := e.accountID(noMarket, systemOwner, asset.ID, types.AccountTypeFeesInfrastructure)
 	_, ok := e.accs[infraFeeID]
 	if !ok {
 		infraFeeAcc := &types.Account{
@@ -252,7 +252,7 @@ func (e *Engine) EnableAsset(ctx context.Context, asset types.Asset) error {
 	}
 
 	// pending transfers account
-	pendingTransfersID := e.accountID("", "", asset.ID, types.AccountTypePendingTransfers)
+	pendingTransfersID := e.accountID(noMarket, systemOwner, asset.ID, types.AccountTypePendingTransfers)
 	if _, ok := e.accs[pendingTransfersID]; !ok {
 		pendingTransfersAcc := &types.Account{
 			ID:       pendingTransfersID,
@@ -972,7 +972,7 @@ func (e *Engine) MarkToMarket(ctx context.Context, marketID string, transfers []
 
 // GetPartyMargin will return the current margin for a given party.
 func (e *Engine) GetPartyMargin(pos events.MarketPosition, asset, marketID string) (events.Margin, error) {
-	genID := e.accountID("", pos.Party(), asset, types.AccountTypeGeneral)
+	genID := e.accountID(noMarket, pos.Party(), asset, types.AccountTypeGeneral)
 	marginID := e.accountID(marketID, pos.Party(), asset, types.AccountTypeMargin)
 	bondID := e.accountID(marketID, pos.Party(), asset, types.AccountTypeBond)
 	genAcc, err := e.GetAccountByID(genID)
@@ -1920,7 +1920,7 @@ func (e *Engine) ClearMarket(ctx context.Context, mktID, asset string, parties [
 	resps := make([]*types.TransferResponse, 0, len(parties))
 
 	for _, v := range parties {
-		generalAcc, err := e.GetAccountByID(e.accountID("", v, asset, types.AccountTypeGeneral))
+		generalAcc, err := e.GetAccountByID(e.accountID(noMarket, v, asset, types.AccountTypeGeneral))
 		if err != nil {
 			e.log.Debug(
 				"Failed to get the general account",
@@ -2393,7 +2393,7 @@ func (e *Engine) CreateMarketAccounts(ctx context.Context, marketID, asset strin
 
 func (e *Engine) HasGeneralAccount(party, asset string) bool {
 	_, err := e.GetAccountByID(
-		e.accountID("", party, asset, types.AccountTypeGeneral))
+		e.accountID(noMarket, party, asset, types.AccountTypeGeneral))
 	return err == nil
 }
 
@@ -2403,7 +2403,7 @@ func (e *Engine) Withdraw(ctx context.Context, partyID, asset string, amount *nu
 	if !e.AssetExists(asset) {
 		return nil, ErrInvalidAssetID
 	}
-	acc, err := e.GetAccountByID(e.accountID("", partyID, asset, types.AccountTypeGeneral))
+	acc, err := e.GetAccountByID(e.accountID(noMarket, partyID, asset, types.AccountTypeGeneral))
 	if err != nil {
 		return nil, ErrAccountDoesNotExist
 	}

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -1151,6 +1151,12 @@ func (e *Engine) TransferFunds(
 			logging.Int("reference", len(references)),
 		)
 	}
+	if len(feeTransfers) != len(feeTransfersAccountType) {
+		e.log.Panic("not the same amount of fee transfers and accounts types to process",
+			logging.Int("fee-transfers", len(feeTransfers)),
+			logging.Int("fee-accounts-types", len(feeTransfersAccountType)),
+		)
+	}
 
 	resps := make([]*types.TransferResponse, 0, len(transfers))
 	for i := range transfers {
@@ -1545,7 +1551,7 @@ func (e *Engine) getTransferFundsFeesTransferRequest(
 	accountType types.AccountType,
 ) (*types.TransferRequest, error) {
 	// only type supported here
-	if t.Type != types.TransferTypeInfrastructureFeeDistribute {
+	if t.Type != types.TransferTypeInfrastructureFeePay {
 		return nil, errors.New("only infrastructure fee distribute type supported")
 	}
 

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -591,7 +591,7 @@ func testEnableAssetSuccess(t *testing.T) {
 			Symbol: "MYASSET",
 		},
 	}
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	err := eng.EnableAsset(context.Background(), asset)
 	assert.NoError(t, err)
 
@@ -608,7 +608,7 @@ func testEnableAssetFailureDuplicate(t *testing.T) {
 			Symbol: "MYASSET",
 		},
 	}
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	err := eng.EnableAsset(context.Background(), asset)
 	assert.NoError(t, err)
 
@@ -2418,7 +2418,7 @@ func getTestEngine(t *testing.T, market string) *testEngine {
 	// 2 new assets
 	// 3 asset insurance accounts
 	// 1 reward account
-	broker.EXPECT().Send(gomock.Any()).Times(14)
+	broker.EXPECT().Send(gomock.Any()).Times(17)
 	// system accounts created
 
 	eng := collateral.New(logging.NewTestLogger(), conf, broker, time.Now())
@@ -2574,27 +2574,27 @@ func TestHash(t *testing.T) {
 
 	// Create the accounts
 	eng.broker.EXPECT().Send(gomock.Any()).AnyTimes()
-	id1, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), "t1", testMarketAsset)
+	id1, err := eng.CreatePartyGeneralAccount(context.Background(), "t1", testMarketAsset)
 	require.NoError(t, err)
 
-	id2, err := eng.Engine.CreatePartyGeneralAccount(context.Background(), "t2", testMarketAsset)
+	id2, err := eng.CreatePartyGeneralAccount(context.Background(), "t2", testMarketAsset)
 	require.NoError(t, err)
 
-	_, err = eng.Engine.CreatePartyMarginAccount(context.Background(), "t1", testMarketID, testMarketAsset)
+	_, err = eng.CreatePartyMarginAccount(context.Background(), "t1", testMarketID, testMarketAsset)
 	require.NoError(t, err)
 
 	// Add balances
 	require.NoError(t,
-		eng.Engine.UpdateBalance(context.Background(), id1, num.NewUint(100)),
+		eng.UpdateBalance(context.Background(), id1, num.NewUint(100)),
 	)
 
 	require.NoError(t,
-		eng.Engine.UpdateBalance(context.Background(), id2, num.NewUint(500)),
+		eng.UpdateBalance(context.Background(), id2, num.NewUint(500)),
 	)
 
 	hash := eng.Hash()
 	require.Equal(t,
-		"f98893cf460f1401f25b606be0740dde890c7913b4d98966964335bcfd1390b8",
+		"5761f3e3f1fa279b0197c292b86874e2b8b84f128cbb469ea1822d918c394ac7",
 		hex.EncodeToString(hash),
 		"It should match against the known hash",
 	)

--- a/collateral/snapshot_test.go
+++ b/collateral/snapshot_test.go
@@ -41,6 +41,12 @@ func TestCheckpoint(t *testing.T) {
 	err = eng.Engine.UpdateBalance(ctx, mktInsAcc.ID, insBal)
 	assert.Nil(t, err)
 
+	pendingTransfersAcc := eng.GetPendingTransfersAccount(testMarketAsset)
+	assert.NoError(t, eng.UpdateBalance(ctx, pendingTransfersAcc.ID, num.NewUint(1789)))
+
+	pendingTransfersAcc = eng.GetPendingTransfersAccount(testMarketAsset)
+	assert.NoError(t, eng.UpdateBalance(ctx, pendingTransfersAcc.ID, num.NewUint(1789)))
+
 	// topup the global reward account
 	rewardAccount, err := eng.CreateOrGetAssetRewardPoolAccount(ctx, "VOTE")
 	assert.Nil(t, err)
@@ -89,6 +95,9 @@ func TestCheckpoint(t *testing.T) {
 	loadedReward, err := loadEng.GetGlobalRewardAccount("VOTE")
 	require.NoError(t, err)
 	require.Equal(t, num.NewUint(10000), loadedReward.Balance)
+
+	loadedPendingTransfers := loadEng.GetPendingTransfersAccount(testMarketAsset)
+	require.Equal(t, num.NewUint(1789), loadedPendingTransfers.Balance)
 
 	for _, feeAcc := range loadEng.GetInfraFeeAccountIDs() {
 		if strings.Contains(feeAcc, testMarketAsset) {

--- a/collateral/transfer_funds_test.go
+++ b/collateral/transfer_funds_test.go
@@ -109,7 +109,7 @@ func testTakeFromGeneralDoNotDistribute(t *testing.T) {
 				MinAmount: num.NewUint(90),
 			},
 		},
-		// 2 general accounts
+		// 1 general accounts
 		[]types.AccountType{
 			types.AccountTypeGeneral,
 		},

--- a/collateral/transfer_funds_test.go
+++ b/collateral/transfer_funds_test.go
@@ -1,0 +1,363 @@
+package collateral_test
+
+import (
+	"context"
+	"testing"
+
+	"code.vegaprotocol.io/vega/types"
+	"code.vegaprotocol.io/vega/types/num"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollateralTransferFunds(t *testing.T) {
+	t.Run("invalid number of parameters", testInvalidNumberOfParameters)
+	t.Run("general to general", testTransferFundsFromGeneralToGeneral)
+	t.Run("general to reward pool", testTransferFundsFromGeneralToRewardPool)
+	t.Run("take from general do not distribute", testTakeFromGeneralDoNotDistribute)
+	t.Run("distribute only from pending transfer", testDistributeScheduleFunds)
+}
+
+func testDistributeScheduleFunds(t *testing.T) {
+	e := getTestEngine(t, "test-market")
+	defer e.Finish()
+
+	party1 := "party1"
+	initialBalance := num.NewUint(90)
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	pendingTransfersAcc := e.GetPendingTransfersAccount(testMarketAsset)
+	assert.Equal(t, pendingTransfersAcc.Balance, num.Zero())
+
+	err := e.UpdateBalance(context.Background(), pendingTransfersAcc.ID, initialBalance)
+	assert.Nil(t, err)
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(4)
+
+	// now we create the transfers:
+	resps, err := e.TransferFunds(
+		context.Background(),
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(90), // we assume the transfer to the other party is 90
+				},
+				Type:      types.TransferTypeTransferFundsDistribute,
+				MinAmount: num.NewUint(90),
+			},
+		},
+		// 1 general accounts
+		[]types.AccountType{
+			types.AccountTypeGeneral,
+		},
+		[]string{
+			"pending-transfer-account-to-party1",
+		},
+		// no fees, they are paid before
+		[]*types.Transfer{},
+		[]types.AccountType{},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, resps, 1)
+
+	// ensure balances now
+	acc1, err := e.GetPartyGeneralAccount(party1, testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, acc1.Balance, num.NewUint(90))
+
+	pendingTransfersAcc = e.GetPendingTransfersAccount(testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, pendingTransfersAcc.Balance, num.Zero())
+}
+
+func testTakeFromGeneralDoNotDistribute(t *testing.T) {
+	e := getTestEngine(t, "test-market")
+	defer e.Finish()
+
+	party1 := "party1"
+	initialBalance := num.NewUint(100)
+
+	// create party1 account + top up
+	// no need to create party2 account, this account
+	// should be created on the go
+	e.broker.EXPECT().Send(gomock.Any()).Times(3)
+
+	p1AccID, err := e.CreatePartyGeneralAccount(
+		context.Background(), party1, testMarketAsset)
+	require.NoError(t, err)
+
+	err = e.UpdateBalance(context.Background(), p1AccID, initialBalance)
+	assert.Nil(t, err)
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(4)
+
+	// now we create the transfers:
+	resps, err := e.TransferFunds(
+		context.Background(),
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(90), // we assume the transfer to the other party is 90
+				},
+				Type:      types.TransferTypeTransferFundsSend,
+				MinAmount: num.NewUint(90),
+			},
+		},
+		// 2 general accounts
+		[]types.AccountType{
+			types.AccountTypeGeneral,
+		},
+		[]string{
+			"party1-to-party2",
+		},
+		// fee transfer
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(10), // we should have just enough to pay the fee
+				},
+				Type:      types.TransferTypeInfrastructureFeePay,
+				MinAmount: num.NewUint(10),
+			},
+		},
+		[]types.AccountType{
+			types.AccountTypeGeneral, // only one account, the general account of party
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, resps, 2)
+
+	// ensure balances now
+	acc1, err := e.GetPartyGeneralAccount(party1, testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, acc1.Balance, num.Zero())
+
+	pendingTransfersAcc := e.GetPendingTransfersAccount(testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, pendingTransfersAcc.Balance, num.NewUint(90))
+}
+
+func testTransferFundsFromGeneralToGeneral(t *testing.T) {
+	e := getTestEngine(t, "test-market")
+	defer e.Finish()
+
+	party1 := "party1"
+	party2 := "party2"
+	initialBalance := num.NewUint(100)
+
+	// create party1 account + top up
+	// no need to create party2 account, this account
+	// should be created on the go
+	e.broker.EXPECT().Send(gomock.Any()).Times(3)
+
+	p1AccID, err := e.CreatePartyGeneralAccount(
+		context.Background(), party1, testMarketAsset)
+	require.NoError(t, err)
+
+	err = e.UpdateBalance(context.Background(), p1AccID, initialBalance)
+	assert.Nil(t, err)
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(8)
+
+	// now we create the transfers:
+	resps, err := e.TransferFunds(
+		context.Background(),
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(90), // we assume the transfer to the other party is 90
+				},
+				Type:      types.TransferTypeTransferFundsSend,
+				MinAmount: num.NewUint(90),
+			},
+			{
+				Owner: party2,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(90),
+				},
+				Type:      types.TransferTypeTransferFundsDistribute,
+				MinAmount: num.NewUint(90),
+			},
+		},
+		// 2 general accounts
+		[]types.AccountType{
+			types.AccountTypeGeneral,
+			types.AccountTypeGeneral,
+		},
+		[]string{
+			"party1-to-party2",
+			"party1-to-party2",
+		},
+		// fee transfer
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(10), // we should have just enough to pay the fee
+				},
+				Type:      types.TransferTypeInfrastructureFeePay,
+				MinAmount: num.NewUint(10),
+			},
+		},
+		[]types.AccountType{
+			types.AccountTypeGeneral, // only one account, the general account of party
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, resps, 3)
+
+	// ensure balances now
+	acc1, err := e.GetPartyGeneralAccount(party1, testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, acc1.Balance, num.Zero())
+
+	acc2, err := e.GetPartyGeneralAccount(party2, testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, acc2.Balance, num.NewUint(90))
+
+	pendingTransfersAcc := e.GetPendingTransfersAccount(testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, pendingTransfersAcc.Balance, num.Zero())
+}
+
+func testTransferFundsFromGeneralToRewardPool(t *testing.T) {
+	e := getTestEngine(t, "test-market")
+	defer e.Finish()
+
+	party1 := "party1"
+	initialBalance := num.NewUint(100)
+
+	// create party1 account + top up
+	// no need to create party2 account, this account
+	// should be created on the go
+	e.broker.EXPECT().Send(gomock.Any()).Times(3)
+
+	p1AccID, err := e.CreatePartyGeneralAccount(
+		context.Background(), party1, testMarketAsset)
+	require.NoError(t, err)
+
+	err = e.UpdateBalance(context.Background(), p1AccID, initialBalance)
+	assert.Nil(t, err)
+
+	// create the pool
+	e.broker.EXPECT().Send(gomock.Any()).Times(1)
+	rewardAccID, err := e.CreateOrGetAssetRewardPoolAccount(context.Background(), testMarketAsset)
+	assert.NoError(t, err)
+
+	e.broker.EXPECT().Send(gomock.Any()).Times(6)
+
+	// now we create the transfers:
+	resps, err := e.TransferFunds(
+		context.Background(),
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(90), // we assume the transfer to the other party is 90
+				},
+				Type:      types.TransferTypeTransferFundsSend,
+				MinAmount: num.NewUint(90),
+			},
+			{
+				Owner: "",
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(90),
+				},
+				Type:      types.TransferTypeTransferFundsDistribute,
+				MinAmount: num.NewUint(90),
+			},
+		},
+		// 2 general accounts
+		[]types.AccountType{
+			types.AccountTypeGeneral,
+			types.AccountTypeGlobalReward,
+		},
+		[]string{
+			"party1-to-reward",
+			"party1-to-reward",
+		},
+		// fee transfer
+		[]*types.Transfer{
+			{
+				Owner: party1,
+				Amount: &types.FinancialAmount{
+					Asset:  testMarketAsset,
+					Amount: num.NewUint(10), // we should have just enough to pay the fee
+				},
+				Type:      types.TransferTypeInfrastructureFeePay,
+				MinAmount: num.NewUint(10),
+			},
+		},
+		[]types.AccountType{
+			types.AccountTypeGeneral, // only one account, the general account of party
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, resps, 3)
+
+	// ensure balances now
+	acc1, err := e.GetPartyGeneralAccount(party1, testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, acc1.Balance, num.Zero())
+
+	rewardAcc, err := e.GetAccountByID(rewardAccID)
+	assert.NoError(t, err)
+	assert.Equal(t, rewardAcc.Balance, num.NewUint(90))
+
+	pendingTransfersAcc := e.GetPendingTransfersAccount(testMarketAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, pendingTransfersAcc.Balance, num.Zero())
+}
+
+func testInvalidNumberOfParameters(t *testing.T) {
+	e := getTestEngine(t, "test-market")
+	defer e.Finish()
+
+	assert.Panics(t, func() {
+		e.TransferFunds(
+			context.Background(),
+			make([]*types.Transfer, 3),
+			make([]types.AccountType, 2),
+			make([]string, 3),
+			make([]*types.Transfer, 1),
+			make([]types.AccountType, 1),
+		)
+	})
+	assert.Panics(t, func() {
+		e.TransferFunds(
+			context.Background(),
+			make([]*types.Transfer, 3),
+			make([]types.AccountType, 3),
+			make([]string, 1),
+			make([]*types.Transfer, 1),
+			make([]types.AccountType, 1),
+		)
+	})
+	assert.Panics(t, func() {
+		e.TransferFunds(
+			context.Background(),
+			make([]*types.Transfer, 3),
+			make([]types.AccountType, 3),
+			make([]string, 3),
+			make([]*types.Transfer, 2),
+			make([]types.AccountType, 1),
+		)
+	})
+}

--- a/events/bus.go
+++ b/events/bus.go
@@ -103,6 +103,7 @@ const (
 	KeyRotationEvent
 	StateVarEvent
 	NetworkLimitsEvent
+	TransferEvent
 )
 
 var (
@@ -155,6 +156,7 @@ var (
 		eventspb.BusEventType_BUS_EVENT_TYPE_KEY_ROTATION:        KeyRotationEvent,
 		eventspb.BusEventType_BUS_EVENT_TYPE_STATE_VAR:           StateVarEvent,
 		eventspb.BusEventType_BUS_EVENT_TYPE_NETWORK_LIMITS:      NetworkLimitsEvent,
+		eventspb.BusEventType_BUS_EVENT_TYPE_TRANSFER:            TransferEvent,
 	}
 
 	toProto = map[Type]eventspb.BusEventType{
@@ -197,6 +199,7 @@ var (
 		KeyRotationEvent:        eventspb.BusEventType_BUS_EVENT_TYPE_KEY_ROTATION,
 		StateVarEvent:           eventspb.BusEventType_BUS_EVENT_TYPE_STATE_VAR,
 		NetworkLimitsEvent:      eventspb.BusEventType_BUS_EVENT_TYPE_NETWORK_LIMITS,
+		TransferEvent:           eventspb.BusEventType_BUS_EVENT_TYPE_TRANSFER,
 	}
 
 	eventStrings = map[Type]string{
@@ -240,6 +243,7 @@ var (
 		KeyRotationEvent:        "KeyRotationEvent",
 		StateVarEvent:           "StateVarEvent",
 		NetworkLimitsEvent:      "NetworkLimitsEvent",
+		TransferEvent:           "TransferEvent",
 	}
 )
 

--- a/events/transfer.go
+++ b/events/transfer.go
@@ -1,0 +1,73 @@
+package events
+
+import (
+	"context"
+
+	eventspb "code.vegaprotocol.io/protos/vega/events/v1"
+	"code.vegaprotocol.io/vega/types"
+)
+
+// Transfer ...
+type TransferFunds struct {
+	*Base
+	transfer *eventspb.Transfer
+}
+
+func NewOneOffTransferFundsEvent(
+	ctx context.Context,
+	t *types.OneOffTransfer,
+) *TransferFunds {
+	return &TransferFunds{
+		Base:     newBase(ctx, TransferEvent),
+		transfer: t.IntoEvent(),
+	}
+}
+
+func NewRecurringTransferFundsEvent(
+	ctx context.Context,
+	t *types.RecurringTransfer,
+) *TransferFunds {
+	return &TransferFunds{
+		Base:     newBase(ctx, TransferEvent),
+		transfer: t.IntoEvent(),
+	}
+}
+
+func (t TransferFunds) PartyID() string {
+	return t.transfer.From
+}
+
+func (t TransferFunds) TransferFunds() eventspb.Transfer {
+	return t.Proto()
+}
+
+func (t TransferFunds) Proto() eventspb.Transfer {
+	return *t.transfer
+}
+
+func (t TransferFunds) StreamMessage() *eventspb.BusEvent {
+	p := t.Proto()
+
+	return &eventspb.BusEvent{
+		Version: eventspb.Version,
+		Id:      t.eventID(),
+		Block:   t.TraceID(),
+		ChainId: t.ChainID(),
+		Type:    t.et.ToProto(),
+		Event: &eventspb.BusEvent_Transfer{
+			Transfer: &p,
+		},
+	}
+}
+
+func TransferFundsEventFromStream(ctx context.Context, be *eventspb.BusEvent) *TransferFunds {
+	event := be.GetTransfer()
+	if event == nil {
+		return nil
+	}
+
+	return &TransferFunds{
+		Base:     newBaseFromStream(ctx, TransferEvent, be),
+		transfer: event,
+	}
+}

--- a/events/tx_error.go
+++ b/events/tx_error.go
@@ -62,6 +62,10 @@ func NewTxErrEvent(ctx context.Context, err error, partyID string, tx interface{
 		evt.evt.Transaction = &eventspb.TxErrorEvent_RestoreSnapshot{
 			RestoreSnapshot: tv,
 		}
+	case *commandspb.Transfer:
+		evt.evt.Transaction = &eventspb.TxErrorEvent_Transfer{
+			Transfer: tv,
+		}
 	case error: // unsupported command error
 		evt.evt.ErrMsg = fmt.Sprintf("%v - %v", err, tv)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645
+	code.vegaprotocol.io/protos v0.47.1-0.20220120111721-e332535f918e
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220118134126-26f681c98f91

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220120114214-d3f38a8f1b9d
+	code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220118134126-26f681c98f91

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220120111721-e332535f918e
+	code.vegaprotocol.io/protos v0.47.1-0.20220120114214-d3f38a8f1b9d
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220118134126-26f681c98f91

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21
+	code.vegaprotocol.io/protos v0.47.1-0.20220120165004-0f1ec728fcf5
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220118134126-26f681c98f91

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220119191224-7bf7c156facb
+	code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220118134126-26f681c98f91
@@ -166,4 +166,3 @@ require (
 )
 
 replace github.com/shopspring/decimal => github.com/vegaprotocol/decimal v1.2.1-0.20210705145732-aaa563729a0a
-replace code.vegaprotocol.io/protos => ../protos

--- a/go.mod
+++ b/go.mod
@@ -166,3 +166,4 @@ require (
 )
 
 replace github.com/shopspring/decimal => github.com/vegaprotocol/decimal v1.2.1-0.20210705145732-aaa563729a0a
+replace code.vegaprotocol.io/protos => ../protos

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220120165004-0f1ec728fcf5
+	code.vegaprotocol.io/protos v0.47.1-0.20220120181901-2c1a0e3dc46f
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220118134126-26f681c98f91

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21 h1:oRkrNsysd2q
 code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/protos v0.47.1-0.20220120165004-0f1ec728fcf5 h1:zJLApke5O2I4DWyyKUeqS7UMuGU+m8Npqh2RriR9sl0=
 code.vegaprotocol.io/protos v0.47.1-0.20220120165004-0f1ec728fcf5/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120181901-2c1a0e3dc46f h1:d9keq2mdWWgOFq8YyZjTB7VO3aqfhhLgYbNy6eAuxb4=
+code.vegaprotocol.io/protos v0.47.1-0.20220120181901-2c1a0e3dc46f/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090 h1:SF7ZRvZ/JASJNEQigbuUwk1rQuugLy6gqbOFs8D8VXI=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,10 @@ code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645 h1:CNFPhxo3gsL
 code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/protos v0.47.1-0.20220120111721-e332535f918e h1:iucZEESyxXcV9WMelVQii+2fzti79qgwYFCWZ8rC7Nk=
 code.vegaprotocol.io/protos v0.47.1-0.20220120111721-e332535f918e/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120113701-f7ca27cba35a h1:MV71RHhNK0klqStwH15WNsr1g6Zns6qRb2ao7mZ+eNI=
+code.vegaprotocol.io/protos v0.47.1-0.20220120113701-f7ca27cba35a/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120114214-d3f38a8f1b9d h1:ZNVDaUs+bS3bPbb2z2UpKrD1p92PSIy2+BacSd5I4Hw=
+code.vegaprotocol.io/protos v0.47.1-0.20220120114214-d3f38a8f1b9d/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090 h1:SF7ZRvZ/JASJNEQigbuUwk1rQuugLy6gqbOFs8D8VXI=

--- a/go.sum
+++ b/go.sum
@@ -13,10 +13,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3 h1:/A09Q3EEiJF+/WiJfKiqzp1zvcWphiYR8lf2N/JSJBU=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:1Gwg5D0PbFEE92Vip8EU0/+n80Kx3GwlGvP850S0op8=
 code.vegaprotocol.io/protos v0.47.1-0.20220118110318-7b90b251de07/go.mod h1:NORK22Evpwn0GoetL7H6/oVUzGcfjAJEJTzw+zTkSyE=
-code.vegaprotocol.io/protos v0.47.1-0.20220119163910-00b9ef4c3829 h1:gtLh5EuaBCmdEjqAKSMmrAC7XQoNera4BNE6btuL4SM=
-code.vegaprotocol.io/protos v0.47.1-0.20220119163910-00b9ef4c3829/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
-code.vegaprotocol.io/protos v0.47.1-0.20220119191224-7bf7c156facb h1:8ak6Q4jT2Hq4tEF8G7n1l4eIQ9lHgQXA0vn7eGv8eQI=
-code.vegaprotocol.io/protos v0.47.1-0.20220119191224-7bf7c156facb/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645 h1:CNFPhxo3gsLNVyJ6F5pTjnXhwdRdLBroyOtaAK4fPAg=
+code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090 h1:SF7ZRvZ/JASJNEQigbuUwk1rQuugLy6gqbOFs8D8VXI=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ code.vegaprotocol.io/protos v0.47.1-0.20220120144708-769a85363044 h1:wNxu1DxlBX8
 code.vegaprotocol.io/protos v0.47.1-0.20220120144708-769a85363044/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21 h1:oRkrNsysd2qOIQt174RYiRBnclTv+tB5QZY+nZ7OMz4=
 code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120165004-0f1ec728fcf5 h1:zJLApke5O2I4DWyyKUeqS7UMuGU+m8Npqh2RriR9sl0=
+code.vegaprotocol.io/protos v0.47.1-0.20220120165004-0f1ec728fcf5/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090 h1:SF7ZRvZ/JASJNEQigbuUwk1rQuugLy6gqbOFs8D8VXI=

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,14 @@ code.vegaprotocol.io/protos v0.47.1-0.20220120113701-f7ca27cba35a h1:MV71RHhNK0k
 code.vegaprotocol.io/protos v0.47.1-0.20220120113701-f7ca27cba35a/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/protos v0.47.1-0.20220120114214-d3f38a8f1b9d h1:ZNVDaUs+bS3bPbb2z2UpKrD1p92PSIy2+BacSd5I4Hw=
 code.vegaprotocol.io/protos v0.47.1-0.20220120114214-d3f38a8f1b9d/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120130517-93716d676a77 h1:hEjZV3ZHhXY9etrADR1FTbKMKFs+qfcCtFq8FyYnUFE=
+code.vegaprotocol.io/protos v0.47.1-0.20220120130517-93716d676a77/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120130607-942789dafa4e h1:KtGNEuhaLNVPjOnsymtlRjfb4ZZPpCHTwiZhoQgxMpI=
+code.vegaprotocol.io/protos v0.47.1-0.20220120130607-942789dafa4e/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120144708-769a85363044 h1:wNxu1DxlBX8fKgFSVisCJGKNWGZ+kC7P6vEPQmzWreo=
+code.vegaprotocol.io/protos v0.47.1-0.20220120144708-769a85363044/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21 h1:oRkrNsysd2qOIQt174RYiRBnclTv+tB5QZY+nZ7OMz4=
+code.vegaprotocol.io/protos v0.47.1-0.20220120150151-13a742c17a21/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090 h1:SF7ZRvZ/JASJNEQigbuUwk1rQuugLy6gqbOFs8D8VXI=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:
 code.vegaprotocol.io/protos v0.47.1-0.20220118110318-7b90b251de07/go.mod h1:NORK22Evpwn0GoetL7H6/oVUzGcfjAJEJTzw+zTkSyE=
 code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645 h1:CNFPhxo3gsLNVyJ6F5pTjnXhwdRdLBroyOtaAK4fPAg=
 code.vegaprotocol.io/protos v0.47.1-0.20220120110732-c522857dc645/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220120111721-e332535f918e h1:iucZEESyxXcV9WMelVQii+2fzti79qgwYFCWZ8rC7Nk=
+code.vegaprotocol.io/protos v0.47.1-0.20220120111721-e332535f918e/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20211015074835-9ed837d93090 h1:SF7ZRvZ/JASJNEQigbuUwk1rQuugLy6gqbOFs8D8VXI=

--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -129,5 +129,7 @@ func defaultNetParams() map[string]value {
 		SnapshotIntervalLength: NewInt(IntGTE(0)).Mutable(true).MustUpdate("1000"),
 
 		FloatingPointUpdatesDuration: NewDuration().Mutable(true).MustUpdate("5m"),
+
+		TransferFeeFactor: NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("0.01"),
 	}
 }

--- a/netparams/keys.go
+++ b/netparams/keys.go
@@ -109,6 +109,8 @@ const (
 	SnapshotIntervalLength = "snapshot.interval.length"
 
 	FloatingPointUpdatesDuration = "network.floatingPointUpdates.delay"
+
+	TransferFeeFactor = "transfer.fee.factor"
 )
 
 var AllKeys = map[string]struct{}{
@@ -193,4 +195,5 @@ var AllKeys = map[string]struct{}{
 	StakingAndDelegationRewardOptimalStakeMultiplier:      {},
 	SnapshotIntervalLength:                                {},
 	FloatingPointUpdatesDuration:                          {},
+	TransferFeeFactor:                                     {},
 }

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -233,7 +233,7 @@ func NewApp(
 
 	app.abci.
 		HandleDeliverTx(txn.TransferFundsCommand,
-			app.SendEventOnError(app.DeliverTransferFunds)).
+			app.SendEventOnError(addDeterministicID(app.DeliverTransferFunds))).
 		HandleDeliverTx(txn.SubmitOrderCommand,
 			app.SendEventOnError(app.DeliverSubmitOrder)).
 		HandleDeliverTx(txn.CancelOrderCommand,
@@ -802,14 +802,14 @@ func (app *App) RequireValidatorMasterPubKey(ctx context.Context, tx abci.Tx) er
 	return nil
 }
 
-func (app *App) DeliverTransferFunds(ctx context.Context, tx abci.Tx) error {
+func (app *App) DeliverTransferFunds(ctx context.Context, tx abci.Tx, id string) error {
 	tfr := &commandspb.Transfer{}
 	if err := tx.Unmarshal(tfr); err != nil {
 		return err
 	}
 
 	party := tx.Party()
-	transferFunds, err := types.NewTransferFromProto(party, tfr)
+	transferFunds, err := types.NewTransferFromProto(id, party, tfr)
 	if err != nil {
 		return err
 	}

--- a/processor/mocks/banking_mock.go
+++ b/processor/mocks/banking_mock.go
@@ -11,7 +11,6 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
-	time "time"
 )
 
 // MockBanking is a mock of Banking interface
@@ -108,17 +107,17 @@ func (mr *MockBankingMockRecorder) EnableERC20(arg0, arg1, arg2, arg3, arg4, arg
 }
 
 // TransferFunds mocks base method
-func (m *MockBanking) TransferFunds(arg0 context.Context, arg1, arg2, arg3 string, arg4, arg5 vega.AccountType, arg6 *num.Uint, arg7 string, arg8 *time.Time) error {
+func (m *MockBanking) TransferFunds(arg0 context.Context, arg1 *types.TransferFunds) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransferFunds", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret := m.ctrl.Call(m, "TransferFunds", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TransferFunds indicates an expected call of TransferFunds
-func (mr *MockBankingMockRecorder) TransferFunds(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+func (mr *MockBankingMockRecorder) TransferFunds(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferFunds", reflect.TypeOf((*MockBanking)(nil).TransferFunds), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferFunds", reflect.TypeOf((*MockBanking)(nil).TransferFunds), arg0, arg1)
 }
 
 // WithdrawBuiltinAsset mocks base method

--- a/processor/mocks/banking_mock.go
+++ b/processor/mocks/banking_mock.go
@@ -11,6 +11,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+	time "time"
 )
 
 // MockBanking is a mock of Banking interface
@@ -104,6 +105,20 @@ func (m *MockBanking) EnableERC20(arg0 context.Context, arg1 *types.ERC20AssetLi
 func (mr *MockBankingMockRecorder) EnableERC20(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableERC20", reflect.TypeOf((*MockBanking)(nil).EnableERC20), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// TransferFunds mocks base method
+func (m *MockBanking) TransferFunds(arg0 context.Context, arg1, arg2, arg3 string, arg4, arg5 vega.AccountType, arg6 *num.Uint, arg7 string, arg8 *time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransferFunds", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TransferFunds indicates an expected call of TransferFunds
+func (mr *MockBankingMockRecorder) TransferFunds(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferFunds", reflect.TypeOf((*MockBanking)(nil).TransferFunds), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 // WithdrawBuiltinAsset mocks base method

--- a/processor/mocks/validator_topology_mock.go
+++ b/processor/mocks/validator_topology_mock.go
@@ -5,39 +5,38 @@
 package mocks
 
 import (
-	context "context"
-	reflect "reflect"
-
 	v1 "code.vegaprotocol.io/protos/vega/commands/v1"
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/tendermint/tendermint/abci/types"
 	types0 "github.com/tendermint/tendermint/types"
+	reflect "reflect"
 )
 
-// MockValidatorTopology is a mock of ValidatorTopology interface.
+// MockValidatorTopology is a mock of ValidatorTopology interface
 type MockValidatorTopology struct {
 	ctrl     *gomock.Controller
 	recorder *MockValidatorTopologyMockRecorder
 }
 
-// MockValidatorTopologyMockRecorder is the mock recorder for MockValidatorTopology.
+// MockValidatorTopologyMockRecorder is the mock recorder for MockValidatorTopology
 type MockValidatorTopologyMockRecorder struct {
 	mock *MockValidatorTopology
 }
 
-// NewMockValidatorTopology creates a new mock instance.
+// NewMockValidatorTopology creates a new mock instance
 func NewMockValidatorTopology(ctrl *gomock.Controller) *MockValidatorTopology {
 	mock := &MockValidatorTopology{ctrl: ctrl}
 	mock.recorder = &MockValidatorTopologyMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockValidatorTopology) EXPECT() *MockValidatorTopologyMockRecorder {
 	return m.recorder
 }
 
-// AddKeyRotate mocks base method.
+// AddKeyRotate mocks base method
 func (m *MockValidatorTopology) AddKeyRotate(arg0 context.Context, arg1 string, arg2 uint64, arg3 *v1.KeyRotateSubmission) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddKeyRotate", arg0, arg1, arg2, arg3)
@@ -45,13 +44,13 @@ func (m *MockValidatorTopology) AddKeyRotate(arg0 context.Context, arg1 string, 
 	return ret0
 }
 
-// AddKeyRotate indicates an expected call of AddKeyRotate.
+// AddKeyRotate indicates an expected call of AddKeyRotate
 func (mr *MockValidatorTopologyMockRecorder) AddKeyRotate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddKeyRotate", reflect.TypeOf((*MockValidatorTopology)(nil).AddKeyRotate), arg0, arg1, arg2, arg3)
 }
 
-// AddNodeRegistration mocks base method.
+// AddNodeRegistration mocks base method
 func (m *MockValidatorTopology) AddNodeRegistration(arg0 context.Context, arg1 *v1.NodeRegistration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddNodeRegistration", arg0, arg1)
@@ -59,13 +58,13 @@ func (m *MockValidatorTopology) AddNodeRegistration(arg0 context.Context, arg1 *
 	return ret0
 }
 
-// AddNodeRegistration indicates an expected call of AddNodeRegistration.
+// AddNodeRegistration indicates an expected call of AddNodeRegistration
 func (mr *MockValidatorTopologyMockRecorder) AddNodeRegistration(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNodeRegistration", reflect.TypeOf((*MockValidatorTopology)(nil).AddNodeRegistration), arg0, arg1)
 }
 
-// AllVegaPubKeys mocks base method.
+// AllVegaPubKeys mocks base method
 func (m *MockValidatorTopology) AllVegaPubKeys() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllVegaPubKeys")
@@ -73,25 +72,25 @@ func (m *MockValidatorTopology) AllVegaPubKeys() []string {
 	return ret0
 }
 
-// AllVegaPubKeys indicates an expected call of AllVegaPubKeys.
+// AllVegaPubKeys indicates an expected call of AllVegaPubKeys
 func (mr *MockValidatorTopologyMockRecorder) AllVegaPubKeys() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllVegaPubKeys", reflect.TypeOf((*MockValidatorTopology)(nil).AllVegaPubKeys))
 }
 
-// BeginBlock mocks base method.
+// BeginBlock mocks base method
 func (m *MockValidatorTopology) BeginBlock(arg0 context.Context, arg1 types.RequestBeginBlock, arg2 []*types0.Validator) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "BeginBlock", arg0, arg1, arg2)
 }
 
-// BeginBlock indicates an expected call of BeginBlock.
+// BeginBlock indicates an expected call of BeginBlock
 func (mr *MockValidatorTopologyMockRecorder) BeginBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginBlock", reflect.TypeOf((*MockValidatorTopology)(nil).BeginBlock), arg0, arg1, arg2)
 }
 
-// IsValidator mocks base method.
+// IsValidator mocks base method
 func (m *MockValidatorTopology) IsValidator() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsValidator")
@@ -99,13 +98,13 @@ func (m *MockValidatorTopology) IsValidator() bool {
 	return ret0
 }
 
-// IsValidator indicates an expected call of IsValidator.
+// IsValidator indicates an expected call of IsValidator
 func (mr *MockValidatorTopologyMockRecorder) IsValidator() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidator", reflect.TypeOf((*MockValidatorTopology)(nil).IsValidator))
 }
 
-// IsValidatorNodeID mocks base method.
+// IsValidatorNodeID mocks base method
 func (m *MockValidatorTopology) IsValidatorNodeID(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsValidatorNodeID", arg0)
@@ -113,13 +112,13 @@ func (m *MockValidatorTopology) IsValidatorNodeID(arg0 string) bool {
 	return ret0
 }
 
-// IsValidatorNodeID indicates an expected call of IsValidatorNodeID.
+// IsValidatorNodeID indicates an expected call of IsValidatorNodeID
 func (mr *MockValidatorTopologyMockRecorder) IsValidatorNodeID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidatorNodeID", reflect.TypeOf((*MockValidatorTopology)(nil).IsValidatorNodeID), arg0)
 }
 
-// IsValidatorVegaPubKey mocks base method.
+// IsValidatorVegaPubKey mocks base method
 func (m *MockValidatorTopology) IsValidatorVegaPubKey(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsValidatorVegaPubKey", arg0)
@@ -127,13 +126,13 @@ func (m *MockValidatorTopology) IsValidatorVegaPubKey(arg0 string) bool {
 	return ret0
 }
 
-// IsValidatorVegaPubKey indicates an expected call of IsValidatorVegaPubKey.
+// IsValidatorVegaPubKey indicates an expected call of IsValidatorVegaPubKey
 func (mr *MockValidatorTopologyMockRecorder) IsValidatorVegaPubKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidatorVegaPubKey", reflect.TypeOf((*MockValidatorTopology)(nil).IsValidatorVegaPubKey), arg0)
 }
 
-// Len mocks base method.
+// Len mocks base method
 func (m *MockValidatorTopology) Len() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Len")
@@ -141,19 +140,19 @@ func (m *MockValidatorTopology) Len() int {
 	return ret0
 }
 
-// Len indicates an expected call of Len.
+// Len indicates an expected call of Len
 func (mr *MockValidatorTopologyMockRecorder) Len() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockValidatorTopology)(nil).Len))
 }
 
-// UpdateValidatorSet mocks base method.
+// UpdateValidatorSet mocks base method
 func (m *MockValidatorTopology) UpdateValidatorSet(arg0 []string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateValidatorSet", arg0)
 }
 
-// UpdateValidatorSet indicates an expected call of UpdateValidatorSet.
+// UpdateValidatorSet indicates an expected call of UpdateValidatorSet
 func (mr *MockValidatorTopologyMockRecorder) UpdateValidatorSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorSet", reflect.TypeOf((*MockValidatorTopology)(nil).UpdateValidatorSet), arg0)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -176,7 +176,7 @@ type Banking interface {
 	DepositERC20(context.Context, *types.ERC20Deposit, string, uint64, uint64, string) error
 	WithdrawERC20(context.Context, string, string, string, *num.Uint, *types.Erc20WithdrawExt) error
 	ERC20WithdrawalEvent(context.Context, *types.ERC20Withdrawal, uint64, uint64, string) error
-	TransferFunds(context.Context, string, string, string, types.AccountType, types.AccountType, *num.Uint, string, *time.Time) error
+	TransferFunds(context.Context, *types.TransferFunds) error
 }
 
 // NetworkParameters ...

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -176,6 +176,7 @@ type Banking interface {
 	DepositERC20(context.Context, *types.ERC20Deposit, string, uint64, uint64, string) error
 	WithdrawERC20(context.Context, string, string, string, *num.Uint, *types.Erc20WithdrawExt) error
 	ERC20WithdrawalEvent(context.Context, *types.ERC20Withdrawal, uint64, uint64, string) error
+	TransferFunds(context.Context, string, string, string, types.AccountType, types.AccountType, *num.Uint, string, *time.Time) error
 }
 
 // NetworkParameters ...

--- a/processor/tx_v2.go
+++ b/processor/tx_v2.go
@@ -118,6 +118,8 @@ func (t TxV2) Command() txn.Command {
 		return txn.KeyRotateSubmissionCommand
 	case *commandspb.InputData_StateVariableProposal:
 		return txn.StateVariableProposalCommand
+	case *commandspb.InputData_TransferFunds:
+		return txn.TransferFundsCommand
 	default:
 		panic("unsupported command")
 	}
@@ -163,6 +165,8 @@ func (t TxV2) GetCmd() interface{} {
 		return cmd.KeyRotateSubmission
 	case *commandspb.InputData_StateVariableProposal:
 		return cmd.StateVariableProposal
+	case *commandspb.InputData_TransferFunds:
+		return cmd.TransferFunds
 	default:
 		return errors.New("unsupported command")
 	}
@@ -284,6 +288,12 @@ func (t TxV2) Unmarshal(i interface{}) error {
 			return errors.New("failed to unmarshal StateVariableProposal")
 		}
 		*underlyingCmd = *cmd.StateVariableProposal
+	case *commandspb.InputData_TransferFunds:
+		underlyingCmd, ok := i.(*commandspb.TransferFunds)
+		if !ok {
+			return errors.New("failed to unmarshal TransferFunds")
+		}
+		*underlyingCmd = *cmd.TransferFunds
 	default:
 		return errors.New("unsupported command")
 	}

--- a/processor/tx_v2.go
+++ b/processor/tx_v2.go
@@ -118,7 +118,7 @@ func (t TxV2) Command() txn.Command {
 		return txn.KeyRotateSubmissionCommand
 	case *commandspb.InputData_StateVariableProposal:
 		return txn.StateVariableProposalCommand
-	case *commandspb.InputData_TransferFunds:
+	case *commandspb.InputData_Transfer:
 		return txn.TransferFundsCommand
 	default:
 		panic("unsupported command")
@@ -165,8 +165,8 @@ func (t TxV2) GetCmd() interface{} {
 		return cmd.KeyRotateSubmission
 	case *commandspb.InputData_StateVariableProposal:
 		return cmd.StateVariableProposal
-	case *commandspb.InputData_TransferFunds:
-		return cmd.TransferFunds
+	case *commandspb.InputData_Transfer:
+		return cmd.Transfer
 	default:
 		return errors.New("unsupported command")
 	}
@@ -288,12 +288,12 @@ func (t TxV2) Unmarshal(i interface{}) error {
 			return errors.New("failed to unmarshal StateVariableProposal")
 		}
 		*underlyingCmd = *cmd.StateVariableProposal
-	case *commandspb.InputData_TransferFunds:
-		underlyingCmd, ok := i.(*commandspb.TransferFunds)
+	case *commandspb.InputData_Transfer:
+		underlyingCmd, ok := i.(*commandspb.Transfer)
 		if !ok {
 			return errors.New("failed to unmarshal TransferFunds")
 		}
-		*underlyingCmd = *cmd.TransferFunds
+		*underlyingCmd = *cmd.Transfer
 	default:
 		return errors.New("unsupported command")
 	}

--- a/rewards/mocks/val_performance_mock.go
+++ b/rewards/mocks/val_performance_mock.go
@@ -5,36 +5,35 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	decimal "github.com/shopspring/decimal"
+	reflect "reflect"
 )
 
-// MockValidatorPerformance is a mock of ValidatorPerformance interface.
+// MockValidatorPerformance is a mock of ValidatorPerformance interface
 type MockValidatorPerformance struct {
 	ctrl     *gomock.Controller
 	recorder *MockValidatorPerformanceMockRecorder
 }
 
-// MockValidatorPerformanceMockRecorder is the mock recorder for MockValidatorPerformance.
+// MockValidatorPerformanceMockRecorder is the mock recorder for MockValidatorPerformance
 type MockValidatorPerformanceMockRecorder struct {
 	mock *MockValidatorPerformance
 }
 
-// NewMockValidatorPerformance creates a new mock instance.
+// NewMockValidatorPerformance creates a new mock instance
 func NewMockValidatorPerformance(ctrl *gomock.Controller) *MockValidatorPerformance {
 	mock := &MockValidatorPerformance{ctrl: ctrl}
 	mock.recorder = &MockValidatorPerformanceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockValidatorPerformance) EXPECT() *MockValidatorPerformanceMockRecorder {
 	return m.recorder
 }
 
-// ValidatorPerformanceScore mocks base method.
+// ValidatorPerformanceScore mocks base method
 func (m *MockValidatorPerformance) ValidatorPerformanceScore(arg0 string) decimal.Decimal {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidatorPerformanceScore", arg0)
@@ -42,7 +41,7 @@ func (m *MockValidatorPerformance) ValidatorPerformanceScore(arg0 string) decima
 	return ret0
 }
 
-// ValidatorPerformanceScore indicates an expected call of ValidatorPerformanceScore.
+// ValidatorPerformanceScore indicates an expected call of ValidatorPerformanceScore
 func (mr *MockValidatorPerformanceMockRecorder) ValidatorPerformanceScore(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorPerformanceScore", reflect.TypeOf((*MockValidatorPerformance)(nil).ValidatorPerformanceScore), arg0)

--- a/txn/command.go
+++ b/txn/command.go
@@ -43,6 +43,8 @@ const (
 	KeyRotateSubmissionCommand Command = 0x50
 	// StateVariableProposalCommand ...
 	StateVariableProposalCommand Command = 0x51
+	// StateVariableProposalCommand ...
+	TransferFundsCommand Command = 0x2
 )
 
 var commandName = map[Command]string{
@@ -65,6 +67,7 @@ var commandName = map[Command]string{
 	CheckpointRestoreCommand:        "Checkpoint Restore",
 	KeyRotateSubmissionCommand:      "Key Rotate Submission",
 	StateVariableProposalCommand:    "State Variable Proposal",
+	TransferFundsCommand:            "Transfer Funds",
 }
 
 func (cmd Command) IsValidatorCommand() bool {

--- a/types/banking.go
+++ b/types/banking.go
@@ -1,0 +1,127 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
+	"code.vegaprotocol.io/vega/types/num"
+)
+
+var (
+	ErrMissingTransferKind     = errors.New("missing transfer kind")
+	ErrCannotTransferZeroFunds = errors.New("cannot transfer zero funds")
+)
+
+type TransferCommandKind int
+
+const (
+	TransferCommandKindOneOff TransferCommandKind = iota
+	TransferCommandKindRecurring
+)
+
+type transferBase struct {
+	From            string
+	FromAccountType AccountType
+	To              string
+	ToAccountType   AccountType
+	Asset           string
+	Amount          *num.Uint
+	Reference       string
+}
+
+func (t *transferBase) IsValid(okZeroAmount bool) error {
+	// ensure amount makes senses
+	if !okZeroAmount && t.Amount.IsZero() {
+		return ErrCannotTransferZeroFunds
+	}
+
+	switch t.FromAccountType {
+	case AccountTypeGeneral /*, AccountTypeLockedForStaking*/ :
+		break
+	default:
+		return fmt.Errorf("unsupported from account type: %v", t.FromAccountType)
+	}
+
+	switch t.ToAccountType {
+	case AccountTypeGeneral, AccountTypeGlobalReward /*, AccountTypeLockedForStaking*/ :
+		break
+	default:
+		return fmt.Errorf("unsupported to account type: %v", t.ToAccountType)
+	}
+
+	return nil
+}
+
+type OneOffTransfer struct {
+	*transferBase
+	DeliverOn *time.Time
+}
+
+type RecurringTransfer struct {
+	*transferBase
+	StartEpoch uint64
+	EndEpoch   uint64
+	Factor     num.Decimal
+}
+
+// Just a wrapper, use the Kind on a
+// switch to access the proper value
+type TransferFunds struct {
+	Kind      TransferCommandKind
+	OneOff    *OneOffTransfer
+	Recurring *RecurringTransfer
+}
+
+func NewTransferFromProto(from string, tf *commandspb.Transfer) (*TransferFunds, error) {
+	base, err := newTransferBase(from, tf)
+	if err != nil {
+		return nil, err
+	}
+	switch tf.Kind.(type) {
+	case *commandspb.Transfer_OneOff:
+		return newOneOffTransfer(base, tf)
+	case *commandspb.Transfer_Recurring:
+		return newRecurringTransfer(base, tf)
+	default:
+		return nil, ErrMissingTransferKind
+	}
+}
+
+func newTransferBase(from string, tf *commandspb.Transfer) (*transferBase, error) {
+	amount, overflowed := num.UintFromString(tf.Amount, 10)
+	if overflowed {
+		return nil, errors.New("invalid transfer amount")
+	}
+
+	return &transferBase{
+		From:            from,
+		FromAccountType: tf.FromAccountType,
+		To:              tf.To,
+		ToAccountType:   tf.ToAccountType,
+		Asset:           tf.Asset,
+		Amount:          amount,
+		Reference:       tf.Reference,
+	}, nil
+}
+
+func newOneOffTransfer(base *transferBase, tf *commandspb.Transfer) (*TransferFunds, error) {
+	var t *time.Time
+	if tf.GetOneOff().GetDeliverOn() > 0 {
+		tmpt := time.Unix(tf.GetOneOff().GetDeliverOn(), 0)
+		t = &tmpt
+	}
+
+	return &TransferFunds{
+		Kind: TransferCommandKindOneOff,
+		OneOff: &OneOffTransfer{
+			transferBase: base,
+			DeliverOn:    t,
+		},
+	}, nil
+}
+
+func newRecurringTransfer(base *transferBase, tf *commandspb.Transfer) (*TransferFunds, error) {
+	return nil, nil
+}

--- a/types/checkpoint.go
+++ b/types/checkpoint.go
@@ -51,6 +51,7 @@ type Checkpoint struct {
 	Block             []byte
 	Rewards           []byte
 	KeyRotations      []byte
+	Banking           []byte
 }
 
 type DelegationEntry struct {
@@ -146,6 +147,7 @@ func NewCheckpointFromProto(pc *checkpoint.Checkpoint) *Checkpoint {
 		Block:             pc.Block,
 		Rewards:           pc.Rewards,
 		KeyRotations:      pc.KeyRotations,
+		Banking:           pc.Banking,
 	}
 }
 
@@ -160,6 +162,7 @@ func (c Checkpoint) IntoProto() *checkpoint.Checkpoint {
 		Block:             c.Block,
 		Rewards:           c.Rewards,
 		KeyRotations:      c.KeyRotations,
+		Banking:           c.Banking,
 	}
 }
 
@@ -178,7 +181,7 @@ func (c *Checkpoint) SetBlockHeight(height int64) error {
 // HashBytes returns the data contained in the checkpoint as a []byte for hashing
 // the order in which the data is added to the slice matters.
 func (c Checkpoint) HashBytes() []byte {
-	ret := make([]byte, 0, len(c.Governance)+len(c.Assets)+len(c.Collateral)+len(c.NetworkParameters)+len(c.Delegation)+len(c.Epoch)+len(c.Block)+len(c.Rewards)+len(c.KeyRotations))
+	ret := make([]byte, 0, len(c.Governance)+len(c.Assets)+len(c.Collateral)+len(c.NetworkParameters)+len(c.Delegation)+len(c.Epoch)+len(c.Block)+len(c.Rewards)+len(c.KeyRotations)+len(c.Banking))
 	// the order in which we append is quite important
 	ret = append(ret, c.NetworkParameters...)
 	ret = append(ret, c.Assets...)
@@ -188,6 +191,7 @@ func (c Checkpoint) HashBytes() []byte {
 	ret = append(ret, c.Block...)
 	ret = append(ret, c.Governance...)
 	ret = append(ret, c.Rewards...)
+	ret = append(ret, c.Banking...)
 	return append(ret, c.KeyRotations...)
 }
 
@@ -212,6 +216,8 @@ func (c *Checkpoint) Set(name CheckpointName, val []byte) {
 		c.Rewards = val
 	case KeyRotationsCheckpoint:
 		c.KeyRotations = val
+	case BankingCheckpoint:
+		c.Banking = val
 	}
 }
 
@@ -236,6 +242,8 @@ func (c Checkpoint) Get(name CheckpointName) []byte {
 		return c.Rewards
 	case KeyRotationsCheckpoint:
 		return c.KeyRotations
+	case BankingCheckpoint:
+		return c.Banking
 	}
 	return nil
 }

--- a/types/checkpoint.go
+++ b/types/checkpoint.go
@@ -29,6 +29,7 @@ const (
 	BlockCheckpoint          CheckpointName = "block" // pseudo-checkpoint, really...
 	PendingRewardsCheckpoint CheckpointName = "rewards"
 	KeyRotationsCheckpoint   CheckpointName = "key-rotations"
+	BankingCheckpoint        CheckpointName = "banking"
 )
 
 type Block struct {

--- a/types/checkpoint.go
+++ b/types/checkpoint.go
@@ -177,7 +177,7 @@ func (c *Checkpoint) SetBlockHeight(height int64) error {
 // HashBytes returns the data contained in the checkpoint as a []byte for hashing
 // the order in which the data is added to the slice matters.
 func (c Checkpoint) HashBytes() []byte {
-	ret := make([]byte, 0, len(c.Governance)+len(c.Assets)+len(c.Collateral)+len(c.NetworkParameters)+len(c.Delegation)+len(c.Epoch)+len(c.Block)+len(c.KeyRotations))
+	ret := make([]byte, 0, len(c.Governance)+len(c.Assets)+len(c.Collateral)+len(c.NetworkParameters)+len(c.Delegation)+len(c.Epoch)+len(c.Block)+len(c.Rewards)+len(c.KeyRotations))
 	// the order in which we append is quite important
 	ret = append(ret, c.NetworkParameters...)
 	ret = append(ret, c.Assets...)

--- a/types/collateral.go
+++ b/types/collateral.go
@@ -196,4 +196,6 @@ const (
 	AccountTypeGlobalInsurance AccountType = proto.AccountType_ACCOUNT_TYPE_GLOBAL_INSURANCE
 	// Global reward accounts contain rewards per asset.
 	AccountTypeGlobalReward AccountType = proto.AccountType_ACCOUNT_TYPE_GLOBAL_REWARD
+	// Global account to hold pending transfers.
+	AccountTypePendingTransfers AccountType = proto.AccountType_ACCOUNT_TYPE_PENDING_TRANSFERS
 )

--- a/types/transfer.go
+++ b/types/transfer.go
@@ -87,5 +87,7 @@ const (
 	// Bond slashing.
 	TransferTypeBondSlashing TransferType = proto.TransferType_TRANSFER_TYPE_BOND_SLASHING
 	// Stake reward.
-	TransferTypeRewardPayout TransferType = proto.TransferType_TRANSFER_TYPE_STAKE_REWARD
+	TransferTypeRewardPayout            TransferType = proto.TransferType_TRANSFER_TYPE_STAKE_REWARD
+	TransferTypeTransferFundsSend       TransferType = proto.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_SEND
+	TransferTypeTransferFundsDistribute TransferType = proto.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_DISTRIBUTE
 )

--- a/types/transfer.go
+++ b/types/transfer.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"errors"
+
 	proto "code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/types/num"
 )
@@ -28,6 +30,18 @@ func (f *FinancialAmount) IntoProto() *proto.FinancialAmount {
 	}
 }
 
+func FinancialAmountFromProto(p *proto.FinancialAmount) (*FinancialAmount, error) {
+	amount, overflow := num.UintFromString(p.Amount, 10)
+	if overflow {
+		return nil, errors.New("invalid amount")
+	}
+
+	return &FinancialAmount{
+		Asset:  p.Asset,
+		Amount: amount,
+	}, nil
+}
+
 func (t *Transfer) IntoProto() *proto.Transfer {
 	return &proto.Transfer{
 		Owner:     t.Owner,
@@ -35,6 +49,25 @@ func (t *Transfer) IntoProto() *proto.Transfer {
 		Type:      t.Type,
 		MinAmount: num.UintToString(t.MinAmount),
 	}
+}
+
+func TransferFromProto(p *proto.Transfer) (*Transfer, error) {
+	amount, err := FinancialAmountFromProto(p.Amount)
+	if err != nil {
+		return nil, err
+	}
+
+	minAmount, overflow := num.UintFromString(p.MinAmount, 10)
+	if overflow {
+		return nil, errors.New("invalid min amount")
+	}
+
+	return &Transfer{
+		Owner:     p.Owner,
+		Amount:    amount,
+		Type:      p.Type,
+		MinAmount: minAmount,
+	}, nil
 }
 
 func (t *Transfer) String() string {


### PR DESCRIPTION
This PR covers:
- OneOff transfers
- Add the command processing
- the checkpoints handling

As it grows quite a bit it doesn't cover:
- recurring transfers (checkpoint and snapshots included)
- snapshots of the of the OneOff transfers

part of #4580  