### PR TITLE
LP fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - [4747](https://github.com/vegaprotocol/vega/pull/4747) - Dispatch network parameter updates at the same block when loaded from checkpoint
 - [4756](https://github.com/vegaprotocol/vega/pull/4756) - Fix for markets loaded from snapshot not terminated by their oracle
 - [4590](https://github.com/vegaprotocol/vega/pull/4590) - Added verification of uint market data in integration test
+- [4749](https://github.com/vegaprotocol/vega/pull/4794) - Fixed issue where LP orders did not get redeployed
 
 ## 0.47.6
 *2022-02-01*

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -2832,3 +2832,82 @@ func Test2965EnsureLPOrdersAreNotCancelleableWithCancelAll(t *testing.T) {
 		}
 	})
 }
+
+func TestMissingLP(t *testing.T) {
+	party1 := "party1"
+	party2 := "party2"
+	party3 := "party3"
+	auxParty, auxParty2 := "auxParty", "auxParty2"
+	now := time.Unix(10, 0)
+	closingAt := time.Unix(10000000000, 0)
+	tm := getTestMarket(t, now, closingAt, nil, &types.AuctionDuration{
+		Duration: 1,
+	})
+
+	addAccount(tm, party1)
+	addAccount(tm, party2)
+	addAccount(tm, party3)
+	addAccount(tm, auxParty)
+	addAccount(tm, auxParty2)
+	tm.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	// Assure liquidity auction won't be triggered
+	tm.market.OnMarketLiquidityTargetStakeTriggeringRatio(context.Background(), num.DecimalFromFloat(0))
+	// ensure auction durations are 1 second
+	tm.market.OnMarketAuctionMinimumDurationUpdate(context.Background(), time.Second)
+	alwaysOnBid := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "alwaysOnBid", types.SideBuy, auxParty, 1, 800000)
+	conf, err := tm.market.SubmitOrder(context.Background(), alwaysOnBid)
+	require.NotNil(t, conf)
+	require.NoError(t, err)
+	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
+
+	alwaysOnAsk := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "alwaysOnAsk", types.SideSell, auxParty, 1, 8200000)
+	conf, err = tm.market.SubmitOrder(context.Background(), alwaysOnAsk)
+	require.NotNil(t, conf)
+	require.NoError(t, err)
+	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
+	// create orders so we can leave opening auction
+	auxOrders := []*types.Order{
+		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "uncross1", types.SideBuy, auxParty, 1, 3500000),
+		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "uncross2", types.SideSell, auxParty2, 1, 3500000),
+	}
+	for _, o := range auxOrders {
+		conf, err := tm.market.SubmitOrder(context.Background(), o)
+		require.NotNil(t, conf)
+		require.NoError(t, err)
+	}
+	now = now.Add(time.Second * 2) // opening auction is 1 second, move time ahead by 2 seconds so we leave auction
+	tm.market.OnChainTimeUpdate(context.Background(), now)
+
+	// Here we are in auction
+	assert.False(t, tm.mas.InAuction())
+
+	// Send LP order
+
+	lps := &types.LiquidityProvisionSubmission{
+		MarketID:         tm.market.GetID(),
+		CommitmentAmount: num.NewUint(10000),
+		Fee:              num.DecimalFromFloat(0.01),
+		Sells: []*types.LiquidityOrder{
+			&types.LiquidityOrder{Reference: types.PeggedReferenceMid, Proportion: 1, Offset: num.NewUint(10000)},
+		},
+		Buys: []*types.LiquidityOrder{
+			&types.LiquidityOrder{Reference: types.PeggedReferenceMid, Proportion: 1, Offset: num.NewUint(10000)},
+		},
+	}
+
+	tm.market.SubmitLiquidityProvision(context.Background(), lps, party1, "Error")
+
+	// Check we have 2 orders on each side of the book (4 in total)
+	assert.EqualValues(t, 4, tm.market.GetOrdersOnBookCount())
+
+	// Send in a limit order to move the BEST_BID and MID price
+	newBestBid := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "nbb", types.SideBuy, auxParty, 1, 810000)
+	conf, err = tm.market.SubmitOrder(context.Background(), newBestBid)
+	require.NotNil(t, conf)
+	require.NoError(t, err)
+	require.Equal(t, types.OrderStatusActive, conf.Order.Status)
+
+	// Check we have 5 orders in total
+	assert.EqualValues(t, 5, tm.market.GetOrdersOnBookCount())
+}

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -2889,10 +2889,10 @@ func TestMissingLP(t *testing.T) {
 		CommitmentAmount: num.NewUint(10000),
 		Fee:              num.DecimalFromFloat(0.01),
 		Sells: []*types.LiquidityOrder{
-			&types.LiquidityOrder{Reference: types.PeggedReferenceMid, Proportion: 1, Offset: num.NewUint(10000)},
+			{Reference: types.PeggedReferenceMid, Proportion: 1, Offset: num.NewUint(10000)},
 		},
 		Buys: []*types.LiquidityOrder{
-			&types.LiquidityOrder{Reference: types.PeggedReferenceMid, Proportion: 1, Offset: num.NewUint(10000)},
+			{Reference: types.PeggedReferenceMid, Proportion: 1, Offset: num.NewUint(10000)},
 		},
 	}
 

--- a/integration/features/auctions/2952-opening-auction-extension-csv.feature
+++ b/integration/features/auctions/2952-opening-auction-extension-csv.feature
@@ -112,10 +112,11 @@ Feature: Set up a market, with an opening auction, then uncross the book
     Then the following transfers should happen:
       | from    | to      | from account         | to account              | market id | amount  | asset |
       | party3 | market  | ACCOUNT_TYPE_MARGIN  | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC20 | 1574328 | ETH   |
-      | party3 | party3 | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_MARGIN     | ETH/DEC20 | 2399217 | ETH   |
+      | party3 | party3 | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_MARGIN     | ETH/DEC20 | 1799229 | ETH   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin  | general   |
-      | party3 | ETH   | ETH/DEC20 | 2399217 | 988550783 |
+      | party3 | ETH   | ETH/DEC20 | 1799229 | 988550783 |
+      #| party3 | ETH   | ETH/DEC20 | 2399217 | 988550783 |
 
     # Amend orders to set slippage to 180
     When the parties amend the following orders:

--- a/integration/features/auctions/2952-opening-auction-extension-csv.feature
+++ b/integration/features/auctions/2952-opening-auction-extension-csv.feature
@@ -115,7 +115,7 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | party3 | party3 | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_MARGIN     | ETH/DEC20 | 1799229 | ETH   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin  | general   |
-      | party3 | ETH   | ETH/DEC20 | 1799229 | 988550783 |
+      | party3 | ETH   | ETH/DEC20 | 1799229 | 989150771 |
       #| party3 | ETH   | ETH/DEC20 | 2399217 | 988550783 |
 
     # Amend orders to set slippage to 180
@@ -131,11 +131,11 @@ Feature: Set up a market, with an opening auction, then uncross the book
     # Check MTM Loss transfer happened
     Then the following transfers should happen:
       | from    | to      | from account         | to account              | market id | amount  | asset |
-      | party3 | market  | ACCOUNT_TYPE_MARGIN  | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC20 | 2000000 | ETH   |
-      | party3 | party3 | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_MARGIN     | ETH/DEC20 | 2224903 | ETH   |
+      | party3 | market  | ACCOUNT_TYPE_MARGIN  | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC20 | 1799229 | ETH   |
+      | party3 | party3 | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_MARGIN     | ETH/DEC20 | 2024132 | ETH   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin  | general   |
-      | party3 | ETH   | ETH/DEC20 | 2624120 | 986325880 |
+      | party3 | ETH   | ETH/DEC20 | 2024132 | 986925868 |
 
     # Amend orders to set slippage to 140
     # Amending prices down, so amend buy order first, so it doesn't uncross with the lowered sell order
@@ -153,7 +153,7 @@ Feature: Set up a market, with an opening auction, then uncross the book
     Then the following transfers should happen:
       | from    | to      | from account            | to account           | market id | amount  | asset |
       | market  | party3 | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN  | ETH/DEC20 | 4000000 | ETH   |
-      | party3 | party3 | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL | ETH/DEC20 | 5049792 | ETH   |
+      | party3 | party3 | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL | ETH/DEC20 | 4449804 | ETH   |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin  | general   |
       | party3 | ETH   | ETH/DEC20 | 1574328 | 991375672 |

--- a/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -276,14 +276,15 @@ Feature: Test liquidity provider reward distribution
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference    |
       | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
-      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 2                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 3                | TYPE_LIMIT | TIF_GTC | party2-buy  |
 
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
 
     And the following trades should be executed:
-      | buyer   | price | size | seller  |
+      | buyer  | price | size | seller  |
       | party2 | 951   | 12   | lp1     |
-      | party2 | 1000  | 8    | party1 |
+      | party2 | 951   | 3    | lp2     |
+      | party2 | 1000  | 5    | party1 |
 
     And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
 
@@ -382,12 +383,13 @@ Feature: Test liquidity provider reward distribution
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference    |
       | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
-      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 2                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 3                | TYPE_LIMIT | TIF_GTC | party2-buy  |
 
     And the following trades should be executed:
-      | buyer   | price | size | seller  |
-      | party2 | 951   | 12   | lp1     |
-      | party2 | 1000  | 8    | party1 |
+      | buyer  | price | size | seller |
+      | party2 | 951   | 12   | lp1    |
+      | party2 | 951   | 3    | lp2    |
+      | party2 | 1000  | 5    | party1 |
 
     And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
 
@@ -410,10 +412,10 @@ Feature: Test liquidity provider reward distribution
       | lp3 | lp3   | ETH/DEC21 | 10000             | 0.001 | sell | MID              | 2          | 1      | amendment |
 
     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
-      | party | equity like share | average entry valuation |
-      | lp1   | 0.7366            | 10000                   |
-      | lp2   | 0.1841            | 10000                   |
-      | lp3   | 0.0791            | 116278                  |
+      | party | equity like share  | average entry valuation |
+      | lp1   | 0.7362029616262406 | 10000                   |
+      | lp2   | 0.1840507404065602 | 10000                   |
+      | lp3   | 0.0797462979671992 | 115397.670549084859473  |
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |

--- a/integration/features/fees/trading-fees.feature
+++ b/integration/features/fees/trading-fees.feature
@@ -1615,15 +1615,16 @@ Scenario: WIP - Testing fees in continuous trading with two pegged trades and on
     Then the parties place the following orders:
       | party    | market id | side | volume | price | resulting trades | type       | tif     |
       | trader3a | ETH/DEC21 | buy  | 10     | 990   | 0                | TYPE_LIMIT | TIF_GTC |
-      | trader4  | ETH/DEC21 | sell | 30     | 990   | 1                | TYPE_LIMIT | TIF_GTC |
+      | trader4  | ETH/DEC21 | sell | 30     | 990   | 2                | TYPE_LIMIT | TIF_GTC |
       
      Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader3a | ETH   | ETH/DEC21 | 3216   | 96834   |
-      | trader4  | ETH   | ETH/DEC21 | 3600   | 96320   |
+      | trader4  | ETH   | ETH/DEC21 | 5580   | 94875   |
+
     
     And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
-    And the accumulated liquidity fees should be "10" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "31" for the market "ETH/DEC21"
 
     Then the following trades should be executed:
       # | buyer    | price | size | seller  | maker   | taker   | buyer_fee | seller_fee | maker_fee |
@@ -1654,23 +1655,23 @@ Scenario: WIP - Testing fees in continuous trading with two pegged trades and on
     And the following transfers should happen:
       | from    | to       | from account            | to account                       | market id | amount | asset |
       | trader4 | market   | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_FEES_MAKER          | ETH/DEC21 | 50     | ETH   |
-      | trader4 |          | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_FEES_INFRASTRUCTURE |           | 20     | ETH   |
-      | trader4 | market   | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 10     | ETH   |
+      | trader4 |          | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_FEES_INFRASTRUCTURE |           | 61     | ETH   |
+      | trader4 | market   | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 31     | ETH   |
       | market  | trader3a | ACCOUNT_TYPE_FEES_MAKER | ACCOUNT_TYPE_GENERAL             | ETH/DEC21 | 50     | ETH   |  
 
     Then the parties should have the following account balances:
       | party      | asset | market id | margin | general |
-      | trader3a    | ETH   | ETH/DEC21 | 3216    | 96834    | 
-      | trader4     | ETH   | ETH/DEC21 | 3600    | 96320    |
+      | trader3a   | ETH   | ETH/DEC21 | 3216   | 96834   |
+      | trader4    | ETH   | ETH/DEC21 | 5580   | 94875   |
 
     # And the accumulated infrastructure fee should be "20" for the market "ETH/DEC21"
-    And the accumulated liquidity fees should be "10" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "31" for the market "ETH/DEC21"
 
     When the network moves ahead "11" blocks
     
     And the following transfers should happen:
       | from   | to   | from account                | to account           | market id | amount | asset |
-      | market | aux1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 10     | ETH   |
+      | market | aux1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 31     | ETH   |
 
 Scenario: Testing fees when network parameters are changed (in continuous trading with one trade and no liquidity providers) 
  Description : Changing net params does change the fees being collected appropriately even if the market is already running

--- a/integration/features/liquidity-provision/lp-distressed-closeout.feature
+++ b/integration/features/liquidity-provision/lp-distressed-closeout.feature
@@ -175,8 +175,8 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     # getting closer to distressed LP, still in continuous trading
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1760   | 0       | 0    |
-    And the insurance pool balance should be "4651" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 2816   | 0       | 0    |
+    And the insurance pool balance should be "3616" for the market "ETH/DEC21"
 
     # Move price out of bounds
     When the network moves ahead "2" blocks
@@ -188,7 +188,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | 1010       | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 2323         | 5000           | 23            |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1760   | 0       | 0    |
+      | party0 | ETH   | ETH/DEC21 | 2816   | 0       | 0    |
 
     # end price auction
     When the network moves ahead "301" blocks
@@ -197,7 +197,8 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | 1055       | TRADING_MODE_CONTINUOUS | 1       | 1045      | 1065      | 3481         | 5000           | 33            |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 265    | 1405    | 0    |
+      | party0 | ETH   | ETH/DEC21 | 928    | 1573    | 0    |
+      # count balances did not match for party(party0)
       # values before uint stuff
       # | party0 | ETH   | ETH/DEC21 | 253    | 1419    | 0    |
-    And the insurance pool balance should be "4651" for the market "ETH/DEC21"
+    And the insurance pool balance should be "3616" for the market "ETH/DEC21"

--- a/integration/features/liquidity-provision/mid-price-issue-amend.feature
+++ b/integration/features/liquidity-provision/mid-price-issue-amend.feature
@@ -92,8 +92,11 @@ Feature: Replicate unexpected margin issues - no mid price pegs
       | sell | 8200000000 | 1      |
       | sell | 8190000000 | 1      |
       | buy  | 810000000  | 1      |
-      #| sell | 4510000000 | 3      |
-      #| buy  | 4490000000 | 5      |
+    # The bug is fixed, so we should also see the LP orders
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | buy  | 4490000000 | 5      |
     ## Let's see if amending the LP in a trivial way changes anything at all
     When the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type   |

--- a/integration/features/liquidity-provision/mid-price-issue-amend.feature
+++ b/integration/features/liquidity-provision/mid-price-issue-amend.feature
@@ -1,0 +1,120 @@
+Feature: Replicate unexpected margin issues - no mid price pegs
+
+  Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | DAI | 5              |
+    And the log normal risk model named "dai-lognormal-risk":
+      | risk aversion | tau         | mu | r | sigma |
+      | 0.00001       | 0.000114077 | 0  | 0 | 0.41  |
+    And the markets:
+      | id        | quote name | asset | risk model         | margin calculator         | auction duration | fees         | price monitoring | oracle config          | decimal places |
+      | DAI/DEC22 | DAI        | DAI   | dai-lognormal-risk | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 5              |
+    And the following network parameters are set:
+      | name                              | value |
+      | market.auction.minimumDuration    | 1     |
+      | market.stake.target.scalingFactor | 10    |
+
+
+
+  @MidPrice @LPAmend
+  Scenario: Changing orders copying the script
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 810000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+    ## LP orders are gone! this is where things go wrong
+    ## THIS IS WRONG!!!
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 8200000000 | 1      |
+      | buy  | 800000000  | 1      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    
+    ## Let's see if amending the LP in a trivial way changes anything at all
+    When the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type   |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | amendment |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | amendment |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 8200000000 | 1      |
+      | buy  | 800000000  | 1      |
+      | buy  | 810000000  | 1      |
+      | sell | 4515000000 | 5      |
+      | buy  | 4495000000 | 5      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party2 | party2-1  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4515000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4495000000 | 5      |
+      | buy  | 810000000  | 1      |
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | sell | 1      | 8190000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 8200000000 | 1      |
+      | sell | 8190000000 | 1      |
+      | buy  | 810000000  | 1      |
+      #| sell | 4510000000 | 3      |
+      #| buy  | 4490000000 | 5      |
+    ## Let's see if amending the LP in a trivial way changes anything at all
+    When the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type   |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | amendment |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | amendment |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 8200000000 | 1      |
+      | buy  | 810000000  | 1      |
+      | sell | 4510000000 | 5      |
+      | buy  | 4490000000 | 5      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party1 | party3-2  |
+    ## Now the volumes are different compared to when we created both orders + deleted both at the same time???
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8190000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+

--- a/integration/features/liquidity-provision/mid-price-issue.feature
+++ b/integration/features/liquidity-provision/mid-price-issue.feature
@@ -439,6 +439,7 @@ Feature: Replicate unexpected margin issues - no mid price pegs
     When the parties place the following orders:
       | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
       | party2 | DAI/DEC22 | buy  | 1      | 810000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+
     ## LP orders are gone! this is where things go wrong
     ## THIS IS WRONG!!!
     Then the order book should have the following volumes for market "DAI/DEC22":
@@ -446,8 +447,8 @@ Feature: Replicate unexpected margin issues - no mid price pegs
       | sell | 8200000000 | 1      |
       | buy  | 800000000  | 1      |
       | buy  | 810000000  | 1      |
-      #| sell | 4510000000 | 5      |
-      #| buy  | 4490000000 | 5      |
+      | sell | 4515000000 | 5      |
+      | buy  | 4495000000 | 5      |
     And the mark price should be "3500000000" for the market "DAI/DEC22"
     When the parties cancel the following orders:
       | party  | reference |
@@ -465,18 +466,18 @@ Feature: Replicate unexpected margin issues - no mid price pegs
     ## Buy side is gone, sell side only has volume of 3, so LP is doing SOMETHING, but what?
     Then the order book should have the following volumes for market "DAI/DEC22":
       | side | price      | volume |
-      | sell | 4510000000 | 3      |
+      | sell | 4510000000 | 5      |
       | sell | 8200000000 | 1      |
       | sell | 8190000000 | 1      |
       | buy  | 810000000  | 1      |
-      #| buy  | 4490000000 | 5      |
+      | buy  | 4490000000 | 5      |
     When the parties cancel the following orders:
       | party  | reference |
       | party1 | party3-2  |
     ## Now the volumes are different compared to when we created both orders + deleted both at the same time???
     Then the order book should have the following volumes for market "DAI/DEC22":
       | side | price      | volume |
-      | sell | 4510000000 | 3      |
+      | sell | 4510000000 | 5      |
       | sell | 8190000000 | 1      |
       | buy  | 4490000000 | 5      |
       | buy  | 810000000  | 1      |
@@ -525,8 +526,8 @@ Feature: Replicate unexpected margin issues - no mid price pegs
       | sell | 8200000000 | 1      |
       | buy  | 800000000  | 1      |
       | buy  | 810000000  | 1      |
-      #| sell | 4510000000 | 5      |
-      #| buy  | 4490000000 | 5      |
+      | sell | 4515000000 | 5      |
+      | buy  | 4495000000 | 5      |
     And the mark price should be "3500000000" for the market "DAI/DEC22"
     When the parties cancel the following orders:
       | party  | reference |
@@ -547,8 +548,8 @@ Feature: Replicate unexpected margin issues - no mid price pegs
       | sell | 8200000000 | 1      |
       | sell | 8190000000 | 1      |
       | buy  | 810000000  | 1      |
-      #| sell | 4510000000 | 3      |
-      #| buy  | 4490000000 | 5      |
+      | sell | 4510000000 | 5      |
+      | buy  | 4490000000 | 5      |
     When the parties cancel the following orders:
       | party  | reference |
       | party2 | party3-2  |

--- a/integration/features/liquidity-provision/mid-price-issue.feature
+++ b/integration/features/liquidity-provision/mid-price-issue.feature
@@ -1,0 +1,543 @@
+Feature: Replicate unexpected margin issues - no mid price pegs
+
+  Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | DAI | 5              |
+    And the log normal risk model named "dai-lognormal-risk":
+      | risk aversion | tau         | mu | r | sigma |
+      | 0.00001       | 0.000114077 | 0  | 0 | 0.41  |
+    And the markets:
+      | id        | quote name | asset | risk model         | margin calculator         | auction duration | fees         | price monitoring | oracle config          | decimal places |
+      | DAI/DEC22 | DAI        | DAI   | dai-lognormal-risk | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 5              |
+    And the following network parameters are set:
+      | name                              | value |
+      | market.auction.minimumDuration    | 1     |
+      | market.stake.target.scalingFactor | 10    |
+
+  @MidPrice
+  Scenario: Mid price works as expected
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+      | party3          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | buy  | MID              | 1          | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | sell | MID              | 1          | 10     | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party3 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party3 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4500000010 | 9      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4499999990 | 9      |
+      | buy  | 800000000  | 1      |
+
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (sell side high)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | buy  | MID              | 1          | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | sell | MID              | 1          | 10     | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4500000010 | 9      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4499999990 | 9      |
+      | buy  | 800000000  | 1      |
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (buy side low)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | buy  | MID              | 1          | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | sell | MID              | 1          | 10     | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party2 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4500000010 | 9      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4499999990 | 9      |
+      | buy  | 800000000  | 1      |
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (sell side high) - low commitment
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (buy side low) - half commitment
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party2 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (buy side low) - updating orders (manually, bring prices closer)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party2 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | buy  | 1      | 810000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+      | party2 | DAI/DEC22 | sell | 1      | 8190000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | sell | 8190000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party1 | party2-1  |
+      | party2 | party3-2  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8190000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (buy side low) - updating orders (manually move prices apart)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party2 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | buy  | 1      | 790000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+      | party2 | DAI/DEC22 | sell | 1      | 8210000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | sell | 8210000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+      | buy  | 790000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party1 | party2-1  |
+      | party2 | party3-2  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8210000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 790000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (LP high) - updating orders (manually, bring prices closer)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 810000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+      | party1 | DAI/DEC22 | sell | 1      | 8190000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | sell | 8190000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party2 | party2-1  |
+      | party1 | party3-2  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8190000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+  @MidPrice
+  Scenario: Mid price should work even if LP has limit order on the book (LP high) - updating orders (manually move prices apart)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 790000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+      | party1 | DAI/DEC22 | sell | 1      | 8210000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | sell | 8210000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+      | buy  | 790000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party2 | party2-1  |
+      | party1 | party3-2  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8210000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 790000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+  @MidPrice @LPWrong
+  Scenario: Changing orders copying the script
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 810000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+    ## LP orders are gone! this is where things go wrong
+    ## THIS IS WRONG!!!
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 8200000000 | 1      |
+      | buy  | 800000000  | 1      |
+      | buy  | 810000000  | 1      |
+      #| sell | 4510000000 | 5      |
+      #| buy  | 4490000000 | 5      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party2 | party2-1  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4515000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4495000000 | 5      |
+      | buy  | 810000000  | 1      |
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party1 | DAI/DEC22 | sell | 1      | 8190000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    ## THIS IS EVEN MORE WRONG, some LP orders remain, others are gone
+    ## Buy side is gone, sell side only has volume of 3, so LP is doing SOMETHING, but what?
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 3      |
+      | sell | 8200000000 | 1      |
+      | sell | 8190000000 | 1      |
+      | buy  | 810000000  | 1      |
+      #| buy  | 4490000000 | 5      |
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party1 | party3-2  |
+    ## Now the volumes are different compared to when we created both orders + deleted both at the same time???
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 3      |
+      | sell | 8190000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 810000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And debug detailed orderbook volumes for market "DAI/DEC22"
+
+  @MidPriceWIP
+  Scenario: Mid price should work even if LP has limit order on the book (LP high) - updating orders (manually move prices apart)
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset   | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | buy  | MID              | 1          | 10000000 | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 10000000000       | 0.01 | sell | MID              | 1          | 10000000 | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party1 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party1 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+
+    ## Now change our orders manually
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 790000000  | 0                | TYPE_LIMIT | TIF_GTC | party1-b  |
+      | party1 | DAI/DEC22 | sell | 1      | 8210000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-b  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8200000000 | 1      |
+      | sell | 8210000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 800000000  | 1      |
+      | buy  | 790000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party2 | party2-1  |
+      | party1 | party3-2  |
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4510000000 | 5      |
+      | sell | 8210000000 | 1      |
+      | buy  | 4490000000 | 5      |
+      | buy  | 790000000  | 1      |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+

--- a/integration/features/liquidity-provision/unexpected-auction.feature
+++ b/integration/features/liquidity-provision/unexpected-auction.feature
@@ -85,6 +85,11 @@ Feature: Replicate unexpected margin issues.
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search    | initial   | release   |
       | party1 | DAI/DEC22 | 207868082   | 228654890 | 249441698 | 291015314 |
+    And debug detailed orderbook volumes for market "DAI/DEC22"
+
+    And the liquidity provisions should have the following states:
+      | id  | party  | market    | commitment amount | status        |
+      | lp1 | party1 | DAI/DEC22 | 20000000          | STATUS_ACTIVE |
 
     When the parties place the following orders:
       | party  | market id | side | volume | price      | resulting trades | type       | tif     |
@@ -95,6 +100,10 @@ Feature: Replicate unexpected margin issues.
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search    | initial   | release   |
       | party1 | DAI/DEC22 | 138578719   | 152436590 | 166294462 | 194010206 |
+    And the liquidity provisions should have the following states:
+      | id  | party  | market    | commitment amount | status        |
+      | lp1 | party1 | DAI/DEC22 | 20000000          | STATUS_ACTIVE |
+    And debug detailed liquidity provision events
 
     Then debug transfers
     And debug detailed orderbook volumes for market "DAI/DEC22"

--- a/integration/features/liquidity-provision/unexpected-auction.feature
+++ b/integration/features/liquidity-provision/unexpected-auction.feature
@@ -72,13 +72,13 @@ Feature: Replicate unexpected margin issues.
     And clear transfer response events
 
     When the parties place the following orders:
-      | party  | market id | side | volume | price      | resulting trades | type       | tif     |
-      | party2 | DAI/DEC22 | buy  | 1      | 3500000015 | 0                | TYPE_LIMIT | TIF_GTC |
-      | party3 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC |
-      | party1 | DAI/DEC22 | buy  | 1      | 3499999960 | 0                | TYPE_LIMIT | TIF_GTC |
-      | party2 | DAI/DEC22 | sell | 1      | 3500000010 | 0                | TYPE_LIMIT | TIF_GTC |
-      | party3 | DAI/DEC22 | sell | 1      | 3500000040 | 0                | TYPE_LIMIT | TIF_GTC |
-      | party1 | DAI/DEC22 | sell | 1      | 3500000015 | 1                | TYPE_LIMIT | TIF_GTC |
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000015 | 0                | TYPE_LIMIT | TIF_GTC | p2-1      |
+      | party3 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | p3-1      |
+      | party1 | DAI/DEC22 | buy  | 1      | 3499999960 | 0                | TYPE_LIMIT | TIF_GTC | p1-1      |
+      | party2 | DAI/DEC22 | sell | 1      | 3500000010 | 0                | TYPE_LIMIT | TIF_GTC | p2-2      |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000040 | 0                | TYPE_LIMIT | TIF_GTC | p3-2      |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000015 | 1                | TYPE_LIMIT | TIF_GTC | p1-2      |
     Then the mark price should be "3500000015" for the market "DAI/DEC22"
     And debug detailed orderbook volumes for market "DAI/DEC22"
     And debug market data for "DAI/DEC22"
@@ -115,3 +115,9 @@ Feature: Replicate unexpected margin issues.
     And debug transfers
     And debug orderbook volumes for market "DAI/DEC22"
     And debug detailed orderbook volumes for market "DAI/DEC22"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party1 | p1-1      |
+    Then debug detailed orderbook volumes for market "DAI/DEC22"
+    And debug market data for "DAI/DEC22"

--- a/integration/features/liquidity-provision/unexpected-auction.feature
+++ b/integration/features/liquidity-provision/unexpected-auction.feature
@@ -1,0 +1,108 @@
+Feature: Replicate unexpected margin issues.
+
+  Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | DAI | 5              |
+    And the log normal risk model named "dai-lognormal-risk":
+      | risk aversion | tau         | mu | r | sigma |
+      | 0.00001       | 0.000114077 | 0  | 0 | 0.41  |
+    And the markets:
+      | id        | quote name | asset | risk model         | margin calculator         | auction duration | fees         | price monitoring | oracle config          | decimal places |
+      | DAI/DEC22 | DAI        | DAI   | dai-lognormal-risk | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 5              |
+    And the following network parameters are set:
+      | name                              | value |
+      | market.auction.minimumDuration    | 1     |
+      | market.stake.target.scalingFactor | 10    |
+
+  @Lewis
+  Scenario: Attempt to recreate margin drain for LP
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+      | party3          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | buy  | BID              | 10         | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | buy  | BID              | 10         | 20     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | sell | ASK              | 10         | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | sell | ASK              | 10         | 20     | lp-1      | submission |
+      # Balances (DAI): 110000000000
+
+    ## Let's start trading, set a mark price ~3.5bln
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000010 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000020 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party3 |
+    And the mark price should be "3500000005" for the market "DAI/DEC22"
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | search    | initial   | release   |
+      | party1 | DAI/DEC22 | 138578718   | 152436589 | 166294461 | 194010205 |
+      | party2 | DAI/DEC22 | 136014608   | 149616068 | 163217529 | 190420451 |
+      | party3 | DAI/DEC22 | 138578733   | 152436606 | 166294479 | 194010226 |
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 3500000020 | 1      |
+      | sell | 3500000030 | 1      |
+      | sell | 3500000040 | 1      |
+      | buy  | 3499999980 | 1      |
+      | buy  | 3499999990 | 1      |
+      | buy  | 3500000000 | 1      |
+
+    Then debug detailed orderbook volumes for market "DAI/DEC22"
+    And clear transfer response events
+    
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000020 | 0                | TYPE_LIMIT | TIF_GTC | party3-3  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000020 | 1                | TYPE_LIMIT | TIF_GTC | party2-3  |
+    Then the mark price should be "3500000020" for the market "DAI/DEC22"
+
+    ## Always keep track of what's going on
+    Then debug detailed orderbook volumes for market "DAI/DEC22"
+    And clear transfer response events
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000015 | 0                | TYPE_LIMIT | TIF_GTC |
+      | party3 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | DAI/DEC22 | buy  | 1      | 3499999960 | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | DAI/DEC22 | sell | 1      | 3500000010 | 0                | TYPE_LIMIT | TIF_GTC |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000040 | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | DAI/DEC22 | sell | 1      | 3500000015 | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the mark price should be "3500000015" for the market "DAI/DEC22"
+    And debug detailed orderbook volumes for market "DAI/DEC22"
+    And debug market data for "DAI/DEC22"
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | search    | initial   | release   |
+      | party1 | DAI/DEC22 | 207868082   | 228654890 | 249441698 | 291015314 |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     |
+      | party1 | DAI/DEC22 | buy  | 1      | 3500000020 | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the mark price should be "3500000020" for the market "DAI/DEC22"
+    And debug detailed orderbook volumes for market "DAI/DEC22"
+    And debug market data for "DAI/DEC22"
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | search    | initial   | release   |
+      | party1 | DAI/DEC22 | 138578719   | 152436590 | 166294462 | 194010206 |
+
+    Then debug transfers
+    And debug detailed orderbook volumes for market "DAI/DEC22"
+    And debug market data for "DAI/DEC22"
+
+    And clear transfer response events
+    Then debug accounts
+    And debug market data for "DAI/DEC22"
+    And debug transfers
+    And debug orderbook volumes for market "DAI/DEC22"
+    And debug detailed orderbook volumes for market "DAI/DEC22"

--- a/integration/features/liquidity-provision/unexpected-auction.feature
+++ b/integration/features/liquidity-provision/unexpected-auction.feature
@@ -25,10 +25,10 @@ Feature: Replicate unexpected margin issues.
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
-      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | buy  | BID              | 10         | 10     | lp-1      | submission |
-      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | buy  | BID              | 10         | 20     | lp-1      | submission |
-      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | sell | ASK              | 10         | 10     | lp-1      | submission |
-      | lp1 | party1 | DAI/DEC22 | 20000000          | 0.01 | sell | ASK              | 10         | 20     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | buy  | BID              | 10         | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | buy  | BID              | 10         | 20     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | sell | ASK              | 10         | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | sell | ASK              | 10         | 20     | lp-1      | submission |
       # Balances (DAI): 110000000000
 
     ## Let's start trading, set a mark price ~3.5bln
@@ -45,17 +45,17 @@ Feature: Replicate unexpected margin issues.
       | party2 | 3500000000 | 1    | party3 |
     And the mark price should be "3500000005" for the market "DAI/DEC22"
     And the parties should have the following margin levels:
-      | party  | market id | maintenance | search    | initial   | release   |
-      | party1 | DAI/DEC22 | 138578718   | 152436589 | 166294461 | 194010205 |
-      | party2 | DAI/DEC22 | 136014608   | 149616068 | 163217529 | 190420451 |
-      | party3 | DAI/DEC22 | 138578733   | 152436606 | 166294479 | 194010226 |
+      | party  | market id | maintenance | search    | initial   | release    |
+      | party1 | DAI/DEC22 | 831472306   | 914619536 | 997766767 | 1164061228 |
+      | party2 | DAI/DEC22 | 136014608   | 149616068 | 163217529 | 190420451  |
+      | party3 | DAI/DEC22 | 138578733   | 152436606 | 166294479 | 194010226  |
     And the order book should have the following volumes for market "DAI/DEC22":
       | side | price      | volume |
       | sell | 3500000020 | 1      |
-      | sell | 3500000030 | 1      |
-      | sell | 3500000040 | 1      |
-      | buy  | 3499999980 | 1      |
-      | buy  | 3499999990 | 1      |
+      | sell | 3500000030 | 6      |
+      | sell | 3500000040 | 6      |
+      | buy  | 3499999980 | 6      |
+      | buy  | 3499999990 | 6      |
       | buy  | 3500000000 | 1      |
 
     Then debug detailed orderbook volumes for market "DAI/DEC22"
@@ -83,13 +83,13 @@ Feature: Replicate unexpected margin issues.
     And debug detailed orderbook volumes for market "DAI/DEC22"
     And debug market data for "DAI/DEC22"
     And the parties should have the following margin levels:
-      | party  | market id | maintenance | search    | initial   | release   |
-      | party1 | DAI/DEC22 | 207868082   | 228654890 | 249441698 | 291015314 |
+      | party  | market id | maintenance | search    | initial    | release    |
+      | party1 | DAI/DEC22 | 900761672   | 990837839 | 1080914006 | 1261066340 |
     And debug detailed orderbook volumes for market "DAI/DEC22"
 
     And the liquidity provisions should have the following states:
       | id  | party  | market    | commitment amount | status        |
-      | lp1 | party1 | DAI/DEC22 | 20000000          | STATUS_ACTIVE |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | STATUS_ACTIVE |
 
     When the parties place the following orders:
       | party  | market id | side | volume | price      | resulting trades | type       | tif     |
@@ -98,11 +98,11 @@ Feature: Replicate unexpected margin issues.
     And debug detailed orderbook volumes for market "DAI/DEC22"
     And debug market data for "DAI/DEC22"
     And the parties should have the following margin levels:
-      | party  | market id | maintenance | search    | initial   | release   |
-      | party1 | DAI/DEC22 | 138578719   | 152436590 | 166294462 | 194010206 |
+      | party  | market id | maintenance | search    | initial    | release    |
+      | party1 | DAI/DEC22 | 884094922   | 972504414 | 1060913906 | 1237732890 |
     And the liquidity provisions should have the following states:
       | id  | party  | market    | commitment amount | status        |
-      | lp1 | party1 | DAI/DEC22 | 20000000          | STATUS_ACTIVE |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | STATUS_ACTIVE |
     And debug detailed liquidity provision events
 
     Then debug transfers

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -363,6 +363,10 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		steps.DebugLPs(execsetup.broker, execsetup.log)
 		return nil
 	})
+	s.Step(`^debug detailed liquidity provision events$`, func() error {
+		steps.DebugLPDetail(execsetup.log, execsetup.broker)
+		return nil
+	})
 	s.Step(`^debug orderbook volumes for market "([^"]*)"$`, func(mkt string) error {
 		return steps.DebugVolumesForMarket(execsetup.log, execsetup.broker, mkt)
 	})

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -366,10 +366,17 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^debug orderbook volumes for market "([^"]*)"$`, func(mkt string) error {
 		return steps.DebugVolumesForMarket(execsetup.log, execsetup.broker, mkt)
 	})
+	s.Step(`^debug detailed orderbook volumes for market "([^"]*)"$`, func(mkt string) error {
+		return steps.DebugVolumesForMarketDetail(execsetup.log, execsetup.broker, mkt)
+	})
 
 	// Event steps
 	s.Step(`^clear all events$`, func() error {
 		steps.ClearAllEvents(execsetup.broker)
+		return nil
+	})
+	s.Step(`^clear transfer response events$`, func() error {
+		steps.ClearTransferResponseEvents(execsetup.broker)
 		return nil
 	})
 	s.Step(`^the following events should be emitted"$`, func(table *godog.Table) error {

--- a/integration/steps/clear_events.go
+++ b/integration/steps/clear_events.go
@@ -5,3 +5,7 @@ import "code.vegaprotocol.io/vega/integration/stubs"
 func ClearAllEvents(broker *stubs.BrokerStub) {
 	broker.ClearAllEvents()
 }
+
+func ClearTransferResponseEvents(broker *stubs.BrokerStub) {
+	broker.ClearTransferResponseEvents()
+}

--- a/integration/steps/debug_lps.go
+++ b/integration/steps/debug_lps.go
@@ -1,6 +1,8 @@
 package steps
 
 import (
+	"fmt"
+
 	"code.vegaprotocol.io/vega/integration/stubs"
 	"code.vegaprotocol.io/vega/logging"
 )
@@ -12,4 +14,24 @@ func DebugLPs(broker *stubs.BrokerStub, log *logging.Logger) {
 		p := lp.Proto()
 		log.Infof("LP %s, %#v\n", p.String(), p)
 	}
+}
+
+func DebugLPDetail(log *logging.Logger, broker *stubs.BrokerStub) {
+	log.Info("DUMPING DETAILED LIQUIDITY PROVISION EVENTS")
+	data := broker.GetLPEvents()
+	buys := fmt.Sprintf("\n\t\t|%25s |%10s |%25s |%10s |", "Order ID", "Offset", "Reference", "Proportion")
+	s := fmt.Sprintf("\n\t|%10s |%10s |%20s |%10s |%10s |%20s |", "ID", "Party", "Commitment Amount", "Market", "Fee", "Status")
+	for _, lp := range data {
+		p := lp.Proto()
+		s += fmt.Sprintf("\n\t|%10s |%10s |%20s |%10s |%10s |%20s |", p.Id, p.PartyId, p.CommitmentAmount, p.MarketId, p.Fee, p.Status.String())
+		s += buys + " (buy)"
+		for _, o := range p.Buys {
+			s += fmt.Sprintf("\n\t\t|%25s |%10s |%25s |%10d |", o.OrderId, o.LiquidityOrder.Offset, o.LiquidityOrder.Reference.String(), o.LiquidityOrder.Proportion)
+		}
+		s += buys + " (sell)"
+		for _, o := range p.Sells {
+			s += fmt.Sprintf("\n\t\t|%25s |%10s |%25s |%10d |", o.OrderId, o.LiquidityOrder.Offset, o.LiquidityOrder.Reference.String(), o.LiquidityOrder.Proportion)
+		}
+	}
+	log.Infof("%s\n", s)
 }

--- a/integration/steps/debug_volumes.go
+++ b/integration/steps/debug_volumes.go
@@ -19,3 +19,17 @@ func DebugVolumesForMarket(log *logging.Logger, broker *stubs.BrokerStub, market
 	}
 	return nil
 }
+
+func DebugVolumesForMarketDetail(log *logging.Logger, broker *stubs.BrokerStub, marketID string) error {
+	sell, buy := broker.GetActiveOrderDepth(marketID)
+	s := fmt.Sprintf("\nSELL orders:\n\t|%20s |%10s |%10s |%40s |", "Party", "Volume", "Remaining", "Price")
+	for _, o := range sell {
+		s += fmt.Sprintf("\n\t|%20s |%10d |%10d |%40s |", o.PartyId, o.Size, o.Remaining, o.Price)
+	}
+	s += fmt.Sprintf("\nBUY orders:\n\t|%20s |%10s |%10s |%40s |", "Party", "Volume", "Remaining", "Price")
+	for _, o := range buy {
+		s += fmt.Sprintf("\n\t|%20s |%10d |%10d |%40s |", o.PartyId, o.Size, o.Remaining, o.Price)
+	}
+	log.Infof("%s\n", s)
+	return nil
+}

--- a/integration/steps/market/defaults/oracle-config/default-dai-for-future.json
+++ b/integration/steps/market/defaults/oracle-config/default-dai-for-future.json
@@ -34,4 +34,4 @@
   },
   "quoteName": "DAI",
   "settlementAsset": "DAI"
-},
+}

--- a/integration/steps/market/defaults/oracle-config/default-dai-for-future.json
+++ b/integration/steps/market/defaults/oracle-config/default-dai-for-future.json
@@ -1,5 +1,4 @@
 {
-  "maturity": "2022-12-31T23:59:59Z",
   "oracleSpecForSettlementPrice": {
     "id": "100",
     "pubKeys": ["0x0000"],

--- a/integration/steps/market/defaults/oracle-config/default-dai-for-future.json
+++ b/integration/steps/market/defaults/oracle-config/default-dai-for-future.json
@@ -1,0 +1,38 @@
+{
+  "maturity": "2022-12-31T23:59:59Z",
+  "oracleSpecForSettlementPrice": {
+    "id": "100",
+    "pubKeys": ["0x0000"],
+    "filters": [
+      {
+        "key": {
+          "name": "price.DAI.value",
+          "type": "TYPE_INTEGER"
+        },
+        "conditions": [
+        ]
+      }
+    ],
+    "status": "STATUS_UNSPECIFIED"
+  },
+  "oracleSpecForTradingTermination": {
+    "pubKeys": ["0x0000"],
+    "filters": [
+      {
+        "key": {
+          "name": "price.DAI.value",
+          "type": "TYPE_INTEGER"
+        },
+        "conditions": [
+        ]
+      }
+    ],
+    "status": "STATUS_UNSPECIFIED"
+  },
+  "oracleSpecBinding": {
+    "settlementPriceProperty": "price.DAI.value",
+    "tradingTerminationProperty": "price.DAI.value"
+  },
+  "quoteName": "DAI",
+  "settlementAsset": "DAI"
+},

--- a/integration/steps/market/oracle_configs.go
+++ b/integration/steps/market/oracle_configs.go
@@ -18,6 +18,7 @@ var (
 	defaultOracleConfigFileNames = []string{
 		"defaults/oracle-config/default-eth-for-future.json",
 		"defaults/oracle-config/default-usd-for-future.json",
+		"defaults/oracle-config/default-dai-for-future.json",
 	}
 )
 

--- a/integration/stubs/broker_stub.go
+++ b/integration/stubs/broker_stub.go
@@ -253,7 +253,8 @@ func (b *BrokerStub) GetActiveOrderDepth(marketID string) (sell []*types.Order, 
 		}
 		sell = append(sell, ord)
 	}
-	return
+
+	return sell, buy
 }
 
 func (b *BrokerStub) GetMarket(marketID string) *types.Market {

--- a/integration/stubs/broker_stub.go
+++ b/integration/stubs/broker_stub.go
@@ -166,6 +166,13 @@ func (b *BrokerStub) ClearAllEvents() {
 	b.mu.Unlock()
 }
 
+func (b *BrokerStub) ClearTransferResponseEvents() {
+	b.mu.Lock()
+	cs := make([]events.Event, 0, len(b.data[events.TransferResponses]))
+	b.data[events.TransferResponses] = cs
+	b.mu.Unlock()
+}
+
 func (b *BrokerStub) GetBookDepth(market string) (sell map[string]uint64, buy map[string]uint64) {
 	batch := b.GetImmBatch(events.OrderEvent)
 	if len(batch) == 0 {
@@ -207,6 +214,46 @@ func (b *BrokerStub) GetBookDepth(market string) (sell map[string]uint64, buy ma
 	}
 
 	return sell, buy
+}
+
+func (b *BrokerStub) GetActiveOrderDepth(marketID string) (sell []*types.Order, buy []*types.Order) {
+	batch := b.GetImmBatch(events.OrderEvent)
+	if len(batch) == 0 {
+		return nil, nil
+	}
+	active := make(map[string]*types.Order, len(batch))
+	for _, e := range batch {
+		var ord *types.Order
+		switch et := e.(type) {
+		case *events.Order:
+			ord = et.Order()
+		case events.Order:
+			ord = et.Order()
+		default:
+			continue
+		}
+		if ord.MarketId != marketID {
+			continue
+		}
+		if ord.Status == types.Order_STATUS_ACTIVE {
+			active[ord.Id] = ord
+		} else {
+			delete(active, ord.Id)
+		}
+	}
+	c := len(active) / 2
+	if len(active)%2 == 1 {
+		c++
+	}
+	sell, buy = make([]*types.Order, 0, c), make([]*types.Order, 0, c)
+	for _, ord := range active {
+		if ord.Side == types.Side_SIDE_BUY {
+			buy = append(buy, ord)
+			continue
+		}
+		sell = append(sell, ord)
+	}
+	return
 }
 
 func (b *BrokerStub) GetMarket(marketID string) *types.Market {

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -757,7 +757,7 @@ func (e *Engine) createOrdersFromShape(
 			// we check if the order was not nil, which mean we already had a deployed order
 			// if the order as not traded, and the size haven't changed, then we have nothing
 			// to do about it. If the size has changed, then we will want to recreate one.
-			(order != nil && (!order.HasTraded() && order.Size == o.LiquidityImpliedVolume)) ||
+			(order != nil && (!order.HasTraded() && order.Size == o.LiquidityImpliedVolume && order.Price.EQ(o.Price))) ||
 			// we check o.Price == 0 just to make sure we are able to price
 			// the order, in which case the size will have been calculated
 			// properly by the engine.


### PR DESCRIPTION
Fix a bug where LP orders disappeared when new orders were placed. This changed a lot of integration tests, as the order book had more orders on it and the trades, mark price, and margin requirements changed.

Fixes #4796 