### PR TITLE
fix execution snapshot by handling generated providers properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - [4524](https://github.com/vegaprotocol/vega/pull/4524) - Updated `vega verify genesis` to understand new `app_state` layout
 - [4515](https://github.com/vegaprotocol/vega/pull/4515) - Set log level in snapshot engine
 - [4721](https://github.com/vegaprotocol/vega/pull/4721) - Save checkpoint with `UnixNano` when taking a snapshot
+- [4728](https://github.com/vegaprotocol/vega/pull/4728) - Fix restoring markets from snapshot by handling generated providers properly
 - [4522](https://github.com/vegaprotocol/vega/pull/4522) - Set transfer responses event when paying rewards
 - [4566](https://github.com/vegaprotocol/vega/pull/4566) - Withdrawal fails should return a status rejected rather than cancelled
 - [4582](https://github.com/vegaprotocol/vega/pull/4582) - Deposits stayed in memory indefinitely, and withdrawal keys were not being sorted to ensure determinism.

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -93,10 +93,12 @@ type Engine struct {
 	npv netParamsValues
 
 	// Snapshot
-	snapshotSerialised           []byte
-	snapshotHash                 []byte
-	marketsStateProviders        []types.StateProvider
-	previouslySnapshottedMarkets map[string]struct{} // Map of previously snapshotted market IDs
+	snapshotSerialised    []byte
+	snapshotHash          []byte
+	newGeneratedProviders []types.StateProvider // new providers generated during the last state change
+
+	// Map of all active snapshot providers that the execution engine has generated
+	generatedProviders map[string]struct{}
 }
 
 type netParamsValues struct {
@@ -157,20 +159,20 @@ func NewEngine(
 	log = log.Named(namedLogger)
 	log.SetLevel(executionConfig.Level.Get())
 	e := &Engine{
-		log:                          log,
-		Config:                       executionConfig,
-		markets:                      map[string]*Market{},
-		time:                         ts,
-		collateral:                   collateral,
-		assets:                       assets,
-		idgen:                        NewIDGen(),
-		broker:                       broker,
-		oracle:                       oracle,
-		npv:                          defaultNetParamsValues(),
-		previouslySnapshottedMarkets: map[string]struct{}{},
-		stateVarEngine:               stateVarEngine,
-		feesTracker:                  feesTracker,
-		marketTracker:                marketTracker,
+		log:                log,
+		Config:             executionConfig,
+		markets:            map[string]*Market{},
+		time:               ts,
+		collateral:         collateral,
+		assets:             assets,
+		idgen:              NewIDGen(),
+		broker:             broker,
+		oracle:             oracle,
+		npv:                defaultNetParamsValues(),
+		generatedProviders: map[string]struct{}{},
+		stateVarEngine:     stateVarEngine,
+		feesTracker:        feesTracker,
+		marketTracker:      marketTracker,
 	}
 
 	// Add time change event handler

--- a/execution/engine_snapshot_test.go
+++ b/execution/engine_snapshot_test.go
@@ -199,15 +199,18 @@ func TestValidMarketSnapshot(t *testing.T) {
 	keys := engine.Keys()
 	require.Equal(t, 1, len(keys))
 	key := keys[0]
+
+	// The snapshot engine will call GetHash first so we keep that order
+	// to mimic the flow
+	hash1, err := engine.GetHash(key)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, hash1)
+
 	// Take the snapshot and hash
 	bytes, providers, err := engine.GetState(key)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, bytes)
 	assert.Len(t, providers, 4)
-
-	hash1, err := engine.GetHash(key)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, hash1)
 
 	// Turn the bytes back into a payload and restore to a new engine
 	engine2, ctrl := createEngine(t)

--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -153,10 +153,7 @@ func (m *Market) changed() bool {
 		m.as.Changed() ||
 		m.peggedOrders.Changed() ||
 		m.expiringOrders.Changed() ||
-		m.equityShares.Changed() ||
-		m.liquidity.Changed() ||
-		m.position.Changed() ||
-		m.tsCalc.Changed())
+		m.equityShares.Changed())
 }
 
 func (m *Market) getState() *types.ExecMarket {

--- a/liquidity/target/snapshot.go
+++ b/liquidity/target/snapshot.go
@@ -86,7 +86,7 @@ func (e *SnapshotEngine) GetTheoreticalTargetStake(rf types.RiskFactor, now time
 }
 
 func (e *SnapshotEngine) Namespace() types.SnapshotNamespace {
-	return types.LiquiditySnapshot
+	return types.LiquidityTargetSnapshot
 }
 
 func (e *SnapshotEngine) Keys() []string {

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -126,6 +126,8 @@ var nodeOrder = []types.SnapshotNamespace{
 	types.ExecutionSnapshot,              // creates the markets, returns matching and positions engines for state providers
 	types.MatchingSnapshot,               // this requires a market
 	types.PositionsSnapshot,              // again, needs a market
+	types.LiquiditySnapshot,
+	types.LiquidityTargetSnapshot,
 	types.EpochSnapshot,
 	types.StakingSnapshot,
 	types.StakeVerifierSnapshot,
@@ -663,7 +665,15 @@ func (e *Engine) update(ns types.SnapshotNamespace) (bool, error) {
 			return update, err
 		}
 		if len(nsps) > 0 {
+			// The provider has generated new providers, register them with the engine
+			// add them to the AVL tree
 			e.AddProviders(nsps...)
+			for _, n := range nsps {
+				e.log.Debug("Provider generated",
+					logging.String("namespace", n.Namespace().String()),
+				)
+				e.update(n.Namespace())
+			}
 		}
 		e.log.Debug("State updated",
 			logging.String("node-key", k),

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -66,6 +66,7 @@ const (
 	WitnessSnapshot                SnapshotNamespace = "witness"
 	TopologySnapshot               SnapshotNamespace = "topology"
 	LiquiditySnapshot              SnapshotNamespace = "liquidity"
+	LiquidityTargetSnapshot        SnapshotNamespace = "liquiditytarget"
 	FutureStateSnapshot            SnapshotNamespace = "futureState"
 	FloatingPointConsensusSnapshot SnapshotNamespace = "floatingpoint"
 	FeeTrackerSnapshot             SnapshotNamespace = "feestracker"
@@ -77,34 +78,35 @@ const (
 
 var (
 	nsMap = map[string]SnapshotNamespace{
-		"collateral":     CollateralSnapshot,
-		"assets":         AssetsSnapshot,
-		"banking":        BankingSnapshot,
-		"checkpoint":     CheckpointSnapshot,
-		"app":            AppSnapshot,
-		"netparams":      NetParamsSnapshot,
-		"delegation":     DelegationSnapshot,
-		"governance":     GovernanceSnapshot,
-		"positions":      PositionsSnapshot,
-		"matching":       MatchingSnapshot,
-		"execution":      ExecutionSnapshot,
-		"epoch":          EpochSnapshot,
-		"staking":        StakingSnapshot,
-		"rewards":        RewardSnapshot,
-		"spam":           SpamSnapshot,
-		"eventforwarder": EventForwarderSnapshot,
-		"replay":         ReplayProtectionSnapshot,
-		"notary":         NotarySnapshot,
-		"limits":         LimitSnapshot,
-		"witness":        WitnessSnapshot,
-		"topology":       TopologySnapshot,
-		"idgenerator":    IDGenSnapshot,
-		"stakeverifier":  StakeVerifierSnapshot,
-		"liquidity":      LiquiditySnapshot,
-		"futureState":    FutureStateSnapshot,
-		"floatingpoint":  FloatingPointConsensusSnapshot,
-		"feestracker":    FeeTrackerSnapshot,
-		"markettracker":  MarketTrackerSnapshot,
+		"collateral":      CollateralSnapshot,
+		"assets":          AssetsSnapshot,
+		"banking":         BankingSnapshot,
+		"checkpoint":      CheckpointSnapshot,
+		"app":             AppSnapshot,
+		"netparams":       NetParamsSnapshot,
+		"delegation":      DelegationSnapshot,
+		"governance":      GovernanceSnapshot,
+		"positions":       PositionsSnapshot,
+		"matching":        MatchingSnapshot,
+		"execution":       ExecutionSnapshot,
+		"epoch":           EpochSnapshot,
+		"staking":         StakingSnapshot,
+		"rewards":         RewardSnapshot,
+		"spam":            SpamSnapshot,
+		"eventforwarder":  EventForwarderSnapshot,
+		"replay":          ReplayProtectionSnapshot,
+		"notary":          NotarySnapshot,
+		"limits":          LimitSnapshot,
+		"witness":         WitnessSnapshot,
+		"topology":        TopologySnapshot,
+		"idgenerator":     IDGenSnapshot,
+		"stakeverifier":   StakeVerifierSnapshot,
+		"liquidity":       LiquiditySnapshot,
+		"liquiditytarget": LiquidityTargetSnapshot,
+		"futureState":     FutureStateSnapshot,
+		"floatingpoint":   FloatingPointConsensusSnapshot,
+		"feestracker":     FeeTrackerSnapshot,
+		"markettracker":   MarketTrackerSnapshot,
 	}
 
 	ErrSnapshotHashMismatch         = errors.New("snapshot hashes do not match")

--- a/types/snapshot_nodes.go
+++ b/types/snapshot_nodes.go
@@ -1017,7 +1017,7 @@ func (p *PayloadLiquidityTarget) plToProto() interface{} {
 }
 
 func (*PayloadLiquidityTarget) Namespace() SnapshotNamespace {
-	return LiquiditySnapshot
+	return LiquidityTargetSnapshot
 }
 
 func (p *PayloadLiquidityTarget) Key() string {


### PR DESCRIPTION
closes #4694 

Mostly just handling the generated-providers from the execution engine properly.