### PR TITLE
save checkpoint nextcp with more precision in its snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - [4516](https://github.com/vegaprotocol/vega/pull/4516) - Fix release number title typo - 0.46.1 > 0.46.2
 - [4524](https://github.com/vegaprotocol/vega/pull/4524) - Updated `vega verify genesis` to understand new `app_state` layout
 - [4515](https://github.com/vegaprotocol/vega/pull/4515) - Set log level in snapshot engine
+- [4721](https://github.com/vegaprotocol/vega/pull/4721) - Save checkpoint with `UnixNano` when taking a snapshot
 - [4522](https://github.com/vegaprotocol/vega/pull/4522) - Set transfer responses event when paying rewards
 - [4566](https://github.com/vegaprotocol/vega/pull/4566) - Withdrawal fails should return a status rejected rather than cancelled
 - [4582](https://github.com/vegaprotocol/vega/pull/4582) - Deposits stayed in memory indefinitely, and withdrawal keys were not being sorted to ensure determinism.

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -168,6 +168,7 @@ func (e *Engine) BalanceCheckpoint(ctx context.Context) (*types.CheckpointState,
 // Checkpoint returns the overall checkpoint.
 func (e *Engine) Checkpoint(ctx context.Context, t time.Time) (*types.CheckpointState, error) {
 	// start time will be zero -> add delta to this time, and return
+
 	if e.nextCP.IsZero() {
 		e.setNextCP(t.Add(e.delta))
 		return nil, nil
@@ -199,13 +200,14 @@ func (e *Engine) makeCheckpoint(ctx context.Context) *types.CheckpointState {
 	if err := cp.SetBlockHeight(h); err != nil {
 		e.log.Panic("could not set block height", logging.Error(err))
 	}
-	snap := &types.CheckpointState{}
+	cpState := &types.CheckpointState{}
 	// setCheckpoint hides the vega type mess
-	if err := snap.SetCheckpoint(cp); err != nil {
+	if err := cpState.SetCheckpoint(cp); err != nil {
 		panic(fmt.Errorf("checkpoint could not be created: %w", err))
 	}
 
-	return snap
+	e.log.Debug("checkpoint taken", logging.Int64("block-height", h))
+	return cpState
 }
 
 // Load - loads checkpoint data for all components by name.

--- a/checkpoint/snapshot_test.go
+++ b/checkpoint/snapshot_test.go
@@ -1,0 +1,66 @@
+package checkpoint_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	snapshot "code.vegaprotocol.io/protos/vega/snapshot/v1"
+	"code.vegaprotocol.io/vega/types"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckpointSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	e := getTestEngine(t)
+	e.OnTimeElapsedUpdate(ctx, 10*time.Second)
+
+	// This is 2022-02-04T11:50:12.655Z
+	now := time.Unix(0, 1643975412655000000)
+
+	// take a checkpoint so that we set the next-checkpoint time
+	cp, err := e.Checkpoint(ctx, now)
+	require.NoError(t, err)
+	require.Nil(t, cp)
+
+	// take a snapshot
+	keys := e.Keys()
+	data, _, err := e.GetState(keys[0])
+	require.NoError(t, err)
+
+	snap := &snapshot.Payload{}
+	err = proto.Unmarshal(data, snap)
+	require.Nil(t, err)
+
+	// Load the snapshot into a new engne
+	snapEngine := getTestEngine(t)
+	e.OnTimeElapsedUpdate(ctx, 10*time.Second) // netparam will get propagated into it
+	_, err = snapEngine.LoadState(ctx, types.PayloadFromProto(snap))
+	require.NoError(t, err)
+
+	// this is 2022-02-04T11:50:22.591Z, if we failed to snapshot the microseconds we would be in a position where
+	// restored-next-cp < now < original-next-cp
+	now = time.Unix(0, 1643975422591000000)
+
+	c1, err := e.Checkpoint(ctx, now)
+	require.NoError(t, err)
+	c2, err := snapEngine.Checkpoint(ctx, now)
+	require.NoError(t, err)
+
+	// Check that both engines do not take a checkpoint
+	require.Nil(t, c1)
+	require.Nil(t, c2)
+
+	// shuffle forward
+	now = now.Add(time.Second)
+	c1, err = e.Checkpoint(ctx, now)
+	require.NoError(t, err)
+	c2, err = snapEngine.Checkpoint(ctx, now)
+	require.NoError(t, err)
+
+	// Check that they both now do
+	require.NotNil(t, c1)
+	require.NotNil(t, c2)
+}


### PR DESCRIPTION
closes #4720 

The snapshotting of the checkpoint engine can cause instabilities while reloading because we do not save the nextCP time with enough precision. This can lead to a situation where `restored-nextCP < OnCommit-time < original-nextCP` and results in the restored node taking a snapshot, and the original nodes not.

We now use `t.UnixNano()` instead of `t.Unix()`.