### PR TITLE
fix nullblockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [4580](https://github.com/vegaprotocol/vega/pull/4580) - Add transfer command support (recurring transfers)
 - [4643](https://github.com/vegaprotocol/vega/issues/4643) - Add noise to floating point consensus variables in QA
 - [4639](https://github.com/vegaprotocol/vega/pull/4639) - Add cancel transfer command
+- [4750](https://github.com/vegaprotocol/vega/pull/4750) - Fix null blockchain by forcing it to always be a non-validator node
 - [4823](https://github.com/vegaprotocol/vega/pull/4283) - Reward refactoring for network treasury
 - [4647](https://github.com/vegaprotocol/vega/pull/4647) - Added endpoint `SubmitRawTransaction` to provide support for different transaction request message versions
 - [4653](https://github.com/vegaprotocol/vega/issues/4653) - Replace asset insurance pool with network treasury

--- a/blockchain/nullchain/nullchain.go
+++ b/blockchain/nullchain/nullchain.go
@@ -61,7 +61,6 @@ type NullBlockchain struct {
 func NewClient(
 	log *logging.Logger,
 	cfg blockchain.NullChainConfig,
-	app ApplicationService,
 ) *NullBlockchain {
 	// setup logger
 	log = log.Named(namedLogger)
@@ -70,7 +69,6 @@ func NewClient(
 	now := time.Now()
 	n := &NullBlockchain{
 		log:                  log,
-		app:                  app,
 		srvAddress:           net.JoinHostPort(cfg.IP, strconv.Itoa(cfg.Port)),
 		chainID:              vgrand.RandomStr(12),
 		transactionsPerBlock: cfg.TransactionsPerBlock,
@@ -83,6 +81,10 @@ func NewClient(
 	}
 
 	return n
+}
+
+func (n *NullBlockchain) SetABCIApp(app ApplicationService) {
+	n.app = app
 }
 
 // ReloadConf update the internal configuration.
@@ -326,8 +328,9 @@ func (n *NullBlockchain) SendTransactionCommit(ctx context.Context, tx []byte) (
 }
 
 func (n *NullBlockchain) Validators(_ context.Context, _ *int64) ([]*tmtypes.Validator, error) {
-	n.log.Error("not implemented")
-	return nil, ErrNotImplemented
+	// TODO: if we are feeling brave we, could pretend to have a validator set and open
+	// up the nullblockchain to more code paths
+	return []*tmtypes.Validator{}, nil
 }
 
 func (n *NullBlockchain) GenesisValidators(_ context.Context) ([]*tmtypes.Validator, error) {

--- a/blockchain/nullchain/nullchain_test.go
+++ b/blockchain/nullchain/nullchain_test.go
@@ -181,7 +181,8 @@ func getTestNullChain(t *testing.T, txnPerBlock uint64, d time.Duration) *testNu
 	cfg.TransactionsPerBlock = txnPerBlock
 	cfg.Level = encoding.LogLevel{Level: logging.DebugLevel}
 
-	n := nullchain.NewClient(logging.NewTestLogger(), cfg, app)
+	n := nullchain.NewClient(logging.NewTestLogger(), cfg)
+	n.SetABCIApp(app)
 	require.NotNil(t, n)
 
 	app.EXPECT().InitChain(gomock.Any()).Times(1)

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -208,6 +208,8 @@ func (n *NodeCommand) stopServices(_ []string) error {
 
 func (n *NodeCommand) startBlockchain() (*processor.App, error) {
 	// if tm chain, setup the client
+
+	var null *nullchain.NullBlockchain
 	switch n.conf.Blockchain.ChainProvider {
 	case blockchain.ProviderTendermint:
 		a, err := abci.NewClient(n.conf.Blockchain.Tendermint.ClientAddr)
@@ -215,6 +217,9 @@ func (n *NodeCommand) startBlockchain() (*processor.App, error) {
 			return nil, err
 		}
 		n.blockchainClient = blockchain.NewClient(a)
+	case blockchain.ProviderNullChain:
+		null = nullchain.NewClient(n.Log, n.conf.Blockchain.Null)
+		n.blockchainClient = blockchain.NewClient(null)
 	}
 
 	app := processor.NewApp(
@@ -274,12 +279,9 @@ func (n *NodeCommand) startBlockchain() (*processor.App, error) {
 			return nil, err
 		}
 	case blockchain.ProviderNullChain:
-		abciApp := app.Abci()
-		null := nullchain.NewClient(n.Log, n.conf.Blockchain.Null, abciApp)
-
+		null.SetABCIApp(app.Abci())
 		// nullchain acts as both the client and the server because its does everything
 		n.blockchainServer = blockchain.NewServer(null)
-		n.blockchainClient = blockchain.NewClient(null)
 	default:
 		return nil, ErrUnknownChainProvider
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,7 @@ func NewDefaultConfig() Config {
 }
 
 func (c Config) IsValidator() bool {
-	return c.NodeMode == cfgencoding.NodeModeValidator
+	return c.NodeMode == cfgencoding.NodeModeValidator && c.Blockchain.ChainProvider != blockchain.ProviderNullChain
 }
 
 type Loader struct {

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -587,7 +587,7 @@ func (app *App) OnBeginBlock(req tmtypes.RequestBeginBlock) (ctx context.Context
 
 	// read the state of validator set from the previous end of block
 	var vd []*tmtypesint.Validator
-	if app.blockchainClient != nil && req.Header.Height > 0 {
+	if req.Header.Height > 0 {
 		h := req.Header.Height - 1
 		vd, _ = app.blockchainClient.Validators(&h)
 	}


### PR DESCRIPTION
closes #4669 

Two things:
1) we now force the node to be a non-validator if in nullblockchain mode, this allows us to side-step all the `ethClient` interactions nicely.
2) The nullblockchain now returns an empty list from `Validators()` which makes things a little easier and we don't have to remember to check that `app.blockchainClient != nil`.