### PR TITLE
use the idgen.NextID() in the fake order used for MTM during leaveAuction

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -947,6 +947,7 @@ func (m *Market) leaveAuction(ctx context.Context, now time.Time) {
 	cmp := m.getCurrentMarkPrice()
 	mcmp := num.Zero().Div(cmp, m.priceFactor) // create the market representation of the price
 	m.confirmMTM(ctx, &types.Order{
+		ID:            m.idgen.NextID(),
 		Price:         cmp,
 		OriginalPrice: mcmp,
 	})


### PR DESCRIPTION
The leaveAuction call  run confirmMTM, which in his turn may distress traders. In order to run confirmMTM, we need to send an order (from which only the price is used). This also add an ID so the eventual generated orders in resolvedClosedOutParties then get a proper reference.

without this the references looks like this:
```
LS-
disressed-N-
```
instead of:
```
LS-0CD0B657B50AC3391D78F5F157FB81A2F404114D9616F4A5442087B614905334
distressed-0-0CD0B657B50AC3391D78F5F157FB81A2F404114D9616F4A5442087B614905334
```