### PR TITLE
Update LP tests following floating point consensus merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🗑️ Deprecation
 
 ### 🛠 Improvements
+- [4640](https://github.com/vegaprotocol/vega/pull/4640) - Update feature tests related to liquidity provision following integration of probability of trading with floating point consensus
 - [4558](https://github.com/vegaprotocol/vega/pull/4558) - Add MacOS install steps and information required to use `dockerisedvega.sh` script with private docker repository
 - [4496](https://github.com/vegaprotocol/vega/pull/4496) - State variable engine for floating point consensus
 - [4481](https://github.com/vegaprotocol/vega/pull/4481) - Add an example client application that uses the null-blockchain

--- a/integration/features/price_monitoring/volume-near-price-mon-bounds-2.feature
+++ b/integration/features/price_monitoring/volume-near-price-mon-bounds-2.feature
@@ -91,10 +91,9 @@ Feature: Test margin for lp near price monitoring boundaries
       | buy  | 89943    | 0      |
       | buy  | 89942    | 69     |
 
-
     And the parties should have the following margin levels:
       | party    | market id  | maintenance | search   | initial  | release  |
-      | lp1       | ETH2/MAR22 | 1986563     | 2185219  | 2383875  | 2781188  |
+      | lp1      | ETH2/MAR22 | 1986563     | 2185219  | 2383875  | 2781188  |
 
     # # now we place an order which makes the best bid 89943.
     Then the parties place the following orders:
@@ -110,13 +109,12 @@ Feature: Test margin for lp near price monitoring boundaries
     # # but 89942 is no longer the best bid, so the risk model is used to get prob of trading. This now given by the log-normal model
     # # Hence a bit volume is required to meet commitment and thus the margin requirement moves but not much.
 
-    # And the order book should have the following volumes for market "ETH2/MAR22":
-    #   | side | price    | volume |
-    #   | sell | 110965   | 56     |
-    #   | buy  | 89943    | 1      |
-    #   | buy  | 89942    | 136    |
+    And the order book should have the following volumes for market "ETH2/MAR22":
+      | side | price    | volume |
+      | sell | 110965   | 56     |
+      | buy  | 89943    | 1      |
+      | buy  | 89942    | 69    |
 
-
-    # And the parties should have the following margin levels:
-    #   | party    | market id  | maintenance | search   | initial  | release |
-    #   | lp1       | ETH2/MAR22 | 3592950     | 3952245  | 4311540  | 5030130 |
+    And the parties should have the following margin levels:
+      | party    | market id  | maintenance | search   | initial  | release |
+      | lp1      | ETH2/MAR22 | 1986563     | 2185219  | 2383875  | 2781188 |

--- a/integration/features/price_monitoring/volume-near-price-mon-bounds.feature
+++ b/integration/features/price_monitoring/volume-near-price-mon-bounds.feature
@@ -90,12 +90,9 @@ Feature: Test margin for lp near price monitoring boundaries
     # but 900 is no longer the best bid, so the risk model is used to get prob of trading. This is 0.1 (see above).
     # Hence a lot more volume is required to meet commitment and thus the margin requirement jumps substantially.
 
-    # And the parties should have the following margin levels:
-    #   | party | market id | maintenance | search   | initial   | release   |
-    #   | lp1    | ETH/DEC21 | 86666700    | 95333370 | 104000040 | 121333380 |
-    #   # value before uint stuff
-    #   #| lp1    | ETH/DEC21 | 86666701    | 95333371 | 104000041 | 121333381 |
-
+    And the parties should have the following margin levels:
+      | party | market id | maintenance | search   | initial   | release   |
+      | lp1    | ETH/DEC21 | 86666700    | 95333370 | 104000040 | 121333380 |
 
   Scenario: second scenario for volume at near price monitoring bounds with log-normal
 
@@ -194,14 +191,13 @@ Feature: Test margin for lp near price monitoring boundaries
     # but 900 is no longer the best bid, so the risk model is used to get prob of trading. This now given by the log-normal model
     # Hence a bit volume is required to meet commitment and thus the margin requirement moves but not much.
 
-    # Then the order book should have the following volumes for market "ETH2/MAR22":
-    #   | side | price    | volume |
-    #   | sell | 1109     | 90173  |
-    #   | buy  | 901      | 1      |
-    #   | buy  | 900      | 299251 |
-    #   | buy  | 899      | 0      |
+    Then the order book should have the following volumes for market "ETH2/MAR22":
+      | side | price    | volume |
+      | sell | 1109     | 90173  |
+      | buy  | 901      | 1      |
+      | buy  | 900      | 112672 |
+      | buy  | 899      | 0      |
 
-
-    # And the parties should have the following margin levels:
-    #   | party | market id  | maintenance | search   | initial  | release   |
-    #   | lp1    | ETH2/MAR22 | 80237809    | 88261589 | 96285370 | 112332932 |
+    And the parties should have the following margin levels:
+      | party | market id  | maintenance | search   | initial  | release   |
+      | lp1   | ETH2/MAR22 | 32569511    | 35826462 | 39083413 | 45597315 |


### PR DESCRIPTION
Updated commented out values following integration of probability of trading with floating point consensus. 

Updated values are closer to values in preceding test steps so the resulting change brings more stability in the results (note comments say values shouldn't change by much which is the case now, but wasn't with previous implementation). 

Closes #4641 .

