### PR TITLE
remove idgen fields from execution snapshot since they are now genera…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@
 - [4639](https://github.com/vegaprotocol/vega/pull/4639) - Add cancel transfer command
 - [4750](https://github.com/vegaprotocol/vega/pull/4750) - Fix null blockchain by forcing it to always be a non-validator node
 - [4754](https://github.com/vegaprotocol/vega/pull/4754) - Fix null blockchain properly this time
-- [4823](https://github.com/vegaprotocol/vega/pull/4283) - Reward refactoring for network treasury
+- [4754](https://github.com/vegaprotocol/vega/pull/4754) - Remove old id generator fields from execution engine's snapshot
+- [4830](https://github.com/vegaprotocol/vega/pull/4830) - Reward refactoring for network treasury
 - [4647](https://github.com/vegaprotocol/vega/pull/4647) - Added endpoint `SubmitRawTransaction` to provide support for different transaction request message versions
 - [4653](https://github.com/vegaprotocol/vega/issues/4653) - Replace asset insurance pool with network treasury
 - [4638](https://github.com/vegaprotocol/vega/pull/4638) - CI add option to specify connected changes in other repos

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.48.1-0.20220221094950-1e1116d0e983
+	code.vegaprotocol.io/protos v0.48.1-0.20220221113328-2bef6ffb4ee6
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20220202150846-b6aba31dcdb0
 	code.vegaprotocol.io/vegawallet v0.11.2-0.20220203201033-ca5496e787a7

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3 h1:/A09Q3EEiJF+/WiJfKiqzp1zvcWphiYR8lf2N/JSJBU=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:1Gwg5D0PbFEE92Vip8EU0/+n80Kx3GwlGvP850S0op8=
-code.vegaprotocol.io/protos v0.48.1-0.20220221094950-1e1116d0e983 h1:gh7t/dj6pniNluI4XxpwJcmDCxXIbqWay8oEjE9zg0g=
-code.vegaprotocol.io/protos v0.48.1-0.20220221094950-1e1116d0e983/go.mod h1:sGGn35s31oBNLNCC5tFiKtfNEPiKm3UghOKNaO+bq58=
+code.vegaprotocol.io/protos v0.48.1-0.20220221113328-2bef6ffb4ee6 h1:Wsk5qs88a6A5+eokEiT0kDjrXGofDkwup2xBnRZ32eM=
+code.vegaprotocol.io/protos v0.48.1-0.20220221113328-2bef6ffb4ee6/go.mod h1:sGGn35s31oBNLNCC5tFiKtfNEPiKm3UghOKNaO+bq58=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20220128163854-7eab67fa60d2/go.mod h1:pNHKwqRDkotUN0s6jErl7Eb2EpZa2HAf03lyPMTCUT0=

--- a/types/snapshot_nodes.go
+++ b/types/snapshot_nodes.go
@@ -266,10 +266,7 @@ type MatchingBook struct {
 }
 
 type ExecutionMarkets struct {
-	Markets   []*ExecMarket
-	Batches   uint64
-	Orders    uint64
-	Proposals uint64
+	Markets []*ExecMarket
 }
 
 type ExecMarket struct {
@@ -2642,10 +2639,7 @@ func ExecutionMarketsFromProto(em *snapshot.ExecutionMarkets) *ExecutionMarkets 
 		mkts = append(mkts, ExecMarketFromProto(m))
 	}
 	return &ExecutionMarkets{
-		Markets:   mkts,
-		Batches:   em.Batches,
-		Orders:    em.Orders,
-		Proposals: em.Proposals,
+		Markets: mkts,
 	}
 }
 
@@ -2655,10 +2649,7 @@ func (e ExecutionMarkets) IntoProto() *snapshot.ExecutionMarkets {
 		mkts = append(mkts, m.IntoProto())
 	}
 	return &snapshot.ExecutionMarkets{
-		Markets:   mkts,
-		Batches:   e.Batches,
-		Orders:    e.Orders,
-		Proposals: e.Proposals,
+		Markets: mkts,
 	}
 }
 

--- a/types/snapshot_nodes_test.go
+++ b/types/snapshot_nodes_test.go
@@ -436,9 +436,6 @@ func getDummyData() *types.Chunk {
 						CurrentMarkPrice: num.NewUint(10),
 					},
 				},
-				Batches:   0,
-				Orders:    2,
-				Proposals: 2,
 			},
 		},
 	}, &types.Payload{


### PR DESCRIPTION
closes #4774 

IDs are now generated in a different way and so are no longer stored in the snapshot, so we don't need these fields anymore.