### PR TITLE
4788 fix snapshots rejected markets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - [4623](https://github.com/vegaprotocol/vega/pull/4623) - Bug fix for `--snapshot.db-path` parameter not being used if it is set
 - [4634](https://github.com/vegaprotocol/vega/pull/4634) - Bug fix for `--snapshot.max-retries` parameter not working correctly
 - [4775](https://github.com/vegaprotocol/vega/pull/4775) - Restore all market fields when restoring from a snapshot
+- [4845](https://github.com/vegaprotocol/vega/pull/4845) - Fix restoring rejected markets by signalling to the generated providers that their parent is dead
 - [4651](https://github.com/vegaprotocol/vega/pull/4651) - An array of fixes in the snapshot code path
 - [4658](https://github.com/vegaprotocol/vega/pull/4658) - Allow replaying a chain from zero when old snapshots exist
 - [4659](https://github.com/vegaprotocol/vega/pull/4659) - Fix liquidity provision commands decode

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ retest: ## Re-run all unit tests
 
 .PHONY: test
 test: ## Run unit tests
-	go test -v ./...
+	go test -v -failfast ./...
 
 .PHONY: integrationtest
 integrationtest: ## run integration tests, showing ledger movements and full scenario output

--- a/assets/snapshot.go
+++ b/assets/snapshot.go
@@ -36,6 +36,10 @@ func (s *Service) Keys() []string {
 	return hashKeys
 }
 
+func (s *Service) Stopped() bool {
+	return false
+}
+
 func (s *Service) serialiseActive() ([]byte, error) {
 	enabled := s.GetEnabledAssets()
 	sort.SliceStable(enabled, func(i, j int) bool { return enabled[i].ID < enabled[j].ID })

--- a/banking/snapshot.go
+++ b/banking/snapshot.go
@@ -49,6 +49,10 @@ func (e *Engine) Keys() []string {
 	return hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) serialiseRecurringTransfers() ([]byte, error) {
 	payload := types.Payload{
 		Data: &types.PayloadBankingRecurringTransfers{

--- a/blockchain/abci/app.go
+++ b/blockchain/abci/app.go
@@ -23,6 +23,7 @@ type replayProtector interface {
 	DeliverTx(Tx) error
 	CheckTx(Tx) error
 	GetReplacement() *ReplayProtector
+	Stopped() bool
 }
 
 type App struct {

--- a/blockchain/abci/replay_protection.go
+++ b/blockchain/abci/replay_protection.go
@@ -137,6 +137,10 @@ func (rp *replayProtectorNoop) Keys() []string {
 	return hashKeys
 }
 
+func (rp *replayProtectorNoop) Stopped() bool {
+	return false
+}
+
 func (rp *replayProtectorNoop) GetHash(_ string) ([]byte, error) {
 	return nil, nil
 }

--- a/blockchain/abci/replay_snapshot.go
+++ b/blockchain/abci/replay_snapshot.go
@@ -35,6 +35,10 @@ func (rp *ReplayProtector) Keys() []string {
 	return hashKeys
 }
 
+func (rp *ReplayProtector) Stopped() bool {
+	return false
+}
+
 func (rp *ReplayProtector) serialiseReplayProtection() ([]byte, error) {
 	blocks := []*types.ReplayBlockTransactions{}
 	for _, block := range rp.txs {

--- a/checkpoint/snapshot.go
+++ b/checkpoint/snapshot.go
@@ -21,6 +21,10 @@ func (e *Engine) Keys() []string {
 	}
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) setNextCP(t time.Time) {
 	e.nextCP = t
 	e.state.Checkpoint.NextCp = t.UnixNano()

--- a/collateral/snapshot.go
+++ b/collateral/snapshot.go
@@ -38,6 +38,10 @@ func (e *Engine) Keys() []string {
 	return e.state.hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) GetHash(k string) ([]byte, error) {
 	return e.state.getHash(k)
 }

--- a/delegation/snapshot.go
+++ b/delegation/snapshot.go
@@ -32,6 +32,10 @@ func (e *Engine) Keys() []string {
 	return hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) serialiseLastReconTime() ([]byte, error) {
 	payload := types.Payload{
 		Data: &types.PayloadDelegationLastReconTime{

--- a/epochtime/snapshot.go
+++ b/epochtime/snapshot.go
@@ -35,6 +35,10 @@ func (s *Svc) Keys() []string {
 	return []string{s.pl.Key()}
 }
 
+func (s *Svc) Stopped() bool {
+	return false
+}
+
 func (s *Svc) GetHash(k string) ([]byte, error) {
 	if k != s.pl.Key() {
 		return nil, types.ErrSnapshotKeyDoesNotExist

--- a/evtforward/snapshot.go
+++ b/evtforward/snapshot.go
@@ -33,6 +33,10 @@ func (f *Forwarder) Keys() []string {
 	return hashKeys
 }
 
+func (f *Forwarder) Stopped() bool {
+	return false
+}
+
 func (f *Forwarder) serialise() ([]byte, error) {
 	// this is done without the lock because nothing can be acked during the commit phase which is when the snapshot is taken
 	keys := make([]string, 0, len(f.ackedEvts))

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -95,6 +95,7 @@ type Engine struct {
 	npv netParamsValues
 
 	// Snapshot
+	stateChanged          bool
 	snapshotSerialised    []byte
 	snapshotHash          []byte
 	newGeneratedProviders []types.StateProvider // new providers generated during the last state change
@@ -474,6 +475,7 @@ func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) err
 }
 
 func (e *Engine) removeMarket(mktID string) {
+	e.stateChanged = true
 	delete(e.markets, mktID)
 	for i, mkt := range e.marketsCpy {
 		if mkt.GetID() == mktID {

--- a/execution/engine_snapshot.go
+++ b/execution/engine_snapshot.go
@@ -149,12 +149,18 @@ func (e *Engine) getSerialiseSnapshotAndHash() (snapshot, hash []byte, providers
 
 	e.snapshotSerialised = s
 	e.snapshotHash = h
+	e.stateChanged = false
 
 	return s, h, pvds, nil
 }
 
 func (e *Engine) changed() bool {
 	if len(e.snapshotSerialised) == 0 {
+		return true
+	}
+
+	if e.stateChanged {
+		e.log.Debug("state-changed in execution engine itself")
 		return true
 	}
 	for _, m := range e.markets {

--- a/execution/engine_snapshot.go
+++ b/execution/engine_snapshot.go
@@ -180,6 +180,10 @@ func (e *Engine) Keys() []string {
 	return []string{marketsKey}
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) GetHash(_ string) ([]byte, error) {
 	_, hash, _, err := e.getSerialiseSnapshotAndHash()
 	if err != nil {

--- a/execution/fees_tracker_snapshot.go
+++ b/execution/fees_tracker_snapshot.go
@@ -33,6 +33,10 @@ func (f *FeesTracker) Keys() []string {
 	return hashKeys
 }
 
+func (f *FeesTracker) Stopped() bool {
+	return false
+}
+
 func assetFeesToProto(partyFees map[string]*num.Uint) []*snapshot.PartyFees {
 	parties := make([]string, 0, len(partyFees))
 	for k := range partyFees {

--- a/execution/market.go
+++ b/execution/market.go
@@ -123,6 +123,7 @@ type TargetStakeCalculator interface {
 	UpdateScalingFactor(sFactor num.Decimal) error
 	UpdateTimeWindow(tWindow time.Duration)
 	Changed() bool
+	StopSnapshots()
 }
 
 type MarketCollateral interface {
@@ -3112,6 +3113,11 @@ func (m *Market) cleanupOnReject(ctx context.Context) {
 			logging.Error(err))
 		return
 	}
+
+	m.matching.StopSnapshots()
+	m.position.StopSnapshots()
+	m.liquidity.StopSnapshots()
+	m.tsCalc.StopSnapshots()
 
 	// then send the responses
 	m.broker.Send(events.NewTransferResponse(ctx, tresps))

--- a/execution/market_tracker_snapshot.go
+++ b/execution/market_tracker_snapshot.go
@@ -33,6 +33,10 @@ func (m *MarketTracker) Keys() []string {
 	return marketTrackerHashKeys
 }
 
+func (m *MarketTracker) Stopped() bool {
+	return false
+}
+
 func (m *MarketTracker) serialiseMarketTracker() []*snapshot.MarketVolumeTracker {
 	markets := make([]string, 0, len(m.marketIDMarketTracker))
 	for k := range m.marketIDMarketTracker {

--- a/governance/snapshot.go
+++ b/governance/snapshot.go
@@ -132,6 +132,10 @@ func (e *Engine) Keys() []string {
 	return hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) GetHash(k string) ([]byte, error) {
 	_, hash, err := e.getSerialisedAndHash(k)
 	return hash, err

--- a/limits/snapshot.go
+++ b/limits/snapshot.go
@@ -72,6 +72,10 @@ func (e *Engine) Keys() []string {
 	return hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) GetHash(k string) ([]byte, error) {
 	_, hash, err := e.getSerialisedAndHash(k)
 	return hash, err

--- a/liquidity/snapshot.go
+++ b/liquidity/snapshot.go
@@ -92,6 +92,10 @@ func (e *SnapshotEngine) Keys() []string {
 	return e.hashKeys
 }
 
+func (e *SnapshotEngine) Stopped() bool {
+	return e.stopped
+}
+
 func (e *SnapshotEngine) OnSuppliedStakeToObligationFactorUpdate(v num.Decimal) {
 	e.parametersChanged = true
 	e.Engine.OnSuppliedStakeToObligationFactorUpdate(v)
@@ -261,7 +265,7 @@ func (e *SnapshotEngine) serialise(k string) ([]byte, []byte, error) {
 	}
 
 	if e.stopped {
-		return nil, nil, types.ErrSnapshotProviderStopped
+		return nil, nil, nil
 	}
 
 	if !changed {

--- a/liquidity/snapshot_test.go
+++ b/liquidity/snapshot_test.go
@@ -223,8 +223,12 @@ func TestStopSnapshotTaking(t *testing.T) {
 	// signal to kill the engine's snapshots
 	te.engine.StopSnapshots()
 
-	_, _, err := te.engine.GetState(keys[0])
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
-	_, err = te.engine.GetHash(keys[0])
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	s, _, err := te.engine.GetState(keys[0])
+	assert.NoError(t, err)
+	assert.Nil(t, s)
+
+	h, err := te.engine.GetHash(keys[0])
+	assert.NoError(t, err)
+	assert.Nil(t, h)
+	assert.True(t, te.engine.Stopped())
 }

--- a/liquidity/snapshot_test.go
+++ b/liquidity/snapshot_test.go
@@ -215,3 +215,16 @@ func TestSnapshotRoundTrip(t *testing.T) {
 		assert.Equalf(t, expectedHashes2[key], hex.EncodeToString(h), "hashes for key %q does not match", key)
 	}
 }
+
+func TestStopSnapshotTaking(t *testing.T) {
+	te := newTestEngine(t, initialTime)
+	keys := te.engine.Keys()
+
+	// signal to kill the engine's snapshots
+	te.engine.StopSnapshots()
+
+	_, _, err := te.engine.GetState(keys[0])
+	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	_, err = te.engine.GetHash(keys[0])
+	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+}

--- a/liquidity/target/snapshot.go
+++ b/liquidity/target/snapshot.go
@@ -29,6 +29,7 @@ type SnapshotEngine struct {
 	*Engine
 	hash    []byte
 	data    []byte
+	stopped bool
 	changed bool
 	buf     *proto.Buffer
 	key     string
@@ -55,6 +56,10 @@ func NewSnapshotEngine(
 		key:     key,
 		keys:    []string{key},
 	}
+}
+
+func (e *SnapshotEngine) StopSnapshots() {
+	e.stopped = true
 }
 
 func (e *SnapshotEngine) Changed() bool {
@@ -154,6 +159,10 @@ func (e *SnapshotEngine) serialisePrevious() []*snapshot.TimestampedOpenInterest
 // serialise marshal the snapshot state, populating the data and hash fields
 // with updated values.
 func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
+	if e.stopped {
+		return nil, nil, types.ErrSnapshotProviderStopped
+	}
+
 	if !e.changed {
 		return e.data, e.hash, nil // we already have what we need
 	}

--- a/liquidity/target/snapshot.go
+++ b/liquidity/target/snapshot.go
@@ -99,6 +99,10 @@ func (e *SnapshotEngine) Keys() []string {
 	return e.keys
 }
 
+func (e *SnapshotEngine) Stopped() bool {
+	return e.stopped
+}
+
 func (e *SnapshotEngine) GetHash(k string) ([]byte, error) {
 	if k != e.key {
 		return nil, types.ErrSnapshotKeyDoesNotExist
@@ -160,7 +164,7 @@ func (e *SnapshotEngine) serialisePrevious() []*snapshot.TimestampedOpenInterest
 // with updated values.
 func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
 	if e.stopped {
-		return nil, nil, types.ErrSnapshotProviderStopped
+		return nil, nil, nil
 	}
 
 	if !e.changed {

--- a/liquidity/target/snapshot_test.go
+++ b/liquidity/target/snapshot_test.go
@@ -65,3 +65,17 @@ func TestSaveAndLoadSnapshot(t *testing.T) {
 	a.NoError(err)
 	a.Equal(h1, h2)
 }
+
+func TestStopSnapshotTaking(t *testing.T) {
+	marketID := "market-1"
+	key := fmt.Sprintf("target:%s", marketID)
+	se := newSnapshotEngine(marketID)
+
+	// signal to kill the engine's snapshots
+	se.StopSnapshots()
+
+	_, _, err := se.GetState(key)
+	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	_, err = se.GetHash(key)
+	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+}

--- a/liquidity/target/snapshot_test.go
+++ b/liquidity/target/snapshot_test.go
@@ -74,8 +74,12 @@ func TestStopSnapshotTaking(t *testing.T) {
 	// signal to kill the engine's snapshots
 	se.StopSnapshots()
 
-	_, _, err := se.GetState(key)
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
-	_, err = se.GetHash(key)
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	s, _, err := se.GetState(key)
+	assert.NoError(t, err)
+	assert.Nil(t, s)
+
+	h, err := se.GetHash(key)
+	assert.NoError(t, err)
+	assert.Nil(t, h)
+	assert.True(t, se.Stopped())
 }

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -41,6 +41,7 @@ type OrderBook struct {
 	batchID                  uint64
 	indicativePriceAndVolume *IndicativePriceAndVolume
 	snapshot                 *types.PayloadMatchingBook
+	stopped                  bool // if true then we should stop creating snapshots
 }
 
 // CumulativeVolumeLevel represents the cumulative volume at a price level for both bid and ask.

--- a/matching/snapshot.go
+++ b/matching/snapshot.go
@@ -19,6 +19,10 @@ func (b *OrderBook) Keys() []string {
 	return []string{b.snapshot.Key()}
 }
 
+func (b *OrderBook) Stopped() bool {
+	return b.stopped
+}
+
 func (b OrderBook) Namespace() types.SnapshotNamespace {
 	return types.MatchingSnapshot
 }
@@ -26,6 +30,10 @@ func (b OrderBook) Namespace() types.SnapshotNamespace {
 func (b *OrderBook) GetHash(key string) ([]byte, error) {
 	if key != b.snapshot.Key() {
 		return nil, types.ErrSnapshotKeyDoesNotExist
+	}
+
+	if b.stopped {
+		return nil, nil
 	}
 
 	payload, _, e := b.GetState(key)
@@ -42,7 +50,7 @@ func (b *OrderBook) GetState(key string) ([]byte, []types.StateProvider, error) 
 	}
 
 	if b.stopped {
-		return nil, nil, types.ErrSnapshotProviderStopped
+		return nil, nil, nil
 	}
 
 	// Copy all the state into a domain object

--- a/matching/snapshot_test.go
+++ b/matching/snapshot_test.go
@@ -198,8 +198,11 @@ func TestStopSnapshotTaking(t *testing.T) {
 	// signal to kill the engine's snapshots
 	ob.ob.StopSnapshots()
 
-	_, _, err = ob.ob.GetState(key)
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
-	_, err = ob.ob.GetHash(key)
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	s, _, err := ob.ob.GetState(key)
+	assert.NoError(t, err)
+	assert.Nil(t, s)
+	h, err := ob.ob.GetHash(key)
+	assert.NoError(t, err)
+	assert.Nil(t, h)
+	assert.True(t, ob.ob.Stopped())
 }

--- a/netparams/snapshot.go
+++ b/netparams/snapshot.go
@@ -120,6 +120,10 @@ func (s *Store) Keys() []string {
 	return s.state.Keys()
 }
 
+func (s *Store) Stopped() bool {
+	return false
+}
+
 func (s *Store) GetHash(k string) ([]byte, error) {
 	return s.state.GetHash(k)
 }

--- a/notary/snapshot.go
+++ b/notary/snapshot.go
@@ -101,6 +101,10 @@ func (n *SnapshotNotary) Keys() []string {
 	return hashKeys
 }
 
+func (n *SnapshotNotary) Stopped() bool {
+	return false
+}
+
 func (n *SnapshotNotary) GetHash(k string) ([]byte, error) {
 	_, hash, err := n.getSerialisedAndHash(k)
 	return hash, err

--- a/positions/snapshot.go
+++ b/positions/snapshot.go
@@ -90,6 +90,10 @@ func (e *SnapshotEngine) Keys() []string {
 	return []string{e.marketID}
 }
 
+func (e *SnapshotEngine) Stopped() bool {
+	return e.stopped
+}
+
 func (e *SnapshotEngine) GetHash(k string) ([]byte, error) {
 	if k != e.marketID {
 		return nil, types.ErrSnapshotKeyDoesNotExist
@@ -146,7 +150,7 @@ func (e *SnapshotEngine) LoadState(_ context.Context, payload *types.Payload) ([
 // with updated values.
 func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
 	if e.stopped {
-		return nil, nil, types.ErrSnapshotProviderStopped
+		return nil, nil, nil
 	}
 
 	if !e.changed {

--- a/positions/snapshot_test.go
+++ b/positions/snapshot_test.go
@@ -252,8 +252,11 @@ func TestStopSnapshotTaking(t *testing.T) {
 	// signal to kill the engine's snapshots
 	engine.StopSnapshots()
 
-	_, _, err := engine.GetState(keys[0])
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
-	_, err = engine.GetHash(keys[0])
-	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	s, _, err := engine.GetState(keys[0])
+	assert.NoError(t, err)
+	assert.Nil(t, s)
+	h, err := engine.GetHash(keys[0])
+	assert.NoError(t, err)
+	assert.Nil(t, h)
+	assert.True(t, engine.Stopped())
 }

--- a/positions/snapshot_test.go
+++ b/positions/snapshot_test.go
@@ -13,6 +13,7 @@ import (
 	"code.vegaprotocol.io/vega/types/num"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -242,4 +243,17 @@ func TestSnapshotHashNoPositions(t *testing.T) {
 	h1, err := engine.GetHash(keys[0])
 	require.Nil(t, err)
 	require.Equal(t, "278f2eff5adc1ea5b8365bd04c6e534ef64ca43df737c22ee61db46a8dac5870", hex.EncodeToString(h1))
+}
+
+func TestStopSnapshotTaking(t *testing.T) {
+	engine := getTestEngine(t)
+	keys := engine.Keys()
+
+	// signal to kill the engine's snapshots
+	engine.StopSnapshots()
+
+	_, _, err := engine.GetState(keys[0])
+	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
+	_, err = engine.GetHash(keys[0])
+	assert.ErrorIs(t, err, types.ErrSnapshotProviderStopped)
 }

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -66,36 +66,33 @@ type StatsService interface {
 // Engine the snapshot engine.
 type Engine struct {
 	Config
+	log *logging.Logger
 
-	ctx        context.Context
-	cfunc      context.CancelFunc
-	time       TimeService
-	stats      StatsService
-	db         db.DB
-	dbPath     string
-	log        *logging.Logger
-	avl        *iavl.MutableTree
-	namespaces []types.SnapshotNamespace
-	nsKeys     map[types.SnapshotNamespace][]string
-	nsTreeKeys map[types.SnapshotNamespace][][]byte
-	keyNoNS    map[string]string // full key => key used by provider
-	hashes     map[string][]byte
-	versions   []int64
-	interval   int64
-	current    int64
+	ctx          context.Context
+	cfunc        context.CancelFunc
+	timeService  TimeService
+	statsService StatsService
+	db           db.DB
+	dbPath       string
+
+	avl             *iavl.MutableTree
+	namespaces      []types.SnapshotNamespace
+	nsKeys          map[types.SnapshotNamespace][]string // takes us from a namespace to the provider keys in that namespace e.g governance => {active, enacted}
+	nsTreeKeys      map[types.SnapshotNamespace][][]byte // takes us from a namespace to the AVL tree keys in that namespace e.g governanec => {governance.active, governance.enacted}
+	treeKeyProvider map[string]string                    // takes us from the key of the AVL tree node, to the provider key e.g checkpoint.all => all
+	keyHashes       map[string][]byte                    // takes us from the key of the AVL tree, to the last known hash of that node
+	versions        []int64
+	interval        int64
+	current         int64
 
 	providers          map[string]types.StateProvider
 	restoreProvs       []types.PostRestore
 	beforeRestoreProvs []types.PreRestore
 	providersNS        map[types.SnapshotNamespace][]types.StateProvider
-	providerTS         map[string]StateProviderT
-	pollCtx            context.Context
-	pollCfunc          context.CancelFunc
 
-	last          *iavl.ImmutableTree
-	hash          []byte
-	version       int64
-	versionHeight map[uint64]int64
+	last             *iavl.ImmutableTree
+	lastSnapshotHash []byte // the root hash of the last snapshot that was taken
+	versionHeight    map[uint64]int64
 
 	snapshot  *types.Snapshot
 	snapRetry int
@@ -103,6 +100,11 @@ type Engine struct {
 	// the general snapshot info this engine is responsible for
 	wrap *types.PayloadAppState
 	app  *types.AppState
+
+	// unused bit related to experiemental channel based snapshot update stuff?
+	providerTS map[string]StateProviderT
+	pollCtx    context.Context
+	pollCfunc  context.CancelFunc
 }
 
 // order in which snapshots are to be restored.
@@ -157,14 +159,14 @@ func New(ctx context.Context, vegapath paths.Paths, conf Config, log *logging.Lo
 	}
 	app := appPL.Namespace()
 	eng := &Engine{
-		Config:     conf,
-		ctx:        sctx,
-		cfunc:      cfunc,
-		time:       tm,
-		stats:      stats,
-		dbPath:     dbPath,
-		log:        log,
-		namespaces: []types.SnapshotNamespace{},
+		Config:       conf,
+		log:          log,
+		ctx:          sctx,
+		cfunc:        cfunc,
+		timeService:  tm,
+		statsService: stats,
+		dbPath:       dbPath,
+		namespaces:   []types.SnapshotNamespace{},
 		nsKeys: map[types.SnapshotNamespace][]string{
 			app: {appPL.Key()},
 		},
@@ -173,16 +175,16 @@ func New(ctx context.Context, vegapath paths.Paths, conf Config, log *logging.Lo
 				[]byte(types.KeyFromPayload(appPL)),
 			},
 		},
-		keyNoNS:       map[string]string{},
-		hashes:        map[string][]byte{},
-		providers:     map[string]types.StateProvider{},
-		providersNS:   map[types.SnapshotNamespace][]types.StateProvider{},
-		versions:      make([]int64, 0, conf.KeepRecent), // cap determines how many versions we keep
-		versionHeight: map[uint64]int64{},
-		wrap:          appPL,
-		app:           appPL.AppState,
-		interval:      1, // default to every block
-		current:       1,
+		treeKeyProvider: map[string]string{},
+		keyHashes:       map[string][]byte{},
+		providers:       map[string]types.StateProvider{},
+		providersNS:     map[types.SnapshotNamespace][]types.StateProvider{},
+		versions:        make([]int64, 0, conf.KeepRecent), // cap determines how many versions we keep
+		versionHeight:   map[uint64]int64{},
+		wrap:            appPL,
+		app:             appPL.AppState,
+		interval:        1, // default to every block
+		current:         1,
 	}
 	return eng, nil
 }
@@ -288,7 +290,6 @@ func (e *Engine) Loaded() (bool, error) {
 			continue
 		}
 		if app.AppState.Height == height {
-			e.version = version
 			e.last = e.avl.ImmutableTree
 			return true, e.load(e.ctx)
 		}
@@ -343,11 +344,9 @@ func (e *Engine) initialiseTree() error {
 }
 
 func (e *Engine) loadTree() error {
-	v, err := e.avl.Load()
-	if err != nil {
+	if _, err := e.avl.Load(); err != nil {
 		return err
 	}
-	e.version = v
 	e.last = e.avl.ImmutableTree
 	return nil
 }
@@ -445,8 +444,8 @@ func (e *Engine) applySnap(ctx context.Context) error {
 	// we're done restoring, now save the snapshot locally, so we can provide it moving forwards
 	now := time.Unix(e.app.Time, 0)
 	// restore app state
-	e.time.SetTimeNow(ctx, now)
-	e.stats.SetHeight(e.app.Height)
+	e.timeService.SetTimeNow(ctx, now)
+	e.statsService.SetHeight(e.app.Height)
 
 	// before we starts restoring the providers
 	for _, pp := range e.beforeRestoreProvs {
@@ -477,9 +476,9 @@ func (e *Engine) applySnap(ctx context.Context) error {
 		}
 	}
 
-	e.current = e.interval   // set the snapshot counter to the interval so that we do not create a duplicate snapshot on commit
-	e.hash = e.snapshot.Hash // set the engine's "last snapshot hash" field to the hash of the snapshot we've just loaded
-	e.snapshot = nil         // we're done, we can clear the snapshot state
+	e.current = e.interval               // set the snapshot counter to the interval so that we do not create a duplicate snapshot on commit
+	e.lastSnapshotHash = e.snapshot.Hash // set the engine's "last snapshot hash" field to the hash of the snapshot we've just loaded
+	e.snapshot = nil                     // we're done, we can clear the snapshot state
 
 	return nil
 }
@@ -494,7 +493,7 @@ func (e *Engine) setTreeNode(i int, p *types.Payload) error {
 	// hash the node and save it into our cache of node hashes for comparison at the next snapshot
 	hash := crypto.Hash(data)
 	key := p.GetTreeKey()
-	e.hashes[key] = hash
+	e.keyHashes[key] = hash
 
 	return nil
 }
@@ -557,7 +556,7 @@ func (e *Engine) GetMissingChunks() []uint32 {
 // Info simply returns the current snapshot hash
 // Can be used for the TM info call.
 func (e *Engine) Info() ([]byte, int64) {
-	return e.hash, int64(e.app.Height)
+	return e.lastSnapshotHash, int64(e.app.Height)
 }
 
 func (e *Engine) Snapshot(ctx context.Context) (b []byte, errlol error) {
@@ -571,6 +570,7 @@ func (e *Engine) Snapshot(ctx context.Context) (b []byte, errlol error) {
 	defer metrics.StartSnapshot("all")()
 	// always iterate over slices, so loops are deterministic
 	updated := false
+
 	for _, ns := range e.namespaces {
 		u, err := e.update(ns)
 		if err != nil {
@@ -600,7 +600,7 @@ func (e *Engine) Snapshot(ctx context.Context) (b []byte, errlol error) {
 		appUpdate = true
 		e.app.Block = block
 	}
-	vNow := e.time.GetTimeNow().Unix()
+	vNow := e.timeService.GetTimeNow().Unix()
 	if e.app.Time != vNow {
 		e.app.Time = vNow
 		appUpdate = true
@@ -622,7 +622,7 @@ func (e *Engine) Snapshot(ctx context.Context) (b []byte, errlol error) {
 		updated = true
 	}
 	if !updated {
-		return e.hash, nil
+		return e.lastSnapshotHash, nil
 	}
 	return e.saveCurrentTree()
 }
@@ -632,8 +632,7 @@ func (e *Engine) saveCurrentTree() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	e.hash = h
-	e.version = v
+	e.lastSnapshotHash = h
 	if len(e.versions) >= cap(e.versions) {
 		if err := e.avl.DeleteVersion(e.versions[0]); err != nil {
 			// this is not a fatal error, but still we should be paying attention.
@@ -662,44 +661,54 @@ func (e *Engine) update(ns types.SnapshotNamespace) (bool, error) {
 		return false, nil
 	}
 	update := false
-	for _, tk := range treeKeys {
-		k := string(tk)
-		p := e.providers[k] // get the specific provider for this key
-		ch := e.hashes[k]
-		kNNS := e.keyNoNS[k]
-		h, err := p.GetHash(kNNS)
+	toRemove := []int{}
+	for i, treeKey := range treeKeys {
+		treeKeyStr := string(treeKey)
+		p := e.providers[treeKeyStr] // get the specific provider for this key
+		lastHash := e.keyHashes[treeKeyStr]
+		providerKey := e.treeKeyProvider[treeKeyStr]
+		currentHash, err := p.GetHash(providerKey)
+
+		if err == types.ErrSnapshotProviderStopped {
+			// this signals the removal of this key
+			toRemove = append(toRemove, i)
+			continue
+		}
+
 		if err != nil {
 			return update, err
 		}
 		// nothing has changed (or both values were nil)
-		if bytes.Equal(ch, h) {
+		if bytes.Equal(lastHash, currentHash) {
 			continue
 		}
 		// hashes were different, we need to update
-		v, nsps, err := p.GetState(kNNS)
+		v, generatedProviders, err := p.GetState(providerKey)
 		if err != nil {
 			return update, err
 		}
-		if len(nsps) > 0 {
+		if len(generatedProviders) > 0 {
 			// The provider has generated new providers, register them with the engine
 			// add them to the AVL tree
-			e.AddProviders(nsps...)
-			for _, n := range nsps {
+			e.AddProviders(generatedProviders...)
+			for _, n := range generatedProviders {
 				e.log.Debug("Provider generated",
 					logging.String("namespace", n.Namespace().String()),
 				)
-				e.update(n.Namespace())
+				if _, err = e.update(n.Namespace()); err != nil {
+					return false, err
+				}
 			}
 		}
 		e.log.Debug("State updated",
-			logging.String("node-key", k),
-			logging.String("state-hash", hex.EncodeToString(h)),
+			logging.String("node-key", treeKeyStr),
+			logging.String("state-hash", hex.EncodeToString(currentHash)),
 		)
-		e.hashes[k] = h
-		if len(v) == 0 && len(h) == 0 {
+		e.keyHashes[treeKeyStr] = currentHash
+		if len(v) == 0 && len(currentHash) == 0 {
 			// empty state -> remove data from snapshot
-			if e.avl.Has(tk) {
-				_, _ = e.avl.Remove(tk)
+			if e.avl.Has(treeKey) {
+				_, _ = e.avl.Remove(treeKey)
 				update = true
 				continue
 			}
@@ -707,10 +716,46 @@ func (e *Engine) update(ns types.SnapshotNamespace) (bool, error) {
 			continue
 		}
 		// new value needs to be set
-		_ = e.avl.Set(tk, v)
+		_ = e.avl.Set(treeKey, v)
 		update = true
 	}
-	return update, nil
+
+	if len(toRemove) == 0 {
+		return update, nil
+	}
+
+	toRemoveMap := map[int]struct{}{}
+	for i := range toRemove {
+		treeKey := treeKeys[i]
+		treeKeyStr := string(treeKey)
+		toRemoveMap[i] = struct{}{}
+
+		// delete everything we've got stored
+		e.log.Debug("State to be removed", logging.String("node-key", treeKeyStr))
+		delete(e.providers, treeKeyStr)
+		delete(e.keyHashes, treeKeyStr)
+		delete(e.treeKeyProvider, treeKeyStr)
+
+		if !e.avl.Has(treeKey) {
+			e.log.Panic("trying to remove non-existent payload from tree", logging.String("key", treeKeyStr))
+			continue
+		}
+
+		if _, removed := e.avl.Remove(treeKey); !removed {
+			e.log.Panic("failed to remove node from AVL tree", logging.String("key", treeKeyStr))
+		}
+	}
+
+	// now purge from the tree keys themselves
+	newTreeKeys := make([][]byte, 0, len(treeKeys)-len(toRemove))
+	for i, tk := range treeKeys {
+		if _, ok := toRemoveMap[i]; !ok {
+			newTreeKeys = append(newTreeKeys, tk)
+		}
+	}
+
+	e.nsTreeKeys[ns] = newTreeKeys
+	return true, nil
 }
 
 func (e *Engine) updateAppState() error {
@@ -735,26 +780,26 @@ func (e *Engine) updateAppState() error {
 }
 
 func (e *Engine) Hash(ctx context.Context) ([]byte, error) {
-	if len(e.hash) != 0 {
-		return e.hash, nil
+	if len(e.lastSnapshotHash) != 0 {
+		return e.lastSnapshotHash, nil
 	}
 	return e.Snapshot(ctx)
 }
 
 func (e *Engine) AddProviders(provs ...types.StateProvider) {
 	for _, p := range provs {
-		ks := p.Keys()
+		keys := p.Keys()
 		ns := p.Namespace()
 		haveKeys, ok := e.nsKeys[ns]
 		if !ok {
 			e.providersNS[ns] = []types.StateProvider{
 				p,
 			}
-			e.nsTreeKeys[ns] = make([][]byte, 0, len(ks))
+			e.nsTreeKeys[ns] = make([][]byte, 0, len(keys))
 			e.namespaces = append(e.namespaces, ns)
-			for _, k := range ks {
+			for _, k := range keys {
 				fullKey := types.GetNodeKey(ns, k)
-				e.keyNoNS[fullKey] = k
+				e.treeKeyProvider[fullKey] = k
 				e.providers[fullKey] = p
 				e.nsTreeKeys[ns] = append(e.nsTreeKeys[ns], []byte(fullKey))
 			}
@@ -764,12 +809,12 @@ func (e *Engine) AddProviders(provs ...types.StateProvider) {
 			if pp, ok := p.(types.PreRestore); ok {
 				e.beforeRestoreProvs = append(e.beforeRestoreProvs, pp)
 			}
-			e.nsKeys[ns] = ks
+			e.nsKeys[ns] = keys
 			continue
 		}
 		// in this case, we are replacing the provider
 		if ns == types.ReplayProtectionSnapshot {
-			for _, k := range ks {
+			for _, k := range keys {
 				fullKey := types.GetNodeKey(ns, k)
 				// replace the old provider with the replacement
 				e.providers[fullKey] = p
@@ -778,7 +823,7 @@ func (e *Engine) AddProviders(provs ...types.StateProvider) {
 			// replace provider reference in the NS map, too
 			for i, oldP := range e.providersNS[ns] {
 				// both in same namespace, have same keys -> replace
-				if strings.StringSliceEqual(ks, oldP.Keys()) {
+				if strings.StringSliceEqual(keys, oldP.Keys()) {
 					e.providersNS[ns][i] = p
 					rpl = true
 					break
@@ -790,7 +835,7 @@ func (e *Engine) AddProviders(provs ...types.StateProvider) {
 			}
 			// no exact match was found, so we'll have to de-duplicate
 		}
-		dedup := uniqueSubset(haveKeys, ks)
+		dedup := uniqueSubset(haveKeys, keys)
 		// note that the replay protection provider can replace itself (Noop -> actual protector)
 		if len(dedup) == 0 && ns != types.ReplayProtectionSnapshot {
 			continue // no new keys were added
@@ -800,7 +845,7 @@ func (e *Engine) AddProviders(provs ...types.StateProvider) {
 		e.providersNS[ns] = append(e.providersNS[ns], p)
 		for _, k := range dedup {
 			fullKey := types.GetNodeKey(ns, k)
-			e.keyNoNS[fullKey] = k
+			e.treeKeyProvider[fullKey] = k
 			e.providers[fullKey] = p
 			e.nsTreeKeys[ns] = append(e.nsTreeKeys[ns], []byte(fullKey))
 		}

--- a/snapshot/engine_test.go
+++ b/snapshot/engine_test.go
@@ -550,14 +550,16 @@ func testRemovingMutlipleKeysSingleNamespace(t *testing.T) {
 	require.Equal(t, b1, b2)
 
 	// Now the only change is we signal remove of a single provider, check the snapshot changes
-	prov.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, types.ErrSnapshotProviderStopped)
+	prov.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, nil)
+	prov.EXPECT().Stopped().Times(1).Return(true)
 	b3, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.NotNil(t, b3)
 	require.NotEqual(t, b1, b3)
 
 	// remove the second provider
-	prov2.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, types.ErrSnapshotProviderStopped)
+	prov2.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, nil)
+	prov2.EXPECT().Stopped().Times(1).Return(true)
 	b4, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.NotNil(t, b4)

--- a/snapshot/engine_test.go
+++ b/snapshot/engine_test.go
@@ -7,6 +7,7 @@ import (
 
 	vegactx "code.vegaprotocol.io/vega/libs/context"
 	"code.vegaprotocol.io/vega/libs/crypto"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/snapshot"
 	"code.vegaprotocol.io/vega/snapshot/mocks"
@@ -107,6 +108,7 @@ func TestEngine(t *testing.T) {
 	t.Run("Adding provider with duplicate key in same namespace: first come, first serve", testAddProvidersDuplicateKeys)
 	t.Run("Create a snapshot, if nothing changes, we don't get the data and the hash remains unchanged", testTakeSnapshot)
 	t.Run("Rejecting a snapshot should return a Snapshot Retry Limit error if rejected too many times", testRejectSnapshot)
+	t.Run("Removing multiple keys within a single namespace", testRemovingMutlipleKeysSingleNamespace)
 }
 
 func TestRestore(t *testing.T) {
@@ -510,4 +512,60 @@ func testRejectSnapshot(t *testing.T) {
 
 	err := engine.RejectSnapshot()
 	assert.ErrorIs(t, types.ErrSnapshotRetryLimit, err)
+}
+
+func testRemovingMutlipleKeysSingleNamespace(t *testing.T) {
+	someState := []byte("hello-i-am-state")
+	someHash := vgcrypto.Hash(someState)
+	engine := getTestEngine(t)
+	defer engine.Finish()
+
+	engine.time.EXPECT().GetTimeNow().Times(5).Return(time.Now())
+
+	// first provider
+	prov := engine.getNewProviderMock()
+	prov.EXPECT().Keys().AnyTimes().Return([]string{"key1"})
+	prov.EXPECT().Namespace().AnyTimes().Return(types.PositionsSnapshot)
+	prov.EXPECT().GetHash(gomock.Any()).Times(2).Return(someHash, nil) // called twice, first to store and second to change for no change
+	prov.EXPECT().GetState(gomock.Any()).Times(1).Return(someState, nil, nil)
+	engine.AddProviders(prov)
+
+	// second provider in the same namespace but with a different key i.e two positions engines, in the same namespace but keyed to difference markets
+	prov2 := engine.getNewProviderMock()
+	prov2.EXPECT().Keys().AnyTimes().Return([]string{"key2"})
+	prov2.EXPECT().Namespace().AnyTimes().Return(types.PositionsSnapshot)
+	prov2.EXPECT().GetHash(gomock.Any()).Times(3).Return(someHash, nil)
+	prov2.EXPECT().GetState(gomock.Any()).Times(1).Return(someState, nil, nil)
+	engine.AddProviders(prov2)
+
+	// initial snapshot
+	b1, err := engine.Snapshot(engine.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, b1)
+
+	// call again to confirm no state changes
+	b2, err := engine.Snapshot(engine.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, b2)
+	require.Equal(t, b1, b2)
+
+	// Now the only change is we signal remove of a single provider, check the snapshot changes
+	prov.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, types.ErrSnapshotProviderStopped)
+	b3, err := engine.Snapshot(engine.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, b3)
+	require.NotEqual(t, b1, b3)
+
+	// remove the second provider
+	prov2.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, types.ErrSnapshotProviderStopped)
+	b4, err := engine.Snapshot(engine.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, b4)
+	require.NotEqual(t, b3, b4)
+
+	// give it another blast now its empty to make sure we don't try to call things again, and that the hash remains the same
+	b5, err := engine.Snapshot(engine.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, b5)
+	require.Equal(t, b4, b5)
 }

--- a/spam/snapshot.go
+++ b/spam/snapshot.go
@@ -15,6 +15,10 @@ func (e *Engine) Keys() []string {
 	return e.hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 // get the serialised form and hash of the given key.
 func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
 	if _, ok := e.policyNameToPolicy[k]; !ok {

--- a/staking/accounting_snapshot.go
+++ b/staking/accounting_snapshot.go
@@ -83,6 +83,10 @@ func (a *Accounting) Keys() []string {
 	return []string{accountsKey}
 }
 
+func (a *Accounting) Stopped() bool {
+	return false
+}
+
 func (a *Accounting) GetHash(k string) ([]byte, error) {
 	_, hash, err := a.getSerialisedAndHash(k)
 	return hash, err

--- a/staking/stake_verifier_snapshot.go
+++ b/staking/stake_verifier_snapshot.go
@@ -87,6 +87,10 @@ func (s *StakeVerifier) Keys() []string {
 	return hashKeys
 }
 
+func (s *StakeVerifier) Stopped() bool {
+	return false
+}
+
 func (s *StakeVerifier) GetHash(k string) ([]byte, error) {
 	_, hash, err := s.getSerialisedAndHash(k)
 	return hash, err

--- a/statevar/snapshot.go
+++ b/statevar/snapshot.go
@@ -34,6 +34,10 @@ func (e *Engine) Keys() []string {
 	return hashKeys
 }
 
+func (e *Engine) Stopped() bool {
+	return false
+}
+
 func (e *Engine) serialiseNextTimeTrigger() []*snapshot.NextTimeTrigger {
 	e.log.Debug("serialising statevar snapshot", logging.Int("n_triggers", len(e.stateVarToNextCalc)))
 	timeTriggers := make([]*snapshot.NextTimeTrigger, 0, len(e.stateVarToNextCalc))

--- a/types/mocks/restore_state_provider_mock.go
+++ b/types/mocks/restore_state_provider_mock.go
@@ -122,3 +122,17 @@ func (mr *MockPostRestoreMockRecorder) OnStateLoaded(arg0 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnStateLoaded", reflect.TypeOf((*MockPostRestore)(nil).OnStateLoaded), arg0)
 }
+
+// Stopped mocks base method.
+func (m *MockPostRestore) Stopped() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stopped")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Stopped indicates an expected call of Stopped.
+func (mr *MockPostRestoreMockRecorder) Stopped() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stopped", reflect.TypeOf((*MockPostRestore)(nil).Stopped))
+}

--- a/types/mocks/state_provider_mock.go
+++ b/types/mocks/state_provider_mock.go
@@ -108,3 +108,17 @@ func (mr *MockStateProviderMockRecorder) Namespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockStateProvider)(nil).Namespace))
 }
+
+// Stopped mocks base method.
+func (m *MockStateProvider) Stopped() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stopped")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Stopped indicates an expected call of Stopped.
+func (mr *MockStateProviderMockRecorder) Stopped() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stopped", reflect.TypeOf((*MockStateProvider)(nil).Stopped))
+}

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -101,6 +101,7 @@ var (
 	ErrInvalidSnapshotStorageMethod = errors.New("invalid snapshot storage method")
 	ErrMissingAppstateNode          = errors.New("appstate missing from tree")
 	ErrMissingPayload               = errors.New("payload missing from exported tree")
+	ErrSnapshotProviderStopped      = errors.New("snapshot provider is no longer producing snapshots")
 )
 
 type SnapshotFormat = snapshot.Format

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -23,6 +23,7 @@ type StateProvider interface {
 	GetHash(key string) ([]byte, error)
 	GetState(key string) ([]byte, []StateProvider, error)
 	LoadState(ctx context.Context, pl *Payload) ([]StateProvider, error)
+	Stopped() bool
 }
 
 // PostRestore is basically a StateProvider which, after the full core state is restored, expects a callback to finalise the state restore
@@ -101,7 +102,6 @@ var (
 	ErrInvalidSnapshotStorageMethod = errors.New("invalid snapshot storage method")
 	ErrMissingAppstateNode          = errors.New("appstate missing from tree")
 	ErrMissingPayload               = errors.New("payload missing from exported tree")
-	ErrSnapshotProviderStopped      = errors.New("snapshot provider is no longer producing snapshots")
 )
 
 type SnapshotFormat = snapshot.Format

--- a/validators/topology_snapshot.go
+++ b/validators/topology_snapshot.go
@@ -36,6 +36,10 @@ func (t *Topology) Keys() []string {
 	return topHashKeys
 }
 
+func (t *Topology) Stopped() bool {
+	return false
+}
+
 func (t *Topology) serialiseNodes() []*snapshot.ValidatorState {
 	nodes := make([]*snapshot.ValidatorState, 0, len(t.validators))
 	for _, node := range t.validators {


### PR DESCRIPTION
closes #4788 

We a market is rejected and we go through cleanup, we call `p.StopSnapshots()` on the generated providers of a market i.e `positions/matching/liquidity/liquidity-target`. Once trigger, those engines then stop producing snapshots and return a `types.ErrSnapshotProviderStopped` error.

The next time the snapshot engine then probes them for a snapshot, it knows that they are dead and need to be removed from the AVL tree.

This means that a snapshot now contains no information about a rejected market, so when we restore from it we no longer try to populate the positions engine for markets that do not exist.