### PR TITLE
Fix snapshot issues (4820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - [4776](https://github.com/vegaprotocol/vega/pull/4776) - Add testing for auction state changes and remove unnecessary market state change
 - [4590](https://github.com/vegaprotocol/vega/pull/4590) - Added verification of uint market data in integration test
 - [4749](https://github.com/vegaprotocol/vega/pull/4794) - Fixed issue where LP orders did not get redeployed
+- [4820](https://github.com/vegaprotocol/vega/pull/4820) - Snapshot fixes for market + update market tracker on trades
 
 ## 0.47.6
 *2022-02-01*

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -379,6 +379,7 @@ func (e *Engine) submitMarket(ctx context.Context, marketConfig *types.Market) e
 		e.stateVarEngine,
 		e.feesTracker,
 		ad,
+		e.marketTracker,
 	)
 	if err != nil {
 		e.log.Error("failed to instantiate market",

--- a/execution/engine_snapshot.go
+++ b/execution/engine_snapshot.go
@@ -81,6 +81,8 @@ func (e *Engine) restoreMarket(ctx context.Context, em *types.ExecMarket) (*Mark
 		e.broker,
 		e.stateVarEngine,
 		ad,
+		e.feesTracker,
+		e.marketTracker,
 	)
 	if err != nil {
 		e.log.Error("failed to instantiate market",

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -721,7 +721,7 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 	maxP := maxPrice.Representation()
 	// now we have to ensure that the min price is ceil'ed, and max price is floored
 	// if the market decimal places != asset decimals (indicated by priceFactor == 1)
-	if m.priceFactor.NEQ(m.one) {
+	if m.priceFactor.NEQ(one) {
 		// if min == 0, don't add 1
 		if !minP.IsZero() {
 			minP.Div(minP, m.priceFactor)

--- a/execution/market.go
+++ b/execution/market.go
@@ -90,6 +90,8 @@ var (
 	ErrCannotStartOpeningAuctionForMarketNotInProposedState = errors.New("cannot start the opening auction for a market not in proposed state")
 	// ErrCannotRepriceDuringAuction.
 	ErrCannotRepriceDuringAuction = errors.New("cannot reprice during auction")
+
+	one = num.One()
 )
 
 // PriceMonitor interface to handle price monitoring/auction triggers
@@ -199,7 +201,6 @@ type Market struct {
 
 	markPrice   *num.Uint
 	priceFactor *num.Uint
-	one         *num.Uint
 
 	// own engines
 	matching           *matching.CachedOrderBook
@@ -248,6 +249,7 @@ type Market struct {
 	stateVarEngine StateVarEngine
 	stateChanged   bool
 	feesTracker    *FeesTracker
+	marketTracker  *MarketTracker
 }
 
 // SetMarketID assigns a deterministic pseudo-random ID to a Market.
@@ -293,6 +295,7 @@ func NewMarket(
 	stateVarEngine StateVarEngine,
 	feesTracker *FeesTracker,
 	assetDetails *assets.Asset,
+	marketTracker *MarketTracker,
 ) (*Market, error) {
 	if len(mkt.ID) == 0 {
 		return nil, ErrEmptyMarketID
@@ -412,8 +415,8 @@ func NewMarket(
 		stateVarEngine:            stateVarEngine,
 		feesTracker:               feesTracker,
 		priceFactor:               priceFactor,
-		one:                       num.NewUint(1), // this is just some optimisation when checking price factor == 1
 		minLPStakeQuantumMultiple: num.MustDecimalFromString("1"),
+		marketTracker:             marketTracker,
 	}
 
 	liqEngine.SetGetStaticPricesFunc(market.getBestStaticPrices)
@@ -503,8 +506,8 @@ func (m *Market) GetMarketData() types.MarketData {
 	for _, b := range bounds {
 		m.priceToMarketPrecision(b.MaxValidPrice) // effictively floors this
 		m.priceToMarketPrecision(b.MinValidPrice)
-		if m.priceFactor.NEQ(m.one) {
-			b.MinValidPrice.AddSum(m.one) // ceil
+		if m.priceFactor.NEQ(one) {
+			b.MinValidPrice.AddSum(one) // ceil
 		}
 	}
 
@@ -1544,9 +1547,9 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 			}
 			// add trade to settlement engine for correct MTM settlement of individual trades
 			m.settlement.AddTrade(trade)
-			m.feeSplitter.AddTradeValue(num.Zero().Mul(
-				num.NewUint(trade.Size), trade.Price,
-			))
+			tradeValue := num.Zero().Mul(num.NewUint(trade.Size), trade.Price)
+			m.feeSplitter.AddTradeValue(tradeValue)
+			m.marketTracker.AddValueTraded(m.mkt.ID, tradeValue)
 		}
 		m.broker.SendBatch(tradeEvts)
 

--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -39,6 +39,8 @@ func NewMarketFromSnapshot(
 	broker Broker,
 	stateVarEngine StateVarEngine,
 	assetDetails *assets.Asset,
+	feesTracker *FeesTracker,
+	marketTracker *MarketTracker,
 ) (*Market, error) {
 	mkt := em.Market
 
@@ -142,6 +144,8 @@ func NewMarketFromSnapshot(
 		priceFactor:                priceFactor,
 		lastMarketValueProxy:       em.LastMarketValueProxy,
 		lastEquityShareDistributed: time.Unix(0, em.LastEquityShareDistributed),
+		feesTracker:                feesTracker,
+		marketTracker:              marketTracker,
 	}
 
 	market.tradableInstrument.Instrument.Product.NotifyOnTradingTerminated(market.tradingTerminated)

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -187,7 +187,7 @@ func (tm *testMarket) Run(ctx context.Context, mktCfg types.Market) *testMarket 
 	feeTracker := execution.NewFeesTracker(epochEngine)
 	mktEngine, err := execution.NewMarket(ctx,
 		tm.log, riskConfig, positionConfig, settlementConfig, matchingConfig,
-		feeConfig, liquidityConfig, collateralEngine, oracleEngine, &mktCfg, tm.now, tm.broker, mas, statevarEngine, feeTracker, cfgAsset,
+		feeConfig, liquidityConfig, collateralEngine, oracleEngine, &mktCfg, tm.now, tm.broker, mas, statevarEngine, feeTracker, cfgAsset, execution.NewMarketTracker(),
 	)
 	require.NoError(tm.t, err)
 
@@ -384,7 +384,7 @@ func getTestMarket2WithDP(
 
 	mktEngine, err := execution.NewMarket(context.Background(),
 		log, riskConfig, positionConfig, settlementConfig, matchingConfig,
-		feeConfig, liquidityConfig, collateralEngine, oracleEngine, mktCfg, now, broker, mas, statevar, feeTracker, cfgAsset)
+		feeConfig, liquidityConfig, collateralEngine, oracleEngine, mktCfg, now, broker, mas, statevar, feeTracker, cfgAsset, execution.NewMarketTracker())
 	assert.NoError(t, err)
 	mktEngine.UpdateRiskFactorsForTest()
 

--- a/types/num/uint.go
+++ b/types/num/uint.go
@@ -15,6 +15,7 @@ var (
 	// initialise max variable.
 	maxUint = setMaxUint()
 	zero    = NewUint(0)
+	one     = NewUint(1)
 )
 
 // Uint A wrapper for a big unsigned int.
@@ -26,6 +27,10 @@ type Uint struct {
 // uint64 passed as a parameter.
 func NewUint(val uint64) *Uint {
 	return &Uint{*uint256.NewInt(val)}
+}
+
+func One() *Uint {
+	return one.Clone()
 }
 
 func Zero() *Uint {


### PR DESCRIPTION
Closes #4820 

1. Added num.One() to num 
2. Removed one from the market as member and made it a global as suggested in the ticket
3. Pass fees tracker and market tracker when loading from snapshot
4. Update market tracker on traded volume