### PR TITLE
Send governance events on checkpoint reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - [4801](https://github.com/vegaprotocol/vega/issues/4801) - added acceptance criteria codes to feature tests for Settlement at expiry spec
 - [4823](https://github.com/vegaprotocol/vega/issues/4823) - simplified performance score
 - [4805](https://github.com/vegaprotocol/vega/issues/4805) - Add command line tool to sign for the asset pool method `set_bridge_address`
+- [4839](https://github.com/vegaprotocol/vega/issues/4839) - Send governance events when restoring proposals on checkpoint reload.
 
 ### 🐛 Fixes
 - [4798](https://github.com/vegaprotocol/vega/pull/4798) - Fix panic in loading topology from snapshot

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	code.vegaprotocol.io/protos v0.48.1-0.20220221113328-2bef6ffb4ee6
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20220202150846-b6aba31dcdb0
-	code.vegaprotocol.io/vegawallet v0.11.2-0.20220203201033-ca5496e787a7
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
@@ -52,6 +51,7 @@ require (
 require github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
 
 require (
+	code.vegaprotocol.io/vegawallet v0.12.1-0.20220217130931-e2d76ed75667 // indirect
 	github.com/BurntSushi/toml v1.0.0 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
 	github.com/DataDog/zstd v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3 h1:/A09Q3EEiJF+/WiJfKiqzp1zvcWphiYR8lf2N/JSJBU=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:1Gwg5D0PbFEE92Vip8EU0/+n80Kx3GwlGvP850S0op8=
+code.vegaprotocol.io/protos v0.48.1-0.20220217115305-b24b47ff9ff0/go.mod h1:sGGn35s31oBNLNCC5tFiKtfNEPiKm3UghOKNaO+bq58=
 code.vegaprotocol.io/protos v0.48.1-0.20220221113328-2bef6ffb4ee6 h1:Wsk5qs88a6A5+eokEiT0kDjrXGofDkwup2xBnRZ32eM=
 code.vegaprotocol.io/protos v0.48.1-0.20220221113328-2bef6ffb4ee6/go.mod h1:sGGn35s31oBNLNCC5tFiKtfNEPiKm3UghOKNaO+bq58=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
@@ -63,8 +64,8 @@ code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopw
 code.vegaprotocol.io/shared v0.0.0-20220128163854-7eab67fa60d2/go.mod h1:pNHKwqRDkotUN0s6jErl7Eb2EpZa2HAf03lyPMTCUT0=
 code.vegaprotocol.io/shared v0.0.0-20220202150846-b6aba31dcdb0 h1:vDjKTd508FwIwoSdZBEvtEfmBeaYdodgLM96v253zKI=
 code.vegaprotocol.io/shared v0.0.0-20220202150846-b6aba31dcdb0/go.mod h1:pNHKwqRDkotUN0s6jErl7Eb2EpZa2HAf03lyPMTCUT0=
-code.vegaprotocol.io/vegawallet v0.11.2-0.20220203201033-ca5496e787a7 h1:AtgLoJ8hcMA7tDiNMp/K782jx+ieJx4c8bP6oJZN2Cg=
-code.vegaprotocol.io/vegawallet v0.11.2-0.20220203201033-ca5496e787a7/go.mod h1:LJktKJaUBb5j+NgujjNEUkKtuLItf/M2+nTv39pnONg=
+code.vegaprotocol.io/vegawallet v0.12.1-0.20220217130931-e2d76ed75667 h1:e63TaeSaVFFyZ25w/zN9YFvA16YY6gKs/w4kusaqoJ4=
+code.vegaprotocol.io/vegawallet v0.12.1-0.20220217130931-e2d76ed75667/go.mod h1:rsWI0Juk/XhLkZpgesA9B9/gDRqcJANbKclA9F3Y9Lk=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=

--- a/governance/checkpoint_test.go
+++ b/governance/checkpoint_test.go
@@ -115,6 +115,7 @@ func testCheckpointSuccess(t *testing.T) {
 	eng2 := getTestEngine(t)
 	defer eng2.ctrl.Finish()
 
+	eng2.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
 	// Load checkpoint
 	require.NoError(t, eng2.Load(ctx, data))
 


### PR DESCRIPTION
Closes #4620 by adding events for all restored proposals. Proposals that have expired are omitted, for obvious reasons.