### PR TITLE
Handle local store snapshot versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 - [4839](https://github.com/vegaprotocol/vega/issues/4839) - Send governance events when restoring proposals on checkpoint reload.
 - [4829](https://github.com/vegaprotocol/vega/issues/4829) - Fix margins calculations for positions with a size of 0 but with a non zero potential sell or buy
 - [4826](https://github.com/vegaprotocol/vega/issues/4826) - Tidying up feature tests in verified folder
-
+- [4843](https://github.com/vegaprotocol/vega/issues/4843) - Make snapshot engine aware of local storage old versions, and manage them accoringly to stop growing disk usage.
 
 
 ### 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 - [4839](https://github.com/vegaprotocol/vega/issues/4839) - Send governance events when restoring proposals on checkpoint reload.
 - [4829](https://github.com/vegaprotocol/vega/issues/4829) - Fix margins calculations for positions with a size of 0 but with a non zero potential sell or buy
 - [4826](https://github.com/vegaprotocol/vega/issues/4826) - Tidying up feature tests in verified folder
-- [4843](https://github.com/vegaprotocol/vega/issues/4843) - Make snapshot engine aware of local storage old versions, and manage them accoringly to stop growing disk usage.
+- [4843](https://github.com/vegaprotocol/vega/issues/4843) - Make snapshot engine aware of local storage old versions, and manage them accordingly to stop growing disk usage.
 
 
 ### 🐛 Fixes

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -437,8 +437,8 @@ func (e *Engine) applySnap(ctx context.Context) error {
 		return types.ErrUnknownSnapshot
 	}
 	// this is the current version
-	e.version = e.snapshot.Meta.Version
-	loaded, err := e.avl.LoadVersionForOverwriting(e.version)
+	version := e.snapshot.Meta.Version
+	loaded, err := e.avl.LoadVersionForOverwriting(version)
 	if err != nil {
 		e.log.Error("Failed to load target version",
 			logging.Error(err),
@@ -446,7 +446,7 @@ func (e *Engine) applySnap(ctx context.Context) error {
 		)
 	}
 	// we need the versions of the snapshot to match, regardless of the version we actually loaded
-	e.avl.SetInitialVersion(uint64(e.snapshot.Meta.Version))
+	e.avl.SetInitialVersion(uint64(version))
 	// now let's clear the versions slice and pretend the more recent versions don't exist yet
 	for i := 0; i < len(e.versions); i++ {
 		if e.versions[i] >= loaded {

--- a/validators/topology_snapshot.go
+++ b/validators/topology_snapshot.go
@@ -68,6 +68,7 @@ func (t *Topology) serialiseNodes() []*snapshot.ValidatorState {
 					ExpectedNextHash:      node.heartbeatTracker.expectedNextHash,
 					ExpectedNextHashSince: node.heartbeatTracker.expectedNexthashSince.UnixNano(),
 				},
+				ValidatorPower: node.validatorPower,
 			},
 		)
 	}
@@ -209,6 +210,7 @@ func (t *Topology) restore(ctx context.Context, topology *types.Topology) error 
 				expectedNextHash:      node.HeartbeatTracker.ExpectedNextHash,
 				expectedNexthashSince: time.Unix(0, node.HeartbeatTracker.ExpectedNextHashSince),
 			},
+			validatorPower: node.ValidatorPower,
 		}
 		for i := 0; i < 10; i++ {
 			vs.heartbeatTracker.blockSigs[i] = node.HeartbeatTracker.BlockSigs[i]


### PR DESCRIPTION
The simplest way to ensure old local store versions are managed/maintained by the node regardless of loading from local store, or via state-sync: fetch available versions, remove old ones (determined by slice cap), and add the reloaded version, too.

Addresses #4682 