### PR TITLE
fix: set app-version to 1 and always pass it back to tendermint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
 - [4686](https://github.com/vegaprotocol/vega/pull/4686) - Fix commit hash problem when checkpoint and snapshot overlap. Ensure the snapshot contains the correct checkpoint state.
 - [4691](https://github.com/vegaprotocol/vega/pull/4691) - Handle undelegate stake with no balances gracefully
 - [4716](https://github.com/vegaprotocol/vega/pull/4716) - Fix protobuf conversion in orders
+- [4861](https://github.com/vegaprotocol/vega/pull/4861) - Set a protocol version and properly send it to `Tendermint` in all cases
 - [4732](https://github.com/vegaprotocol/vega/pull/4732) - `TimeUpdate` is now first event sent
 - [4714](https://github.com/vegaprotocol/vega/pull/4714) - Ensure EEF doesn't process the current block multiple times
 - [4700](https://github.com/vegaprotocol/vega/pull/4700) - Ensure verification of type between oracle spec binding and oracle spec

--- a/blockchain/abci/abci.go
+++ b/blockchain/abci/abci.go
@@ -28,11 +28,7 @@ const (
 
 func (app *App) Info(req types.RequestInfo) types.ResponseInfo {
 	if fn := app.OnInfo; fn != nil {
-		resp := fn(req)
-		// only return this if we actually reloaded a snapshot
-		if resp.LastBlockHeight != 0 {
-			return resp
-		}
+		return fn(req)
 	}
 	return app.BaseApplication.Info(req)
 }

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -356,7 +356,7 @@ func (app *App) Info(_ tmtypes.RequestInfo) tmtypes.ResponseInfo {
 	}
 
 	resp := tmtypes.ResponseInfo{
-		AppVersion: 0, // application protocol version TBD.
+		AppVersion: 1,
 		Version:    app.version,
 	}
 
@@ -367,7 +367,12 @@ func (app *App) Info(_ tmtypes.RequestInfo) tmtypes.ResponseInfo {
 		resp.LastBlockAppHash = hash
 	}
 
-	app.log.Debug("ABCI service INFO requested", logging.Int64("height", resp.LastBlockHeight), logging.String("hash", hex.EncodeToString(resp.LastBlockAppHash)))
+	app.log.Info("ABCI service INFO requested",
+		logging.String("version", resp.Version),
+		logging.Uint64("app-vesion", resp.AppVersion),
+		logging.Int64("height", resp.LastBlockHeight),
+		logging.String("hash", hex.EncodeToString(resp.LastBlockAppHash)),
+	)
 	return resp
 }
 


### PR DESCRIPTION
closes #4384 

I blamed tendermint for a bug here, but it turns out the problem was in vega. How embarrasing.

Anyway, the idea with the app-version is that it only needs to be incremented when a change is made to vega that alters how the app-hash is created. 

How do we know when we've made a change that could do this? I don't know. And maybe in reality we'll always increment it whenever we do any release of vega, but then this has it's own problems when it comes to backporting patches e.g if `0.47.0` has a app-version of `10` and then we give `0.48.0` and app-version of `11`, and then we make `0.47.1` with a consensus breaking change in it, what do we set it to? We could go further and set the app-version to something like `001048010` so that it corresponds to `1.48.10` with enough padding for future proofing, then we won't have a problem. But then if we always increment then patch versions won't be compatible with other patches in the same version.

Ultimately, this decision is bigger than a ticket against snapshot, and is more related to our release process, and how our rolling upgrades of vega for will work. So I think it needs careful consideration then.

So for now I'm not going to try and not be clever and I will set it to 1 so that if in the future we want to do something more exotic, it'll be set to something bigger than 1 so its fine. And for now we at least have vega flexing the TM app-version logic which we weren't really doing before.