### PR TITLE
nullchain has no ethclient, but requires nodecommander for the faucet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [4643](https://github.com/vegaprotocol/vega/issues/4643) - Add noise to floating point consensus variables in QA
 - [4639](https://github.com/vegaprotocol/vega/pull/4639) - Add cancel transfer command
 - [4750](https://github.com/vegaprotocol/vega/pull/4750) - Fix null blockchain by forcing it to always be a non-validator node
+- [4754](https://github.com/vegaprotocol/vega/pull/4754) - Fix null blockchain properly this time
 - [4823](https://github.com/vegaprotocol/vega/pull/4283) - Reward refactoring for network treasury
 - [4647](https://github.com/vegaprotocol/vega/pull/4647) - Added endpoint `SubmitRawTransaction` to provide support for different transaction request message versions
 - [4653](https://github.com/vegaprotocol/vega/issues/4653) - Replace asset insurance pool with network treasury

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -85,7 +85,7 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 	n.eventService = subscribers.NewService(n.broker)
 
 	now := n.timeService.GetTimeNow()
-	n.assets = assets.New(n.Log, n.conf.Assets, n.nodeWallets, n.ethClient, n.timeService, n.conf.IsValidator())
+	n.assets = assets.New(n.Log, n.conf.Assets, n.nodeWallets, n.ethClient, n.timeService, n.conf.HaveEthClient())
 	n.collateral = collateral.New(n.Log, n.conf.Collateral, n.broker, now)
 	n.oracle = oracles.NewEngine(n.Log, n.conf.Oracles, now, n.broker, n.timeService)
 	n.builtinOracle = oracles.NewBuiltinOracle(n.oracle, n.timeService)
@@ -115,14 +115,14 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 	n.timeService.NotifyOnTick(n.netParams.OnChainTimeUpdate)
 	n.eventForwarder = evtforward.New(n.Log, n.conf.EvtForward, n.commander, n.timeService, n.topology)
 
-	if n.conf.IsValidator() {
+	if n.conf.HaveEthClient() {
 		n.eventForwarderEngine = evtforward.NewEngine(n.Log, n.conf.EvtForward)
 	} else {
 		n.eventForwarderEngine = evtforward.NewNoopEngine(n.Log, n.conf.EvtForward)
 	}
 
 	n.stakingAccounts, n.stakeVerifier = staking.New(
-		n.Log, n.conf.Staking, n.broker, n.timeService, n.witness, n.ethClient, n.netParams, n.eventForwarder, n.conf.IsValidator(),
+		n.Log, n.conf.Staking, n.broker, n.timeService, n.witness, n.ethClient, n.netParams, n.eventForwarder, n.conf.HaveEthClient(),
 	)
 	n.epochService = epochtime.NewService(n.Log, n.conf.Epoch, n.timeService, n.broker)
 

--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,14 @@ func NewDefaultConfig() Config {
 }
 
 func (c Config) IsValidator() bool {
-	return c.NodeMode == cfgencoding.NodeModeValidator && c.Blockchain.ChainProvider != blockchain.ProviderNullChain
+	return c.NodeMode == cfgencoding.NodeModeValidator
+}
+
+func (c Config) HaveEthClient() bool {
+	if c.Blockchain.ChainProvider == blockchain.ProviderNullChain {
+		return false
+	}
+	return c.IsValidator()
 }
 
 type Loader struct {


### PR DESCRIPTION
closes #4669 

I was a bit too heavy handed in forcing the nullblockchain to always look like a non-validator, and without the nodecommander stuff the faucet would not work. This fixes it.