### PR TITLE
4567 deterministic order ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [4680](https://github.com/vegaprotocol/vega/issues/4680) - Add `totalTokenSupplyStake` to the snapshots
 - [4645](https://github.com/vegaprotocol/vega/pull/4645) - Add transfers snapshots
 - [4595](https://github.com/vegaprotocol/vega/pull/4595) - Add internal oracle supplying vega time data for time-triggered events
+- [4737](https://github.com/vegaprotocol/vega/pull/4737) - Use a deterministic generator for order ids, set new order ids to the transaction hash of the Submit transaction 
 
 ### 🐛 Fixes
 - [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the null-blockchain with an ERC20 asset

--- a/execution/2500_GTT_amended_to_GTC_expires_test.go
+++ b/execution/2500_GTT_amended_to_GTC_expires_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,5 +56,5 @@ func TestGTTAmendToGTCAmendInPlace_OrderGetExpired(t *testing.T) {
 func randomSha256Hash() string {
 	data := make([]byte, 10)
 	rand.Read(data)
-	return hex.EncodeToString(crypto.Hash(data))
+	return strings.ToUpper(hex.EncodeToString(crypto.Hash(data)))
 }

--- a/execution/2500_GTT_amended_to_GTC_expires_test.go
+++ b/execution/2500_GTT_amended_to_GTC_expires_test.go
@@ -1,13 +1,14 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
 	"encoding/hex"
 	"math/rand"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
+	"code.vegaprotocol.io/vega/libs/crypto"
 
 	"code.vegaprotocol.io/vega/types"
 	"github.com/golang/mock/gomock"

--- a/execution/2876_liquidity_providers_have_all_funds_removed_test.go
+++ b/execution/2876_liquidity_providers_have_all_funds_removed_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ func TestIssue2876(t *testing.T) {
 	closingAt := time.Unix(1000000000, 0)
 	tm := getTestMarketWithDP(t, now, closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{Duration: 30}, 3)
 	ctx := context.Background()
+	ctx = vegacontext.WithTraceID(ctx, randomSha256Hash())
 
 	tm.market.OnChainTimeUpdate(ctx, now)
 
@@ -89,7 +91,7 @@ func TestIssue2876(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, &lporder, "party-2", "lp-order-01")
+	err = tm.market.SubmitLiquidityProvision(ctx, &lporder, "party-2", "lp-order-01", randomSha256Hash())
 	assert.NoError(t, err)
 
 	bondAccount, err := tm.collateralEngine.GetOrCreatePartyBondAccount(ctx, "party-2", tm.market.GetID(), tm.asset)

--- a/execution/2876_liquidity_providers_have_all_funds_removed_test.go
+++ b/execution/2876_liquidity_providers_have_all_funds_removed_test.go
@@ -1,10 +1,11 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"

--- a/execution/2965_refresh_lp_orders_size_test.go
+++ b/execution/2965_refresh_lp_orders_size_test.go
@@ -202,7 +202,6 @@ func TestRefreshLiquidityProvisionOrdersSizes(t *testing.T) {
 	t.Run("ExpectedOrderStatus", func(t *testing.T) {
 		// First collect all the orders events
 		found := []*types.Order{}
-		allOrders := []*types.Order{}
 		for _, e := range tm.events {
 			switch evt := e.(type) {
 			case *events.Order:
@@ -210,7 +209,6 @@ func TestRefreshLiquidityProvisionOrdersSizes(t *testing.T) {
 					evt.Order().Size == 534 { //"V0000000000-0000000010" {
 					found = append(found, mustOrderFromProto(evt.Order()))
 				}
-				allOrders = append(allOrders, mustOrderFromProto(evt.Order()))
 			}
 		}
 

--- a/execution/2965_refresh_lp_orders_size_test.go
+++ b/execution/2965_refresh_lp_orders_size_test.go
@@ -1,10 +1,11 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	vegapb "code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/events"

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -1,10 +1,11 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	proto "code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/events"

--- a/execution/amend_lp_orders_test.go
+++ b/execution/amend_lp_orders_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
@@ -16,7 +17,7 @@ import (
 func TestAmendDeployedCommitment(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auctionEnd := now.Add(10001 * time.Second)
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
@@ -72,7 +73,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+			ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 	)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
@@ -102,7 +103,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.AmendLiquidityProvision(
-			ctx, lpSmallerCommitment, lpparty),
+			ctx, lpSmallerCommitment, lpparty, randomSha256Hash()),
 	)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
@@ -190,7 +191,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.AmendLiquidityProvision(
-			ctx, lpHigherCommitment, lpparty),
+			ctx, lpHigherCommitment, lpparty, randomSha256Hash()),
 	)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
@@ -282,7 +283,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.AmendLiquidityProvision(
-			ctx, lpDifferentShapeCommitment, lpparty),
+			ctx, lpDifferentShapeCommitment, lpparty, randomSha256Hash()),
 	)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
@@ -374,7 +375,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 	// submit our lp
 	require.EqualError(t,
 		tm.market.AmendLiquidityProvision(
-			ctx, lpTooSmallCommitment, lpparty),
+			ctx, lpTooSmallCommitment, lpparty, randomSha256Hash()),
 		"commitment submission rejected, not enough stake",
 	)
 
@@ -401,7 +402,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 	// submit our lp
 	require.EqualError(t,
 		tm.market.AmendLiquidityProvision(
-			ctx, lpTooHighCommitment, lpparty),
+			ctx, lpTooHighCommitment, lpparty, randomSha256Hash()),
 		"commitment submission not allowed",
 	)
 
@@ -425,7 +426,7 @@ func TestAmendDeployedCommitment(t *testing.T) {
 func TestCancelUndeployedCommitmentDuringAuction(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	// auctionEnd := now.Add(10001 * time.Second)
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
@@ -481,7 +482,7 @@ func TestCancelUndeployedCommitmentDuringAuction(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+			ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 	)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
@@ -511,7 +512,7 @@ func TestCancelUndeployedCommitmentDuringAuction(t *testing.T) {
 func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auctionEnd := now.Add(10001 * time.Second)
 	pMonitorSettings := &types.PriceMonitoringSettings{
@@ -573,7 +574,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+			ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 	)
 
 	tm.events = nil
@@ -647,7 +648,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuringAuction(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auctionEnd := now.Add(10001 * time.Second)
 	pMonitorSettings := &types.PriceMonitoringSettings{
@@ -711,7 +712,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuri
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+			ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 	)
 
 	tm.events = nil
@@ -780,7 +781,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuri
 	// order are not deployed while still in auction
 	require.EqualError(t,
 		tm.market.AmendLiquidityProvision(
-			ctx, lpSubmissionUpdate, lpparty),
+			ctx, lpSubmissionUpdate, lpparty, randomSha256Hash()),
 		"margin would be below maintenance: insufficient margin",
 	)
 }

--- a/execution/amends_test_flip_gtt_gtc_test.go
+++ b/execution/amends_test_flip_gtt_gtc_test.go
@@ -36,7 +36,7 @@ func TestOrderBookAmends_FlipToGTT(t *testing.T) {
 		ExpiresAt:   &v10,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa", randomSha256Hash())
 	require.NotNil(t, amendConf)
 	require.NoError(t, err)
 	assert.Equal(t, types.OrderStatusActive, amendConf.Order.Status)
@@ -50,7 +50,7 @@ func TestOrderBookAmends_FlipToGTT(t *testing.T) {
 		ExpiresAt:   &v,
 	}
 
-	amendConf2, err := tm.market.AmendOrder(ctx, amendment2, "aaa")
+	amendConf2, err := tm.market.AmendOrder(ctx, amendment2, "aaa", randomSha256Hash())
 	require.NotNil(t, amendConf2)
 	require.NoError(t, err)
 	assert.Equal(t, types.OrderStatusActive, amendConf2.Order.Status)
@@ -62,7 +62,7 @@ func TestOrderBookAmends_FlipToGTT(t *testing.T) {
 		TimeInForce: types.OrderTimeInForceGTC,
 	}
 
-	amendConf3, err := tm.market.AmendOrder(ctx, amendment3, "aaa")
+	amendConf3, err := tm.market.AmendOrder(ctx, amendment3, "aaa", randomSha256Hash())
 	require.NotNil(t, amendConf3)
 	require.NoError(t, err)
 	assert.Equal(t, types.OrderStatusActive, amendConf3.Order.Status)

--- a/execution/bond_slashing_test.go
+++ b/execution/bond_slashing_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"testing"
@@ -79,7 +80,8 @@ func setMarkPrice(t *testing.T, mkt *testMarket, duration *types.AuctionDuration
 	}
 	// now fast-forward the market so the auction ends
 	now = now.Add(time.Duration(duration.Duration+1) * time.Second)
-	mkt.market.OnChainTimeUpdate(context.Background(), now)
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
+	mkt.market.OnChainTimeUpdate(ctx, now)
 
 	// opening auction ended, mark-price set
 	mktData := mkt.market.GetMarketData()
@@ -134,7 +136,7 @@ func TestAcceptLiquidityProvisionWithSufficientFunds(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	bondAcc, err := tm.collateralEngine.GetOrCreatePartyBondAccount(ctx, mainParty, tm.mktCfg.ID, asset)
@@ -191,7 +193,7 @@ func TestRejectLiquidityProvisionWithInsufficientFundsForInitialMargin(t *testin
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1", randomSha256Hash())
 	require.Error(t, err)
 
 	assert.Equal(t, 0, tm.market.GetLPSCount())
@@ -273,7 +275,7 @@ func TestCloseoutLPWhenCannotCoverMargin(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	require.Equal(t, 1, tm.market.GetLPSCount())
@@ -370,7 +372,7 @@ func TestBondAccountNotUsedForMarginShortageWhenEnoughMoneyInGeneral(t *testing.
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	bondAcc, err := tm.collateralEngine.GetOrCreatePartyBondAccount(ctx, mainParty, tm.mktCfg.ID, asset)
@@ -468,7 +470,7 @@ func TestBondAccountUsedForMarginShortage_PenaltyPaidFromBondAccount(t *testing.
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	genAcc, err := tm.collateralEngine.GetAccountByID(mainPartyGenAccID)
@@ -601,7 +603,7 @@ func TestBondAccountUsedForMarginShortagePenaltyPaidFromMarginAccount_NoCloseout
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	marginAcc, err := tm.collateralEngine.GetAccountByID(mainPartyMarginAccID)
@@ -712,7 +714,7 @@ func TestBondAccountUsedForMarginShortagePenaltyNotPaidOnTransitionFromAuction(t
 	genAccBalanceBeforeLPSubmission := genAcc.Balance.Clone()
 	require.False(t, genAcc.Balance.IsZero())
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	genAcc, err = tm.collateralEngine.GetAccountByID(mainPartyGenAccID)

--- a/execution/bond_slashing_test.go
+++ b/execution/bond_slashing_test.go
@@ -1,11 +1,12 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -281,7 +281,8 @@ func (e *Engine) IsEligibleForProposerBonus(marketID string, value *num.Uint) bo
 
 // SubmitMarketWithLiquidityProvision is submitting a market through
 // the usual governance process.
-func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party, lpID string) error {
+func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party, lpID,
+	deterministicId string) error {
 	if e.log.IsDebug() {
 		e.log.Debug("submit market with liquidity provision",
 			logging.Market(*marketConfig),
@@ -302,7 +303,7 @@ func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketC
 	e.publishMarketInfos(ctx, mkt)
 
 	// now we try to submit the liquidity
-	if err := mkt.SubmitLiquidityProvision(ctx, lp, party, lpID); err != nil {
+	if err := mkt.SubmitLiquidityProvision(ctx, lp, party, lpID, deterministicId); err != nil {
 		e.removeMarket(marketConfig.ID)
 		return err
 	}
@@ -656,7 +657,8 @@ func (e *Engine) cancelAllPartyOrders(ctx context.Context, party string) ([]*typ
 	return confirmations, nil
 }
 
-func (e *Engine) SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, lpID string) (returnedErr error) {
+func (e *Engine) SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party,
+	lpId, deterministicId string) (returnedErr error) {
 	timer := metrics.NewTimeCounter(sub.MarketID, "execution", "LiquidityProvisionSubmission")
 	defer func() {
 		timer.EngineTimeCounterAdd()
@@ -666,7 +668,7 @@ func (e *Engine) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		e.log.Debug("submit liquidity provision",
 			logging.LiquidityProvisionSubmission(*sub),
 			logging.PartyID(party),
-			logging.LiquidityID(lpID),
+			logging.LiquidityID(deterministicId),
 		)
 	}
 
@@ -675,10 +677,11 @@ func (e *Engine) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		return types.ErrInvalidMarketID
 	}
 
-	return mkt.SubmitLiquidityProvision(ctx, sub, party, lpID)
+	return mkt.SubmitLiquidityProvision(ctx, sub, party, lpId, deterministicId)
 }
 
-func (e *Engine) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string) (returnedErr error) {
+func (e *Engine) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string,
+	deterministicId string) (returnedErr error) {
 	timer := metrics.NewTimeCounter(lpa.MarketID, "execution", "LiquidityProvisionAmendment")
 	defer func() {
 		timer.EngineTimeCounterAdd()
@@ -697,7 +700,7 @@ func (e *Engine) AmendLiquidityProvision(ctx context.Context, lpa *types.Liquidi
 		return types.ErrInvalidMarketID
 	}
 
-	return mkt.AmendLiquidityProvision(ctx, lpa, party)
+	return mkt.AmendLiquidityProvision(ctx, lpa, party, deterministicId)
 }
 
 func (e *Engine) CancelLiquidityProvision(ctx context.Context, cancel *types.LiquidityProvisionCancellation, party string) (returnedErr error) {

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -71,7 +71,7 @@ type Assets interface {
 }
 
 type IDGenerator interface {
-	SetID(*types.Order)
+	NextID() string
 }
 
 // Engine is the execution engine.
@@ -276,7 +276,8 @@ func (e *Engine) IsEligibleForProposerBonus(marketID string, value *num.Uint) bo
 
 // SubmitMarketWithLiquidityProvision is submitting a market through
 // the usual governance process.
-func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party, lpID,
+func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party,
+	lpID,
 	deterministicId string) error {
 	if e.log.IsDebug() {
 		e.log.Debug("submit market with liquidity provision",

--- a/execution/equity_shares_test.go
+++ b/execution/equity_shares_test.go
@@ -1,11 +1,12 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"

--- a/execution/equity_shares_test.go
+++ b/execution/equity_shares_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"testing"
@@ -204,7 +205,7 @@ func (esm *equityShareMarket) PartyMarginAccount(party string) *types.Account {
 
 func testWithinMarket(t *testing.T) {
 	var (
-		ctx = context.Background()
+		ctx = vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 		// as we will split fees in 1/3 and 2/3
 		// we use 900000 cause we need this number to be divisible by 3
 		matchingPrice = uint64(900000)

--- a/execution/event_generation_test.go
+++ b/execution/event_generation_test.go
@@ -561,29 +561,29 @@ func TestEvents_Amending(t *testing.T) {
 		Price:    num.NewUint(11),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, o1.Party)
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, o1.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	amendment.Price = num.NewUint(9)
-	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party)
+	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	amendment.Price = nil
 	amendment.SizeDelta = 3
-	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party)
+	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	amendment.SizeDelta = -2
-	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party)
+	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	amendment.SizeDelta = 1
 	amendment.Price = num.NewUint(10)
-	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party)
+	amendConf, err = tm.market.AmendOrder(ctx, amendment, o1.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -641,17 +641,17 @@ func TestEvents_MovingPegsAround(t *testing.T) {
 		Price:    num.NewUint(8),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, o2.Party)
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, o2.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	amendment.Price = num.NewUint(18)
-	amendConf, err = tm.market.AmendOrder(ctx, amendment, o2.Party)
+	amendConf, err = tm.market.AmendOrder(ctx, amendment, o2.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	amendment.Price = num.NewUint(22)
-	amendConf, err = tm.market.AmendOrder(ctx, amendment, o2.Party)
+	amendConf, err = tm.market.AmendOrder(ctx, amendment, o2.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -709,7 +709,7 @@ func TestEvents_MovingPegsAround2(t *testing.T) {
 		Price:    num.NewUint(9),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, o1.Party)
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, o1.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -766,7 +766,7 @@ func TestEvents_AmendOrderToSelfTrade(t *testing.T) {
 		Price:    num.NewUint(10),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, o3.Party)
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, o3.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -824,7 +824,7 @@ func TestEvents_AmendOrderToIncreaseSizeAndPartiallyFill(t *testing.T) {
 		SizeDelta: 5,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, o3.Party)
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, o3.Party, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -946,7 +946,7 @@ func TestEvents_LPOrderRecalculationDueToFill(t *testing.T) {
 		Sells:            sells,
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+	err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 	require.NoError(t, err)
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 

--- a/execution/event_generation_test.go
+++ b/execution/event_generation_test.go
@@ -275,7 +275,7 @@ func TestEvents_CloseOutParty(t *testing.T) {
 	// assert.Equal(t, int64(3), tm.market.GetOrdersOnBookCount())
 	assert.Equal(t, int64(4), tm.market.GetOrdersOnBookCount())
 
-	// Move price high to force a close out
+	// Move price high to force a closed out
 	o2 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order02", types.SideBuy, "party-B", 1, 100)
 	o2conf, err := tm.market.SubmitOrder(ctx, o2)
 	require.NotNil(t, o2conf)

--- a/execution/generator.go
+++ b/execution/generator.go
@@ -4,7 +4,6 @@ import (
 	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/types"
 	"encoding/hex"
-	"fmt"
 )
 
 // idGenerator no mutex required, markets work deterministically, and sequentially.
@@ -14,17 +13,17 @@ type idGenerator struct {
 }
 
 // NewDeterministicIDGenerator returns an idGenerator, and is used to abstract this type.
-func NewDeterministicIDGenerator(rootId string) (*idGenerator, error) {
+func NewDeterministicIDGenerator(rootId string) *idGenerator {
 
 	nextIdBytes, err := hex.DecodeString(rootId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new deterministic id generator:%w", err)
+		panic("failed to create new deterministic id generator: " + err.Error())
 	}
 
 	return &idGenerator{
 		rootId:      rootId,
 		nextIdBytes: nextIdBytes,
-	}, nil
+	}
 }
 
 func (i *idGenerator) SetID(order *types.Order) {

--- a/execution/generator_test.go
+++ b/execution/generator_test.go
@@ -1,0 +1,27 @@
+package execution_test
+
+import (
+	"code.vegaprotocol.io/vega/execution"
+	"code.vegaprotocol.io/vega/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGeneratorCreationFailsWithInvalidRootId(t *testing.T) {
+
+}
+
+func TestOrderIdGeneration(t *testing.T) {
+
+	detId := "E1152CF235F6200ED0EB4598706821031D57403462C31A80B3CDD6B209BFF2E6"
+	gen, err := execution.NewDeterministicIDGenerator(detId)
+	if err != nil {
+		t.Fatalf("failed to create generator:%s", err)
+	}
+
+	order := &types.Order{}
+	gen.SetID(order)
+	assert.Equal(t, detId, order.ID)
+	gen.SetID(order)
+	assert.NotEqual(t, detId, order.ID)
+}

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -1,6 +1,7 @@
 package execution
 
 import (
+	"code.vegaprotocol.io/vega/idgeneration"
 	"context"
 	"errors"
 	"fmt"
@@ -17,7 +18,12 @@ import (
 var ErrCommitmentAmountTooLow = errors.New("commitment amount is too low")
 
 // SubmitLiquidityProvision forwards a LiquidityProvisionSubmission to the Liquidity Engine.
-func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, id string) (err error) {
+func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, lpId,
+	deterministicId string) (err error) {
+
+	m.idgen = idgeneration.NewDeterministicIDGenerator(deterministicId)
+	defer func() { m.idgen = nil }()
+
 	if !m.canSubmitCommitment() {
 		return ErrCommitmentSubmissionNotAllowed
 	}
@@ -43,7 +49,7 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		return ErrPartyAlreadyLiquidityProvider
 	}
 
-	if err := m.liquidity.SubmitLiquidityProvision(ctx, sub, party, id); err != nil {
+	if err := m.liquidity.SubmitLiquidityProvision(ctx, sub, party, lpId, deterministicId); err != nil {
 		return err
 	}
 
@@ -58,7 +64,7 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 		if newerr := m.liquidity.RejectLiquidityProvision(ctx, party); newerr != nil {
 			m.log.Debug("unable to submit cancel liquidity provision submission",
 				logging.String("party", party),
-				logging.String("id", id),
+				logging.String("id", lpId),
 				logging.Error(newerr))
 			err = fmt.Errorf("%v, %w", err, newerr)
 		}
@@ -211,7 +217,14 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 }
 
 // AmendLiquidityProvision forwards a LiquidityProvisionAmendment to the Liquidity Engine.
-func (m *Market) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string) (err error) {
+func (m *Market) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string, deterministicId string) (err error) {
+	m.idgen = idgeneration.NewDeterministicIDGenerator(deterministicId)
+	m.liquidity.SetIdGen(m.idgen)
+	defer func() {
+		m.idgen = nil
+		m.liquidity.SetIdGen(nil)
+	}()
+
 	if !m.canSubmitCommitment() {
 		return ErrCommitmentSubmissionNotAllowed
 	}

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -220,11 +220,7 @@ func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.Liquid
 // AmendLiquidityProvision forwards a LiquidityProvisionAmendment to the Liquidity Engine.
 func (m *Market) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string, deterministicId string) (err error) {
 	m.idgen = idgeneration.NewDeterministicIDGenerator(deterministicId)
-	m.liquidity.SetIdGen(m.idgen)
-	defer func() {
-		m.idgen = nil
-		m.liquidity.SetIdGen(nil)
-	}()
+	defer func() { m.idgen = nil }()
 
 	if !m.canSubmitCommitment() {
 		return ErrCommitmentSubmissionNotAllowed
@@ -1097,7 +1093,7 @@ func (m *Market) finalizeLiquidityProvisionAmendmentAuction(
 ) error {
 	// first parameter is the update to the orders, but we know that during
 	// auction no orders shall be return, so let's just look at the error
-	_, err := m.liquidity.AmendLiquidityProvision(ctx, sub, party)
+	_, err := m.liquidity.AmendLiquidityProvision(ctx, sub, party, m.idgen)
 	if err != nil {
 		m.log.Panic("error while amending liquidity provision, this should not happen at this point, the LP was validated earlier",
 			logging.Error(err))
@@ -1181,7 +1177,7 @@ func (m *Market) finalizeLiquidityProvisionAmendmentContinuous(
 ) error {
 	// first parameter is the update to the orders, but we know that during
 	// auction no orders shall be return, so let's just look at the error
-	cancels, err := m.liquidity.AmendLiquidityProvision(ctx, sub, party)
+	cancels, err := m.liquidity.AmendLiquidityProvision(ctx, sub, party, m.idgen)
 	if err != nil {
 		m.log.Panic("error while amending liquidity provision, this should not happen at this point, the LP was validated earlier",
 			logging.Error(err))

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -384,7 +384,7 @@ func (m *Market) updateAndCreateLPOrders(
 			order.OriginalPrice = order.Price.Clone()
 			order.Price.Mul(order.Price, m.priceFactor)
 		}
-		conf, orderUpdts, err := m.submitOrder(ctx, order, false)
+		conf, orderUpdts, err := m.submitOrder(ctx, order)
 		if err != nil {
 			m.log.Debug("could not submit liquidity provision order, scheduling for closeout",
 				logging.OrderID(order.ID),
@@ -592,7 +592,7 @@ func (m *Market) createInitialLPOrders(ctx context.Context, newOrders []*types.O
 			order.OriginalPrice = order.Price.Clone()
 			order.Price.Mul(order.Price, m.priceFactor)
 		}
-		if conf, _, err := m.submitOrder(ctx, order, false); err != nil {
+		if conf, _, err := m.submitOrder(ctx, order); err != nil {
 			failedOnID = order.ID
 			m.log.Debug("unable to submit liquidity provision order",
 				logging.MarketID(m.GetID()),

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -1,11 +1,12 @@
 package execution
 
 import (
-	"code.vegaprotocol.io/vega/idgeneration"
 	"context"
 	"errors"
 	"fmt"
 	"sort"
+
+	"code.vegaprotocol.io/vega/idgeneration"
 
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/liquidity"
@@ -19,8 +20,8 @@ var ErrCommitmentAmountTooLow = errors.New("commitment amount is too low")
 
 // SubmitLiquidityProvision forwards a LiquidityProvisionSubmission to the Liquidity Engine.
 func (m *Market) SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, lpId,
-	deterministicId string) (err error) {
-
+	deterministicId string) (err error,
+) {
 	m.idgen = idgeneration.NewDeterministicIDGenerator(deterministicId)
 	defer func() { m.idgen = nil }()
 

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -767,7 +767,7 @@ func TestSubmit(t *testing.T) {
 		})
 	})
 
-	t.Run("test close out LP party cont issue 3086", func(t *testing.T) {
+	t.Run("test closed out LP party cont issue 3086", func(t *testing.T) {
 		auctionEnd := now.Add(10001 * time.Second)
 		mktCfg := getMarket(closingAt, pMonitorSettings, &types.AuctionDuration{
 			Duration: 10000,

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"testing"
@@ -33,7 +34,7 @@ func TestSubmit(t *testing.T) {
 	}
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	t.Run("check that we reject LP submission If fee is incorrect", func(t *testing.T) {
 		tm := getTestMarket(t, now, closingAt, nil, nil)
@@ -65,7 +66,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder02")
+		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder02", randomSha256Hash())
 		require.Error(t, err)
 		assert.Equal(t, 0, tm.market.GetLPSCount())
 
@@ -78,7 +79,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder03")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder03", randomSha256Hash())
 		require.Error(t, err)
 		assert.Equal(t, 0, tm.market.GetLPSCount())
 	})
@@ -115,7 +116,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.Error(t, err)
 		assert.Equal(t, 0, tm.market.GetLPSCount())
 
@@ -127,7 +128,7 @@ func TestSubmit(t *testing.T) {
 			Buys:             buys,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder02")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder02", randomSha256Hash())
 		require.Error(t, err)
 		assert.Equal(t, 0, tm.market.GetLPSCount())
 	})
@@ -167,7 +168,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.EqualError(t, err, "SIDE_BUY shape size exceed max (100)")
 		assert.Equal(t, 0, tm.market.GetLPSCount())
 	})
@@ -233,7 +234,7 @@ func TestSubmit(t *testing.T) {
 		// submit our lp
 		require.EqualError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 			"invalid liquidity provision fee",
 		)
 
@@ -242,7 +243,7 @@ func TestSubmit(t *testing.T) {
 		// submit our lp
 		require.EqualError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 			"invalid liquidity provision fee",
 		)
 
@@ -251,7 +252,7 @@ func TestSubmit(t *testing.T) {
 		// submit our lp
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 	})
 
@@ -304,7 +305,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Check we have the right amount of bond balance
@@ -377,7 +378,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Check we have the right amount of bond balance
@@ -509,7 +510,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 		require.Equal(t, types.LiquidityProvisionStatusPending.String(), tm.market.GetLPSState("party-A").String())
 		// Only 3 pegged orders as one fails due to price monitoring
@@ -570,7 +571,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 		require.Equal(t, types.LiquidityProvisionStatusPending.String(), tm.market.GetLPSState("party-A").String())
 		assert.Equal(t, 1, tm.market.GetPeggedOrderCount())
@@ -645,7 +646,7 @@ func TestSubmit(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 		require.Equal(t, types.LiquidityProvisionStatusPending.String(), tm.market.GetLPSState("party-A").String())
 
@@ -737,7 +738,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		tm.events = nil
@@ -826,7 +827,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, ruser2, "liquidity-submission-1"),
+				ctx, lpSubmission, ruser2, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		tm.events = nil
@@ -941,7 +942,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission2, ruser2, "liquidity-submission-2"),
+				ctx, lpSubmission2, ruser2, "liquidity-submission-2", randomSha256Hash()),
 		)
 
 		// make sure LP order is deployed
@@ -1027,7 +1028,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("lp submission is pending", func(t *testing.T) {
@@ -1099,7 +1100,8 @@ func TestSubmit(t *testing.T) {
 		tm.WithSubmittedOrders(t, auctionOrders...)
 
 		// update the time to get out of auction
-		tm.market.OnChainTimeUpdate(context.Background(), auctionEnd)
+		ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
+		tm.market.OnChainTimeUpdate(ctx, auctionEnd)
 
 		t.Run("verify LP orders sizes", func(t *testing.T) {
 			// First collect all the orders events
@@ -1113,20 +1115,29 @@ func TestSubmit(t *testing.T) {
 				}
 			}
 
-			expect := map[string]uint64{
-				"V0000000000-0000000001": 119,
-				"V0000000000-0000000002": 2,
-				"V0000000000-0000000003": 2,
-				"V0000000000-0000000004": 3,
-				"V0000000000-0000000005": 112,
+			expectedQnts := []struct {
+				size  uint64
+				found bool
+			}{{119, false},
+				{2, false},
+				{2, false},
+				{3, false},
+				{112, false}}
+
+			for _, v := range found {
+				for i, expectedQnt := range expectedQnts {
+					if v.Size == expectedQnt.size && expectedQnt.found == false {
+						expectedQnts[i].found = true
+					}
+				}
 			}
 
-			for id, v := range found {
-				fmt.Printf("Found %s, size %v\n", id, v)
-				size, ok := expect[id]
-				assert.True(t, ok, "unexpected order id")
-				assert.Equal(t, size, v.Size, id)
+			allExpectedQntsFound := true
+			for _, exp := range expectedQnts {
+				allExpectedQntsFound = allExpectedQntsFound && exp.found
 			}
+			assert.True(t, allExpectedQntsFound, "missing expected order quantities")
+
 		})
 
 		newOrders := []*types.Order{
@@ -1204,7 +1215,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("lp submission is pending", func(t *testing.T) {
@@ -1298,7 +1309,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("lp submission is pending", func(t *testing.T) {
@@ -1484,7 +1495,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("lp submission is pending", func(t *testing.T) {
@@ -1653,7 +1664,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("lp submission is pending", func(t *testing.T) {
@@ -1788,7 +1799,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("lp submission is pending", func(t *testing.T) {
@@ -1913,7 +1924,7 @@ func TestSubmit(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		// we end the auction
@@ -1962,29 +1973,42 @@ func TestSubmit(t *testing.T) {
 
 			assert.Len(t, found, 3)
 
-			expected := map[string]struct {
-				size   int
+			expected := []struct {
+				size   uint64
 				status types.LiquidityProvisionStatus
+				found  bool
 			}{
-				"V0000000000-0000000001": {
+				{
 					size:   19,
 					status: types.LiquidityProvisionStatusCancelled,
+					found:  false,
 				},
-				"V0000000000-0000000002": {
+				{
 					size:   15,
 					status: types.LiquidityProvisionStatusActive,
+					found:  false,
 				},
-				"V0000000000-0000000007": {
+				{
 					size:   19,
 					status: types.LiquidityProvisionStatusActive,
+					found:  false,
 				},
 			}
 
 			// no ensure that the orders in the map matches the size we have
-			for k, v := range found {
-				assert.Equal(t, expected[k].size, int(v.Size), k)
-				assert.Equal(t, expected[k].status.String(), v.Status.String(), k)
+
+			matched := 0
+			for _, v := range found {
+				for i, exp := range expected {
+					if v.Size == exp.size && v.Status.String() == exp.status.String() && !exp.found {
+						expected[i].found = true
+						matched++
+					}
+				}
 			}
+
+			assert.Equal(t, len(expected), matched, "matched quantites and statues do not match those expected")
+
 		})
 
 		// now the limit order expires, and the LP order size should increase again
@@ -2006,23 +2030,41 @@ func TestSubmit(t *testing.T) {
 
 			assert.Len(t, found, 3)
 
-			expected := map[string]struct {
+			expected := []struct {
 				size   uint64
 				status types.OrderStatus
+				found  bool
 			}{
-				"V0000000000-0000000001": {19, types.OrderStatusActive},
-				// no event sent for expired orders
-				// this is done by the excution engine, we may want to do
-				// that from the market someday
-				"V0000000000-0000000007": {19, types.OrderStatusExpired},
-				"V0000000000-0000000002": {15, types.OrderStatusActive},
+				{
+					size:   19,
+					status: types.OrderStatusActive,
+					found:  false,
+				},
+				{
+					size:   19,
+					status: types.OrderStatusExpired,
+					found:  false,
+				},
+				{
+					size:   15,
+					status: types.OrderStatusActive,
+					found:  false,
+				},
 			}
 
 			// no ensure that the orders in the map matches the size we have
-			for k, v := range found {
-				assert.Equal(t, expected[k].status.String(), v.Status.String(), k)
-				assert.Equal(t, expected[k].size, v.Size, k)
+
+			matched := 0
+			for _, v := range found {
+				for i, exp := range expected {
+					if v.Size == exp.size && v.Status.String() == exp.status.String() && !exp.found {
+						expected[i].found = true
+						matched++
+					}
+				}
 			}
+
+			assert.Equal(t, len(expected), matched, "matched quantites and statues do not match those expected")
 		})
 	})
 }
@@ -2030,7 +2072,7 @@ func TestSubmit(t *testing.T) {
 func TestAmend(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	t.Run("check that fee is selected properly after changes", func(t *testing.T) {
 		auctionEnd := now.Add(10001 * time.Second)
@@ -2088,7 +2130,7 @@ func TestAmend(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+				ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 		)
 
 		t.Run("current liquidity fee is 0.5", func(t *testing.T) {
@@ -2128,7 +2170,7 @@ func TestAmend(t *testing.T) {
 		tm.events = nil
 		require.NoError(t,
 			tm.market.SubmitLiquidityProvision(
-				ctx, lpSubmission2, lpparty2, "liquidity-submission-2"),
+				ctx, lpSubmission2, lpparty2, "liquidity-submission-2", randomSha256Hash()),
 		)
 
 		t.Run("current liquidity fee is still 0.5", func(t *testing.T) {
@@ -2160,7 +2202,7 @@ func TestAmend(t *testing.T) {
 
 		require.NoError(t,
 			tm.market.AmendLiquidityProvision(
-				ctx, lpa, lpparty2),
+				ctx, lpa, lpparty2, randomSha256Hash()),
 		)
 
 		t.Run("current liquidity fee is again 0.1", func(t *testing.T) {
@@ -2208,7 +2250,7 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Check the fee is correct
@@ -2218,7 +2260,7 @@ func TestAmend(t *testing.T) {
 		lpa := &types.LiquidityProvisionAmendment{
 			Fee: num.DecimalFromFloat(0.5),
 		}
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Check the fee is correct
@@ -2285,7 +2327,7 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 		assert.Equal(t, 1, tm.market.GetLPSCount())
 
@@ -2298,7 +2340,7 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.Error(t, err)
 		assert.Equal(t, 1, tm.market.GetLPSCount())
 	})
@@ -2356,7 +2398,7 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 		require.Equal(t, types.LiquidityProvisionStatusPending.String(), tm.market.GetLPSState("party-A").String())
 		assert.Equal(t, 0, tm.market.GetPeggedOrderCount())
@@ -2373,7 +2415,7 @@ func TestAmend(t *testing.T) {
 			Buys:             lps.Buys,
 			Sells:            lps.Sells,
 		}
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Check we have the right amount of bond balance
@@ -2381,7 +2423,7 @@ func TestAmend(t *testing.T) {
 
 		// Amend the commitment
 		lpa.CommitmentAmount = num.NewUint(500)
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Check we have the right amount of bond balance
@@ -2392,7 +2434,7 @@ func TestAmend(t *testing.T) {
 		sells = []*types.LiquidityOrder{newLiquidityOrder(types.PeggedReferenceBestAsk, 1, 50)}
 		lpa.Buys = buys
 		lpa.Sells = sells
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 		assert.Equal(t, 0, tm.market.GetPeggedOrderCount())
 		assert.Equal(t, 0, tm.market.GetParkedOrderCount())
@@ -2450,7 +2492,7 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Leave auction
@@ -2515,7 +2557,7 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 		require.Equal(t, types.LiquidityProvisionStatusPending.String(), tm.market.GetLPSState("party-A").String())
 		assert.Equal(t, 0, tm.market.GetPeggedOrderCount())
@@ -2529,7 +2571,7 @@ func TestAmend(t *testing.T) {
 			Sells:            lps.Sells,
 		}
 
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Now attempt to amend the LP submission with empty fee and commitment amount
@@ -2539,7 +2581,7 @@ func TestAmend(t *testing.T) {
 			Sells:    lps.Sells,
 		}
 
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Now attempt to amend the LP submission with empty buys
@@ -2551,7 +2593,7 @@ func TestAmend(t *testing.T) {
 			Sells:            lps.Sells,
 		}
 
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Now attempt to amend the LP submission with no changes with nil buys and nil sells
@@ -2563,7 +2605,7 @@ func TestAmend(t *testing.T) {
 			Sells:            nil,
 		}
 
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.EqualError(t, err, "empty liquidity provision amendment content")
 
 		// Now attempt to amend the LP submission with no changes with sells and buys empty lists
@@ -2575,7 +2617,7 @@ func TestAmend(t *testing.T) {
 			Sells:            []*types.LiquidityOrder{},
 		}
 
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.EqualError(t, err, "empty liquidity provision amendment content")
 
 		// Check that the original LP submission is still working fine
@@ -2607,14 +2649,14 @@ func TestAmend(t *testing.T) {
 			Sells:            sells,
 		}
 
-		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01")
+		err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-A", "LPOrder01", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Update the fee
 		lpa := &types.LiquidityProvisionAmendment{
 			Fee: num.DecimalFromFloat(0.2),
 		}
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		// Update the fee again with a new reference
@@ -2622,7 +2664,7 @@ func TestAmend(t *testing.T) {
 			Fee:       num.DecimalFromFloat(0.5),
 			Reference: "ref-lp-2",
 		}
-		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err = tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.NoError(t, err)
 
 		t.Run("expect LP references", func(t *testing.T) {
@@ -2662,7 +2704,7 @@ func TestAmend(t *testing.T) {
 		lpa := &types.LiquidityProvisionAmendment{
 			Fee: num.DecimalFromFloat(0.5),
 		}
-		err := tm.market.AmendLiquidityProvision(ctx, lpa, "party-A")
+		err := tm.market.AmendLiquidityProvision(ctx, lpa, "party-A", randomSha256Hash())
 		require.EqualError(t, err, "party is not a liquidity provider")
 	})
 

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -1,11 +1,12 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	proto "code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/events"
@@ -1118,11 +1119,13 @@ func TestSubmit(t *testing.T) {
 			expectedQnts := []struct {
 				size  uint64
 				found bool
-			}{{119, false},
+			}{
+				{119, false},
 				{2, false},
 				{2, false},
 				{3, false},
-				{112, false}}
+				{112, false},
+			}
 
 			for _, v := range found {
 				for i, expectedQnt := range expectedQnts {
@@ -1137,7 +1140,6 @@ func TestSubmit(t *testing.T) {
 				allExpectedQntsFound = allExpectedQntsFound && exp.found
 			}
 			assert.True(t, allExpectedQntsFound, "missing expected order quantities")
-
 		})
 
 		newOrders := []*types.Order{
@@ -2008,7 +2010,6 @@ func TestSubmit(t *testing.T) {
 			}
 
 			assert.Equal(t, len(expected), matched, "matched quantites and statues do not match those expected")
-
 		})
 
 		// now the limit order expires, and the LP order size should increase again

--- a/execution/margin_test.go
+++ b/execution/margin_test.go
@@ -1,10 +1,11 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"

--- a/execution/margin_test.go
+++ b/execution/margin_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
@@ -61,7 +62,8 @@ func TestMargins(t *testing.T) {
 
 	now = now.Add(2 * time.Second)
 	// leave opening auction
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
+	tm.market.OnChainTimeUpdate(ctx, now)
 	data := tm.market.GetMarketData()
 	require.Equal(t, types.MarketTradingModeContinuous, data.MarketTradingMode)
 
@@ -130,14 +132,14 @@ func TestMargins(t *testing.T) {
 		MarketID:  tm.market.GetID(),
 		SizeDelta: 10000,
 	}
-	amendment, err := tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err := tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
 	// Amend price and size up to breach margin
 	amend.SizeDelta = 1000000000
 	amend.Price = num.NewUint(1000000000)
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.Nil(t, amendment)
 	assert.Error(t, err)
 }
@@ -188,7 +190,7 @@ func TestPartialFillMargins(t *testing.T) {
 		require.NoError(t, err)
 	}
 	now = now.Add(time.Second * 2) // opening auction is 1 second, move time ahead by 2 seconds so we leave auction
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	// use party 2+3 to set super high mark price
 	orderSell1 := &types.Order{
@@ -259,7 +261,7 @@ func TestPartialFillMargins(t *testing.T) {
 		MarketID:  tm.market.GetID(),
 		SizeDelta: 999,
 	}
-	amendment, err := tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err := tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.Nil(t, amendment)
 	assert.Error(t, err)
 }

--- a/execution/market.go
+++ b/execution/market.go
@@ -1193,7 +1193,7 @@ func (m *Market) SubmitOrder(
 		return nil, ErrTradingNotAllowed
 	}
 
-	m.idgen.SetID(order)
+	order.ID = m.idgen.NextID()
 	conf, orderUpdates, err := m.submitOrder(ctx, order)
 	if err != nil {
 		return nil, err
@@ -1774,7 +1774,7 @@ func (m *Market) resolveClosedOutParties(ctx context.Context, distressedMarginEv
 	}
 	no.Size = no.Remaining
 
-	m.idgen.SetID(&no)
+	no.ID = m.idgen.NextID()
 	// we need to buy, specify side + max price
 	if networkPos < 0 {
 		no.Side = types.SideBuy
@@ -1993,7 +1993,7 @@ func (m *Market) zeroOutNetwork(ctx context.Context, parties []events.MarketPosi
 		order.Side = nSide
 		order.Status = types.OrderStatusFilled // An order with no remaining must be filled
 
-		m.idgen.SetID(&order)
+		order.ID = m.idgen.NextID()
 
 		// this is the party order
 		partyOrder := types.Order{
@@ -2011,7 +2011,7 @@ func (m *Market) zeroOutNetwork(ctx context.Context, parties []events.MarketPosi
 			Type:          types.OrderTypeNetwork,
 		}
 
-		m.idgen.SetID(&partyOrder)
+		partyOrder.ID = m.idgen.NextID()
 
 		// store the party order, too
 		m.broker.Send(events.NewOrderEvent(ctx, &partyOrder))

--- a/execution/market.go
+++ b/execution/market.go
@@ -1,8 +1,6 @@
 package execution
 
 import (
-	"code.vegaprotocol.io/vega/idgeneration"
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
@@ -12,6 +10,9 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"code.vegaprotocol.io/vega/idgeneration"
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/assets"
 	"code.vegaprotocol.io/vega/events"
@@ -1175,7 +1176,6 @@ func (m *Market) SubmitOrder(
 	party string,
 	deterministicId string,
 ) (*types.OrderConfirmation, error) {
-
 	m.idgen = idgeneration.NewDeterministicIDGenerator(deterministicId)
 	defer func() { m.idgen = nil }()
 
@@ -2282,8 +2282,8 @@ func (m *Market) parkOrder(ctx context.Context, order *types.Order) {
 
 // AmendOrder amend an existing order from the order book.
 func (m *Market) AmendOrder(ctx context.Context, orderAmendment *types.OrderAmendment, party string,
-	deterministicId string) (*types.OrderConfirmation, error) {
-
+	deterministicId string) (*types.OrderConfirmation, error,
+) {
 	m.idgen = idgeneration.NewDeterministicIDGenerator(deterministicId)
 	defer func() { m.idgen = nil }()
 

--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -37,7 +37,6 @@ func NewMarketFromSnapshot(
 	oracleEngine products.OracleEngine,
 	now time.Time,
 	broker Broker,
-	idgen *IDgenerator,
 	stateVarEngine StateVarEngine,
 	assetDetails *assets.Asset,
 ) (*Market, error) {
@@ -106,14 +105,13 @@ func NewMarketFromSnapshot(
 	priceFactor := num.Zero().Exp(num.NewUint(10), num.NewUint(exp))
 	lMonitor := lmon.NewMonitor(tsCalc, mkt.LiquidityMonitoringParameters)
 
-	liqEngine := liquidity.NewSnapshotEngine(liquidityConfig, log, broker, idgen, tradableInstrument.RiskModel, pMonitor, asset, mkt.ID, stateVarEngine, mkt.TickSize())
+	liqEngine := liquidity.NewSnapshotEngine(liquidityConfig, log, broker, tradableInstrument.RiskModel, pMonitor, asset, mkt.ID, stateVarEngine, mkt.TickSize())
 	// call on chain time update straight away, so
 	// the time in the engine is being updatedat creation
 	liqEngine.OnChainTimeUpdate(ctx, now)
 
 	market := &Market{
 		log:                log,
-		idgen:              idgen,
 		mkt:                mkt,
 		closingAt:          time.Unix(0, mkt.MarketTimestamps.Close),
 		currentTime:        now,

--- a/execution/market_state_test.go
+++ b/execution/market_state_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
@@ -59,7 +60,7 @@ func testCannotDoOrderStuffInProposedState(t *testing.T) {
 	assert.Nil(t, o2conf)
 	assert.EqualError(t, err, execution.ErrTradingNotAllowed.Error())
 
-	o3conf, err := tm.market.CancelOrder(ctx, "someparty", "someorder")
+	o3conf, err := tm.market.CancelOrder(ctx, "someparty", "someorder", randomSha256Hash())
 	assert.Nil(t, o3conf)
 	assert.EqualError(t, err, execution.ErrTradingNotAllowed.Error())
 
@@ -69,7 +70,7 @@ func testCannotDoOrderStuffInProposedState(t *testing.T) {
 		SizeDelta: 10,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A", randomSha256Hash())
 	assert.Nil(t, amendConf)
 	assert.EqualError(t, err, execution.ErrTradingNotAllowed.Error())
 
@@ -87,7 +88,7 @@ func testCannotDoOrderStuffInProposedState(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lpsub, "someparty", "lpid1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lpsub, "someparty", "lpid1", randomSha256Hash())
 
 	// we expect an error as this lp may be stupid
 	// but not equal to the trading not allowed one
@@ -157,7 +158,7 @@ func testCanMoveFromPendingToActiveState(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	// now move to after the opening auction time
-	tm.market.OnChainTimeUpdate(context.Background(), now.Add(40*time.Second))
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now.Add(40*time.Second))
 	assert.Equal(t, types.MarketStateActive, tm.market.State())
 }
 
@@ -192,7 +193,7 @@ func testCanPlaceOrderInActiveState(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	// now move to after the opening auction time
-	tm.market.OnChainTimeUpdate(context.Background(), now.Add(40*time.Second))
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now.Add(40*time.Second))
 	assert.Equal(t, types.MarketStateActive, tm.market.State())
 
 	addAccountWithAmount(tm, "someparty", 100000000)

--- a/execution/market_state_test.go
+++ b/execution/market_state_test.go
@@ -1,10 +1,11 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/execution"
 	"code.vegaprotocol.io/vega/types"

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -1,12 +1,13 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/integration/stubs"
 

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -661,7 +661,7 @@ func TestMarketWithTradeClosing(t *testing.T) {
 	// add 2 partys to the party engine
 	// this will create 2 partys, credit their account
 	// and move some monies to the market
-	// this will also output the close accounts
+	// this will also output the closed accounts
 	addAccount(tm, party1)
 	addAccount(tm, party2)
 

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"fmt"
 	"reflect"
@@ -83,7 +84,7 @@ func (m *marketW) SubmitOrder(
 	ctx context.Context,
 	order *types.Order,
 ) (*types.OrderConfirmation, error) {
-	conf, err := m.Market.SubmitOrder(ctx, order.IntoSubmission(), order.Party)
+	conf, err := m.Market.SubmitOrder(ctx, order.IntoSubmission(), order.Party, randomSha256Hash())
 	if err == nil {
 		*order = *conf.Order.Clone()
 	}
@@ -184,7 +185,7 @@ func (tm *testMarket) Run(ctx context.Context, mktCfg types.Market) *testMarket 
 	feeTracker := execution.NewFeesTracker(epochEngine)
 	mktEngine, err := execution.NewMarket(ctx,
 		tm.log, riskConfig, positionConfig, settlementConfig, matchingConfig,
-		feeConfig, liquidityConfig, collateralEngine, oracleEngine, &mktCfg, tm.now, tm.broker, execution.NewIDGen(), mas, statevarEngine, feeTracker, cfgAsset,
+		feeConfig, liquidityConfig, collateralEngine, oracleEngine, &mktCfg, tm.now, tm.broker, mas, statevarEngine, feeTracker, cfgAsset,
 	)
 	require.NoError(tm.t, err)
 
@@ -381,7 +382,7 @@ func getTestMarket2WithDP(
 
 	mktEngine, err := execution.NewMarket(context.Background(),
 		log, riskConfig, positionConfig, settlementConfig, matchingConfig,
-		feeConfig, liquidityConfig, collateralEngine, oracleEngine, mktCfg, now, broker, execution.NewIDGen(), mas, statevar, feeTracker, cfgAsset)
+		feeConfig, liquidityConfig, collateralEngine, oracleEngine, mktCfg, now, broker, mas, statevar, feeTracker, cfgAsset)
 	assert.NoError(t, err)
 	mktEngine.UpdateRiskFactorsForTest()
 
@@ -528,7 +529,7 @@ func addAccountWithAmount(market *testMarket, party string, amnt uint64) *types.
 func (tm *testMarket) WithSubmittedLiquidityProvision(t *testing.T, party, id string, amount uint64, fee string,
 	buys, sells []*types.LiquidityOrder) *testMarket {
 	t.Helper()
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	f, _ := num.DecimalFromString(fee)
 	lps := &types.LiquidityProvisionSubmission{
@@ -540,7 +541,7 @@ func (tm *testMarket) WithSubmittedLiquidityProvision(t *testing.T, party, id st
 	}
 
 	require.NoError(t,
-		tm.market.SubmitLiquidityProvision(ctx, lps, party, id),
+		tm.market.SubmitLiquidityProvision(ctx, lps, party, id, randomSha256Hash()),
 	)
 
 	return tm
@@ -550,7 +551,7 @@ func (tm *testMarket) WithSubmittedLiquidityProvision(t *testing.T, party, id st
 // If one submission fails, it will make the test fail and stop.
 func (tm *testMarket) WithSubmittedOrders(t *testing.T, orders ...*types.Order) *testMarket {
 	t.Helper()
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	for i, order := range orders {
 		order.MarketID = tm.market.GetID()
 		_, err := tm.market.SubmitOrder(ctx, order)
@@ -585,7 +586,7 @@ func TestMarketClosing(t *testing.T) {
 		PubKeys: []string{"0xDEADBEEF"},
 		Data:    properties,
 	})
-	closed := tm.market.OnChainTimeUpdate(context.Background(), closingAt.Add(1*time.Second))
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), closingAt.Add(1*time.Second))
 
 	// there's not settlement price yet
 	assert.False(t, closed)
@@ -593,7 +594,7 @@ func TestMarketClosing(t *testing.T) {
 
 	// let time pass still no settlement price
 	tm.oracleEngine.UpdateCurrentTime(context.Background(), closingAt.Add(2*time.Second))
-	closed = tm.market.OnChainTimeUpdate(context.Background(), closingAt.Add(1*time.Second))
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), closingAt.Add(1*time.Second))
 	assert.False(t, closed)
 	assert.Equal(t, types.MarketStateTradingTerminated, tm.market.State())
 
@@ -605,7 +606,7 @@ func TestMarketClosing(t *testing.T) {
 		Data:    properties,
 	})
 	tm.oracleEngine.UpdateCurrentTime(context.Background(), closingAt.Add(3*time.Second))
-	closed = tm.market.OnChainTimeUpdate(context.Background(), closingAt.Add(3*time.Second))
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), closingAt.Add(3*time.Second))
 	assert.True(t, closed)
 	assert.Equal(t, types.MarketStateSettled, tm.market.State())
 }
@@ -727,7 +728,7 @@ func TestMarketWithTradeClosing(t *testing.T) {
 		PubKeys: []string{"0xDEADBEEF"},
 		Data:    properties,
 	})
-	closed := tm.market.OnChainTimeUpdate(context.Background(), futureTime)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), futureTime)
 	assert.True(t, closed)
 }
 
@@ -818,7 +819,7 @@ func TestMarketGetMarginOnFailNoFund(t *testing.T) {
 	}
 	// leave opening auction
 	now = now.Add(time.Second * 2)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	order1 := &types.Order{
 		Status:      types.OrderStatusActive,
@@ -932,7 +933,7 @@ func TestMarketGetMarginOnAmendOrderCancelReplace(t *testing.T) {
 		ExpiresAt:   &orderBuy.ExpiresAt,
 	}
 
-	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1)
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, randomSha256Hash())
 	if !assert.Nil(t, err) {
 		t.Fatalf("Error: %v", err)
 	}
@@ -1091,7 +1092,7 @@ func TestTriggerByPriceNoTradesInAuction(t *testing.T) {
 		require.NotNil(t, conf)
 	}
 	// leave opening auction by moving time
-	tm.market.OnChainTimeUpdate(context.Background(), openEnd)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), openEnd)
 	now = openEnd
 
 	orderBuy1 := &types.Order{
@@ -1179,10 +1180,10 @@ func TestTriggerByPriceNoTradesInAuction(t *testing.T) {
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, auctionEndTime.UnixNano(), auctionEnd) // In auction
 
-	closed := tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime)
 	assert.False(t, closed)
 
-	closed = tm.market.OnChainTimeUpdate(context.Background(), afterAuciton)
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), afterAuciton)
 	require.Equal(t, types.MarketStateActive, tm.market.State())
 	assert.False(t, closed)
 }
@@ -1253,7 +1254,7 @@ func TestTriggerByPriceAuctionPriceInBounds(t *testing.T) {
 		require.NotNil(t, conf)
 	}
 	// leave auction
-	tm.market.OnChainTimeUpdate(context.Background(), openEnd)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), openEnd)
 	now = openEnd
 
 	orderSell1 := &types.Order{
@@ -1339,7 +1340,7 @@ func TestTriggerByPriceAuctionPriceInBounds(t *testing.T) {
 
 	require.Empty(t, confirmationSell.Trades)
 
-	closed := tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime)
 	assert.False(t, closed)
 
 	now = auctionEndTime
@@ -1385,7 +1386,7 @@ func TestTriggerByPriceAuctionPriceInBounds(t *testing.T) {
 	require.Equal(t, auctionEndTime.UnixNano(), auctionEnd)         // In auction
 	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
 
-	closed = tm.market.OnChainTimeUpdate(context.Background(), afterAuction)
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), afterAuction)
 	require.Equal(t, tm.market.State(), types.MarketStateActive)
 	assert.False(t, closed)
 
@@ -1496,7 +1497,7 @@ func TestTriggerByPriceAuctionPriceOutsideBounds(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// increase time, so we can leave opening auction
-	tm.market.OnChainTimeUpdate(context.Background(), openEnd)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), openEnd)
 	require.Equal(t, types.MarketStateActive, tm.market.State())
 	now = openEnd
 
@@ -1591,7 +1592,7 @@ func TestTriggerByPriceAuctionPriceOutsideBounds(t *testing.T) {
 		TimeInForce: types.OrderTimeInForceGTC,
 	}
 
-	conf, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1)
+	conf, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, randomSha256Hash())
 	require.NoError(t, err)
 	require.NotNil(t, conf)
 	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
@@ -1599,7 +1600,7 @@ func TestTriggerByPriceAuctionPriceOutsideBounds(t *testing.T) {
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, auctionEndTime.UnixNano(), auctionEnd) // In auction
 
-	closed := tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime)
 	assert.False(t, closed)
 
 	now = auctionEndTime
@@ -1645,7 +1646,7 @@ func TestTriggerByPriceAuctionPriceOutsideBounds(t *testing.T) {
 	require.Equal(t, auctionEndTime.UnixNano(), auctionEnd) // In auction
 
 	// Expecting market to still be in auction as auction resulted in invalid price
-	closed = tm.market.OnChainTimeUpdate(context.Background(), initialAuctionEnd)
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), initialAuctionEnd)
 	assert.False(t, closed)
 
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
@@ -1713,7 +1714,7 @@ func TestTriggerByMarketOrder(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// now leave auction
-	tm.market.OnChainTimeUpdate(context.Background(), openingEnd)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), openingEnd)
 	now = openingEnd
 
 	orderSell1 := &types.Order{
@@ -1829,14 +1830,14 @@ func TestTriggerByMarketOrder(t *testing.T) {
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, auctionEndTime.UnixNano(), auctionEnd) // In auction
 
-	closed := tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime)
 	assert.False(t, closed)
 
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, auctionEndTime.UnixNano(), auctionEnd) // Still in auction
 	require.Equal(t, types.MarketStateSuspended, tm.market.State())
 
-	closed = tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime.Add(time.Nanosecond))
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime.Add(time.Nanosecond))
 	require.Equal(t, types.MarketStateActive, tm.market.State()) // left auction
 	assert.False(t, closed)
 
@@ -1935,7 +1936,7 @@ func TestPriceMonitoringBoundsInGetMarketData(t *testing.T) {
 		require.NotNil(t, conf)
 	}
 	// leave auction
-	tm.market.OnChainTimeUpdate(context.Background(), openEnd)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), openEnd)
 	now = openEnd
 
 	orderBuy1 := &types.Order{
@@ -2042,7 +2043,7 @@ func TestPriceMonitoringBoundsInGetMarketData(t *testing.T) {
 
 	require.Empty(t, md.PriceMonitoringBounds)
 
-	closed := tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime)
 	assert.False(t, closed)
 
 	md = tm.market.GetMarketData()
@@ -2053,7 +2054,7 @@ func TestPriceMonitoringBoundsInGetMarketData(t *testing.T) {
 
 	require.Empty(t, md.PriceMonitoringBounds)
 
-	closed = tm.market.OnChainTimeUpdate(context.Background(), auctionEndTime.Add(time.Nanosecond))
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), auctionEndTime.Add(time.Nanosecond))
 	assert.False(t, closed)
 
 	md = tm.market.GetMarketData()
@@ -2127,7 +2128,7 @@ func TestTargetStakeReturnedAndCorrect(t *testing.T) {
 	}
 	// leave opening auction
 	now = now.Add(2 * time.Second)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	orderSell1 := &types.Order{
 		Type:        types.OrderTypeLimit,
@@ -2174,7 +2175,7 @@ func TestTargetStakeReturnedAndCorrect(t *testing.T) {
 }
 
 func TestHandleLPCommitmentChange(t *testing.T) {
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	party1 := "party1"
 	party2 := "party2"
 	party3 := "party3"
@@ -2223,7 +2224,7 @@ func TestHandleLPCommitmentChange(t *testing.T) {
 	}
 	// leave opening auction
 	now = now.Add(2 * time.Second)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	order1 := &types.Order{
 		Type:        types.OrderTypeLimit,
@@ -2343,7 +2344,7 @@ func TestHandleLPCommitmentChange(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tm.market.SubmitLiquidityProvision(ctx, lp, party1, "id-lp"),
+		tm.market.SubmitLiquidityProvision(ctx, lp, party1, "id-lp", randomSha256Hash()),
 	)
 
 	// this will make current target stake returns 2475
@@ -2359,20 +2360,20 @@ func TestHandleLPCommitmentChange(t *testing.T) {
 		Sells:            lp.Sells,
 	}
 	require.Equal(t, execution.ErrNotEnoughStake,
-		tm.market.AmendLiquidityProvision(ctx, lpa, party1),
+		tm.market.AmendLiquidityProvision(ctx, lpa, party1, randomSha256Hash()),
 	)
 
 	// 2000 + 600 should be enough to get us on top of the
 	// target stake
 	lpa.CommitmentAmount = num.NewUint(2000 + 600)
 	require.NoError(t,
-		tm.market.AmendLiquidityProvision(ctx, lpa, party1),
+		tm.market.AmendLiquidityProvision(ctx, lpa, party1, randomSha256Hash()),
 	)
 
 	// 2600 - 125 should be enough to get just at the required stake
 	lpa.CommitmentAmount = num.NewUint(2600 - 125)
 	require.NoError(t,
-		tm.market.AmendLiquidityProvision(ctx, lpa, party1),
+		tm.market.AmendLiquidityProvision(ctx, lpa, party1, randomSha256Hash()),
 	)
 }
 
@@ -2442,7 +2443,7 @@ func TestSuppliedStakeReturnedAndCorrect(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(context.Background(), lp1, party1, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(context.Background(), lp1, party1, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	lp2 := &types.LiquidityProvisionSubmission{
@@ -2457,7 +2458,7 @@ func TestSuppliedStakeReturnedAndCorrect(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(context.Background(), lp2, party2, "id-lp2")
+	err = tm.market.SubmitLiquidityProvision(context.Background(), lp2, party2, "id-lp2", randomSha256Hash())
 	require.NoError(t, err)
 
 	mktData := tm.market.GetMarketData()
@@ -2468,7 +2469,7 @@ func TestSuppliedStakeReturnedAndCorrect(t *testing.T) {
 }
 
 func TestSubmitLiquidityProvisionWithNoOrdersOnBook(t *testing.T) {
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	mainParty := "mainParty"
 	auxParty := "auxParty"
 	auxParty2 := "auxParty2"
@@ -2498,7 +2499,7 @@ func TestSubmitLiquidityProvisionWithNoOrdersOnBook(t *testing.T) {
 		},
 	}
 
-	err := tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1")
+	err := tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	auxOrders := []*types.Order{
@@ -2527,7 +2528,7 @@ func TestSubmitLiquidityProvisionWithNoOrdersOnBook(t *testing.T) {
 }
 
 func TestSubmitLiquidityProvisionInOpeningAuction(t *testing.T) {
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	mainParty := "mainParty"
 	auxParty := "auxParty"
 	p1, p2 := "party1", "party2"
@@ -2557,7 +2558,7 @@ func TestSubmitLiquidityProvisionInOpeningAuction(t *testing.T) {
 
 	require.Equal(t, types.MarketTradingModeOpeningAuction, tm.market.GetMarketData().MarketTradingMode)
 
-	err := tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1")
+	err := tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	tradingOrders := []*types.Order{
@@ -2605,7 +2606,7 @@ func TestLimitOrderChangesAffectLiquidityOrders(t *testing.T) {
 		Duration: 1,
 	})
 	var matchingPrice uint64 = 111
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, mainParty)
 	addAccount(tm, auxParty)
@@ -2671,7 +2672,7 @@ func TestLimitOrderChangesAffectLiquidityOrders(t *testing.T) {
 		},
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	mktDataPrev := mktData
@@ -2689,7 +2690,7 @@ func TestLimitOrderChangesAffectLiquidityOrders(t *testing.T) {
 		// SizeDelta: 9,
 		SizeDelta: 2,
 	}
-	_, err = tm.market.AmendOrder(ctx, amendment, confirmationBuy.Order.Party)
+	_, err = tm.market.AmendOrder(ctx, amendment, confirmationBuy.Order.Party, randomSha256Hash())
 	require.NoError(t, err)
 
 	mktData = tm.market.GetMarketData()
@@ -2742,7 +2743,7 @@ func TestLimitOrderChangesAffectLiquidityOrders(t *testing.T) {
 	lpOrderVolumeOfferPrev = lpOrderVolumeOffer
 	mktDataPrev = mktData
 	// Cancel limit order
-	cancelConf, err := tm.market.CancelOrder(ctx, orderSell1.Party, orderSell1.ID)
+	cancelConf, err := tm.market.CancelOrder(ctx, orderSell1.Party, orderSell1.ID, randomSha256Hash())
 	require.NoError(t, err)
 	require.NotNil(t, cancelConf)
 
@@ -2759,7 +2760,7 @@ func TestLimitOrderChangesAffectLiquidityOrders(t *testing.T) {
 	// Submit another limit order that fills partially on submission
 	// Modify LP order so it's not on the best offer
 	lp1.Sells[0].Offset.AddSum(num.NewUint(1))
-	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1")
+	err = tm.market.SubmitLiquidityProvision(ctx, lp1, mainParty, "id-lp1", randomSha256Hash())
 	require.NoError(t, err)
 
 	auxOrder2 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux-order-2", types.SideSell, auxParty, 7, matchingPrice+1)
@@ -2863,7 +2864,7 @@ func TestOrderBook_Crash2651(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "613f")
 	addAccount(tm, "f9e7")
@@ -2963,7 +2964,7 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "A")
 	addAccount(tm, "B")
@@ -3010,28 +3011,28 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	require.NotNil(t, o1conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o2 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGFN, "Order02", types.SideSell, "B", 25, 11000)
 	o2conf, err := tm.market.SubmitOrder(ctx, o2)
 	require.NotNil(t, o2conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o3 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGFN, "Order03", types.SideBuy, "A", 10, 10500)
 	o3conf, err := tm.market.SubmitOrder(ctx, o3)
 	require.NotNil(t, o3conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o4 := getMarketOrder(tm, now, types.OrderTypeMarket, types.OrderTimeInForceIOC, "Order04", types.SideSell, "C", 5, 0)
 	o4conf, err := tm.market.SubmitOrder(ctx, o4)
 	require.NotNil(t, o4conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o5 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order05", types.SideBuy, "C", 35, 0)
 	o5.PeggedOrder = newPeggedOrder(types.PeggedReferenceMid, 500)
@@ -3039,7 +3040,7 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	require.NotNil(t, o5conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o6 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order06", types.SideBuy, "D", 16, 0)
 	o6.PeggedOrder = newPeggedOrder(types.PeggedReferenceBestBid, 2000)
@@ -3047,7 +3048,7 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	require.NotNil(t, o6conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o7 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTT, "Order07", types.SideSell, "E", 19, 0)
 	o7.PeggedOrder = newPeggedOrder(types.PeggedReferenceBestAsk, 3000)
@@ -3056,14 +3057,14 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	require.NotNil(t, o7conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o8 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order08", types.SideBuy, "F", 25, 10000)
 	o8conf, err := tm.market.SubmitOrder(ctx, o8)
 	require.NotNil(t, o8conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	// This one should crash
 	o9 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order09", types.SideSell, "F", 25, 10250)
@@ -3071,21 +3072,21 @@ func TestOrderBook_Crash2599(t *testing.T) {
 	require.NotNil(t, o9conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o10 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order10", types.SideBuy, "G", 45, 14000)
 	o10conf, err := tm.market.SubmitOrder(ctx, o10)
 	require.NotNil(t, o10conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o11 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order11", types.SideSell, "G", 45, 8500)
 	o11conf, err := tm.market.SubmitOrder(ctx, o11)
 	require.NotNil(t, o11conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 }
 
 func TestTriggerAfterOpeningAuction(t *testing.T) {
@@ -3223,14 +3224,14 @@ func TestTriggerAfterOpeningAuction(t *testing.T) {
 	auctionEnd := tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, openingAuctionEndTime.UnixNano(), auctionEnd) // In opening auction
 
-	closed := tm.market.OnChainTimeUpdate(context.Background(), afterOpeningAuction)
+	closed := tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), afterOpeningAuction)
 	assert.False(t, closed)
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, int64(0), auctionEnd) // Not in auction
 
 	// let's cancel the orders we had to place to end opening auction
 	for _, o := range gtcOrders {
-		_, err := tm.market.CancelOrder(context.Background(), o.Party, o.ID)
+		_, err := tm.market.CancelOrder(context.Background(), o.Party, o.ID, randomSha256Hash())
 		assert.NoError(t, err)
 	}
 	orderBuy2 := &types.Order{
@@ -3275,10 +3276,10 @@ func TestTriggerAfterOpeningAuction(t *testing.T) {
 	auctionEnd = tm.market.GetMarketData().AuctionEnd
 	require.Equal(t, pMonitorAuctionEndTime.UnixNano(), auctionEnd) // In auction
 
-	closed = tm.market.OnChainTimeUpdate(context.Background(), pMonitorAuctionEndTime)
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), pMonitorAuctionEndTime)
 	assert.False(t, closed)
 
-	closed = tm.market.OnChainTimeUpdate(context.Background(), afterPMonitorAuction)
+	closed = tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), afterPMonitorAuction)
 	assert.False(t, closed)
 }
 
@@ -3288,7 +3289,7 @@ func TestOrderBook_Crash2718(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "aaa")
 	addAccount(tm, "bbb")
@@ -3332,7 +3333,7 @@ func TestOrderBook_Crash2718(t *testing.T) {
 	require.NotNil(t, o1conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	// Now the pegged order which will be live
 	o2 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order02", types.SideBuy, "bbb", 1, 0)
@@ -3341,7 +3342,7 @@ func TestOrderBook_Crash2718(t *testing.T) {
 	require.NotNil(t, o2conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 	assert.Equal(t, types.OrderStatusActive, o2.Status)
 	assert.Equal(t, num.NewUint(90), o2.Price)
 
@@ -3351,7 +3352,7 @@ func TestOrderBook_Crash2718(t *testing.T) {
 	require.NotNil(t, o3conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	o2Update := tm.lastOrderUpdate(o2.ID)
 	assert.Equal(t, types.OrderStatusActive, o2Update.Status)
@@ -3376,7 +3377,7 @@ func TestOrderBook_AmendPriceInParkedOrder(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "aaa")
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -3389,7 +3390,7 @@ func TestOrderBook_AmendPriceInParkedOrder(t *testing.T) {
 	require.NotNil(t, o1conf)
 	require.NoError(t, err)
 	now = now.Add(time.Second * 1)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 	assert.Equal(t, types.OrderStatusParked, o1.Status)
 	assert.True(t, o1.Price.IsZero())
 
@@ -3400,7 +3401,7 @@ func TestOrderBook_AmendPriceInParkedOrder(t *testing.T) {
 	}
 
 	// This should fail as we cannot amend a pegged order price
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa", randomSha256Hash())
 	require.Nil(t, amendConf)
 	require.Error(t, types.OrderErrorUnableToAmendPriceOnPeggedOrder, err)
 }
@@ -3409,7 +3410,7 @@ func TestOrderBook_ExpiredOrderTriggersReprice(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "aaa")
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -3430,7 +3431,7 @@ func TestOrderBook_ExpiredOrderTriggersReprice(t *testing.T) {
 
 	// Move the clock forward to expire the first order
 	now = now.Add(time.Second * 10)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.UnixNano())
 	require.NoError(t, err)
 
@@ -3461,7 +3462,7 @@ func TestOrderBook_CrashWithDistressedPartyPeggedOrderNotRemovedFromPeggedList27
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 100000000)
 	addAccountWithAmount(tm, "party-B", 100000000)
@@ -3535,7 +3536,7 @@ func TestOrderBook_CrashWithDistressedPartyPeggedOrderNotRemovedFromPeggedList27
 		Price:   num.NewUint(1002),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-C")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-C", randomSha256Hash())
 	require.NotNil(t, amendConf)
 	require.NoError(t, err)
 
@@ -3546,7 +3547,7 @@ func TestOrderBook_Crash2733(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := now.Add(120 * time.Second)
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{Duration: 30})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 1000000)
 	addAccountWithAmount(tm, "party-B", 1000000)
@@ -3575,7 +3576,7 @@ func TestOrderBook_Crash2733(t *testing.T) {
 
 	// now move time to after auction
 	now = now.Add(31 * time.Second)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	for i := 1; i <= 10; i += 1 {
 		o1 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, fmt.Sprintf("Order4%v", i), types.SideSell, "party-B", uint64(i), uint64(i*150))
@@ -3596,7 +3597,7 @@ func TestOrderBook_Bug2747(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 100000000)
 	addAccountWithAmount(tm, "party-B", 100000000)
@@ -3615,7 +3616,7 @@ func TestOrderBook_Bug2747(t *testing.T) {
 		PeggedOffset:    num.NewUint(20),
 		PeggedReference: types.PeggedReferenceBestAsk,
 	}
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A", randomSha256Hash())
 	assert.Nil(t, amendConf)
 	assert.EqualError(t, err, "OrderError: buy cannot reference best ask price")
 }
@@ -3626,7 +3627,7 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "aaa")
 	auxParty := "auxParty"
@@ -3681,14 +3682,14 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder(t *testing.T) {
 		TimeInForce: types.OrderTimeInForceGTC,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa", randomSha256Hash())
 	require.NotNil(t, amendConf)
 	require.NoError(t, err)
 	assert.Equal(t, types.OrderStatusActive, o2.Status)
 
 	// Move the clock forward to expire any old orders
 	now = now.Add(time.Second * 10)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.UnixNano())
 	require.Equal(t, 0, len(orders))
 	require.NoError(t, err)
@@ -3704,7 +3705,7 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder2(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "aaa")
 	auxParty := "auxParty"
@@ -3762,7 +3763,7 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder2(t *testing.T) {
 		ExpiresAt:   &exp,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "aaa", randomSha256Hash())
 	require.NotNil(t, amendConf)
 	require.NoError(t, err)
 	assert.Equal(t, types.OrderStatusActive, o2.Status)
@@ -3770,7 +3771,7 @@ func TestOrderBook_AmendTIME_IN_FORCEForPeggedOrder2(t *testing.T) {
 
 	// Move the clock forward to expire any old orders
 	now = now.Add(time.Second * 10)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 	orders, err := tm.market.RemoveExpiredOrders(context.Background(), now.UnixNano())
 	require.NoError(t, err)
 
@@ -3789,7 +3790,7 @@ func TestOrderBook_AmendFilledWithActiveStatus2736(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 	addAccount(tm, "party-B")
@@ -3843,7 +3844,7 @@ func TestOrderBook_AmendFilledWithActiveStatus2736(t *testing.T) {
 		Price:   num.NewUint(5000),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-B")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-B", randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 	o2Update := tm.lastOrderUpdate(o2.ID)
@@ -3856,7 +3857,7 @@ func TestOrderBook_PeggedOrderReprice2748(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 100000000)
 	addAccountWithAmount(tm, "party-B", 100000000)
@@ -3909,7 +3910,7 @@ func TestOrderBook_PeggedOrderReprice2748(t *testing.T) {
 		PeggedOffset: num.NewUint(6500),
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-C")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-C", randomSha256Hash())
 	require.NotNil(t, amendConf)
 	require.NoError(t, err)
 
@@ -3923,7 +3924,7 @@ func TestOrderBook_AmendGFNToGTCOrGTTNotAllowed2486(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 100000000)
 	auxParty := "auxParty"
@@ -3973,7 +3974,7 @@ func TestOrderBook_AmendGFNToGTCOrGTTNotAllowed2486(t *testing.T) {
 		TimeInForce: types.OrderTimeInForceGTC,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A", randomSha256Hash())
 	assert.Nil(t, amendConf)
 	assert.EqualError(t, err, "OrderError: Cannot amend TIF from GFA or GFN")
 }
@@ -3982,7 +3983,7 @@ func TestOrderBook_CancelAll2771(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 100000000)
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -4011,7 +4012,7 @@ func TestOrderBook_RejectAmendPriceOnPeggedOrder2658(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -4030,7 +4031,7 @@ func TestOrderBook_RejectAmendPriceOnPeggedOrder2658(t *testing.T) {
 		SizeDelta: 10,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A", randomSha256Hash())
 	assert.Nil(t, amendConf)
 	assert.Error(t, types.OrderErrorUnableToAmendPriceOnPeggedOrder, err)
 	assert.Equal(t, types.OrderStatusParked, o1.Status)
@@ -4041,7 +4042,7 @@ func TestOrderBook_AmendToCancelForceReprice(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -4064,7 +4065,7 @@ func TestOrderBook_AmendToCancelForceReprice(t *testing.T) {
 		SizeDelta: -1,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A", randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -4077,7 +4078,7 @@ func TestOrderBook_AmendExpPersistParkPeggedOrder(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -4100,7 +4101,7 @@ func TestOrderBook_AmendExpPersistParkPeggedOrder(t *testing.T) {
 		SizeDelta: -10,
 	}
 
-	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A")
+	amendConf, err := tm.market.AmendOrder(ctx, amendment, "party-A", randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 	assert.Equal(t, types.OrderStatusParked, o2.Status)
@@ -4117,7 +4118,7 @@ func TestOrderBook_ParkPeggedOrderWhenMovingToAuction(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 	auxParty := "auxParty"
@@ -4185,7 +4186,7 @@ func TestMarket_LeaveAuctionRepricePeggedOrdersShouldFailIfNoMargin(t *testing.T
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	// Create a new party account with very little funding
 	addAccountWithAmount(tm, "party-C", 1)
@@ -4214,7 +4215,7 @@ func TestMarket_LeaveAuctionRepricePeggedOrdersShouldFailIfNoMargin(t *testing.T
 	}
 
 	// Because we do not have enough funds to support our commitment level, we should reject this call
-	err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-C", "LPOrder01")
+	err := tm.market.SubmitLiquidityProvision(ctx, lps, "party-C", "LPOrder01", randomSha256Hash())
 	require.Error(t, err)
 }
 
@@ -4222,7 +4223,7 @@ func TestMarket_LeaveAuctionAndRepricePeggedOrders(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 	addAccount(tm, "party-B")
@@ -4269,7 +4270,7 @@ func TestMarket_LeaveAuctionAndRepricePeggedOrders(t *testing.T) {
 		Sells:            sells,
 	}
 
-	err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-C", "LPOrder01")
+	err = tm.market.SubmitLiquidityProvision(ctx, lps, "party-C", "LPOrder01", randomSha256Hash())
 	require.NoError(t, err)
 
 	// Leave the auction so pegged orders are unparked
@@ -4281,7 +4282,7 @@ func TestMarket_LeaveAuctionAndRepricePeggedOrders(t *testing.T) {
 	require.Equal(t, 0, tm.market.GetParkedOrderCount())
 
 	// Remove an order to invalidate reference prices and force pegged orders to park
-	tm.market.CancelOrder(ctx, o1.Party, o1.ID)
+	tm.market.CancelOrder(ctx, o1.Party, o1.ID, randomSha256Hash())
 	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
 
 	// 1 live orders, 1 normal
@@ -4301,7 +4302,7 @@ func TestOrderBook_ParkLiquidityProvisionOrders(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1000,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 
@@ -4320,7 +4321,7 @@ func TestOrderBook_ParkLiquidityProvisionOrders(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tm.market.SubmitLiquidityProvision(ctx, lp, "party-A", "id-lp"),
+		tm.market.SubmitLiquidityProvision(ctx, lp, "party-A", "id-lp", randomSha256Hash()),
 	)
 
 	// assert.Equal(t,
@@ -4336,7 +4337,7 @@ func TestOrderBook_RemovingLiquidityProvisionOrders(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1000,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party-A")
 
@@ -4355,7 +4356,7 @@ func TestOrderBook_RemovingLiquidityProvisionOrders(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-A", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-A", "id-lp", randomSha256Hash()))
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 
 	// Remove the LPSubmission
@@ -4373,7 +4374,7 @@ func TestOrderBook_ClosingOutLPProviderShouldRemoveCommitment(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1000,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 2000)
 	addAccountWithAmount(tm, "party-B", 10000000)
@@ -4437,7 +4438,7 @@ func TestOrderBook_ClosingOutLPProviderShouldRemoveCommitment(t *testing.T) {
 	tm.stateVar.ReadyForTimeTrigger(tm.asset, tm.market.GetID())
 	tm.stateVar.OnTimeTick(context.Background(), now.Add(6*time.Minute))
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-A", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-A", "id-lp", randomSha256Hash()))
 	require.Equal(t, 0, tm.market.GetParkedOrderCount())
 	require.Equal(t, int64(9), tm.market.GetOrdersOnBookCount())
 	require.Equal(t, 1, tm.market.GetLPSCount())
@@ -4457,7 +4458,7 @@ func TestOrderBook_PartiallyFilledMarketOrderThatWouldWashIOC(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1000,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 10000000)
 	addAccountWithAmount(tm, "party-B", 10000000)
@@ -4507,7 +4508,7 @@ func TestOrderBook_PartiallyFilledMarketOrderThatWouldWashFOKSell(t *testing.T) 
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1000,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 10000000)
 	addAccountWithAmount(tm, "party-B", 10000000)
@@ -4569,7 +4570,7 @@ func TestOrderBook_PartiallyFilledMarketOrderThatWouldWashFOKBuy(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccountWithAmount(tm, "party-A", 10000000)
@@ -4637,7 +4638,7 @@ func TestOrderBook_PartiallyFilledLimitOrderThatWouldWashFOK(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1000,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccountWithAmount(tm, "party-A", 10000000)
 	addAccountWithAmount(tm, "party-B", 10000000)
@@ -4699,7 +4700,7 @@ func TestOrderBook_PartiallyFilledLimitOrderThatWouldWashFOK(t *testing.T) {
 // Tests that during a list of LiquidityProvision order creation (triggered by
 // SubmitLiquidityProvision) fails, the created orders are rolled back.
 func TestLPOrdersRollback(t *testing.T) {
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(10000000000, 0)
 
@@ -4846,7 +4847,7 @@ func TestLPOrdersRollback(t *testing.T) {
 
 	balanceBeforeLP := num.Sum(tm.PartyGeneralAccount(t, "party-2").Balance, tm.PartyMarginAccount(t, "party-2").Balance)
 
-	err := tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp")
+	err := tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp", randomSha256Hash())
 	assert.EqualError(t, err, "margin check failed")
 
 	t.Run("GeneralAccountBalance", func(t *testing.T) {
@@ -4914,7 +4915,7 @@ func TestLPOrdersRollback(t *testing.T) {
 func Test3008CancelLiquidityProvisionWhenTargetStakeNotReached(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
 		Duration: 10000,
@@ -5055,7 +5056,7 @@ func Test3008CancelLiquidityProvisionWhenTargetStakeNotReached(t *testing.T) {
 	// Leave the auction
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10001*time.Second))
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp", randomSha256Hash()))
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 
 	lpCancel := &types.LiquidityProvisionCancellation{
@@ -5071,7 +5072,7 @@ func Test3008CancelLiquidityProvisionWhenTargetStakeNotReached(t *testing.T) {
 func Test3008And3007CancelLiquidityProvision(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
 		Duration: 10000,
@@ -5216,7 +5217,7 @@ func Test3008And3007CancelLiquidityProvision(t *testing.T) {
 	// Leave the auction
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10001*time.Second))
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp", randomSha256Hash()))
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 
 	// this is our second stake provider
@@ -5239,7 +5240,7 @@ func Test3008And3007CancelLiquidityProvision(t *testing.T) {
 	tm.events = nil
 
 	require.NoError(t, tm.market.SubmitLiquidityProvision(
-		ctx, lp2, "party-2-bis", "id-lp-2"))
+		ctx, lp2, "party-2-bis", "id-lp-2", randomSha256Hash()))
 	assert.Equal(t, 2, tm.market.GetLPSCount())
 
 	t.Run("ExpectedOrderStatus", func(t *testing.T) {
@@ -5374,7 +5375,7 @@ func Test3008And3007CancelLiquidityProvision(t *testing.T) {
 func Test2963EnsureMarketValueProxyAndEquitityShareAreInMarketData(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
 		Duration: 10000,
@@ -5519,7 +5520,7 @@ func Test2963EnsureMarketValueProxyAndEquitityShareAreInMarketData(t *testing.T)
 	// Leave the auction
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10001*time.Second))
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp", randomSha256Hash()))
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 
 	// this is our second stake provider
@@ -5542,7 +5543,7 @@ func Test2963EnsureMarketValueProxyAndEquitityShareAreInMarketData(t *testing.T)
 	tm.events = nil
 
 	require.NoError(t, tm.market.SubmitLiquidityProvision(
-		ctx, lp2, "party-2-bis", "id-lp-2"))
+		ctx, lp2, "party-2-bis", "id-lp-2", randomSha256Hash()))
 	assert.Equal(t, 2, tm.market.GetLPSCount())
 
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))
@@ -5555,7 +5556,7 @@ func Test2963EnsureMarketValueProxyAndEquitityShareAreInMarketData(t *testing.T)
 func Test3045DistributeFeesToManyProviders(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
 		Duration: 10000,
@@ -5700,7 +5701,7 @@ func Test3045DistributeFeesToManyProviders(t *testing.T) {
 	// Leave the auction
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10001*time.Second))
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp", randomSha256Hash()))
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 
 	// this is our second stake provider
@@ -5723,7 +5724,7 @@ func Test3045DistributeFeesToManyProviders(t *testing.T) {
 	tm.events = nil
 
 	require.NoError(t, tm.market.SubmitLiquidityProvision(
-		ctx, lp2, "party-2-bis", "id-lp-2"))
+		ctx, lp2, "party-2-bis", "id-lp-2", randomSha256Hash()))
 	assert.Equal(t, 2, tm.market.GetLPSCount())
 
 	t.Run("ExpectedOrderStatus", func(t *testing.T) {
@@ -5797,7 +5798,7 @@ func Test3045DistributeFeesToManyProviders(t *testing.T) {
 func TestAverageEntryValuation(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auctionEnd := now.Add(10001 * time.Second)
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
@@ -5858,7 +5859,7 @@ func TestAverageEntryValuation(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, &lpSubmission, lpparty, "liquidity-submission-1"),
+			ctx, &lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 	)
 
 	lpSubmission2 := lpSubmission
@@ -5867,7 +5868,7 @@ func TestAverageEntryValuation(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, &lpSubmission2, lpparty2, "liquidity-submission-2"),
+			ctx, &lpSubmission2, lpparty2, "liquidity-submission-2", randomSha256Hash()),
 	)
 
 	lpSubmission3 := lpSubmission
@@ -5876,7 +5877,7 @@ func TestAverageEntryValuation(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, &lpSubmission3, lpparty3, "liquidity-submission-3"),
+			ctx, &lpSubmission3, lpparty3, "liquidity-submission-3", randomSha256Hash()),
 	)
 
 	marketData := tm.market.GetMarketData()
@@ -5906,7 +5907,7 @@ func TestAverageEntryValuation(t *testing.T) {
 func TestBondAccountIsReleasedItMarketRejected(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
 		Duration: 10000,
@@ -5959,7 +5960,7 @@ func TestBondAccountIsReleasedItMarketRejected(t *testing.T) {
 	// submit our lp
 	require.NoError(t,
 		tm.market.SubmitLiquidityProvision(
-			ctx, lpSubmission, lpparty, "liquidity-submission-1"),
+			ctx, lpSubmission, lpparty, "liquidity-submission-1", randomSha256Hash()),
 	)
 
 	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
@@ -6000,7 +6001,7 @@ func TestLiquidityMonitoring_GoIntoAndOutOfAuction(t *testing.T) {
 	}
 	tm := getTestMarket(t, now, closingAt, nil, openingDuration)
 	c1 := 0.7
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketLiquidityTargetStakeTriggeringRatio(ctx, num.DecimalFromFloat(c1))
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
@@ -6066,11 +6067,11 @@ func TestLiquidityMonitoring_GoIntoAndOutOfAuction(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tm.market.SubmitLiquidityProvision(ctx, lp1sub, lp1, "id-lp-1"),
+		tm.market.SubmitLiquidityProvision(ctx, lp1sub, lp1, "id-lp-1", randomSha256Hash()),
 	)
 
 	require.NoError(t,
-		tm.market.SubmitLiquidityProvision(ctx, lp2sub, lp2, "id-lp-2"),
+		tm.market.SubmitLiquidityProvision(ctx, lp2sub, lp2, "id-lp-2", randomSha256Hash()),
 	)
 
 	md = tm.market.GetMarketData()
@@ -6182,7 +6183,7 @@ func TestLiquidityMonitoring_GoIntoAndOutOfAuction(t *testing.T) {
 		CommitmentAmount: num.Sum(lp2sub.CommitmentAmount, num.NewUint(25750)),
 	}
 	require.NoError(t,
-		tm.market.AmendLiquidityProvision(ctx, lpa2, lp2),
+		tm.market.AmendLiquidityProvision(ctx, lpa2, lp2, randomSha256Hash()),
 	)
 
 	// progress time so liquidity auction ends
@@ -6206,7 +6207,7 @@ func TestLiquidityMonitoring_GoIntoAndOutOfAuction(t *testing.T) {
 
 	lpa2.CommitmentAmount = lp2Commitment.Clone()
 	require.Error(t,
-		tm.market.AmendLiquidityProvision(ctx, lpa2, lp2),
+		tm.market.AmendLiquidityProvision(ctx, lpa2, lp2, randomSha256Hash()),
 	)
 
 	md = tm.market.GetMarketData()
@@ -6214,7 +6215,7 @@ func TestLiquidityMonitoring_GoIntoAndOutOfAuction(t *testing.T) {
 	require.Greater(t, md.BestStaticBidVolume, zero)
 
 	// Cancelling best_bid should start auction
-	conf, err := tm.market.CancelOrder(ctx, buyOrder1.Party, buyOrder1.ID)
+	conf, err := tm.market.CancelOrder(ctx, buyOrder1.Party, buyOrder1.ID, randomSha256Hash())
 	require.NoError(t, err)
 	require.NotNil(t, conf)
 	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
@@ -6278,7 +6279,7 @@ func TestLiquidityMonitoring_GoIntoAndOutOfAuction(t *testing.T) {
 		CommitmentAmount: num.Sum(lp1Commitment, num.NewUint(10000)),
 	}
 	require.NoError(t,
-		tm.market.AmendLiquidityProvision(ctx, lpa1, lp1),
+		tm.market.AmendLiquidityProvision(ctx, lpa1, lp1, randomSha256Hash()),
 	)
 
 	md = tm.market.GetMarketData()
@@ -6321,7 +6322,7 @@ func TestLiquidityMonitoring_BestBidAskExistAfterAuction(t *testing.T) {
 	}
 	tm := getTestMarket(t, now, closingAt, nil, openingDuration)
 	c1 := 0.0
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketLiquidityTargetStakeTriggeringRatio(ctx, num.DecimalFromFloat(c1))
 	tm.market.OnMarketTargetStakeScalingFactorUpdate(num.DecimalFromFloat(0.0))
 	md := tm.market.GetMarketData()
@@ -6368,7 +6369,7 @@ func TestLiquidityMonitoring_BestBidAskExistAfterAuction(t *testing.T) {
 	}
 
 	require.NoError(t,
-		tm.market.SubmitLiquidityProvision(ctx, lp1sub, lp1, "id-lp-1"),
+		tm.market.SubmitLiquidityProvision(ctx, lp1sub, lp1, "id-lp-1", randomSha256Hash()),
 	)
 
 	md = tm.market.GetMarketData()

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -1,10 +1,11 @@
 package execution_test
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -1,6 +1,7 @@
 package execution_test
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
 	"context"
 	"testing"
 	"time"
@@ -58,26 +59,26 @@ func TestOrderBufferOutputCount(t *testing.T) {
 	one := num.NewUint(1)
 	// Amend price down (generates one order message)
 	amend.Price = num.Zero().Sub(orderBuy.Price, one)
-	amendConf, err := tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err := tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	// Amend price up (generates one order message)
 	amend.Price.AddSum(one, one) // we subtracted one, add 1 to get == to orderBuy.Price, + 1 again
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	// Amend size down (generates one order message)
 	amend.Price = nil
 	amend.SizeDelta = -1
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	// Amend size up (generates one order message)
 	amend.SizeDelta = +1
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -86,14 +87,14 @@ func TestOrderBufferOutputCount(t *testing.T) {
 	amend.TimeInForce = types.OrderTimeInForceGTT
 	exp := now.UnixNano() + 100000000000
 	amend.ExpiresAt = &exp
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	// Amend TIME_IN_FORCE -> GTC (generates one order message)
 	amend.TimeInForce = types.OrderTimeInForceGTC
 	amend.ExpiresAt = nil
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
@@ -101,13 +102,13 @@ func TestOrderBufferOutputCount(t *testing.T) {
 	amend.TimeInForce = types.OrderTimeInForceGTT
 	exp = now.UnixNano() + 100000000000
 	amend.ExpiresAt = &exp
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 
 	exp = now.UnixNano() + 200000000000
 	amend.ExpiresAt = &exp
-	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendConf, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendConf)
 	assert.NoError(t, err)
 }
@@ -148,7 +149,7 @@ func TestAmendCancelResubmit(t *testing.T) {
 		MarketID: confirmation.Order.MarketID,
 		Price:    num.NewUint(101),
 	}
-	amended, err := tm.market.AmendOrder(context.TODO(), amend, confirmation.Order.Party)
+	amended, err := tm.market.AmendOrder(context.TODO(), amend, confirmation.Order.Party, randomSha256Hash())
 	assert.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -158,7 +159,7 @@ func TestAmendCancelResubmit(t *testing.T) {
 		Price:     num.NewUint(101),
 		SizeDelta: 1,
 	}
-	amended, err = tm.market.AmendOrder(context.TODO(), amend, confirmation.Order.Party)
+	amended, err = tm.market.AmendOrder(context.TODO(), amend, confirmation.Order.Party, randomSha256Hash())
 	assert.NotNil(t, amended)
 	assert.NoError(t, err)
 }
@@ -197,7 +198,7 @@ func TestCancelWithWrongPartyID(t *testing.T) {
 		OrderId:  confirmation.Order.ID,
 		MarketId: confirmation.Order.MarketID,
 	}
-	cancelconf, err := tm.market.CancelOrder(context.TODO(), party2, cancelOrder.OrderId)
+	cancelconf, err := tm.market.CancelOrder(context.TODO(), party2, cancelOrder.OrderId, randomSha256Hash())
 	assert.Nil(t, cancelconf)
 	assert.Error(t, err, types.ErrInvalidPartyID)
 }
@@ -244,7 +245,7 @@ func TestMarkPriceUpdateAfterPartialFill(t *testing.T) {
 	}
 	// leave opening auction
 	now = now.Add(2 * time.Second)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	orderBuy := &types.Order{
 		Status:      types.OrderStatusActive,
@@ -316,7 +317,7 @@ func TestExpireCancelGTCOrder(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Move the current time forward
-	tm.market.OnChainTimeUpdate(context.Background(), time.Unix(10, 100))
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), time.Unix(10, 100))
 
 	exp := int64(10000000010)
 	amend := &types.OrderAmendment{
@@ -325,7 +326,7 @@ func TestExpireCancelGTCOrder(t *testing.T) {
 		ExpiresAt:   &exp,
 		TimeInForce: types.OrderTimeInForceGTT,
 	}
-	amended, err := tm.market.AmendOrder(context.Background(), amend, party1)
+	amended, err := tm.market.AmendOrder(context.Background(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -379,7 +380,7 @@ func TestAmendPartialFillCancelReplace(t *testing.T) {
 	}
 	// leave opening auction
 	now = now.Add(2 * time.Second)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	orderBuy := &types.Order{
 		Status:      types.OrderStatusActive,
@@ -420,7 +421,7 @@ func TestAmendPartialFillCancelReplace(t *testing.T) {
 		MarketID: tm.market.GetID(),
 		Price:    num.NewUint(20),
 	}
-	amended, err := tm.market.AmendOrder(context.Background(), amend, party1)
+	amended, err := tm.market.AmendOrder(context.Background(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -464,7 +465,7 @@ func TestAmendWrongPartyID(t *testing.T) {
 		MarketID: confirmation.Order.MarketID,
 		Price:    num.NewUint(101),
 	}
-	amended, err := tm.market.AmendOrder(context.Background(), amend, party2)
+	amended, err := tm.market.AmendOrder(context.Background(), amend, party2, randomSha256Hash())
 	assert.Nil(t, amended)
 	assert.Error(t, err, types.ErrInvalidPartyID)
 }
@@ -479,7 +480,7 @@ func TestPartialFilledWashTrade(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, party1)
 	addAccount(tm, party2)
@@ -594,7 +595,7 @@ func amendOrder(t *testing.T, tm *testMarket, party string, orderID string, size
 	t.Helper()
 	amend := getAmend(tm.market.GetID(), orderID, sizeDelta, price, tif, expiresAt)
 
-	amended, err := tm.market.AmendOrder(context.Background(), amend, party)
+	amended, err := tm.market.AmendOrder(context.Background(), amend, party, randomSha256Hash())
 	if pass {
 		assert.NotNil(t, amended)
 		assert.NoError(t, err)
@@ -688,7 +689,7 @@ func TestAmendToLosePriorityThenCancel(t *testing.T) {
 	amendOrder(t, tm, "party1", order1, 1, 0, types.OrderTimeInForceUnspecified, 0, true)
 
 	// Check we can cancel it
-	cancelconf, _ := tm.market.CancelOrder(context.TODO(), "party1", order1)
+	cancelconf, _ := tm.market.CancelOrder(context.TODO(), "party1", order1, randomSha256Hash())
 	assert.NotNil(t, cancelconf)
 	assert.Equal(t, types.OrderStatusCancelled, cancelconf.Order.Status)
 }
@@ -731,7 +732,7 @@ func TestUnableToAmendGFAGFN(t *testing.T) {
 	}
 	// leave opening auction
 	now = now.Add(2 * time.Second)
-	tm.market.OnChainTimeUpdate(context.Background(), now)
+	tm.market.OnChainTimeUpdate(vegacontext.WithTraceID(context.Background(), randomSha256Hash()), now)
 
 	// test_AmendMarketOrderFail
 	orderID := sendOrder(t, tm, &now, types.OrderTypeLimit, types.OrderTimeInForceGTC, 0, types.SideSell, mainParty, 10, 100)
@@ -785,7 +786,7 @@ func testPeggedOrderRepriceCrashWhenNoLimitOrders(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 	addAccount(tm, "party2")
@@ -807,7 +808,7 @@ func testPeggedOrderUnpark(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccount(tm, "party1")
@@ -854,7 +855,7 @@ func testPeggedOrderAmendToMoveReference(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccount(tm, "party1")
@@ -899,7 +900,7 @@ func testPeggedOrderFilledOrder(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccount(tm, "party1")
@@ -947,7 +948,7 @@ func testParkedOrdersAreUnparkedWhenPossible(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccount(tm, "party1")
@@ -999,7 +1000,7 @@ func testPeggedOrdersLeavingAuction(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 100,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 	addAccount(tm, "party2")
@@ -1039,7 +1040,7 @@ func testPeggedOrdersEnteringAuction(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 100,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccount(tm, "party1")
@@ -1075,7 +1076,7 @@ func testPeggedOrderAddWithNoMarketPrice(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -1097,7 +1098,7 @@ func testPeggedOrderAdd(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
 	addAccount(tm, "party1")
@@ -1143,7 +1144,7 @@ func testPeggedOrderWithReprice(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -1190,7 +1191,7 @@ func testPeggedOrderParkWhenInAuction(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -1212,7 +1213,7 @@ func testPeggedOrderUnparkAfterLeavingAuction(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -1424,7 +1425,7 @@ func testPeggedOrderParkWhenPriceBelowZero(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	for _, acc := range []string{"buyer", "seller", "pegged"} {
 		addAccount(tm, acc)
@@ -1452,7 +1453,7 @@ func testPeggedOrderParkWhenPriceRepricesBelowZero(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	for _, acc := range []string{"buyer", "seller", "pegged"} {
 		addAccount(tm, acc)
@@ -1481,7 +1482,7 @@ func testPeggedOrderParkWhenPriceRepricesBelowZero(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	for _, acc := range []string{"user1", "user2", "user3", "user4", "user5", "user6", "user7"} {
 		addAccount(tm, acc)
@@ -1521,7 +1522,7 @@ func testPeggedOrderParkCancelAll(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "user")
 
@@ -1556,7 +1557,7 @@ func testPeggedOrderExpiring2(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "user")
 
@@ -1601,7 +1602,7 @@ func testPeggedOrderOutputMessages(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "user1")
 	addAccount(tm, "user2")
@@ -1686,7 +1687,7 @@ func testPeggedOrderOutputMessages2(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "user1")
 	addAccount(tm, "user2")
@@ -1735,7 +1736,7 @@ func testPeggedOrderOutputMessages2(t *testing.T) {
 	assert.Equal(t, types.OrderStatusActive, confirmation.Order.Status)
 
 	// Cancel the normal order to park the pegged order
-	tm.market.CancelOrder(ctx, "user2", limitOrder)
+	tm.market.CancelOrder(ctx, "user2", limitOrder, randomSha256Hash())
 	require.Equal(t, types.OrderStatusParked, confirmation.Order.Status)
 	assert.Equal(t, uint64(11), tm.orderEventCount)
 
@@ -1810,7 +1811,7 @@ func testPeggedOrderRepricing(t *testing.T) {
 			tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 				Duration: 1,
 			})
-			ctx := context.Background()
+			ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 			tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 			auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -1934,7 +1935,7 @@ func testPeggedOrderCanDeleteAfterLostPriority(t *testing.T) {
 	amendOrder(t, tm, "party1", buyOrder1, 0, 100, types.OrderTimeInForceUnspecified, 0, true)
 
 	// Try to delete the pegged order
-	cancelconf, _ := tm.market.CancelOrder(context.TODO(), "party1", order.ID)
+	cancelconf, _ := tm.market.CancelOrder(context.TODO(), "party1", order.ID, randomSha256Hash())
 	assert.NotNil(t, cancelconf)
 	assert.Equal(t, types.OrderStatusCancelled, cancelconf.Order.Status)
 }
@@ -1948,7 +1949,7 @@ func testPeggedOrderAmendParkedToLive(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -1982,7 +1983,7 @@ func testPeggedOrderAmendParkedToLive(t *testing.T) {
 	amend := getAmend(tm.market.GetID(), confirmation.Order.ID, 0, 0, types.OrderTimeInForceUnspecified, 0)
 	off := num.NewUint(5)
 	amend.PeggedOffset = off
-	amended, err := tm.market.AmendOrder(ctx, amend, "party1")
+	amended, err := tm.market.AmendOrder(ctx, amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.Equal(t, off, amended.Order.PeggedOrder.Offset)
 	assert.NoError(t, err)
@@ -2003,7 +2004,7 @@ func testPeggedOrderAmendParkedStayParked(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -2024,7 +2025,7 @@ func testPeggedOrderAmendParkedStayParked(t *testing.T) {
 	amend := getAmend(tm.market.GetID(), confirmation.Order.ID, 0, 0, types.OrderTimeInForceUnspecified, 0)
 	off := num.NewUint(15)
 	amend.PeggedOffset = off
-	amended, err := tm.market.AmendOrder(ctx, amend, "party1")
+	amended, err := tm.market.AmendOrder(ctx, amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.Equal(t, off, amended.Order.PeggedOrder.Offset)
 	assert.NoError(t, err)
@@ -2040,7 +2041,7 @@ func testPeggedOrderAmendForcesPark(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -2060,7 +2061,7 @@ func testPeggedOrderAmendForcesPark(t *testing.T) {
 	// Amend offset so we cannot reprice
 	amend := getAmend(tm.market.GetID(), confirmation.Order.ID, 0, 0, types.OrderTimeInForceUnspecified, 0)
 	amend.PeggedOffset = num.NewUint(15)
-	amended, err := tm.market.AmendOrder(ctx, amend, "party1")
+	amended, err := tm.market.AmendOrder(ctx, amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -2075,7 +2076,7 @@ func testPeggedOrderAmendDuringAuction(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -2100,7 +2101,7 @@ func testPeggedOrderAmendDuringAuction(t *testing.T) {
 	// Amend offset so we cannot reprice
 	amend := getAmend(tm.market.GetID(), confirmation.Order.ID, 0, 0, types.OrderTimeInForceUnspecified, 0)
 	amend.PeggedOffset = num.NewUint(5)
-	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1")
+	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -2116,7 +2117,7 @@ func testPeggedOrderAmendReference(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -2152,7 +2153,7 @@ func testPeggedOrderAmendReference(t *testing.T) {
 	// Amend offset so we cannot reprice
 	amend := getAmend(tm.market.GetID(), confirmation.Order.ID, 0, 0, types.OrderTimeInForceUnspecified, 0)
 	amend.PeggedReference = types.PeggedReferenceMid
-	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1")
+	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -2167,7 +2168,7 @@ func testPeggedOrderAmendReferenceInAuction(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -2192,7 +2193,7 @@ func testPeggedOrderAmendReferenceInAuction(t *testing.T) {
 	// Amend offset so we cannot reprice
 	amend := getAmend(tm.market.GetID(), confirmation.Order.ID, 0, 0, types.OrderTimeInForceUnspecified, 0)
 	amend.PeggedReference = types.PeggedReferenceMid
-	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1")
+	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -2207,7 +2208,7 @@ func testPeggedOrderAmendMultipleInAuction(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 
@@ -2235,7 +2236,7 @@ func testPeggedOrderAmendMultipleInAuction(t *testing.T) {
 	amend.TimeInForce = types.OrderTimeInForceGTT
 	exp := int64(20000000000)
 	amend.ExpiresAt = &exp
-	amended, err := tm.market.AmendOrder(ctx, amend, "party1")
+	amended, err := tm.market.AmendOrder(ctx, amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -2253,7 +2254,7 @@ func testPeggedOrderAmendMultiple(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -2293,7 +2294,7 @@ func testPeggedOrderAmendMultiple(t *testing.T) {
 	amend.TimeInForce = types.OrderTimeInForceGTT
 	exp := int64(20000000000)
 	amend.ExpiresAt = &exp
-	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1")
+	amended, err := tm.market.AmendOrder(context.Background(), amend, "party1", randomSha256Hash())
 	require.NotNil(t, amended)
 	assert.NoError(t, err)
 
@@ -2311,7 +2312,7 @@ func testPeggedOrderMidPriceCalc(t *testing.T) {
 	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
 		Duration: 1,
 	})
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -2365,7 +2366,7 @@ func TestPeggedOrderUnparkAfterLeavingAuctionWithNoFunds2772(t *testing.T) {
 	closeSec := int64(10000000000)
 	closingAt := time.Unix(closeSec, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	addAccount(tm, "party1")
 	addAccount(tm, "party2")
@@ -2432,7 +2433,7 @@ func TestOrderBookSimple_CancelGTTOrderThenRunExpiration(t *testing.T) {
 	now := time.Unix(5, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	defer tm.ctrl.Finish()
 
 	addAccount(tm, "aaa")
@@ -2444,7 +2445,7 @@ func TestOrderBookSimple_CancelGTTOrderThenRunExpiration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, o1conf)
 
-	cncl, err := tm.market.CancelOrder(ctx, o1.Party, o1.ID)
+	cncl, err := tm.market.CancelOrder(ctx, o1.Party, o1.ID, randomSha256Hash())
 	require.NoError(t, err)
 	require.NotNil(t, cncl)
 	assert.Equal(t, 0, tm.market.GetPeggedExpiryOrderCount())
@@ -2459,7 +2460,7 @@ func TestGTTExpiredNotFilled(t *testing.T) {
 	now := time.Unix(5, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	defer tm.ctrl.Finish()
 
 	addAccount(tm, "aaa")
@@ -2486,7 +2487,7 @@ func TestGTTExpiredPartiallyFilled(t *testing.T) {
 	})
 	defer tm.ctrl.Finish()
 	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	tm.market.OnMarketAuctionMinimumDurationUpdate(ctx, time.Second)
 
 	auxParty, auxParty2 := "auxParty", "auxParty2"
@@ -2551,7 +2552,7 @@ func TestOrderBook_RemoveExpiredOrders(t *testing.T) {
 	now := time.Unix(5, 0)
 	closingAt := time.Unix(10000000000, 0)
 	tm := getTestMarket(t, now, closingAt, nil, nil)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 	defer tm.ctrl.Finish()
 
 	addAccount(tm, "aaa")
@@ -2624,7 +2625,7 @@ func TestOrderBook_RemoveExpiredOrders(t *testing.T) {
 func Test2965EnsureLPOrdersAreNotCancelleableWithCancelAll(t *testing.T) {
 	now := time.Unix(10, 0)
 	closingAt := time.Unix(1000000000, 0)
-	ctx := context.Background()
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
 
 	mktCfg := getMarket(closingAt, defaultPriceMonitorSettings, &types.AuctionDuration{
 		Duration: 10000,
@@ -2776,7 +2777,7 @@ func Test2965EnsureLPOrdersAreNotCancelleableWithCancelAll(t *testing.T) {
 	// Leave the auction
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10001*time.Second))
 
-	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp"))
+	require.NoError(t, tm.market.SubmitLiquidityProvision(ctx, lp, "party-2", "id-lp", randomSha256Hash()))
 	assert.Equal(t, 1, tm.market.GetLPSCount())
 
 	tm.market.OnChainTimeUpdate(ctx, now.Add(10011*time.Second))

--- a/execution/special_orders.go
+++ b/execution/special_orders.go
@@ -3,13 +3,14 @@
 package execution
 
 import (
+	"context"
+
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/liquidity"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/metrics"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
-	"context"
 )
 
 func (m *Market) repricePeggedOrders(

--- a/execution/special_orders.go
+++ b/execution/special_orders.go
@@ -3,14 +3,13 @@
 package execution
 
 import (
-	"context"
-
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/liquidity"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/metrics"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
+	"context"
 )
 
 func (m *Market) repricePeggedOrders(

--- a/execution/version_test.go
+++ b/execution/version_test.go
@@ -52,26 +52,26 @@ func TestVersioning(t *testing.T) {
 		Price:    num.NewUint(price + 1),
 	}
 
-	amendment, err := tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err := tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
 	// Amend price down, check version moves to 3
 	amend.Price = num.NewUint(price - 1)
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
 	// Amend quantity up, check version moves to 4
 	amend.Price = nil
 	amend.SizeDelta = 1
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
 	// Amend quantity down, check version moves to 5
 	amend.SizeDelta = -2
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
@@ -80,21 +80,21 @@ func TestVersioning(t *testing.T) {
 	exp := now.UnixNano() + 100000000000
 	amend.ExpiresAt = &exp
 	amend.SizeDelta = 0
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
 	// Update expiry time, check version moves to 7
 	exp = now.UnixNano() + 100000000000
 	amend.ExpiresAt = &exp
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 
 	// Flip back GTC, check version moves to 8
 	amend.TimeInForce = types.OrderTimeInForceGTC
 	amend.ExpiresAt = nil
-	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1)
+	amendment, err = tm.market.AmendOrder(context.TODO(), amend, party1, randomSha256Hash())
 	assert.NotNil(t, amendment)
 	assert.NoError(t, err)
 }

--- a/idgeneration/generator.go
+++ b/idgeneration/generator.go
@@ -1,10 +1,11 @@
 package idgeneration
 
 import (
-	"code.vegaprotocol.io/vega/libs/crypto"
-	"code.vegaprotocol.io/vega/types"
 	"encoding/hex"
 	"strings"
+
+	"code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/types"
 )
 
 // idGenerator no mutex required, markets work deterministically, and sequentially.
@@ -15,7 +16,6 @@ type idGenerator struct {
 
 // NewDeterministicIDGenerator returns an idGenerator, and is used to abstract this type.
 func NewDeterministicIDGenerator(rootId string) *idGenerator {
-
 	nextIdBytes, err := hex.DecodeString(rootId)
 	if err != nil {
 		panic("failed to create new deterministic id generator: " + err.Error())

--- a/idgeneration/generator.go
+++ b/idgeneration/generator.go
@@ -5,12 +5,10 @@ import (
 	"strings"
 
 	"code.vegaprotocol.io/vega/libs/crypto"
-	"code.vegaprotocol.io/vega/types"
 )
 
 // idGenerator no mutex required, markets work deterministically, and sequentially.
 type idGenerator struct {
-	rootId      string
 	nextIdBytes []byte
 }
 
@@ -22,12 +20,16 @@ func NewDeterministicIDGenerator(rootId string) *idGenerator {
 	}
 
 	return &idGenerator{
-		rootId:      rootId,
 		nextIdBytes: nextIdBytes,
 	}
 }
 
-func (i *idGenerator) SetID(order *types.Order) {
-	order.ID = strings.ToUpper(hex.EncodeToString(i.nextIdBytes))
+func (i *idGenerator) NextID() string {
+	if i == nil {
+		panic("id generator instance is not initialised")
+	}
+
+	nextId := strings.ToUpper(hex.EncodeToString(i.nextIdBytes))
 	i.nextIdBytes = crypto.Hash(i.nextIdBytes)
+	return nextId
 }

--- a/idgeneration/generator.go
+++ b/idgeneration/generator.go
@@ -1,9 +1,10 @@
-package execution
+package idgeneration
 
 import (
 	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/types"
 	"encoding/hex"
+	"strings"
 )
 
 // idGenerator no mutex required, markets work deterministically, and sequentially.
@@ -27,6 +28,6 @@ func NewDeterministicIDGenerator(rootId string) *idGenerator {
 }
 
 func (i *idGenerator) SetID(order *types.Order) {
-	order.ID = hex.EncodeToString(i.nextIdBytes)
+	order.ID = strings.ToUpper(hex.EncodeToString(i.nextIdBytes))
 	i.nextIdBytes = crypto.Hash(i.nextIdBytes)
 }

--- a/idgeneration/generator_test.go
+++ b/idgeneration/generator_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"code.vegaprotocol.io/vega/idgeneration"
-	"code.vegaprotocol.io/vega/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,9 +14,6 @@ func TestOrderIdGeneration(t *testing.T) {
 	detId := "E1152CF235F6200ED0EB4598706821031D57403462C31A80B3CDD6B209BFF2E6"
 	gen := idgeneration.NewDeterministicIDGenerator(detId)
 
-	order := &types.Order{}
-	gen.SetID(order)
-	assert.Equal(t, detId, order.ID)
-	gen.SetID(order)
-	assert.NotEqual(t, detId, order.ID)
+	assert.Equal(t, detId, gen.NextID())
+	assert.NotEqual(t, detId, gen.NextID())
 }

--- a/idgeneration/generator_test.go
+++ b/idgeneration/generator_test.go
@@ -1,18 +1,17 @@
 package idgeneration_test
 
 import (
+	"testing"
+
 	"code.vegaprotocol.io/vega/idgeneration"
 	"code.vegaprotocol.io/vega/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGeneratorCreationFailsWithInvalidRootId(t *testing.T) {
-
 }
 
 func TestOrderIdGeneration(t *testing.T) {
-
 	detId := "E1152CF235F6200ED0EB4598706821031D57403462C31A80B3CDD6B209BFF2E6"
 	gen := idgeneration.NewDeterministicIDGenerator(detId)
 

--- a/idgeneration/generator_test.go
+++ b/idgeneration/generator_test.go
@@ -1,7 +1,7 @@
-package execution_test
+package idgeneration_test
 
 import (
-	"code.vegaprotocol.io/vega/execution"
+	"code.vegaprotocol.io/vega/idgeneration"
 	"code.vegaprotocol.io/vega/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -14,10 +14,7 @@ func TestGeneratorCreationFailsWithInvalidRootId(t *testing.T) {
 func TestOrderIdGeneration(t *testing.T) {
 
 	detId := "E1152CF235F6200ED0EB4598706821031D57403462C31A80B3CDD6B209BFF2E6"
-	gen, err := execution.NewDeterministicIDGenerator(detId)
-	if err != nil {
-		t.Fatalf("failed to create generator:%s", err)
-	}
+	gen := idgeneration.NewDeterministicIDGenerator(detId)
 
 	order := &types.Order{}
 	gen.SetID(order)

--- a/integration/execution_test.go
+++ b/integration/execution_test.go
@@ -2,7 +2,6 @@ package core_test
 
 import (
 	"context"
-
 	"encoding/hex"
 	"math/rand"
 

--- a/integration/steps/execution.go
+++ b/integration/steps/execution.go
@@ -14,7 +14,8 @@ type Execution interface {
 	AmendOrder(ctx context.Context, amendment *types.OrderAmendment, party string) (*types.OrderConfirmation, error)
 	CancelOrder(ctx context.Context, cancel *types.OrderCancellation, party string) ([]*types.OrderCancellationConfirmation, error)
 	SubmitOrder(ctx context.Context, submission *types.OrderSubmission, party string) (*types.OrderConfirmation, error)
-	SubmitLiquidityProvision(ctx context.Context, submission *types.LiquidityProvisionSubmission, party string, lpID string) error
+	SubmitLiquidityProvision(ctx context.Context, submission *types.LiquidityProvisionSubmission, party string, lpId string,
+		deterministicId string) error
 	AmendLiquidityProvision(ctx context.Context, amendment *types.LiquidityProvisionAmendment, party string) error
 	CancelLiquidityProvision(ctx context.Context, cancel *types.LiquidityProvisionCancellation, party string) error
 	SubmitMarket(ctx context.Context, marketConfig *types.Market) error

--- a/integration/steps/parties_submit_liquidity_provision.go
+++ b/integration/steps/parties_submit_liquidity_provision.go
@@ -1,13 +1,14 @@
 package steps
 
 import (
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
+
+	"code.vegaprotocol.io/vega/libs/crypto"
 
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"

--- a/integration/steps/parties_submit_liquidity_provision.go
+++ b/integration/steps/parties_submit_liquidity_provision.go
@@ -111,7 +111,6 @@ func PartiesSubmitLiquidityProvision(exec Execution, table *godog.Table) error {
 			if err := exec.SubmitLiquidityProvision(context.Background(), sub, party, id, randomSha256Hash()); err != nil {
 				return errSubmittingLiquidityProvision(sub, party, id, err)
 			}
-
 		}
 	}
 	return nil

--- a/integration/steps/parties_submit_liquidity_provision.go
+++ b/integration/steps/parties_submit_liquidity_provision.go
@@ -1,9 +1,12 @@
 package steps
 
 import (
+	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 
 	"code.vegaprotocol.io/vega/types"
@@ -103,12 +106,20 @@ func PartiesSubmitLiquidityProvision(exec Execution, table *godog.Table) error {
 				Buys:             lp.Buys,
 				Reference:        lp.Reference,
 			}
-			if err := exec.SubmitLiquidityProvision(context.Background(), sub, party, id); err != nil {
+
+			if err := exec.SubmitLiquidityProvision(context.Background(), sub, party, id, randomSha256Hash()); err != nil {
 				return errSubmittingLiquidityProvision(sub, party, id, err)
 			}
+
 		}
 	}
 	return nil
+}
+
+func randomSha256Hash() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return hex.EncodeToString(crypto.Hash(data))
 }
 
 func errSubmittingLiquidityProvision(lp *types.LiquidityProvisionSubmission, party, id string, err error) error {

--- a/integration/stubs/time_stub.go
+++ b/integration/stubs/time_stub.go
@@ -1,13 +1,14 @@
 package stubs
 
 import (
-	vegacontext "code.vegaprotocol.io/vega/libs/context"
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
 	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
+	"code.vegaprotocol.io/vega/libs/crypto"
 
 	"code.vegaprotocol.io/vega/oracles"
 )

--- a/integration/stubs/time_stub.go
+++ b/integration/stubs/time_stub.go
@@ -1,8 +1,12 @@
 package stubs
 
 import (
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
+	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
+	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"code.vegaprotocol.io/vega/oracles"
@@ -27,7 +31,8 @@ func (t *TimeStub) GetTimeNow() time.Time {
 
 func (t *TimeStub) SetTime(newNow time.Time) {
 	t.now = newNow
-	t.notify(context.Background(), t.now)
+	ctx := vegacontext.WithTraceID(context.Background(), randomSha256Hash())
+	t.notify(ctx, t.now)
 	t.publishOracleData(context.Background(), t.now)
 }
 
@@ -50,4 +55,10 @@ func (t *TimeStub) publishOracleData(ctx context.Context, ts time.Time) {
 		}
 		subscriber(ctx, data)
 	}
+}
+
+func randomSha256Hash() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return hex.EncodeToString(crypto.Hash(data))
 }

--- a/liquidity/amendments.go
+++ b/liquidity/amendments.go
@@ -36,6 +36,7 @@ func (e *Engine) AmendLiquidityProvision(
 	ctx context.Context,
 	lpa *types.LiquidityProvisionAmendment,
 	party string,
+	idGen IDGen,
 ) ([]*types.Order, error) {
 	if err := e.CanAmend(lpa, party); err != nil {
 		return nil, err
@@ -71,7 +72,7 @@ func (e *Engine) AmendLiquidityProvision(
 		lp.Status = types.LiquidityProvisionStatusUndeployed
 	}
 
-	e.setShapesReferencesOnLiquidityProvision(lp, lpa.Buys, lpa.Sells)
+	e.setShapesReferencesOnLiquidityProvision(lp, lpa.Buys, lpa.Sells, idGen)
 	e.broker.Send(events.NewLiquidityProvisionEvent(ctx, lp))
 	e.provisions.Set(party, lp)
 	return cancels, nil

--- a/liquidity/amendments_test.go
+++ b/liquidity/amendments_test.go
@@ -1,12 +1,13 @@
 package liquidity_test
 
 import (
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
 	"encoding/hex"
 	"math/rand"
 	"testing"
 	"time"
+
+	"code.vegaprotocol.io/vega/libs/crypto"
 
 	proto "code.vegaprotocol.io/protos/vega"
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"

--- a/liquidity/amendments_test.go
+++ b/liquidity/amendments_test.go
@@ -1,7 +1,10 @@
 package liquidity_test
 
 import (
+	"code.vegaprotocol.io/vega/libs/crypto"
 	"context"
+	"encoding/hex"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -40,7 +43,7 @@ func testCanAmend(t *testing.T) {
 
 	// initially submit our provision to be amended, does not matter what's in
 	tng.broker.EXPECT().Send(gomock.Any()).Times(1)
-	err := tng.engine.SubmitLiquidityProvision(ctx, lps, party, "some-id-1")
+	err := tng.engine.SubmitLiquidityProvision(ctx, lps, party, "some-id-1", randomSha256Hash())
 	assert.NoError(t, err)
 
 	lpa := getTestAmendSimpleSubmission()
@@ -62,6 +65,12 @@ func testCanAmend(t *testing.T) {
 	lpa = getTestAmendSimpleSubmission()
 	lpa.Sells = nil
 	assert.NoError(t, tng.engine.CanAmend(lpa, party))
+}
+
+func randomSha256Hash() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return hex.EncodeToString(crypto.Hash(data))
 }
 
 func getTestSubmitSimpleSubmission() *types.LiquidityProvisionSubmission {

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -361,9 +361,9 @@ func (e *Engine) rejectLiquidityProvisionSubmission(ctx context.Context, lps *ty
 // The LiquidityProvision is created if submitted for the first time, updated if a
 // previous one was created for the same PartyId or deleted (if exists) when
 // the CommitmentAmount is set to 0.
-func (e *Engine) SubmitLiquidityProvision(ctx context.Context, lps *types.LiquidityProvisionSubmission, party, id string) error {
+func (e *Engine) SubmitLiquidityProvision(ctx context.Context, lps *types.LiquidityProvisionSubmission, party, deterministicId string) error {
 	if err := e.ValidateLiquidityProvisionSubmission(lps, false); err != nil {
-		e.rejectLiquidityProvisionSubmission(ctx, lps, party, id)
+		e.rejectLiquidityProvisionSubmission(ctx, lps, party, deterministicId)
 		return err
 	}
 
@@ -374,7 +374,7 @@ func (e *Engine) SubmitLiquidityProvision(ctx context.Context, lps *types.Liquid
 	var (
 		now = e.currentTime.UnixNano()
 		lp  = &types.LiquidityProvision{
-			ID:        id,
+			ID:        deterministicId,
 			MarketID:  lps.MarketID,
 			Party:     party,
 			CreatedAt: now,

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -95,7 +95,6 @@ type Engine struct {
 func NewEngine(config Config,
 	log *logging.Logger,
 	broker Broker,
-	idGen IDGen,
 	riskModel RiskModel,
 	priceMonitor PriceMonitor,
 	asset string,
@@ -109,7 +108,6 @@ func NewEngine(config Config,
 		marketID:       marketID,
 		log:            log,
 		broker:         broker,
-		idGen:          idGen,
 		suppliedEngine: supplied.NewEngine(riskModel, priceMonitor, asset, marketID, stateVarEngine, tickSize, log),
 
 		// parameters

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -1,12 +1,13 @@
 package liquidity
 
 import (
-	"code.vegaprotocol.io/vega/idgeneration"
 	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"time"
+
+	"code.vegaprotocol.io/vega/idgeneration"
 
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/liquidity/supplied"

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -1,11 +1,12 @@
 package liquidity_test
 
 import (
-	"code.vegaprotocol.io/vega/idgeneration"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	"code.vegaprotocol.io/vega/idgeneration"
 
 	"code.vegaprotocol.io/vega/integration/stubs"
 

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -133,8 +133,8 @@ func testSubmissionCRUD(t *testing.T) {
 
 	order1 := &types.Order{}
 	order2 := &types.Order{}
-	idGen.SetID(order1)
-	idGen.SetID(order2)
+	order1.ID = idGen.NextID()
+	order2.ID = idGen.NextID()
 
 	expected := &types.LiquidityProvision{
 		ID:               "some-id-1",

--- a/liquidity/engine_test.go
+++ b/liquidity/engine_test.go
@@ -2,7 +2,6 @@ package liquidity_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -512,13 +511,4 @@ func TestCalculateSuppliedStake(t *testing.T) {
 	require.NoError(t, err)
 	suppliedStake = tng.engine.CalculateSuppliedStake()
 	require.Equal(t, num.Sum(lp2.CommitmentAmount, lp3.CommitmentAmount), suppliedStake)
-}
-
-type idGenStub struct {
-	id uint64
-}
-
-func (i *idGenStub) SetID(o *types.Order) {
-	i.id++
-	o.ID = fmt.Sprintf("liquidity-order-%d", i.id)
 }

--- a/liquidity/snapshot.go
+++ b/liquidity/snapshot.go
@@ -41,7 +41,6 @@ type SnapshotEngine struct {
 func NewSnapshotEngine(config Config,
 	log *logging.Logger,
 	broker Broker,
-	idGen IDGen,
 	riskModel RiskModel,
 	priceMonitor PriceMonitor,
 	asset string,
@@ -50,7 +49,7 @@ func NewSnapshotEngine(config Config,
 	tickSize *num.Uint,
 ) *SnapshotEngine {
 	se := &SnapshotEngine{
-		Engine: NewEngine(config, log, broker, idGen, riskModel, priceMonitor, asset, market, stateVarEngine, tickSize),
+		Engine: NewEngine(config, log, broker, riskModel, priceMonitor, asset, market, stateVarEngine, tickSize),
 		pl:     types.Payload{},
 		market: market,
 

--- a/liquidity/snapshot_test.go
+++ b/liquidity/snapshot_test.go
@@ -27,8 +27,8 @@ func TestSnapshotRoundTrip(t *testing.T) {
 		market = "market-id"
 		ctx    = context.Background()
 		e1     = newTestEngine(t, initialTime)
-		e2     = newTestEngineWithIDGen(t, initialTime, e1.idGen)
-		e3     = newTestEngineWithIDGen(t, initialTime, e1.idGen)
+		e2     = newTestEngine(t, initialTime)
+		e3     = newTestEngine(t, initialTime)
 	)
 
 	e1.broker.EXPECT().Send(gomock.Any()).AnyTimes()
@@ -77,10 +77,10 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	}
 
 	require.NoError(t,
-		e1.engine.SubmitLiquidityProvision(ctx, lp1, party1, "some-id-1"),
+		e1.engine.SubmitLiquidityProvision(ctx, lp1, party1, "some-id-1", "f663375fd6843a0807d17b10ad8425a6ba45c8c2dd6339f400c5b2426f900c13"),
 	)
 	require.NoError(t,
-		e1.engine.SubmitLiquidityProvision(ctx, lp2, party2, "some-id-2"),
+		e1.engine.SubmitLiquidityProvision(ctx, lp2, party2, "some-id-2", "0454d8b74441ca3bac8f9b141408502d9b1f297e8ef1054d45775566677a8072"),
 	)
 
 	keys := e1.engine.Keys()
@@ -92,7 +92,7 @@ func TestSnapshotRoundTrip(t *testing.T) {
 		"partiesLiquidityOrders:market-id": "0254d8b74441ca3bac8f9b141408502d9b1f297e8ef1054d45775566677a8072",
 		"partiesOrders:market-id":          "f9cb31b1c4c8df91f6a348d43978c302c8887336107c265259bc74fdddf00e19",
 		"pendingProvisions:market-id":      "6cc4d407a2ea45e37e27993eb6f94134b3f906d080777d94bf99551aa82dc461",
-		"provisions:market-id":             "609b730ff00fb9478ccf2abba16d6551a93fce223a487a8ac4c9f4c05f85b45e",
+		"provisions:market-id":             "4e0a4047c29a61237323bb918e4dbb3933d5acbe06cda105bdff08869ab99f55",
 		"liquiditySupplied:market-id":      "3276bba2a77778ba710ec29e3a6e59212452dbda69eaac8f9160930d1270da1d",
 	}
 
@@ -127,10 +127,10 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 	expectedHashes2 := map[string]string{
 		"parameters:market-id":             "b5eec91c297baf1f06830350dbcb37d79937561ae605d2304eb12680e443775c",
-		"partiesLiquidityOrders:market-id": "c76075385924d7207d9002d2f9855c089f1c409c7e6e235d5b0ddc4a84bc7fc4",
+		"partiesLiquidityOrders:market-id": "c93b5c04bbaf7fac571500ee60caf223b69b0e32a42e23fc0578020e20a62eeb",
 		"partiesOrders:market-id":          "f9cb31b1c4c8df91f6a348d43978c302c8887336107c265259bc74fdddf00e19",
 		"pendingProvisions:market-id":      "627ef55af7f36bea0d09b0081b85d66531a01df060d8e9447e17049a4e152b12",
-		"provisions:market-id":             "c6fc3641b0fd754a55e6f980bae9a6e5a96ac53c42488487318a8ff7f17f365e",
+		"provisions:market-id":             "bf26cd6140ac241665756f8a4e20b8207bad18f3386d3ff6862ec5525f42fffc",
 		"liquiditySupplied:market-id":      "3276bba2a77778ba710ec29e3a6e59212452dbda69eaac8f9160930d1270da1d",
 	}
 
@@ -155,7 +155,7 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	}
 
 	require.NoError(t,
-		e2.engine.SubmitLiquidityProvision(ctx, lp3, party3, "some-id-2"),
+		e2.engine.SubmitLiquidityProvision(ctx, lp3, party3, "some-id-2", "59a8634e030ecf0548d3a77c74a9a251e6e2c90c65af32136e97dcb889e92774"),
 	)
 
 	require.NoError(t,

--- a/matching/order_status_test.go
+++ b/matching/order_status_test.go
@@ -1,7 +1,12 @@
 package matching_test
 
 import (
+	"encoding/hex"
+	"math/rand"
+	"strings"
 	"testing"
+
+	"code.vegaprotocol.io/vega/libs/crypto"
 
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/types"
@@ -249,7 +254,7 @@ func testGTCActive(t *testing.T) {
 func testGTCStoppedNotFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -280,7 +285,7 @@ func testGTCStoppedNotFilled(t *testing.T) {
 func testGTCCancelledNotFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -311,7 +316,7 @@ func testGTCActivePartiallyFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
 	partyID2 := "p2"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -335,7 +340,7 @@ func testGTCActivePartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
-		ID:            "V0000000032-0000000010",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID2,
@@ -357,7 +362,7 @@ func testGTCCancelledPartiallyFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
 	partyID2 := "p2"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -406,7 +411,7 @@ func testGTCStoppedPartiallyFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
 	partyID2 := "p2"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -461,7 +466,7 @@ func testGTCFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
-		ID:            "V0000000032-0000000009",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID1,
@@ -478,7 +483,7 @@ func testGTCFilled(t *testing.T) {
 
 	// now place our GTC order to be filled
 	order := types.Order{
-		ID:            "V0000000032-0000000010",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID2,
@@ -499,7 +504,7 @@ func testGTCFilled(t *testing.T) {
 func testGTTActive(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -526,7 +531,7 @@ func testGTTActive(t *testing.T) {
 func testGTTStoppedNotFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -558,7 +563,7 @@ func testGTTStoppedNotFilled(t *testing.T) {
 func testGTTCancelledNotFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -590,7 +595,7 @@ func testGTTActivePartiallyFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
 	partyID2 := "p2"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -615,7 +620,7 @@ func testGTTActivePartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
-		ID:            "V0000000032-0000000009",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID2,
@@ -638,7 +643,7 @@ func testGTTCancelledPartiallyFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
 	partyID2 := "p2"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -663,7 +668,7 @@ func testGTTCancelledPartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
-		ID:            "V0000000032-0000000009",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID2,
@@ -690,7 +695,7 @@ func testGTTStoppedPartiallyFilled(t *testing.T) {
 	market := "testMarket"
 	partyID1 := "p1"
 	partyID2 := "p2"
-	orderID := "v0000000000000-0000001"
+	orderID := randomSha256Hash()
 
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
@@ -715,7 +720,7 @@ func testGTTStoppedPartiallyFilled(t *testing.T) {
 
 	// now place our order which will consume some of the first order
 	order := types.Order{
-		ID:            "V0000000032-0000000009",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID2,
@@ -748,7 +753,7 @@ func testGTTFilled(t *testing.T) {
 
 	// place a first order to sit in the book
 	order1 := types.Order{
-		ID:            "V0000000032-0000000009",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID1,
@@ -766,7 +771,7 @@ func testGTTFilled(t *testing.T) {
 
 	// now place our GTT order to be filled
 	order := types.Order{
-		ID:            "V0000000032-0000000010",
+		ID:            randomSha256Hash(),
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
 		Party:         partyID2,
@@ -783,6 +788,12 @@ func testGTTFilled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(confirm.Trades))
 	assert.Equal(t, types.OrderStatusFilled, order.Status)
+}
+
+func randomSha256Hash() string {
+	data := make([]byte, 10)
+	rand.Read(data)
+	return strings.ToUpper(hex.EncodeToString(crypto.Hash(data)))
 }
 
 type marketPositionFake struct {

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -143,9 +143,14 @@ func cancelAllOrderForAParty(t *testing.T) {
 	market := "testMarket"
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
+	orderId1 := randomSha256Hash()
+	orderId2 := randomSha256Hash()
+	orderId3 := randomSha256Hash()
+	orderId4 := randomSha256Hash()
+
 	orders := []*types.Order{
 		{
-			ID:            "1111111111111111111111",
+			ID:            orderId1,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -158,7 +163,7 @@ func cancelAllOrderForAParty(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "2222222222222222222222",
+			ID:            orderId2,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -171,7 +176,7 @@ func cancelAllOrderForAParty(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "3333333333333333333333",
+			ID:            orderId3,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -184,7 +189,7 @@ func cancelAllOrderForAParty(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "4444444444444444444444",
+			ID:            orderId4,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -206,9 +211,9 @@ func cancelAllOrderForAParty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, confs, 3)
 	expectedIDs := map[string]struct{}{
-		"1111111111111111111111": {},
-		"2222222222222222222222": {},
-		"4444444444444444444444": {},
+		orderId1: {},
+		orderId2: {},
+		orderId4: {},
 	}
 	for _, conf := range confs {
 		if _, ok := expectedIDs[conf.Order.ID]; ok {
@@ -223,9 +228,15 @@ func getAllOrderForAParty(t *testing.T) {
 	market := "testMarket"
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
+
+	orderId1 := randomSha256Hash()
+	orderId2 := randomSha256Hash()
+	orderId3 := randomSha256Hash()
+	orderId4 := randomSha256Hash()
+
 	orders := []*types.Order{
 		{
-			ID:            "1111111111111111111111",
+			ID:            orderId1,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -238,7 +249,7 @@ func getAllOrderForAParty(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "2222222222222222222222",
+			ID:            orderId2,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -251,7 +262,7 @@ func getAllOrderForAParty(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "3333333333333333333333",
+			ID:            orderId3,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -264,7 +275,7 @@ func getAllOrderForAParty(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "4444444444444444444444",
+			ID:            orderId4,
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -285,9 +296,9 @@ func getAllOrderForAParty(t *testing.T) {
 	ordersLs := book.ob.GetOrdersPerParty("A")
 	assert.Len(t, ordersLs, 3)
 	expectedIDs := map[string]struct{}{
-		"1111111111111111111111": {},
-		"2222222222222222222222": {},
-		"4444444444444444444444": {},
+		orderId1: {},
+		orderId2: {},
+		orderId4: {},
 	}
 	for _, o := range ordersLs {
 		if _, ok := expectedIDs[o.ID]; ok {
@@ -304,7 +315,7 @@ func partyWithNoOrderCancelNothing(t *testing.T) {
 	defer book.Finish()
 	orders := []*types.Order{
 		{
-			ID:            "1111111111111111111111",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -317,7 +328,7 @@ func partyWithNoOrderCancelNothing(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "2222222222222222222222",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -330,7 +341,7 @@ func partyWithNoOrderCancelNothing(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "3333333333333333333333",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -343,7 +354,7 @@ func partyWithNoOrderCancelNothing(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "4444444444444444444444",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -372,7 +383,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
-			ID:            "V0000000032-0000000009",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -385,7 +396,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "V0000000032-0000000010",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -398,7 +409,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "V0000000032-0000000011",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -411,7 +422,7 @@ func testBestBidPriceAndVolume(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "V0000000032-0000000012",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -446,7 +457,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
-			ID:            "V0000000032-0000000009",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -459,7 +470,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "V0000000032-0000000010",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -472,7 +483,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "V0000000032-0000000011",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -485,7 +496,7 @@ func testBestOfferPriceAndVolume(t *testing.T) {
 			TimeInForce:   types.OrderTimeInForceGTC,
 		},
 		{
-			ID:            "V0000000032-0000000012",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -520,7 +531,7 @@ func getClosePNLIncompleteBuy(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
-			ID:            "V0000000032-0000000009",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -534,7 +545,7 @@ func getClosePNLIncompleteBuy(t *testing.T) {
 			CreatedAt:     0,
 		},
 		{
-			ID:            "V0000000032-0000000010",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -579,7 +590,7 @@ func getClosePNLIncompleteSell(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
-			ID:            "V0000000032-0000000009",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -593,7 +604,7 @@ func getClosePNLIncompleteSell(t *testing.T) {
 			CreatedAt:     0,
 		},
 		{
-			ID:            "V0000000032-0000000010",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -638,7 +649,7 @@ func getClosePNLBuy(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
-			ID:            "V0000000032-0000000009",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -652,7 +663,7 @@ func getClosePNLBuy(t *testing.T) {
 			CreatedAt:     0,
 		},
 		{
-			ID:            "V0000000032-0000000010",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -666,7 +677,7 @@ func getClosePNLBuy(t *testing.T) {
 			CreatedAt:     0,
 		},
 		{
-			ID:            "V0000000032-0000000011",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -709,7 +720,7 @@ func getClosePNLSell(t *testing.T) {
 	// 3 orders of size 1, 3 different prices
 	orders := []*types.Order{
 		{
-			ID:            "V0000000032-0000000009",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -723,7 +734,7 @@ func getClosePNLSell(t *testing.T) {
 			CreatedAt:     0,
 		},
 		{
-			ID:            "V0000000032-0000000010",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -737,7 +748,7 @@ func getClosePNLSell(t *testing.T) {
 			CreatedAt:     0,
 		},
 		{
-			ID:            "V0000000032-0000000011",
+			ID:            randomSha256Hash(),
 			Status:        types.OrderStatusActive,
 			Type:          types.OrderTypeLimit,
 			MarketID:      market,
@@ -781,6 +792,7 @@ func TestOrderBook_CancelReturnsTheOrderFromTheBook(t *testing.T) {
 	defer book.Finish()
 	currentTimestamp := getCurrentUtcTimestampNano()
 
+	orderId := randomSha256Hash()
 	order1 := types.Order{
 		Status:        types.OrderStatusActive,
 		Type:          types.OrderTypeLimit,
@@ -793,7 +805,7 @@ func TestOrderBook_CancelReturnsTheOrderFromTheBook(t *testing.T) {
 		Remaining:     100,
 		TimeInForce:   types.OrderTimeInForceGTC,
 		CreatedAt:     currentTimestamp,
-		ID:            "v0000000000000-0000001",
+		ID:            orderId,
 	}
 	order2 := types.Order{
 		Status:        types.OrderStatusActive,
@@ -807,7 +819,7 @@ func TestOrderBook_CancelReturnsTheOrderFromTheBook(t *testing.T) {
 		Remaining:     1, // use a wrong remaining here to get the order from the book
 		TimeInForce:   types.OrderTimeInForceGTC,
 		CreatedAt:     currentTimestamp,
-		ID:            "v0000000000000-0000001",
+		ID:            orderId,
 	}
 
 	trades, getErr := book.ob.GetTrades(&order1)
@@ -1166,7 +1178,7 @@ func TestOrderBook_SubmitOrderInvalidMarket(t *testing.T) {
 		Remaining:     100,
 		TimeInForce:   types.OrderTimeInForceGTC,
 		CreatedAt:     0,
-		ID:            fmt.Sprintf("V%010d-%010d", 1, 1),
+		ID:            randomSha256Hash(),
 	}
 
 	trades, getErr := book.ob.GetTrades(newOrder)
@@ -1191,7 +1203,7 @@ func TestOrderBook_CancelSellOrder(t *testing.T) {
 	logger.Debug("BEGIN CANCELLING VALID ORDER")
 
 	// Arrange
-	id := fmt.Sprintf("V%010d-%010d", 1, 1)
+	id := randomSha256Hash()
 	newOrder := &types.Order{
 		Status:        types.OrderStatusActive,
 		Type:          types.OrderTypeLimit,
@@ -1238,7 +1250,7 @@ func TestOrderBook_CancelBuyOrder(t *testing.T) {
 	logger.Debug("BEGIN CANCELLING VALID ORDER")
 
 	// Arrange
-	id := fmt.Sprintf("V%010d-%010d", 1, 1)
+	id := randomSha256Hash()
 	newOrder := &types.Order{
 		Status:        types.OrderStatusActive,
 		Type:          types.OrderTypeLimit,
@@ -1284,7 +1296,7 @@ func TestOrderBook_CancelOrderByID(t *testing.T) {
 	defer logger.Sync()
 	logger.Debug("BEGIN CANCELLING VALID ORDER BY ID")
 
-	id := fmt.Sprintf("V%010d-%010d", 1, 1)
+	id := randomSha256Hash()
 	newOrder := &types.Order{
 		Status:        types.OrderStatusActive,
 		Type:          types.OrderTypeLimit,
@@ -1336,7 +1348,7 @@ func TestOrderBook_CancelOrderMarketMismatch(t *testing.T) {
 		Status:    types.OrderStatusActive,
 		Type:      types.OrderTypeLimit,
 		MarketID:  market,
-		ID:        fmt.Sprintf("V%010d-%010d", 1, 1),
+		ID:        randomSha256Hash(),
 		Party:     "A",
 		Size:      100,
 		Remaining: 100,
@@ -2157,8 +2169,9 @@ func TestOrderBook_PartialFillIOCOrder(t *testing.T) {
 	defer logger.Sync()
 	logger.Debug("BEGIN PARTIAL FILL IOC ORDER")
 
+	orderId := randomSha256Hash()
 	newOrder := &types.Order{
-		ID:            "V0000000032-0000000009",
+		ID:            orderId,
 		Status:        types.OrderStatusActive,
 		Type:          types.OrderTypeLimit,
 		MarketID:      market,
@@ -2178,11 +2191,11 @@ func TestOrderBook_PartialFillIOCOrder(t *testing.T) {
 
 	assert.Equal(t, nil, err)
 	assert.NotNil(t, confirmation)
-	assert.Equal(t, "V0000000032-0000000009", confirmation.Order.ID)
+	assert.Equal(t, orderId, confirmation.Order.ID)
 	assert.Equal(t, 0, len(confirmation.Trades))
 	assert.Equal(t, len(trades), len(confirmation.Trades))
 
-	iocOrderID := "1000000000000000000000" // Must be 22 characters
+	iocOrderID := randomSha256Hash()
 	iocOrder := &types.Order{
 		Status:        types.OrderStatusActive,
 		Type:          types.OrderTypeLimit,
@@ -3028,8 +3041,8 @@ func TestOrderBook_GetTradesInLineWithSubmitOrderDuringAuction(t *testing.T) {
 
 	orders := book.ob.EnterAuction()
 	assert.Equal(t, 0, len(orders))
-	order1Id := "1000000000000000000000" // Must be 22 characters
-	order2Id := "1000000000000000000001" // Must be 22 characters
+	order1Id := randomSha256Hash()
+	order2Id := randomSha256Hash()
 
 	order1 := &types.Order{
 		Status:        types.OrderStatusActive,
@@ -3256,22 +3269,22 @@ func TestOrderBook_BidAndAskPresentAfterAuction(t *testing.T) {
 	matchingPrice := uint64(100)
 	party1 := "party1"
 	party2 := "party2"
-	makeOrder(t, book, market, "needTwentyTwoCharacts1", types.SideBuy, matchingPrice-1, party1, 1)
+	makeOrder(t, book, market, randomSha256Hash(), types.SideBuy, matchingPrice-1, party1, 1)
 
 	require.Equal(t, false, book.ob.BidAndAskPresentAfterAuction())
 	require.Equal(t, false, book.ob.CanUncross())
 
-	makeOrder(t, book, market, "needTwentyTwoCharacts2", types.SideSell, matchingPrice+1, party2, 1)
+	makeOrder(t, book, market, randomSha256Hash(), types.SideSell, matchingPrice+1, party2, 1)
 
 	require.Equal(t, true, book.ob.BidAndAskPresentAfterAuction())
 	require.Equal(t, false, book.ob.CanUncross())
 
-	makeOrder(t, book, market, "needTwentyTwoCharacts3", types.SideBuy, matchingPrice, party1, 1)
+	makeOrder(t, book, market, randomSha256Hash(), types.SideBuy, matchingPrice, party1, 1)
 
 	require.Equal(t, true, book.ob.BidAndAskPresentAfterAuction())
 	require.Equal(t, false, book.ob.CanUncross())
 
-	makeOrder(t, book, market, "needTwentyTwoCharacts4", types.SideSell, matchingPrice, party2, 1)
+	makeOrder(t, book, market, randomSha256Hash(), types.SideSell, matchingPrice, party2, 1)
 
 	require.Equal(t, true, book.ob.BidAndAskPresentAfterAuction())
 	require.Equal(t, true, book.ob.CanUncross())
@@ -3283,12 +3296,12 @@ func TestOrderBook_BidAndAskPresentAfterAuction(t *testing.T) {
 
 	require.Equal(t, int64(0), book.ob.GetTotalNumberOfOrders())
 
-	makeOrder(t, book, market, "needTwentyTwoCharacts5", types.SideBuy, matchingPrice, party1, 1)
+	makeOrder(t, book, market, randomSha256Hash(), types.SideBuy, matchingPrice, party1, 1)
 
 	require.Equal(t, false, book.ob.BidAndAskPresentAfterAuction())
 	require.Equal(t, false, book.ob.CanUncross())
 
-	makeOrder(t, book, market, "needTwentyTwoCharacts6", types.SideSell, matchingPrice, party2, 1)
+	makeOrder(t, book, market, randomSha256Hash(), types.SideSell, matchingPrice, party2, 1)
 
 	require.Equal(t, false, book.ob.BidAndAskPresentAfterAuction())
 	require.Equal(t, false, book.ob.CanUncross())

--- a/matching/simpleorders_test.go
+++ b/matching/simpleorders_test.go
@@ -754,6 +754,7 @@ func TestOrderBookSimple_CancelDistressedOrders(t *testing.T) {
 	market := "testMarket"
 	book := getTestOrderBook(t, market)
 	defer book.Finish()
+
 	order := types.Order{
 		Status:        types.OrderStatusActive,
 		MarketID:      market,
@@ -766,7 +767,7 @@ func TestOrderBookSimple_CancelDistressedOrders(t *testing.T) {
 		TimeInForce:   types.OrderTimeInForceGTT,
 		Type:          types.OrderTypeLimit,
 		ExpiresAt:     10,
-		ID:            "v0000000000000-0000001",
+		ID:            randomSha256Hash(),
 	}
 	confirm, err := book.SubmitOrder(&order)
 	assert.NoError(t, err)
@@ -783,7 +784,7 @@ func TestOrderBookSimple_CancelDistressedOrders(t *testing.T) {
 		Remaining:     10,
 		TimeInForce:   types.OrderTimeInForceGTC,
 		Type:          types.OrderTypeLimit,
-		ID:            "v0000000000000-0000002",
+		ID:            randomSha256Hash(),
 	}
 	confirm, err = book.SubmitOrder(&order2)
 	assert.NoError(t, err)

--- a/matching/validation.go
+++ b/matching/validation.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	minOrderIDLen = 22
-	maxOrderIDLen = 22
+	maxOrderIDLen = 64
 )
 
 func (b OrderBook) validateOrder(orderMessage *types.Order) (err error) {

--- a/matching/validation.go
+++ b/matching/validation.go
@@ -1,14 +1,15 @@
 package matching
 
 import (
+	"encoding/hex"
+
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 )
 
 const (
-	minOrderIDLen = 22
-	maxOrderIDLen = 64
+	orderIdLen = 64
 )
 
 func (b OrderBook) validateOrder(orderMessage *types.Order) (err error) {
@@ -53,8 +54,9 @@ func (b OrderBook) validateOrder(orderMessage *types.Order) (err error) {
 }
 
 func validateOrderID(orderID string) error {
+	_, err := hex.DecodeString(orderID)
 	idLen := len(orderID)
-	if idLen < minOrderIDLen || idLen > maxOrderIDLen {
+	if err != nil || idLen != orderIdLen {
 		return types.ErrInvalidOrderID
 	}
 	return nil

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -235,7 +235,7 @@ func NewApp(
 		HandleDeliverTx(txn.CancelTransferFundsCommand,
 			app.SendEventOnError(app.DeliverCancelTransferFunds)).
 		HandleDeliverTx(txn.SubmitOrderCommand,
-			app.SendEventOnError(app.DeliverSubmitOrder)).
+			app.SendEventOnError(addDeterministicID(app.DeliverSubmitOrder))).
 		HandleDeliverTx(txn.CancelOrderCommand,
 			app.SendEventOnError(app.DeliverCancelOrder)).
 		HandleDeliverTx(txn.AmendOrderCommand,
@@ -874,7 +874,7 @@ func (app *App) DeliverCancelTransferFunds(ctx context.Context, tx abci.Tx) erro
 	return app.banking.CancelTransferFunds(ctx, types.NewCancelTransferFromProto(tx.Party(), cancel))
 }
 
-func (app *App) DeliverSubmitOrder(ctx context.Context, tx abci.Tx) error {
+func (app *App) DeliverSubmitOrder(ctx context.Context, tx abci.Tx, deterministicId string) error {
 	s := &commandspb.OrderSubmission{}
 	if err := tx.Unmarshal(s); err != nil {
 		return err
@@ -888,7 +888,7 @@ func (app *App) DeliverSubmitOrder(ctx context.Context, tx abci.Tx) error {
 		return err
 	}
 	// Submit the create order request to the execution engine
-	conf, err := app.exec.SubmitOrder(ctx, os, tx.Party())
+	conf, err := app.exec.SubmitOrder(ctx, os, tx.Party(), deterministicId)
 	if conf != nil {
 		if app.log.GetLevel() <= logging.DebugLevel {
 			app.log.Debug("Order confirmed",

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -1088,12 +1088,14 @@ func (app *App) DeliverLiquidityProvision(ctx context.Context, tx abci.Tx, deter
 		return err
 	}
 
+	liquidityProvisionId := deterministicId
+
 	idBytes, err := hex.DecodeString(deterministicId)
 	if err != nil {
 		return fmt.Errorf("failed to generated liquidity provision id:%w", err)
 	}
 
-	liquidityProvisionId := hex.EncodeToString(vgcrypto.Hash(append(idBytes, []byte("SALT")...)))
+	deterministicId = hex.EncodeToString(vgcrypto.Hash(append(idBytes, []byte("SALT")...)))
 
 	partyID := tx.Party()
 

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"code.vegaprotocol.io/vega/idgeneration"
+
 	"code.vegaprotocol.io/protos/commands"
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
 	vgfs "code.vegaprotocol.io/shared/libs/fs"
@@ -1099,14 +1101,9 @@ func (app *App) DeliverLiquidityProvision(ctx context.Context, tx abci.Tx, deter
 		return err
 	}
 
-	liquidityProvisionId := deterministicId
-
-	idBytes, err := hex.DecodeString(deterministicId)
-	if err != nil {
-		return fmt.Errorf("failed to generated liquidity provision id:%w", err)
-	}
-
-	deterministicId = hex.EncodeToString(vgcrypto.Hash(append(idBytes, []byte("SALT")...)))
+	idGen := idgeneration.NewDeterministicIDGenerator(deterministicId)
+	liquidityProvisionId := idGen.NextID()
+	deterministicId = idGen.NextID()
 
 	partyID := tx.Party()
 

--- a/processor/mocks/execution_engine_mock.go
+++ b/processor/mocks/execution_engine_mock.go
@@ -50,18 +50,18 @@ func (mr *MockExecutionEngineMockRecorder) AmendLiquidityProvision(arg0, arg1, a
 }
 
 // AmendOrder mocks base method.
-func (m *MockExecutionEngine) AmendOrder(arg0 context.Context, arg1 *types.OrderAmendment, arg2 string) (*types.OrderConfirmation, error) {
+func (m *MockExecutionEngine) AmendOrder(arg0 context.Context, arg1 *types.OrderAmendment, arg2, arg3 string) (*types.OrderConfirmation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AmendOrder", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AmendOrder", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.OrderConfirmation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AmendOrder indicates an expected call of AmendOrder.
-func (mr *MockExecutionEngineMockRecorder) AmendOrder(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockExecutionEngineMockRecorder) AmendOrder(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AmendOrder", reflect.TypeOf((*MockExecutionEngine)(nil).AmendOrder), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AmendOrder", reflect.TypeOf((*MockExecutionEngine)(nil).AmendOrder), arg0, arg1, arg2, arg3)
 }
 
 // CancelLiquidityProvision mocks base method.
@@ -79,18 +79,18 @@ func (mr *MockExecutionEngineMockRecorder) CancelLiquidityProvision(arg0, arg1, 
 }
 
 // CancelOrder mocks base method.
-func (m *MockExecutionEngine) CancelOrder(arg0 context.Context, arg1 *types.OrderCancellation, arg2 string) ([]*types.OrderCancellationConfirmation, error) {
+func (m *MockExecutionEngine) CancelOrder(arg0 context.Context, arg1 *types.OrderCancellation, arg2, arg3 string) ([]*types.OrderCancellationConfirmation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelOrder", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CancelOrder", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*types.OrderCancellationConfirmation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CancelOrder indicates an expected call of CancelOrder.
-func (mr *MockExecutionEngineMockRecorder) CancelOrder(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockExecutionEngineMockRecorder) CancelOrder(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelOrder", reflect.TypeOf((*MockExecutionEngine)(nil).CancelOrder), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelOrder", reflect.TypeOf((*MockExecutionEngine)(nil).CancelOrder), arg0, arg1, arg2, arg3)
 }
 
 // Hash mocks base method.
@@ -136,17 +136,17 @@ func (mr *MockExecutionEngineMockRecorder) StartOpeningAuction(arg0, arg1 interf
 }
 
 // SubmitLiquidityProvision mocks base method.
-func (m *MockExecutionEngine) SubmitLiquidityProvision(arg0 context.Context, arg1 *types.LiquidityProvisionSubmission, arg2, arg3 string) error {
+func (m *MockExecutionEngine) SubmitLiquidityProvision(arg0 context.Context, arg1 *types.LiquidityProvisionSubmission, arg2, arg3, arg4 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitLiquidityProvision", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SubmitLiquidityProvision", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SubmitLiquidityProvision indicates an expected call of SubmitLiquidityProvision.
-func (mr *MockExecutionEngineMockRecorder) SubmitLiquidityProvision(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockExecutionEngineMockRecorder) SubmitLiquidityProvision(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitLiquidityProvision", reflect.TypeOf((*MockExecutionEngine)(nil).SubmitLiquidityProvision), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitLiquidityProvision", reflect.TypeOf((*MockExecutionEngine)(nil).SubmitLiquidityProvision), arg0, arg1, arg2, arg3, arg4)
 }
 
 // SubmitMarket mocks base method.
@@ -164,30 +164,30 @@ func (mr *MockExecutionEngineMockRecorder) SubmitMarket(arg0, arg1 interface{}) 
 }
 
 // SubmitMarketWithLiquidityProvision mocks base method.
-func (m *MockExecutionEngine) SubmitMarketWithLiquidityProvision(arg0 context.Context, arg1 *types.Market, arg2 *types.LiquidityProvisionSubmission, arg3, arg4 string) error {
+func (m *MockExecutionEngine) SubmitMarketWithLiquidityProvision(arg0 context.Context, arg1 *types.Market, arg2 *types.LiquidityProvisionSubmission, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitMarketWithLiquidityProvision", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "SubmitMarketWithLiquidityProvision", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SubmitMarketWithLiquidityProvision indicates an expected call of SubmitMarketWithLiquidityProvision.
-func (mr *MockExecutionEngineMockRecorder) SubmitMarketWithLiquidityProvision(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockExecutionEngineMockRecorder) SubmitMarketWithLiquidityProvision(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitMarketWithLiquidityProvision", reflect.TypeOf((*MockExecutionEngine)(nil).SubmitMarketWithLiquidityProvision), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitMarketWithLiquidityProvision", reflect.TypeOf((*MockExecutionEngine)(nil).SubmitMarketWithLiquidityProvision), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // SubmitOrder mocks base method.
-func (m *MockExecutionEngine) SubmitOrder(arg0 context.Context, arg1 *types.OrderSubmission, arg2 string) (*types.OrderConfirmation, error) {
+func (m *MockExecutionEngine) SubmitOrder(arg0 context.Context, arg1 *types.OrderSubmission, arg2, arg3 string) (*types.OrderConfirmation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitOrder", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SubmitOrder", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.OrderConfirmation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SubmitOrder indicates an expected call of SubmitOrder.
-func (mr *MockExecutionEngineMockRecorder) SubmitOrder(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockExecutionEngineMockRecorder) SubmitOrder(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitOrder", reflect.TypeOf((*MockExecutionEngine)(nil).SubmitOrder), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitOrder", reflect.TypeOf((*MockExecutionEngine)(nil).SubmitOrder), arg0, arg1, arg2, arg3)
 }

--- a/processor/mocks/oracle_adaptors_mock.go
+++ b/processor/mocks/oracle_adaptors_mock.go
@@ -50,17 +50,3 @@ func (mr *MockOracleAdaptorsMockRecorder) Normalise(arg0, arg1 interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Normalise", reflect.TypeOf((*MockOracleAdaptors)(nil).Normalise), arg0, arg1)
 }
-
-// Validate mocks base method
-func (m *MockOracleAdaptors) Validate(arg0 v1.OracleDataSubmission_OracleSource, arg1 *oracles.OracleData) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Validate indicates an expected call of Validate
-func (mr *MockOracleAdaptorsMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockOracleAdaptors)(nil).Validate), arg0, arg1)
-}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -62,14 +62,14 @@ type ExecutionEngine interface {
 
 	// market stuff
 	SubmitMarket(ctx context.Context, marketConfig *types.Market) error
-	SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party, lpid string) error
+	SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party, lpid, deterministicId string) error
 	RejectMarket(ctx context.Context, marketid string) error
 	StartOpeningAuction(ctx context.Context, marketid string) error
 
 	// LP stuff
-	SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, determiniticId string) error
+	SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, lpId, deterministicId string) error
 	CancelLiquidityProvision(ctx context.Context, order *types.LiquidityProvisionCancellation, party string) error
-	AmendLiquidityProvision(ctx context.Context, order *types.LiquidityProvisionAmendment, party string) error
+	AmendLiquidityProvision(ctx context.Context, order *types.LiquidityProvisionAmendment, party string, deterministicId string) error
 	Hash() []byte
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -57,8 +57,8 @@ type RewardEngine interface {
 type ExecutionEngine interface {
 	// orders stuff
 	SubmitOrder(ctx context.Context, orderSubmission *types.OrderSubmission, party string, deterministicId string) (*types.OrderConfirmation, error)
-	CancelOrder(ctx context.Context, order *types.OrderCancellation, party string) ([]*types.OrderCancellationConfirmation, error)
-	AmendOrder(ctx context.Context, order *types.OrderAmendment, party string) (*types.OrderConfirmation, error)
+	CancelOrder(ctx context.Context, order *types.OrderCancellation, party string, deterministicId string) ([]*types.OrderCancellationConfirmation, error)
+	AmendOrder(ctx context.Context, order *types.OrderAmendment, party string, deterministicId string) (*types.OrderConfirmation, error)
 
 	// market stuff
 	SubmitMarket(ctx context.Context, marketConfig *types.Market) error
@@ -67,7 +67,7 @@ type ExecutionEngine interface {
 	StartOpeningAuction(ctx context.Context, marketid string) error
 
 	// LP stuff
-	SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, id string) error
+	SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, determiniticId string) error
 	CancelLiquidityProvision(ctx context.Context, order *types.LiquidityProvisionCancellation, party string) error
 	AmendLiquidityProvision(ctx context.Context, order *types.LiquidityProvisionAmendment, party string) error
 	Hash() []byte

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -56,7 +56,7 @@ type RewardEngine interface {
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/execution_engine_mock.go -package mocks code.vegaprotocol.io/vega/processor ExecutionEngine
 type ExecutionEngine interface {
 	// orders stuff
-	SubmitOrder(ctx context.Context, orderSubmission *types.OrderSubmission, party string) (*types.OrderConfirmation, error)
+	SubmitOrder(ctx context.Context, orderSubmission *types.OrderSubmission, party string, deterministicId string) (*types.OrderConfirmation, error)
 	CancelOrder(ctx context.Context, order *types.OrderCancellation, party string) ([]*types.OrderCancellationConfirmation, error)
 	AmendOrder(ctx context.Context, order *types.OrderAmendment, party string) (*types.OrderConfirmation, error)
 


### PR DESCRIPTION
Closes #4567 

Four possible implementations considered to ensure that order ids are deterministic.  It was a case of which is least worst, below are the solutions considered, we opted for option 1.

1) The public API method of the service creates and sets the id generator  on the Market/Engine based on the a deterministic id passed into the method, the method nils out the generator on return (defer) to ensure ids are not reused.  Risk of a nil pointer if our test coverage is lacking.  

2) Having the id access the tx hash and from the context and using this to set it's state.  Brittle, depends on the ctx being correctly setup.

3) Singleton for the id generator which is updated on Begin Block/Deliver TX, problematic for testing.  

4)   Having the ability to register a listener callback on the App for when BeginBlock/DeliverTx  that is passed the corresponding block hash/tx hash.  Each market/Engine with an id generator would register a listener and update it's id generator accordingly on callback.  Really just a more complex singleton,


