### PR TITLE
Feature/fix margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 - [4823](https://github.com/vegaprotocol/vega/issues/4823) - simplified performance score
 - [4805](https://github.com/vegaprotocol/vega/issues/4805) - Add command line tool to sign for the asset pool method `set_bridge_address`
 - [4839](https://github.com/vegaprotocol/vega/issues/4839) - Send governance events when restoring proposals on checkpoint reload.
+- [4829](https://github.com/vegaprotocol/vega/issues/4829) - Fix margins calculations for positions with a size of 0 but with a non zero potential sell or buy
+
 
 ### 🐛 Fixes
 - [4798](https://github.com/vegaprotocol/vega/pull/4798) - Fix panic in loading topology from snapshot

--- a/execution/market.go
+++ b/execution/market.go
@@ -1557,6 +1557,13 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 		if !end {
 			orderUpdates = m.confirmMTM(ctx, conf.Order)
 		}
+	} else {
+		// we had no trade, but still want to register this position in the settlement
+		// engine I guess
+		party := conf.Order.Party
+		if pos, ok := m.position.GetPositionByPartyID(party); ok {
+			m.settlement.AddPosition(party, pos)
+		}
 	}
 
 	return orderUpdates

--- a/integration/features/closeout-margin-plus-iPool-greater-than-cost-of-closeout.feature
+++ b/integration/features/closeout-margin-plus-iPool-greater-than-cost-of-closeout.feature
@@ -412,20 +412,3 @@ Scenario: case 2 using lognomal risk model
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error |
       | party1 | ETH/DEC19 | sell | 400    | 100   | 0                | TYPE_LIMIT | TIF_GTC | ref-1     | margin check failed |
-
-    # # all general acc balance goes to margin account for the order, 'party1' should have 100*100*3
-    # #in the margin account as its Position*Markprice*Initialfactor
-    # And the parties should have the following account balances:
-    #   | party  | asset | market id | margin   | general   |
-    #   | party1 | USD   | ETH/DEC19 | 30000    |  0    |
-    # Then the parties should have the following margin levels:
-    #   | party  | market id | maintenance | search | initial | release  |
-    #   | party1 | ETH/DEC19 | 29273       | 35127  | 43909   | 58546    |
-
-    #  # then party2 places an order, this trades with party1 and we calculate the margins again
-    #  When the parties place the following orders:
-    #    | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
-    #    | party2 | ETH/DEC19 | buy  | 500    | 100   | 1                | TYPE_LIMIT | TIF_GTC | ref-1     |
-
-    # And the mark price should be "100" for the market "ETH/DEC19"
-    # And the insurance pool balance should be "23500" for the market "ETH/DEC19"

--- a/integration/features/closeout-margin-plus-iPool-greater-than-cost-of-closeout.feature
+++ b/integration/features/closeout-margin-plus-iPool-greater-than-cost-of-closeout.feature
@@ -1,0 +1,431 @@
+Feature: Test closeout type 1: margin >= cost of closeout
+
+#   Scenario: case 1 (using simple risk model) from https://docs.google.com/spreadsheets/d/1CIPH0aQmIKj6YeFW9ApP_l-jwB4OcsNQ/edit#gid=1555964910
+#   Background:
+
+#     And the simple risk model named "simple-risk-model-1":
+#       | long | short | max move up | min move down | probability of trading |
+#       | 1    | 2     | 100         | -100          | 0.1                    |
+
+#     And the margin calculator named "margin-calculator-1":
+#       | search factor | initial factor | release factor |
+#       | 2             | 3              | 5              |
+
+#     And the markets:
+#       | id        | quote name | asset | risk model          | margin calculator   | auction duration | fees         | price monitoring | oracle config          |
+#       | ETH/DEC19 | USD        | USD   | simple-risk-model-1 | margin-calculator-1 | 1                | default-none | default-none     | default-eth-for-future |
+#     And the following network parameters are set:
+#       | name                           | value |
+#       | market.auction.minimumDuration | 1     |
+
+# # setup accounts
+#     Given the initial insurance pool balance is "15000" for the markets:
+#     Given the parties deposit on asset's general account the following amount:
+#       | party            | asset | amount     |
+#       | sellSideProvider | USD   | 1000000000 |
+#       | buySideProvider  | USD   | 1000000000 |
+#       | party1           | USD   | 30000      |
+#       | party2           | USD   | 50000000   |
+#       | party3           | USD   | 30000      |
+#       | aux1             | USD   | 1000000000 |
+#       | aux2             | USD   | 1000000000 |
+
+#     # And the cumulated balance for all accounts should be worth "4050060000"
+#     # Then "party1" should have general account balance of "30000" for asset "USD"
+#     # setup order book
+#     When the parties place the following orders:
+#       | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+#       | sellSideProvider | ETH/DEC19 | sell | 1000   | 150   | 0                | TYPE_LIMIT | TIF_GTC | sell-provider-1 |
+#       | aux1             | ETH/DEC19 | sell | 1      | 300   | 0                | TYPE_LIMIT | TIF_GTC | aux-s-1         |
+#       | aux1             | ETH/DEC19 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | aux-s-2         |
+#       | aux2             | ETH/DEC19 | buy  | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | aux-b-2         |
+#       | buySideProvider  | ETH/DEC19 | buy  | 1000   | 80    | 0                | TYPE_LIMIT | TIF_GTC | buy-provider-1  |
+#       | aux2             | ETH/DEC19 | buy  | 1      | 20    | 0                | TYPE_LIMIT | TIF_GTC | aux-b-1         |
+#     Then the parties should have the following account balances:
+#       | party            | asset | market id | margin    | general     |
+#       | aux1             | USD   | ETH/DEC19 | 3600      |  999996400  |
+#       | aux2             | USD   | ETH/DEC19 | 960       |  999999040  |
+#       | sellSideProvider | USD   | ETH/DEC19 | 2700000   |  997300000  |
+#       | buySideProvider  | USD   | ETH/DEC19 | 540000    |  999460000  |
+
+#     Then the opening auction period ends for market "ETH/DEC19"
+#     #And the mark price should be "100" for the market "ETH/DEC19"
+#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+#     # party 1 place an order + we check margins
+#     When the parties place the following orders:
+#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | party1 | ETH/DEC19 | sell | 100    | 100   | 0                | TYPE_LIMIT | TIF_GTC | ref-1     |
+
+#     # all general acc balance goes to margin account for the order, 'party1' should have 100*100*3
+#     # in the margin account as its Position*Markprice*Initialfactor
+
+#      # then party2 places an order, this trades with party1 and we calculate the margins again
+#      When the parties place the following orders:
+#        | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#        | party2 | ETH/DEC19 | buy  | 100    | 100   | 1                | TYPE_LIMIT | TIF_GTC | ref-1     |
+
+#     And the mark price should be "100" for the market "ETH/DEC19"
+#     And the insurance pool balance should be "15000" for the market "ETH/DEC19"
+
+#     #check margin account and margin level
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin   | general   |
+#       | party1 | USD   | ETH/DEC19 | 30000    |  0        |
+#       | party2 | USD   | ETH/DEC19 | 30000    |  49970000 |
+
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party1 | ETH/DEC19 | 25000       | 50000  | 75000   | 125000   |
+#       | party2 | ETH/DEC19 | 12000       | 24000  | 36000   | 60000    |
+
+#     When the parties place the following orders:
+#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | party2 | ETH/DEC19 | buy  | 1      | 126   | 0                | TYPE_LIMIT | TIF_GTC | ref-1-xxx |
+
+#     # New margin level calculated after placing an order
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party2 | ETH/DEC19 | 12100       | 24200  | 36300   | 60500    |
+
+#     # Margin account balance brought up to new initial level as order is placed (despite all balance being above search level)
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin | general   |
+#       | party2 | USD   | ETH/DEC19 | 36300  |  49963700 |
+
+#     When the parties place the following orders:
+#      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#      | party3 | ETH/DEC19 | sell | 1      | 126   | 1                | TYPE_LIMIT | TIF_GTC | ref-1-xxx |
+#     Then the mark price should be "126" for the market "ETH/DEC19"
+#     And the insurance pool balance should be "40000" for the market "ETH/DEC19"
+
+#     # Margin account balance not updated following a trade (above search)
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party2 | ETH/DEC19 | 17372       | 34744  | 52116   | 86860    |
+
+#     # MTM win transfer
+#     Then the following transfers should happen:
+#       | from   | to     | from account            | to account          | market id | amount | asset |
+#       | market | party2 | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN | ETH/DEC19 | 2600   | USD   |
+
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin | general   |
+#       | party2 | USD   | ETH/DEC19 | 38900  |  49963700 |
+
+#     Then the parties should have the following margin levels:
+#     #check margin account and margin level
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party1 | ETH/DEC19 | 0           | 0      | 0       | 0        |
+#       | party2 | ETH/DEC19 | 17372       | 34744  | 52116   | 86860    |
+#       | party3 | ETH/DEC19 | 276         | 552    | 828     | 1380     |
+
+
+#     Then the order book should have the following volumes for market "ETH/DEC19":
+#       | side | price    | volume |
+#       | sell | 150      | 900   |
+#       | sell | 300      | 1      |
+#       | buy  | 80       | 1000   |
+#       | buy  | 20       | 1      |
+
+#     Then the mark price should be "126" for the market "ETH/DEC19"
+#     And the insurance pool balance should be "40000" for the market "ETH/DEC19"
+
+#     Then the parties should have the following account balances:
+#       | party            | asset | market id | margin    | general     |
+#       | party1           | USD   | ETH/DEC19 | 0         |  0          |
+#       | party2           | USD   | ETH/DEC19 | 38900     |  49963700   |
+#       | party3           | USD   | ETH/DEC19 | 600       |  29400      |
+#       | aux1             | USD   | ETH/DEC19 | 1324      |  999998650  |
+#       | aux2             | USD   | ETH/DEC19 | 986       |  999999040  |
+#       | sellSideProvider | USD   | ETH/DEC19 | 758400    |  999244000  |
+#       | buySideProvider  | USD   | ETH/DEC19 | 540000    |  999460000  |
+
+#    And the cumulated balance for all accounts should be worth "4050075000"
+#    And the insurance pool balance should be "40000" for the market "ETH/DEC19"
+
+#     # order book volume change
+#     Then the parties cancel the following orders:
+#       | party           | reference        |
+#       | sellSideProvider|  sell-provider-1 |
+#       | buySideProvider | buy-provider-1   |
+
+#     When the parties place the following orders:
+#       | party            | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | sellSideProvider | ETH/DEC19 | sell | 1000   | 500   | 0                | TYPE_LIMIT | TIF_GTC | sell-provider-2 |
+#       | buySideProvider  | ETH/DEC19 | buy  | 1000   | 20    | 0                | TYPE_LIMIT | TIF_GTC | buy-provider-2  |
+
+#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+#     #check margin account and margin level
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin   | general   |
+#       | party2 | USD   | ETH/DEC19 | 38900    |  49963700 |
+#       | party3 | USD   | ETH/DEC19 | 600      |  29400    |
+
+#      Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release |
+#       | party2 | ETH/DEC19 | 17372       | 34744  | 52116   | 86860   |
+#       | party3 | ETH/DEC19 | 276         | 552    | 828     | 1380    |
+
+#     When the parties place the following orders:
+#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | party2 | ETH/DEC19 | buy  | 50     | 30    | 0                | TYPE_LIMIT | TIF_GTC | ref-2-xxx |
+
+#      Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release |
+#       | party2 | ETH/DEC19 | 29732       | 59464  | 89196   | 148660  |
+
+#     #check margin account and margin level
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin   | general   |
+#       | party2 | USD   | ETH/DEC19 | 89196    |  49913404 |
+#       | party3 | USD   | ETH/DEC19 | 600      |  29400    |
+
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party2 | ETH/DEC19 | 29732       | 59464  | 89196   | 148660   |
+#       | party3 | ETH/DEC19  | 276        | 552    | 828     | 1380     |
+
+#     When the parties place the following orders:
+#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | party3 | ETH/DEC19 | sell | 50     | 30    | 1                | TYPE_LIMIT | TIF_GTC | ref-3-xxx |
+#     And the insurance pool balance should be "40000" for the market "ETH/DEC19"
+#     Then the mark price should be "30" for the market "ETH/DEC19"
+#     # Then the order book should have the following volumes for market "ETH/DEC19":
+#       | side | price    | volume |
+#       | sell | 500      | 1000   |
+#       | sell | 300      | 1      |
+#       | buy  | 20       | 1001   |
+
+#     Then the parties should have the following profit and loss:
+#       | party  | volume | unrealised pnl | realised pnl |
+#       | party3 | -51    | 96             | 0            |
+
+#     #check margin account and margin level
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin   | general   |
+#       | party2 | USD   | ETH/DEC19 | 18120    | 49974784  |
+#       | party3 | USD   | ETH/DEC19 | 30096    |  0        |
+
+#     # party3 maintenance margin: position*(mark_price*risk_factor_short+slippage_per_unit) + mark_price*risk_factor_short=51*(30*2+466)+0=26826
+#     # (slippage calulated as follows) slippager_per_unit=exit_price-mark_price=(300*1+500*50)/51-30=496-30=466
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party2 | ETH/DEC19 | 6040        | 12080  | 18120   | 30200    |
+#       | party3 | ETH/DEC19 | 26826       | 53652  | 80478   | 134130   |
+
+#     Then the order book should have the following volumes for market "ETH/DEC19":
+#       | side | price    | volume |
+#       | sell | 500      | 1000   |
+#       | sell | 300      | 1      |
+
+#     When the parties place the following orders:
+#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | party3 | ETH/DEC19 | sell | 50     | 30    | 0                | TYPE_LIMIT | TIF_GTC | ref-3-xxx |
+
+#     # party3 maintenance margin: position*(mark_price*risk_factor_short+slippage_per_unit) + open_order*mark_price*risk_factor_short=51*(30*2+466) + 50 * 30 * 2 = 26826 + 3000 = 29826
+#     # (slippage calulated as follows) slippager_per_unit=exit_price-mark_price=(300*1+500*50)/51-30=496-30=466
+
+#     # party3 has put the order twice
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party3 | ETH/DEC19 | 29826       | 59652  | 89478   | 149130   |
+
+#     Then the order book should have the following volumes for market "ETH/DEC19":
+#       | side | price    | volume |
+#       | sell | 500      | 1000   |
+#       | sell | 300      | 1      |
+#       | sell | 30       | 50     |
+#       | buy  | 20       | 1001   |
+
+#     And the insurance pool balance should be "40000" for the market "ETH/DEC19"
+
+#     #check margin account and margin level
+#     And the parties should have the following account balances:
+#       | party  | asset | market id | margin   | general   |
+#       | party2 | USD   | ETH/DEC19 | 18120    | 49974784  |
+#       | party3 | USD   | ETH/DEC19 | 30096    |  0        |
+
+#     Then the parties should have the following margin levels:
+#       | party  | market id | maintenance | search | initial | release  |
+#       | party2 | ETH/DEC19 | 6040        | 12080  | 18120   | 30200    |
+#       | party3 | ETH/DEC19 | 29826       | 59652  | 89478   | 149130   |
+
+#     When the parties place the following orders:
+#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+#       | party2 | ETH/DEC19 | buy  | 50     | 30    | 1                | TYPE_LIMIT | TIF_GTC | ref-2-xxx |
+
+#     And the insurance pool balance should be "22826" for the market "ETH/DEC19"
+
+#      #party3 gets closeout with MTM
+#     And the parties should have the following account balances:
+#         | party  | asset | market id | margin   | general   |
+#         | party1 | USD   | ETH/DEC19 | 0        |  0        |
+#         | party2 | USD   | ETH/DEC19 | 22620   |  49970284 |
+#         | party3 | USD   | ETH/DEC19 | 0        |  0        |
+
+#     Then the parties should have the following profit and loss:
+#        | party  | volume | unrealised pnl | realised pnl |
+#        | party1 | 0      | 0              | -30000       |
+#        | party2 | 201    | -7096          | 0            |
+#        | party3 | 0      | 0              | -30000       |
+
+Scenario: case 2 using lognomal risk model
+  Background:
+
+    And the log normal risk model named "lognormal-risk-model-fish":
+      | risk aversion | tau  | mu | r     | sigma |
+      | 0.001         | 0.01 | 0  | 0.0   | 1.2   |
+      #calculated risk factor long: 0.336895684; risk factor short: 0.4878731
+
+    And the price monitoring updated every "1" seconds named "price-monitoring-1":
+      | horizon | probability | auction extension |
+      | 1       | 0.99999999  | 300               |
+
+    And the margin calculator named "margin-calculator-1":
+      | search factor | initial factor | release factor |
+      | 1.2           | 1.5            | 2              |
+
+    And the markets:
+      | id        | quote name | asset | risk model                | margin calculator   | auction duration | fees         | price monitoring  | oracle config          |
+      | ETH/DEC19 | ETH        | USD   | lognormal-risk-model-fish | margin-calculator-1 | 1                | default-none | default-none | default-eth-for-future |
+
+    And the following network parameters are set:
+      | name                           | value |
+      | market.auction.minimumDuration | 1     |
+
+# setup accounts
+    Given the initial insurance pool balance is "15000" for the markets:
+    Given the parties deposit on asset's general account the following amount:
+      | party            | asset | amount     |
+      | sellSideProvider | USD   | 1000000000 |
+      | buySideProvider  | USD   | 1000000000 |
+      | party1           | USD   | 30000      |
+      | party2           | USD   | 50000000   |
+      | party3           | USD   | 30000      |
+      | aux1             | USD   | 1000000000 |
+      | aux2             | USD   | 1000000000 |
+     #And the cumulated balance for all accounts should be worth "4050075000"
+# setup order book
+    When the parties place the following orders:
+      | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+      | sellSideProvider | ETH/DEC19 | sell | 1000   | 150   | 0                | TYPE_LIMIT | TIF_GTC | sell-provider-1 |
+     # | party1           | ETH/DEC19 | sell | 100    | 120   | 0                | TYPE_LIMIT | TIF_GTC | party1-s-1      |
+      | aux1             | ETH/DEC19 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | aux-s-2         |
+      | aux2             | ETH/DEC19 | buy  | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | aux-b-2         |
+      | party2           | ETH/DEC19 | buy  | 100    | 80    | 0                | TYPE_LIMIT | TIF_GTC | party2-b-1      |
+      | buySideProvider  | ETH/DEC19 | buy  | 1000   | 70    | 0                | TYPE_LIMIT | TIF_GTC | buy-provider-1  |
+
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the mark price should be "100" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+   # party1 maintenance margin: position*(mark_price*risk_factor_short+slippage_per_unit) + OrderVolume x Order_price x risk_factor_short  = 100 x 100 x 0.4878731  is about 4879
+
+    When the parties place the following orders:
+      | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+      | party1           | ETH/DEC19 | sell | 100    | 120   | 0                | TYPE_LIMIT | TIF_GTC | party1-s-1      |
+
+ # party1 margin account: MarginInitialFactor x MaintenanceMarginLevel = 4879*1.5
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 7318   |  22682   |
+
+ # party1 maintenance margin level: position*(mark_price*risk_factor_short+slippage_per_unit) + OrderVolume x Mark_price x risk_factor_short  = 100 x 100 x 0.4878731  is about 4879
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 4879        | 5854   | 7318    | 9758     |
+
+  # party1 place more order volume 300
+    When the parties place the following orders:
+      | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+      | party1           | ETH/DEC19 | sell | 300    | 120   | 0                | TYPE_LIMIT | TIF_GTC | party1-s-1      |
+
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 29272  |  728     |
+
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 19515       | 23418  | 29272   | 39030    |
+
+    And the order book should have the following volumes for market "ETH/DEC19":
+      | side | price | volume |
+      | sell | 150   | 1000   |
+      | sell | 120   | 400    |
+      | buy  | 80    | 100    |
+      | buy  | 70    | 1000   |
+
+    And the mark price should be "100" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    #########################################
+    #MTM closeout party1
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | aux1   | ETH/DEC19 | sell | 1      | 110   | 0                | TYPE_LIMIT | TIF_GTC | ref-4     |
+      | aux2   | ETH/DEC19 | buy  | 1      | 110   | 1                | TYPE_LIMIT | TIF_GTC | ref-5     |
+
+    # margin on order should be mark_price x volume x rf = 110 x 400 x 0.4878731 = 21466
+    # which is not what we see below; the number below corresponds to mark price of 100
+
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 21467       | 25760  | 32200   | 42934    |
+
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 29272  |  728     |
+
+    And the mark price should be "110" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | aux1   | ETH/DEC19 | buy  | 1      | 119   | 0                | TYPE_LIMIT | TIF_GTC | ref-4     |
+      | aux2   | ETH/DEC19 | sell | 1      | 119   | 1                | TYPE_LIMIT | TIF_GTC | ref-2     |
+
+    And the mark price should be "119" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    And the order book should have the following volumes for market "ETH/DEC19":
+      | side | price | volume |
+      | sell | 150   | 1000   |
+      | sell | 120   | 400    |
+      | buy  | 80    | 100    |
+      | buy  | 70    | 1000   |
+
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 29272  |  728     |
+
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 23223       | 27867  | 34834   | 46446    |
+
+    Then the parties should have the following profit and loss:
+      | party           | volume | unrealised pnl | realised pnl |
+      | party1          | 0      | 0              | 0            |
+
+    # party 1 place an order + we check margins
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error |
+      | party1 | ETH/DEC19 | sell | 400    | 100   | 0                | TYPE_LIMIT | TIF_GTC | ref-1     | margin check failed |
+
+    # # all general acc balance goes to margin account for the order, 'party1' should have 100*100*3
+    # #in the margin account as its Position*Markprice*Initialfactor
+    # And the parties should have the following account balances:
+    #   | party  | asset | market id | margin   | general   |
+    #   | party1 | USD   | ETH/DEC19 | 30000    |  0    |
+    # Then the parties should have the following margin levels:
+    #   | party  | market id | maintenance | search | initial | release  |
+    #   | party1 | ETH/DEC19 | 29273       | 35127  | 43909   | 58546    |
+
+    #  # then party2 places an order, this trades with party1 and we calculate the margins again
+    #  When the parties place the following orders:
+    #    | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+    #    | party2 | ETH/DEC19 | buy  | 500    | 100   | 1                | TYPE_LIMIT | TIF_GTC | ref-1     |
+
+    # And the mark price should be "100" for the market "ETH/DEC19"
+    # And the insurance pool balance should be "23500" for the market "ETH/DEC19"

--- a/integration/features/margin/614-margin-calculations-fixes.feature
+++ b/integration/features/margin/614-margin-calculations-fixes.feature
@@ -51,8 +51,8 @@ Feature: test bugfix 614 for margin calculations
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general |
       | tamlyn  | ETH   | ETH/DEC19 | 3952   | 6104    |
-      | chris   | ETH   | ETH/DEC19 | 3760   | 6240    |
+      | chris   | ETH   | ETH/DEC19 | 5600   | 4400    |
       | edd     | ETH   | ETH/DEC19 | 5456   | 4544    |
       | barney  | ETH   | ETH/DEC19 | 992    | 8952    |
-      | rebecca | ETH   | ETH/DEC19 | 3760   | 6240    |
+      | rebecca | ETH   | ETH/DEC19 | 5600   | 4400    |
     And the cumulated balance for all accounts should be worth "2051000"

--- a/integration/features/parties-margin-with-0-pos-cleared-on-cancel.feature
+++ b/integration/features/parties-margin-with-0-pos-cleared-on-cancel.feature
@@ -1,0 +1,151 @@
+Feature: Close potential positions
+
+  Scenario: Cancel all order from party with only potential position release all margins
+  Background:
+
+    And the log normal risk model named "lognormal-risk-model-fish":
+      | risk aversion | tau  | mu | r     | sigma |
+      | 0.001         | 0.01 | 0  | 0.0   | 1.2   |
+      #calculated risk factor long: 0.336895684; risk factor short: 0.4878731
+
+    And the price monitoring updated every "1" seconds named "price-monitoring-1":
+      | horizon | probability | auction extension |
+      | 1       | 0.99999999  | 300               |
+
+    And the margin calculator named "margin-calculator-1":
+      | search factor | initial factor | release factor |
+      | 1.2           | 1.5            | 2              |
+
+    And the markets:
+      | id        | quote name | asset | risk model                | margin calculator   | auction duration | fees         | price monitoring  | oracle config          |
+      | ETH/DEC19 | ETH        | USD   | lognormal-risk-model-fish | margin-calculator-1 | 1                | default-none | default-none | default-eth-for-future |
+
+    And the following network parameters are set:
+      | name                           | value |
+      | market.auction.minimumDuration | 1     |
+
+# setup accounts
+    Given the initial insurance pool balance is "15000" for the markets:
+    Given the parties deposit on asset's general account the following amount:
+      | party            | asset | amount     |
+      | sellSideProvider | USD   | 1000000000 |
+      | buySideProvider  | USD   | 1000000000 |
+      | party1           | USD   | 30000      |
+      | party2           | USD   | 50000000   |
+      | party3           | USD   | 30000      |
+      | aux1             | USD   | 1000000000 |
+      | aux2             | USD   | 1000000000 |
+     #And the cumulated balance for all accounts should be worth "4050075000"
+# setup order book
+    When the parties place the following orders:
+      | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+      | sellSideProvider | ETH/DEC19 | sell | 1000   | 150   | 0                | TYPE_LIMIT | TIF_GTC | sell-provider-1 |
+     # | party1           | ETH/DEC19 | sell | 100    | 120   | 0                | TYPE_LIMIT | TIF_GTC | party1-s-1      |
+      | aux1             | ETH/DEC19 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | aux-s-2         |
+      | aux2             | ETH/DEC19 | buy  | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | aux-b-2         |
+      | party2           | ETH/DEC19 | buy  | 100    | 80    | 0                | TYPE_LIMIT | TIF_GTC | party2-b-1      |
+      | buySideProvider  | ETH/DEC19 | buy  | 1000   | 70    | 0                | TYPE_LIMIT | TIF_GTC | buy-provider-1  |
+
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the mark price should be "100" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+   # party1 maintenance margin: position*(mark_price*risk_factor_short+slippage_per_unit) + OrderVolume x Order_price x risk_factor_short  = 100 x 100 x 0.4878731  is about 4879
+
+    When the parties place the following orders:
+      | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+      | party1           | ETH/DEC19 | sell | 100    | 120   | 0                | TYPE_LIMIT | TIF_GTC | party1-s-1      |
+
+ # party1 margin account: MarginInitialFactor x MaintenanceMarginLevel = 4879*1.5
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 7318   |  22682   |
+
+ # party1 maintenance margin level: position*(mark_price*risk_factor_short+slippage_per_unit) + OrderVolume x Mark_price x risk_factor_short  = 100 x 100 x 0.4878731  is about 4879
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 4879        | 5854   | 7318    | 9758     |
+
+  # party1 place more order volume 300
+    When the parties place the following orders:
+      | party            | market id | side | volume | price | resulting trades | type       | tif     | reference       |
+      | party1           | ETH/DEC19 | sell | 300    | 120   | 0                | TYPE_LIMIT | TIF_GTC | party1-s-2      |
+
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 29272  |  728     |
+
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 19515       | 23418  | 29272   | 39030    |
+
+    And the order book should have the following volumes for market "ETH/DEC19":
+      | side | price | volume |
+      | sell | 150   | 1000   |
+      | sell | 120   | 400    |
+      | buy  | 80    | 100    |
+      | buy  | 70    | 1000   |
+
+    And the mark price should be "100" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | aux1   | ETH/DEC19 | sell | 1      | 110   | 0                | TYPE_LIMIT | TIF_GTC | ref-4     |
+      | aux2   | ETH/DEC19 | buy  | 1      | 110   | 1                | TYPE_LIMIT | TIF_GTC | ref-5     |
+
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 21467       | 25760  | 32200   | 42934    |
+
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 29272  |  728     |
+
+    ### At this point party1 have not traded and should have a position of 0
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party1 | 0      | 0              | 0            |
+
+    And the mark price should be "110" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    ### Now we cancel the party1 orders
+    Then the parties cancel the following orders:
+      | party  | reference  |
+      | party1 | party1-s-1 |
+
+    ### balances are reduced (not)
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 29272  |  728     |
+
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 21467       | 25760  | 32200   | 42934    |
+
+    ### cancel the last order
+    Then the parties cancel the following orders:
+      | party  | reference  |
+      | party1 | party1-s-2 |
+
+    ### balance are 0 out
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 0      | 30000    |
+
+    ### still same margin levels
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release  |
+      | party1 | ETH/DEC19 | 21467       | 25760  | 32200   | 42934    |
+
+    ### then we place new orders and get a trade
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | aux1   | ETH/DEC19 | sell | 1      | 130   | 0                | TYPE_LIMIT | TIF_GTC | ref-4     |
+      | aux2   | ETH/DEC19 | buy  | 1      | 130   | 1                | TYPE_LIMIT | TIF_GTC | ref-5     |
+
+    ### balance are still 0
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin | general  |
+      | party1  | USD   | ETH/DEC19 | 0      | 30000    |

--- a/integration/features/release-margins-issues-decimals.feature
+++ b/integration/features/release-margins-issues-decimals.feature
@@ -173,7 +173,7 @@ Feature: Test margin release on order cancel
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | partyGuy | ETH   | ETH/DEC19 | 120000 | 0       |
+      | partyGuy | ETH   | ETH/DEC19 | 60000  | 60000   |
 
   Scenario: a party place a new order in the system, party is closing position via closeout of other parties
     Given the parties deposit on asset's general account the following amount:
@@ -248,4 +248,3 @@ Feature: Test margin release on order cancel
     Then the parties should have the following profit and loss:
       | party        | volume | unrealised pnl | realised pnl |
       | partyGuyGood | 0      | 0              | 9000000      |
-

--- a/integration/features/release-margins-issues.feature
+++ b/integration/features/release-margins-issues.feature
@@ -169,7 +169,7 @@ Feature: Test margin release on order cancel
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | partyGuy | ETH   | ETH/DEC19 | 120    | 0       |
+      | partyGuy | ETH   | ETH/DEC19 | 60     | 60      |
 
   Scenario: a party place a new order in the system, party is closing position via closeout of other parties
     Given the parties deposit on asset's general account the following amount:

--- a/integration/features/verified/closeout-cascade.feature
+++ b/integration/features/verified/closeout-cascade.feature
@@ -1,6 +1,6 @@
 Feature: Closeout-cascades
 # This is a test case to demonstrate that closeout cascade does NOT happen. In this test case, trader3 gets closed
-# out first after buying volume 50 at price 100, and then trader3's position is sold (via the network counterparty) to trader2 whose order is first in the order book 
+# out first after buying volume 50 at price 100, and then trader3's position is sold (via the network counterparty) to trader2 whose order is first in the order book
 # (volume 50 price 50)
 # At this moment, trader2 is under margin but the fuse breaks (if the mark price is actually updated from 100 to 50)
 # however, the design of the system is like a fuse and circuit breaker, the mark price will NOT update, so trader2 will not be closed out
@@ -9,7 +9,7 @@ Feature: Closeout-cascades
 
     And the margin calculator named "margin-calculator-1":
       | search factor | initial factor | release factor |
-      | 1.5           | 2              | 3              | 
+      | 1.5           | 2              | 3              |
     And the markets:
       | id        | quote name | asset | risk model                  | margin calculator   | auction duration | fees         | price monitoring | oracle config          |
       | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | margin-calculator-1 | 1                | default-none | default-none     | default-eth-for-future |
@@ -17,22 +17,22 @@ Feature: Closeout-cascades
       | name                           | value |
       | market.auction.minimumDuration | 1     |
 
-  Scenario: Distressed position gets taken over by another party whose margin level is insufficient to support it (however mark price doesn't get updated on closeout trade and hence no further closeouts are carried out) 
+  Scenario: Distressed position gets taken over by another party whose margin level is insufficient to support it (however mark price doesn't get updated on closeout trade and hence no further closeouts are carried out)
    # setup accounts, we are trying to closeout trader3 first and then trader2
-    
+
     Given the insurance pool balance should be "0" for the market "ETH/DEC19"
-    
+
     Given the parties deposit on asset's general account the following amount:
       | party        | asset | amount        |
       | auxiliary1   | BTC   | 1000000000000 |
       | auxiliary2   | BTC   | 1000000000000 |
-      | trader2      | BTC   | 150           |
+      | trader2      | BTC   | 2000          |
       | trader3      | BTC   | 100           |
 
-    Then the cumulated balance for all accounts should be worth "2000000000250"
+    Then the cumulated balance for all accounts should be worth "2000000002100"
 
   # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
-  # trading happens at the end of the open auction period 
+  # trading happens at the end of the open auction period
     Then the parties place the following orders:
       | party     | market id | side | volume | price  | resulting trades| type       | tif     | reference |
       | auxiliary2| ETH/DEC19 | buy  | 5      | 5      | 0               | TYPE_LIMIT | TIF_GTC | aux-b-5    |
@@ -44,62 +44,65 @@ Feature: Closeout-cascades
     Then the auction ends with a traded volume of "10" at a price of "10"
     And the mark price should be "10" for the market "ETH/DEC19"
 
-    And the cumulated balance for all accounts should be worth "2000000000250"
+    And the cumulated balance for all accounts should be worth "2000000002100"
 
     # setup trader2 position to be ready to takeover trader3's position once trader3 is closed out
-    When the parties place the following orders: 
+    When the parties place the following orders:
       | party     | market id | side | volume| price | resulting trades | type       | tif     | reference      |
       | trader2   | ETH/DEC19 | buy  | 50    | 50    | 0                | TYPE_LIMIT | TIF_GTC | buy-position-3 |
-     
+
     And the parties should have the following margin levels:
       | party     | market id  | maintenance | search | initial | release |
       | trader2   | ETH/DEC19  | 50          | 75     | 100     | 150     |
 
     Then the parties should have the following account balances:
       | party   | asset | market id | margin   | general |
-      | trader2 | BTC   | ETH/DEC19 | 100      | 50      |
-    
-    And the cumulated balance for all accounts should be worth "2000000000250"
+      | trader2 | BTC   | ETH/DEC19 | 100      | 1900    |
+
+    And the cumulated balance for all accounts should be worth "2000000002100"
 
     # setup trader3 position and close it out
-    When the parties place the following orders: 
+    When the parties place the following orders:
       | party      | market id | side | volume| price | resulting trades | type       | tif     | reference      |
       | trader3    | ETH/DEC19 | buy  | 50    | 100   | 0                | TYPE_LIMIT | TIF_GTC | buy-position-3 |
       | auxiliary1 | ETH/DEC19 | sell | 50    | 100   | 1                | TYPE_LIMIT | TIF_GTC | sell-provider-1|
       | auxiliary2 | ETH/DEC19 | buy  | 50    | 10    | 0                | TYPE_LIMIT | TIF_GTC | sell-provider-1|
 
     And the mark price should be "100" for the market "ETH/DEC19"
-       Then debug transfers
-    # trader3 got close-out, trader3's order has been sold to network, and then trader2 bought the order from the network 
-    # as it had the highest buy price 
+    Then debug transfers
+    # trader3 got close-out, trader3's order has been sold to network, and then trader2 bought the order from the network
+    # as it had the highest buy price
+
+    Then debug trades
+    Then debug orders
     And the following trades should be executed:
-      | buyer   | price | size | seller  | 
-      | network |  50   | 50   | trader3 | 
-      | trader2 |  50   | 50   | network | 
+      | buyer   | price | size | seller  |
+      | network |  50   | 50   | trader3 |
+      | trader2 |  50   | 50   | network |
 
     And the mark price should be "100" for the market "ETH/DEC19"
 
-    And the cumulated balance for all accounts should be worth "2000000000250"
+    And the cumulated balance for all accounts should be worth "2000000002100"
 
-    # check that trader3 is closed-out but trader2 is not 
+    # check that trader3 is closed-out but trader2 is not
     And the parties should have the following margin levels:
       | party   | market id | maintenance | search | initial | release |
-      | trader2 | ETH/DEC19 | 50          | 75     | 100     | 150     |
+      | trader2 | ETH/DEC19 | 500          | 750     | 1000     | 1500     |
       | trader3 | ETH/DEC19 | 0           | 0      | 0       | 0       |
-     Then the parties should have the following profit and loss: 
+     Then the parties should have the following profit and loss:
       | party   | volume | unrealised pnl | realised pnl |
       | trader2 | 50     | 2500           | -2400        |
       | trader3 | 0      | 0              | -100         |
 
     # check trader2 margin level, trader2 is not closed-out yet since new mark price is not updated
-    # eventhough  trader2 does not have enough margin 
+    # eventhough  trader2 does not have enough margin
     Then the parties should have the following account balances:
       | party      | asset | market id | margin    | general      |
-      | trader2    | BTC   | ETH/DEC19 | 200       | 50           |
+      | trader2    | BTC   | ETH/DEC19 | 1100       | 1000           |
       | trader3    | BTC   | ETH/DEC19 | 0         | 0            |
       | auxiliary1 | BTC   | ETH/DEC19 | 109400    | 999999889700 |
       | auxiliary2 | BTC   | ETH/DEC19 | 3200      | 999999997700 |
-     
+
     # setup new mark price, which is the same as when trader2 traded with network
     Then the parties place the following orders:
       | party     | market id | side | volume | price  | resulting trades| type       | tif     | reference |
@@ -108,10 +111,10 @@ Feature: Closeout-cascades
 
     And the mark price should be "50" for the market "ETH/DEC19"
 
-    #trader2 got closed-out 
+    #trader2 got closed-out
     Then the parties should have the following profit and loss:
       | party   | volume | unrealised pnl | realised pnl |
-      | trader2 | 0      | 0              | -150         |
+      | trader2 | 0      | 0              | -2000         |
 
     And the parties should have the following margin levels:
       | party   | market id | maintenance | search | initial | release |
@@ -121,9 +124,9 @@ Feature: Closeout-cascades
 
     Then the parties should have the following profit and loss:
       | party           | volume | unrealised pnl | realised pnl |
-      | trader2         | 0      |     0          | -150         |
-      | trader3         | 0      |     0          | -100         | 
-      | auxiliary1      | -70    |  2100          | -2250        |
+      | trader2         | 0      |     0          | -2000         |
+      | trader3         | 0      |     0          | -100         |
+      | auxiliary1      | -70    |  2100          | -400        |
       | auxiliary2      |  70    |  2400          | -2000        |
 
     Then the order book should have the following volumes for market "ETH/DEC19":
@@ -134,5 +137,3 @@ Feature: Closeout-cascades
       | buy  | 50       | 0      |
       | buy  | 10       | 0      |
       | buy  | 5        | 5      |
-      
-    

--- a/integration/features/verified/insurance-pool-balance-test.feature
+++ b/integration/features/verified/insurance-pool-balance-test.feature
@@ -8,8 +8,8 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | 1    | 2     | 100         | -100          | 0.1                    |
 
     And the margin calculator named "margin-calculator-1":
-      | search factor | initial factor | release factor | 
-      | 2             | 3              | 5              | 
+      | search factor | initial factor | release factor |
+      | 2             | 3              | 5              |
 
     And the markets:
       | id        | quote name | asset | risk model          | margin calculator   | auction duration | fees         | price monitoring | oracle config          |
@@ -45,7 +45,7 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | aux2             | USD   | ETH/DEC19 | 960       |  999999040  |
       | sellSideProvider | USD   | ETH/DEC19 | 2700000   |  997300000  |
       | buySideProvider  | USD   | ETH/DEC19 | 540000    |  999460000  |
-      
+
     Then the opening auction period ends for market "ETH/DEC19"
     And the mark price should be "100" for the market "ETH/DEC19"
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
@@ -54,17 +54,17 @@ Feature: Test closeout type 1: margin >= cost of closeout
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party1 | ETH/DEC19 | sell | 100    | 100   | 0                | TYPE_LIMIT | TIF_GTC | ref-1     |
-    
-    # all general acc balance goes to margin account for the order, 'party1' should have 100*100*3 
+
+    # all general acc balance goes to margin account for the order, 'party1' should have 100*100*3
     # in the margin account as its Position*Markprice*Initialfactor
 
      # then party2 places an order, this trades with party1 and we calculate the margins again
      When the parties place the following orders:
        | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
        | party2 | ETH/DEC19 | buy  | 100    | 100   | 1                | TYPE_LIMIT | TIF_GTC | ref-1     |
-    
+
     And the mark price should be "100" for the market "ETH/DEC19"
-    And the insurance pool balance should be "15000" for the market "ETH/DEC19" 
+    And the insurance pool balance should be "15000" for the market "ETH/DEC19"
 
     #check margin account and margin level
     And the parties should have the following account balances:
@@ -80,7 +80,7 @@ Feature: Test closeout type 1: margin >= cost of closeout
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party2 | ETH/DEC19 | buy  | 1      | 126   | 0                | TYPE_LIMIT | TIF_GTC | ref-1-xxx |
-  
+
     # New margin level calculated after placing an order
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release  |
@@ -90,12 +90,12 @@ Feature: Test closeout type 1: margin >= cost of closeout
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   |
       | party2 | USD   | ETH/DEC19 | 36300  |  49963700 |
-  
+
     When the parties place the following orders:
      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
      | party3 | ETH/DEC19 | sell | 1      | 126   | 1                | TYPE_LIMIT | TIF_GTC | ref-1-xxx |
-    Then the mark price should be "126" for the market "ETH/DEC19"    
-    And the insurance pool balance should be "40000" for the market "ETH/DEC19" 
+    Then the mark price should be "126" for the market "ETH/DEC19"
+    And the insurance pool balance should be "40000" for the market "ETH/DEC19"
 
     # Margin account balance not updated following a trade (above search)
     Then the parties should have the following margin levels:
@@ -106,7 +106,7 @@ Feature: Test closeout type 1: margin >= cost of closeout
     Then the following transfers should happen:
       | from   | to     | from account            | to account          | market id | amount | asset |
       | market | party2 | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN | ETH/DEC19 | 2600   | USD   |
- 
+
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   |
       | party2 | USD   | ETH/DEC19 | 38900  |  49963700 |
@@ -125,8 +125,8 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | buy  | 80       | 1000   |
       | buy  | 20       | 1      |
 
-    Then the mark price should be "126" for the market "ETH/DEC19"   
-    And the insurance pool balance should be "40000" for the market "ETH/DEC19" 
+    Then the mark price should be "126" for the market "ETH/DEC19"
+    And the insurance pool balance should be "40000" for the market "ETH/DEC19"
 
     Then the parties should have the following account balances:
       | party            | asset | market id | margin    | general     |
@@ -135,11 +135,11 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | party3           | USD   | ETH/DEC19 | 600       |  29400      |
       | aux1             | USD   | ETH/DEC19 | 1324      |  999998650  |
       | aux2             | USD   | ETH/DEC19 | 986       |  999999040  |
-      | sellSideProvider | USD   | ETH/DEC19 | 758400    |  999244000  |
-      | buySideProvider  | USD   | ETH/DEC19 | 540000    |  999460000  |
+      | sellSideProvider | USD   | ETH/DEC19 | 602400    |  999400000  |
+      | buySideProvider  | USD   | ETH/DEC19 | 300000    |  999700000  |
 
-   And the cumulated balance for all accounts should be worth "4050075000" 
-   And the insurance pool balance should be "40000" for the market "ETH/DEC19" 
+   And the cumulated balance for all accounts should be worth "4050075000"
+   And the insurance pool balance should be "40000" for the market "ETH/DEC19"
 
     # order book volume change
     Then the parties cancel the following orders:
@@ -187,8 +187,8 @@ Feature: Test closeout type 1: margin >= cost of closeout
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party3 | ETH/DEC19 | sell | 50     | 30    | 1                | TYPE_LIMIT | TIF_GTC | ref-3-xxx |
-    And the insurance pool balance should be "40000" for the market "ETH/DEC19" 
-    Then the mark price should be "30" for the market "ETH/DEC19"  
+    And the insurance pool balance should be "40000" for the market "ETH/DEC19"
+    Then the mark price should be "30" for the market "ETH/DEC19"
     # Then the order book should have the following volumes for market "ETH/DEC19":
       | side | price    | volume |
       | sell | 500      | 1000   |
@@ -224,7 +224,7 @@ Feature: Test closeout type 1: margin >= cost of closeout
     # party3 maintenance margin: position*(mark_price*risk_factor_short+slippage_per_unit) + open_order*mark_price*risk_factor_short=51*(30*2+466) + 50 * 30 * 2 = 26826 + 3000 = 29826
     # (slippage calulated as follows) slippager_per_unit=exit_price-mark_price=(300*1+500*50)/51-30=496-30=466
 
-    # party3 has put the order twice 
+    # party3 has put the order twice
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release  |
       | party3 | ETH/DEC19 | 29826       | 59652  | 89478   | 149130   |
@@ -235,8 +235,8 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | sell | 300      | 1      |
       | sell | 30       | 50     |
       | buy  | 20       | 1001   |
-  
-    And the insurance pool balance should be "40000" for the market "ETH/DEC19" 
+
+    And the insurance pool balance should be "40000" for the market "ETH/DEC19"
 
     #check margin account and margin level
     And the parties should have the following account balances:
@@ -253,9 +253,9 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party2 | ETH/DEC19 | buy  | 50     | 30    | 1                | TYPE_LIMIT | TIF_GTC | ref-2-xxx |
 
-    And the insurance pool balance should be "22826" for the market "ETH/DEC19" 
+    And the insurance pool balance should be "22826" for the market "ETH/DEC19"
 
-     #party3 gets closeout with MTM 
+     #party3 gets closeout with MTM
     And the parties should have the following account balances:
         | party  | asset | market id | margin   | general   |
         | party1 | USD   | ETH/DEC19 | 0        |  0        |

--- a/settlement/engine.go
+++ b/settlement/engine.go
@@ -245,7 +245,7 @@ func (e *Engine) SettleMTM(ctx context.Context, markPrice *num.Uint, positions [
 		current.price = markPrice
 		// we don't want to accidentally MTM a party who closed out completely when they open
 		// a new position at a later point, so remove if size == 0
-		if current.size == 0 {
+		if current.size == 0 && current.Buy() == 0 && current.Sell() == 0 {
 			// broke this up into its own func for symmetry
 			e.rmPosition(party)
 		}
@@ -355,6 +355,10 @@ func (e *Engine) getCurrentPosition(party string, evt events.MarketPosition) *po
 		e.pos[party] = p
 	}
 	return p
+}
+
+func (e *Engine) AddPosition(party string, evt events.MarketPosition) {
+	_ = e.getCurrentPosition(party, evt)
 }
 
 func (e *Engine) rmPosition(party string) {


### PR DESCRIPTION
Ensure parties with a position size of 0, but potential buy and/or sell stay in settlement engine, so we can calculate margins for them.

close #4821  