### PR TITLE
4606 state sync fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 ### 🐛 Fixes
 - [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the null-blockchain with an ERC20 asset
 - [4692](https://github.com/vegaprotocol/vega/pull/4692) - Set statistics block height after a snapshot reload
+- [4702](https://github.com/vegaprotocol/vega/pull/4702) - User tree importer and exporter to transfer snapshots via `statesync`
 - [4516](https://github.com/vegaprotocol/vega/pull/4516) - Fix release number title typo - 0.46.1 > 0.46.2
 - [4524](https://github.com/vegaprotocol/vega/pull/4524) - Updated `vega verify genesis` to understand new `app_state` layout
 - [4515](https://github.com/vegaprotocol/vega/pull/4515) - Set log level in snapshot engine

--- a/blockchain/abci/replay_protection.go
+++ b/blockchain/abci/replay_protection.go
@@ -39,8 +39,9 @@ func NewReplayProtector(tolerance uint) *ReplayProtector {
 	return rp
 }
 
-func (*ReplayProtector) GetReplacement() *ReplayProtector {
-	return nil
+// GetReplacement if we've already replace it with a real one, replacing again gets itself.
+func (r *ReplayProtector) GetReplacement() *ReplayProtector {
+	return r
 }
 
 // SetHeight tells the ReplayProtector to clear the oldest cached Tx in the internal ring buffer.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.47.1-0.20220131091008-3391a9eb20de
+	code.vegaprotocol.io/protos v0.47.1-0.20220204105635-1eab5e979407
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20220128163854-7eab67fa60d2
 	code.vegaprotocol.io/vegawallet v0.11.1-0.20220128170319-bd1b750459bb

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3 h1:/A09Q3EEiJF+/WiJfKiqzp1zvcWphiYR8lf2N/JSJBU=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:1Gwg5D0PbFEE92Vip8EU0/+n80Kx3GwlGvP850S0op8=
 code.vegaprotocol.io/protos v0.47.1-0.20220128102417-182c89e00442/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
-code.vegaprotocol.io/protos v0.47.1-0.20220131091008-3391a9eb20de h1:VD32KHw//3E2QyO/VyMqhNSBBrzuGeCnocXERhyLMYw=
-code.vegaprotocol.io/protos v0.47.1-0.20220131091008-3391a9eb20de/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
+code.vegaprotocol.io/protos v0.47.1-0.20220204105635-1eab5e979407 h1:jNM+wUM854GLVppZczmouebF4cyWMIcxUnWqs9KSQx0=
+code.vegaprotocol.io/protos v0.47.1-0.20220204105635-1eab5e979407/go.mod h1:KqJcg62sUHV0qEhlZIZojEypzk3V1ZE3tBS+wdqjddU=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20220128163854-7eab67fa60d2 h1:GKg+68ulAI0UPhru2FgGE+qGuqoTQbnNDF31LU8e+jA=

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -25,11 +25,6 @@ import (
 
 type SnapshotSource int
 
-const (
-	SnapshotSourceLocal SnapshotSource = iota
-	SnapshotSourceTendermint
-)
-
 const SnapshotDBName = "snapshot"
 
 type StateProviderT interface {
@@ -206,7 +201,7 @@ func (e *Engine) ReloadConfig(cfg Config) {
 
 // List returns all snapshots available.
 func (e *Engine) List() ([]*types.Snapshot, error) {
-	trees := make([]*types.Snapshot, 0, len(e.versions))
+	snapshots := make([]*types.Snapshot, 0, len(e.versions))
 	// TM list of snapshots is limited to the 10 most recent ones.
 	i := len(e.versions) - 11
 	if i < 0 {
@@ -220,12 +215,15 @@ func (e *Engine) List() ([]*types.Snapshot, error) {
 		}
 		snap, err := types.SnapshotFromTree(tree)
 		if err != nil {
-			return nil, err
+			e.log.Error("could not list snapshot",
+				logging.Int64("version", v),
+				logging.Error(err))
+			continue // if we have a borked snapshot we just won't list it
 		}
-		trees = append(trees, snap)
+		snapshots = append(snapshots, snap)
 		e.versionHeight[snap.Height] = snap.Meta.Version
 	}
-	return trees, nil
+	return snapshots, nil
 }
 
 // Start kicks the snapshot engine into its initial state setting up the DB connections
@@ -253,6 +251,7 @@ func (e *Engine) Start() error {
 // from a snapshots stored locally. It is an error if a snapshot is not found
 // for this height.
 func (e *Engine) LoadHeight(ctx context.Context, h int64) error {
+	e.log.Debug("loading snapshot for height", logging.Int64("height", h))
 	// setup AVL tree from local store
 	e.initialiseTree()
 	if h < 0 {
@@ -348,7 +347,7 @@ func (e *Engine) load(ctx context.Context) error {
 	}
 	e.snapshot = snap
 	// apply, no need to set the tree, it's coming from local store
-	return e.applySnap(ctx, SnapshotSourceLocal)
+	return e.applySnap(ctx)
 }
 
 func (e *Engine) ReceiveSnapshot(snap *types.Snapshot) error {
@@ -377,10 +376,21 @@ func (e *Engine) RejectSnapshot() error {
 }
 
 func (e *Engine) ApplySnapshot(ctx context.Context) error {
-	return e.applySnap(ctx, SnapshotSourceTendermint)
+	// remove all existing snapshot and create an initial empty tree
+	e.Start()
+
+	// Import the AVL tree from the snapshot data so we have a working copy
+	// that is consistent with the other nodes
+	if err := e.snapshot.TreeFromSnapshot(e.avl); err != nil {
+		e.log.Error("failed to recreate tree", logging.Error(err))
+		return err
+	}
+
+	// Load the snapshot data into each provider
+	return e.applySnap(ctx)
 }
 
-func (e *Engine) applySnap(ctx context.Context, source SnapshotSource) error {
+func (e *Engine) applySnap(ctx context.Context) error {
 	if e.snapshot == nil {
 		return types.ErrUnknownSnapshot
 	}
@@ -404,7 +414,7 @@ func (e *Engine) applySnap(ctx context.Context, source SnapshotSource) error {
 			}
 		}
 
-		if err := e.setTreeNode(i, pl, source); err != nil {
+		if err := e.setTreeNode(i, pl); err != nil {
 			return err
 		}
 		// node was verified and set on tree
@@ -455,17 +465,10 @@ func (e *Engine) applySnap(ctx context.Context, source SnapshotSource) error {
 	e.hash = e.snapshot.Hash // set the engine's "last snapshot hash" field to the hash of the snapshot we've just loaded
 	e.snapshot = nil         // we're done, we can clear the snapshot state
 
-	// no need to save the tree, we already have it from when loaded it locally
-	if source == SnapshotSourceLocal {
-		return nil
-	}
-	if _, err := e.saveCurrentTree(); err != nil {
-		return err
-	}
 	return nil
 }
 
-func (e *Engine) setTreeNode(i int, p *types.Payload, source SnapshotSource) error {
+func (e *Engine) setTreeNode(i int, p *types.Payload) error {
 	// unpack payload
 	data, err := proto.Marshal(p.IntoProto())
 	if err != nil {
@@ -477,21 +480,6 @@ func (e *Engine) setTreeNode(i int, p *types.Payload, source SnapshotSource) err
 	key := p.GetTreeKey()
 	e.hashes[key] = hash
 
-	if source == SnapshotSourceLocal {
-		// we've loaded from local store and so we don't need to fiddle with the AVL tree
-		// since we've just loaded from it!
-		return nil
-	}
-
-	_ = e.avl.Set([]byte(key), data)
-	if exp := e.snapshot.Meta.NodeHashes[i].Hash; exp != hex.EncodeToString(hash) {
-		key := p.GetTreeKey()
-		e.log.Error("Snapshot node not restored - hash mismatch",
-			logging.String("node-key", key),
-		)
-		_, _ = e.avl.Remove([]byte(key))
-		return types.ErrNodeHashMismatch
-	}
 	return nil
 }
 

--- a/snapshot/engine_test.go
+++ b/snapshot/engine_test.go
@@ -13,10 +13,12 @@ import (
 	"code.vegaprotocol.io/vega/types"
 	tmocks "code.vegaprotocol.io/vega/types/mocks"
 
+	"github.com/cosmos/iavl"
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	db "github.com/tendermint/tm-db"
 )
 
 type tstEngine struct {
@@ -48,6 +50,56 @@ func getTestEngine(t *testing.T) *tstEngine {
 	}
 }
 
+// returns an avl tree populated with some payloads.
+func getPopulatedTree(t *testing.T) *iavl.MutableTree {
+	t.Helper()
+	testPayloads := []types.Payload{
+		{
+			Data: &types.PayloadAppState{
+				AppState: &types.AppState{
+					Height: 64,
+				},
+			},
+		},
+		{
+			Data: &types.PayloadGovernanceActive{
+				GovernanceActive: &types.GovernanceActive{},
+			},
+		},
+		{
+			Data: &types.PayloadGovernanceEnacted{
+				GovernanceEnacted: &types.GovernanceEnacted{},
+			},
+		},
+		{
+			Data: &types.PayloadDelegationActive{
+				DelegationActive: &types.DelegationActive{},
+			},
+		},
+		{
+			Data: &types.PayloadEpoch{
+				EpochState: &types.EpochState{
+					Seq:                  7,
+					ReadyToStartNewEpoch: true,
+				},
+			},
+		},
+	}
+
+	tree, err := iavl.NewMutableTree(db.NewMemDB(), 0)
+	tree.Load()
+	require.NoError(t, err)
+
+	for _, p := range testPayloads {
+		v, _ := proto.Marshal(p.IntoProto())
+		tree.Set([]byte(p.GetTreeKey()), v)
+	}
+
+	// Save it
+	tree.SaveVersion()
+	return tree
+}
+
 // basic engine functionality tests.
 func TestEngine(t *testing.T) {
 	t.Run("Adding a provider calls what we expect on the state provider", testAddProviders)
@@ -60,6 +112,43 @@ func TestRestore(t *testing.T) {
 	t.Run("Restoring a snapshot from chain works as expected", testReloadSnapshot)
 	t.Run("Restoring replay protectors replaces the provider as expected", testReloadReplayProtectors)
 	t.Run("Restoring a snapshot calls the post-restore callback if available", testReloadRestore)
+}
+
+func TestTreeToSnapshot(t *testing.T) {
+	t.Run("A tree can be exported serialised and then imported", testTreeExportImport)
+}
+
+func testTreeExportImport(t *testing.T) {
+	// get a avl tree with some payloads in it
+	tree := getPopulatedTree(t)
+
+	// export the tree into snapshot data
+	snap, err := types.SnapshotFromTree(tree.ImmutableTree)
+	require.NoError(t, err)
+	require.Equal(t, snap.Hash, tree.Hash())
+	require.Equal(t, snap.Meta.Version, tree.Version())
+	require.Equal(t, len(snap.Nodes), int(tree.Size()))
+	// We expect more nodehashes than nodes since nodes only contain the leaf nodes
+	// with payloads whereas nodehashes contain the payload-less subtree-roots
+	require.Greater(t, len(snap.Meta.NodeHashes), len(snap.Nodes))
+
+	// Note IRL it would be now that snapshot is serialised and sent
+	// via TM to the node restoring from a snapshot
+
+	// Make a new tree waiting to import the snapshot
+	importedTree, err := iavl.NewMutableTree(db.NewMemDB(), 0)
+	importedTree.Load()
+	require.NoError(t, err)
+
+	// import the snapshot data into a new avl tree
+	err = snap.TreeFromSnapshot(importedTree)
+	require.NoError(t, err)
+
+	// The new tree should be identical to the previous
+	assert.Equal(t, tree.Hash(), importedTree.Hash())
+	assert.Equal(t, tree.Size(), importedTree.Size())
+	assert.Equal(t, tree.Height(), importedTree.Height())
+	assert.Equal(t, tree.Version(), importedTree.Version())
 }
 
 func testAddProviders(t *testing.T) {


### PR DESCRIPTION
 closes #4606 

The bulk of this change is to use the exporter/importer functionality in the IAVL package to transpot the avl tree across between tendermints when a snapshot is requested via statesync. This is necessary so that the shape of the tree (and therefore its root hash) is identical to the tree on the other nodes.

In doing this, a lot of code became redundant and things are a little tidier