### PR TITLE
make trade ids unique using the deterministic id generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - [4595](https://github.com/vegaprotocol/vega/pull/4595) - Add internal oracle supplying vega time data for time-triggered events
 - [4737](https://github.com/vegaprotocol/vega/pull/4737) - Use a deterministic generator for order ids, set new order ids to the transaction hash of the Submit transaction 
 - [4741](https://github.com/vegaprotocol/vega/pull/4741) - Hash again list of hash from engines
+- [4751](https://github.com/vegaprotocol/vega/pull/4751) - Make trade ids unique using the deterministic id generator 
 
 ### 🐛 Fixes
 - [4521](https://github.com/vegaprotocol/vega/pull/4521) - Better error when trying to use the null-blockchain with an ERC20 asset

--- a/execution/auction.go
+++ b/execution/auction.go
@@ -49,7 +49,7 @@ func (m *Market) checkAuction(ctx context.Context, now time.Time) {
 			return
 		}
 		m.log.Info("leaving opening auction for market", logging.String("market-id", m.mkt.ID))
-		m.LeaveAuction(ctx, now)
+		m.leaveAuction(ctx, now)
 		// the market is now in a ACTIVE state
 		m.mkt.State = types.MarketStateActive
 		// the market is now properly open, so set the timestamp to when the opening auction actually ended
@@ -96,7 +96,7 @@ func (m *Market) checkAuction(ctx context.Context, now time.Time) {
 				m.extendAuctionIncompleteBook()
 				return
 			}
-			m.LeaveAuction(ctx, now)
+			m.leaveAuction(ctx, now)
 		}
 	}
 	// This is where FBA handling will go

--- a/execution/event_generation_test.go
+++ b/execution/event_generation_test.go
@@ -56,7 +56,7 @@ func startMarketInAuction(t *testing.T, ctx context.Context, now *time.Time) *te
 func leaveAuction(tm *testMarket, ctx context.Context, now *time.Time) {
 	// Leave auction to force the order to be removed
 	*now = now.Add(time.Second * 20)
-	tm.market.LeaveAuction(ctx, *now)
+	tm.market.LeaveAuctionWithIdGen(ctx, *now, newTestIdGenerator())
 }
 
 func processEventsWithCounter(t *testing.T, tm *testMarket, mdb *subscribers.MarketDepthBuilder, i int) {

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -2736,5 +2736,5 @@ func TestAmend(t *testing.T) {
 }
 
 func newTestIdGenerator() execution.IDGenerator {
-	return idgeneration.NewDeterministicIDGenerator("2446F4AEFB505123E1EBE0AA160421E47A4B708F9227F440C100AB24503380BD")
+	return idgeneration.New(vgcrypto.RandomHash())
 }

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"code.vegaprotocol.io/vega/execution"
+	"code.vegaprotocol.io/vega/idgeneration"
+
 	vegacontext "code.vegaprotocol.io/vega/libs/context"
 
 	proto "code.vegaprotocol.io/protos/vega"
@@ -313,7 +316,7 @@ func TestSubmit(t *testing.T) {
 		assert.Equal(t, num.NewUint(1000), tm.market.GetBondAccountBalance(ctx, "party-A", tm.market.GetID(), tm.asset))
 
 		// Leave auction
-		tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+		tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 		// Check we have an accepted LP submission
 		assert.Equal(t, 1, tm.market.GetLPSCount())
@@ -388,7 +391,7 @@ func TestSubmit(t *testing.T) {
 		// Leave auction
 		now = now.Add(time.Second * 40)
 		tm.market.OnChainTimeUpdate(ctx, now)
-		tm.market.LeaveAuction(ctx, now)
+		tm.market.LeaveAuctionWithIdGen(ctx, now, newTestIdGenerator())
 
 		// Check we have an accepted LP submission
 		assert.Equal(t, 1, tm.market.GetLPSCount())
@@ -580,7 +583,7 @@ func TestSubmit(t *testing.T) {
 
 		// Leave the auction so we can uncross the book
 		now = now.Add(time.Second * 20)
-		tm.market.LeaveAuction(ctx, now)
+		tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 		tm.market.OnChainTimeUpdate(ctx, now)
 		assert.Equal(t, 1, tm.market.GetPeggedOrderCount())
 		assert.Equal(t, 0, tm.market.GetParkedOrderCount())
@@ -653,7 +656,7 @@ func TestSubmit(t *testing.T) {
 
 		// Leave the auction so we can uncross the book
 		now = now.Add(time.Second * 20)
-		tm.market.LeaveAuction(ctx, now)
+		tm.market.LeaveAuctionWithIdGen(ctx, now, newTestIdGenerator())
 		tm.market.OnChainTimeUpdate(ctx, now)
 
 		// Save the total amount of assets we have in general+margin+bond
@@ -2307,7 +2310,7 @@ func TestAmend(t *testing.T) {
 		require.NoError(t, err)
 
 		// Leave auction
-		tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+		tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 		// mark price is set at 10, orders on book
 
 		buys := []*types.LiquidityOrder{
@@ -2497,7 +2500,7 @@ func TestAmend(t *testing.T) {
 		require.NoError(t, err)
 
 		// Leave auction
-		tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+		tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 		// Check we have an accepted LP submission
 		assert.Equal(t, 1, tm.market.GetLPSCount())
@@ -2726,4 +2729,8 @@ func TestAmend(t *testing.T) {
 		err := tm.market.CancelLiquidityProvision(ctx, lpc, "party-A")
 		require.EqualError(t, err, "party is not a liquidity provider")
 	})
+}
+
+func newTestIdGenerator() execution.IDGenerator {
+	return idgeneration.NewDeterministicIDGenerator("2446F4AEFB505123E1EBE0AA160421E47A4B708F9227F440C100AB24503380BD")
 }

--- a/execution/market_for_test.go
+++ b/execution/market_for_test.go
@@ -8,6 +8,16 @@ import (
 	"code.vegaprotocol.io/vega/types/num"
 )
 
+func (m *Market) EnterAuction(ctx context.Context) {
+	m.enterAuction(ctx)
+}
+
+func (m *Market) LeaveAuctionWithIdGen(ctx context.Context, now time.Time, generator IDGenerator) {
+	m.idgen = generator
+	defer func() { m.idgen = nil }()
+	m.leaveAuction(ctx, now)
+}
+
 // GetPeggedOrderCount returns the number of pegged orders in the market.
 func (m *Market) GetPeggedOrderCount() int {
 	return len(m.peggedOrders.orders)

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -2968,7 +2968,7 @@ func TestOrderBook_Crash2651(t *testing.T) {
 	require.NoError(t, err)
 
 	// Leave auction and uncross the book
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 	require.Equal(t, 3, tm.market.GetPeggedOrderCount())
 	require.Equal(t, 3, tm.market.GetParkedOrderCount())
 	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // still in auction
@@ -3399,7 +3399,9 @@ func TestOrderBook_Crash2718(t *testing.T) {
 	assert.True(t, o2Update.Price.IsZero())
 
 	// Flip out of auction to un-park it
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
+
 	o2Update = tm.lastOrderUpdate(o2.ID)
 	assert.Equal(t, types.OrderStatusActive, o2Update.Status)
 	assert.Equal(t, num.NewUint(100), o2Update.Price)
@@ -4306,7 +4308,7 @@ func TestMarket_LeaveAuctionAndRepricePeggedOrders(t *testing.T) {
 	require.NoError(t, err)
 
 	// Leave the auction so pegged orders are unparked
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 	// 6 live orders, 2 normal and 4 pegged
 	require.Equal(t, int64(6), tm.market.GetOrdersOnBookCount())
@@ -4429,7 +4431,7 @@ func TestOrderBook_ClosingOutLPProviderShouldRemoveCommitment(t *testing.T) {
 	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
 
 	// Leave auction right away
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 	// Create some normal orders to set the reference prices
 	o1 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order01", types.SideBuy, "party-B", 10, 10)
@@ -4512,7 +4514,7 @@ func TestOrderBook_PartiallyFilledMarketOrderThatWouldWashIOC(t *testing.T) {
 	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
 
 	// Leave auction right away
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 	// Create 2 buy orders that we will try to match against
 	o1 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order01", types.SideBuy, "party-B", 10, 100)
@@ -4562,7 +4564,7 @@ func TestOrderBook_PartiallyFilledMarketOrderThatWouldWashFOKSell(t *testing.T) 
 	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
 
 	// Leave auction right away
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 	// Create 2 buy orders that we will try to match against
 	o1 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order01", types.SideBuy, "party-B", 10, 100)
@@ -4692,7 +4694,7 @@ func TestOrderBook_PartiallyFilledLimitOrderThatWouldWashFOK(t *testing.T) {
 	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
 
 	// Leave auction right away
-	tm.market.LeaveAuction(ctx, now.Add(time.Second*20))
+	tm.market.LeaveAuctionWithIdGen(ctx, now.Add(time.Second*20), newTestIdGenerator())
 
 	md := tm.market.GetMarketData()
 	require.Equal(t, types.MarketTradingModeContinuous, md.MarketTradingMode)

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -1241,7 +1241,7 @@ func testPeggedOrderUnparkAfterLeavingAuction(t *testing.T) {
 	require.NotNil(t, confirmation)
 	assert.NoError(t, err)
 
-	tm.market.LeaveAuction(ctx, closingAt)
+	tm.market.LeaveAuctionWithIdGen(ctx, closingAt, newTestIdGenerator())
 	assert.Equal(t, 0, tm.market.GetParkedOrderCount())
 }
 
@@ -2413,7 +2413,7 @@ func TestPeggedOrderUnparkAfterLeavingAuctionWithNoFunds2772(t *testing.T) {
 	assert.NotNil(t, confirmation3)
 	assert.NoError(t, err)
 
-	tm.market.LeaveAuction(ctx, closingAt)
+	tm.market.LeaveAuctionWithIdGen(ctx, closingAt, newTestIdGenerator())
 
 	buyOrder1 := getOrder(t, tm, &now, types.OrderTypeLimit, types.OrderTimeInForceGTC, 0, types.SideBuy, "party3", 100, 6500)
 	confirmation4, err := tm.market.SubmitOrder(ctx, &buyOrder1)

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -3206,7 +3206,7 @@ func TestOrderBook_AuctionUncrossTamlyn(t *testing.T) {
 	//	assert.Equal(t, side, types.Side_SIDE_BUY)
 
 	// Leave auction and uncross the book
-	//	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
+	//	uncrossedOrders, cancels, err := book.ob.leaveAuction(time.Now())
 	//	assert.Nil(t, err)
 	//	assert.Equal(t, len(uncrossedOrders), 1)
 	//	assert.Equal(t, len(cancels), 0)

--- a/types/matching.go
+++ b/types/matching.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	proto "code.vegaprotocol.io/protos/vega"
@@ -273,8 +272,8 @@ type Trade struct {
 	SellerAuctionBatch uint64
 }
 
-func (t *Trade) SetIDs(aggressive, passive *Order, idx int) {
-	t.ID = fmt.Sprintf("%s-%010d", aggressive.ID, idx)
+func (t *Trade) SetIDs(tradeId string, aggressive, passive *Order) {
+	t.ID = tradeId
 	if aggressive.Side == SideBuy {
 		t.BuyOrder = aggressive.ID
 		t.SellOrder = passive.ID


### PR DESCRIPTION
closes #4752 

This is a change to user the deterministic id generator to generate unique ids for trades.  This will allow a trade to be easily traced through the core node and datanode.   Note, a number of tests were calling 
 the public Market.LeaveAuction  method, this method was public only for testing purposes.  It has been superseded by the LeaveAuctionWithIdGen method which serves the same purpose but additionally set the id generator  on the market.