### PR TITLE
4880 snapshot epoch propagation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,63 +28,6 @@
                 "-test.run",
                 "${workspaceFolder}/integration/features/settlement/settlement_at_expiry.feature:23"
             ]
-        },
-        {
-            "name": "Vega2",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            "program": "${workspaceFolder}/cmd/vega",
-            "args": [
-                "node",
-                "--home=/Users/wwestgarth/nullhome",
-                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
-            ]
-        },
-        {
-            "name": "Nullchain",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            "program": "${workspaceFolder}/cmd/vega",
-            "args": [
-                "node",
-                "--blockchain.chain-provider=nullchain",
-                "--blockchain.nullchain.genesis-file=/Users/wwestgarth/work/scripts/genesis-files/genesis-null.json",
-                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
-                "--nodewallet.eth.address=http://127.0.0.1:545",
-                "--blockchain.nullchain.log-level=debug"
-            ]
-        },
-        {
-            "name": "Nullchain Ropsten",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            "program": "${workspaceFolder}/cmd/vega",
-            "args": [
-                "node",
-                "--blockchain.chain-provider=nullchain",
-                "--blockchain.nullchain.genesis-file=/Users/wwestgarth/work/scripts/genesis-files/genesis-ropsten.json",
-                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
-                "--nodewallet.eth.address=https://ropsten.infura.io/v3/a3868124cd4340079ae33f48af9f9875",
-                "--blockchain.nullchain.log-level=debug"
-            ]
-        },
-        {
-            "name": "Nullchain Mainnet",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            "program": "${workspaceFolder}/cmd/vega",
-            "args": [
-                "node",
-                "--blockchain.chain-provider=nullchain",
-                "--blockchain.nullchain.genesis-file=/Users/wwestgarth/work/scripts/genesis-files/genesis-mainnet.json",
-                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
-                "--nodewallet.eth.address=https://mainnet.infura.io/v3/a3868124cd4340079ae33f48af9f9875",
-                "--blockchain.nullchain.log-level=debug"
-            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,63 @@
                 "-test.run",
                 "${workspaceFolder}/integration/features/settlement/settlement_at_expiry.feature:23"
             ]
+        },
+        {
+            "name": "Vega2",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/vega",
+            "args": [
+                "node",
+                "--home=/Users/wwestgarth/nullhome",
+                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
+            ]
+        },
+        {
+            "name": "Nullchain",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/vega",
+            "args": [
+                "node",
+                "--blockchain.chain-provider=nullchain",
+                "--blockchain.nullchain.genesis-file=/Users/wwestgarth/work/scripts/genesis-files/genesis-null.json",
+                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
+                "--nodewallet.eth.address=http://127.0.0.1:545",
+                "--blockchain.nullchain.log-level=debug"
+            ]
+        },
+        {
+            "name": "Nullchain Ropsten",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/vega",
+            "args": [
+                "node",
+                "--blockchain.chain-provider=nullchain",
+                "--blockchain.nullchain.genesis-file=/Users/wwestgarth/work/scripts/genesis-files/genesis-ropsten.json",
+                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
+                "--nodewallet.eth.address=https://ropsten.infura.io/v3/a3868124cd4340079ae33f48af9f9875",
+                "--blockchain.nullchain.log-level=debug"
+            ]
+        },
+        {
+            "name": "Nullchain Mainnet",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/vega",
+            "args": [
+                "node",
+                "--blockchain.chain-provider=nullchain",
+                "--blockchain.nullchain.genesis-file=/Users/wwestgarth/work/scripts/genesis-files/genesis-mainnet.json",
+                "--nodewallet-passphrase-file=/Users/wwestgarth/pp",
+                "--nodewallet.eth.address=https://mainnet.infura.io/v3/a3868124cd4340079ae33f48af9f9875",
+                "--blockchain.nullchain.log-level=debug"
+            ]
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Fixes
 - [4877](https://github.com/vegaprotocol/vega/issues/4877) - Fix topology and `erc20` topology snapshots
+- [4890](https://github.com/vegaprotocol/vega/issues/4890) - epoch service now notifies other engines when it has restored from a snapshot
 - [4879](https://github.com/vegaprotocol/vega/issues/4879) - Fixes for invalid data types in the `MarketData` proto message.
 - [4881](https://github.com/vegaprotocol/vega/issues/4881) - Set tendermint validators' voting power when loading from snapshot
 - [4882](https://github.com/vegaprotocol/vega/issues/4882) - Fixed tracking of liquidity fee received and added feature tests for the fee based rewards

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -214,6 +214,9 @@ func (e *Engine) OnEpoch(ctx context.Context, ep types.Epoch) {
 		if err := e.distributeRecurringTransfers(ctx, e.currentEpoch); err != nil {
 			e.log.Error("could not distribute recurring transfers", logging.Error(err))
 		}
+	case proto.EpochAction_EPOCH_ACTION_RESTORED:
+		e.log.Debug("epoch restoration notification received", logging.String("epoch", ep.String()))
+		e.currentEpoch = ep.Seq
 	default:
 		e.log.Panic("epoch action should never be UNSPECIFIED", logging.String("epoch", ep.String()))
 	}

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -85,8 +85,7 @@ type TimeService interface {
 // Epochervice ...
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/epoch_service_mock.go -package mocks code.vegaprotocol.io/vega/banking EpochService
 type EpochService interface {
-	NotifyOnEpoch(f func(context.Context, types.Epoch))
-	NotifyOnEpochRestore(f func(context.Context, types.Epoch))
+	NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch))
 }
 
 // Topology ...
@@ -153,8 +152,7 @@ func New(
 ) (e *Engine) {
 	defer func() {
 		tsvc.NotifyOnTick(e.OnTick)
-		epoch.NotifyOnEpoch(e.OnEpoch)
-		epoch.NotifyOnEpochRestore(e.OnEpochRestore)
+		epoch.NotifyOnEpoch(e.OnEpoch, e.OnEpochRestore)
 	}()
 	log = log.Named(namedLogger)
 	log.SetLevel(cfg.Level.Get())

--- a/banking/engine_test.go
+++ b/banking/engine_test.go
@@ -52,6 +52,7 @@ func getTestEngine(t *testing.T) *testEngine {
 	notary.EXPECT().OfferSignatures(gomock.Any(), gomock.Any()).AnyTimes()
 	tsvc.EXPECT().NotifyOnTick(gomock.Any()).Times(1)
 	epoch.EXPECT().NotifyOnEpoch(gomock.Any()).Times(1)
+	epoch.EXPECT().NotifyOnEpochRestore(gomock.Any()).Times(1)
 	eng := banking.New(logging.NewTestLogger(), banking.NewDefaultConfig(), col, erc, tsvc, assets, notary, broker, top, epoch)
 
 	return &testEngine{

--- a/banking/engine_test.go
+++ b/banking/engine_test.go
@@ -51,8 +51,7 @@ func getTestEngine(t *testing.T) *testEngine {
 
 	notary.EXPECT().OfferSignatures(gomock.Any(), gomock.Any()).AnyTimes()
 	tsvc.EXPECT().NotifyOnTick(gomock.Any()).Times(1)
-	epoch.EXPECT().NotifyOnEpoch(gomock.Any()).Times(1)
-	epoch.EXPECT().NotifyOnEpochRestore(gomock.Any()).Times(1)
+	epoch.EXPECT().NotifyOnEpoch(gomock.Any(), gomock.Any()).Times(1)
 	eng := banking.New(logging.NewTestLogger(), banking.NewDefaultConfig(), col, erc, tsvc, assets, notary, broker, top, epoch)
 
 	return &testEngine{

--- a/banking/mocks/epoch_service_mock.go
+++ b/banking/mocks/epoch_service_mock.go
@@ -46,3 +46,15 @@ func (mr *MockEpochServiceMockRecorder) NotifyOnEpoch(arg0 interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpoch", reflect.TypeOf((*MockEpochService)(nil).NotifyOnEpoch), arg0)
 }
+
+// NotifyOnEpochRestore mocks base method.
+func (m *MockEpochService) NotifyOnEpochRestore(arg0 func(context.Context, types.Epoch)) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyOnEpochRestore", arg0)
+}
+
+// NotifyOnEpochRestore indicates an expected call of NotifyOnEpochRestore.
+func (mr *MockEpochServiceMockRecorder) NotifyOnEpochRestore(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpochRestore", reflect.TypeOf((*MockEpochService)(nil).NotifyOnEpochRestore), arg0)
+}

--- a/banking/mocks/epoch_service_mock.go
+++ b/banking/mocks/epoch_service_mock.go
@@ -36,25 +36,13 @@ func (m *MockEpochService) EXPECT() *MockEpochServiceMockRecorder {
 }
 
 // NotifyOnEpoch mocks base method.
-func (m *MockEpochService) NotifyOnEpoch(arg0 func(context.Context, types.Epoch)) {
+func (m *MockEpochService) NotifyOnEpoch(arg0, arg1 func(context.Context, types.Epoch)) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyOnEpoch", arg0)
+	m.ctrl.Call(m, "NotifyOnEpoch", arg0, arg1)
 }
 
 // NotifyOnEpoch indicates an expected call of NotifyOnEpoch.
-func (mr *MockEpochServiceMockRecorder) NotifyOnEpoch(arg0 interface{}) *gomock.Call {
+func (mr *MockEpochServiceMockRecorder) NotifyOnEpoch(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpoch", reflect.TypeOf((*MockEpochService)(nil).NotifyOnEpoch), arg0)
-}
-
-// NotifyOnEpochRestore mocks base method.
-func (m *MockEpochService) NotifyOnEpochRestore(arg0 func(context.Context, types.Epoch)) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyOnEpochRestore", arg0)
-}
-
-// NotifyOnEpochRestore indicates an expected call of NotifyOnEpochRestore.
-func (mr *MockEpochServiceMockRecorder) NotifyOnEpochRestore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpochRestore", reflect.TypeOf((*MockEpochService)(nil).NotifyOnEpochRestore), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpoch", reflect.TypeOf((*MockEpochService)(nil).NotifyOnEpoch), arg0, arg1)
 }

--- a/banking/snapshot.go
+++ b/banking/snapshot.go
@@ -316,5 +316,6 @@ func (e *Engine) restoreAssetActions(ctx context.Context, aa *types.BankingAsset
 }
 
 func (e *Engine) OnEpochRestore(ctx context.Context, ep types.Epoch) {
+	e.log.Debug("epoch restoration notification received", logging.String("epoch", ep.String()))
 	e.currentEpoch = ep.Seq
 }

--- a/banking/snapshot.go
+++ b/banking/snapshot.go
@@ -314,3 +314,7 @@ func (e *Engine) restoreAssetActions(ctx context.Context, aa *types.BankingAsset
 	e.bss.changed[assetActionsKey] = true
 	return nil
 }
+
+func (e *Engine) OnEpochRestore(ctx context.Context, ep types.Epoch) {
+	e.currentEpoch = ep.Seq
+}

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -137,6 +137,7 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 	)
 	n.epochService = epochtime.NewService(n.Log, n.conf.Epoch, n.timeService, n.broker)
 	n.epochService.NotifyOnEpoch(n.topology.OnEpochEvent)
+	n.epochService.NotifyOnEpochRestore(n.topology.OnEpochRestore)
 
 	n.statevar = statevar.New(n.Log, n.conf.StateVar, n.broker, n.topology, n.commander, n.timeService)
 	n.feesTracker = execution.NewFeesTracker(n.epochService)

--- a/cmd/vega/node/start_services.go
+++ b/cmd/vega/node/start_services.go
@@ -136,8 +136,7 @@ func (n *NodeCommand) startServices(_ []string) (err error) {
 		n.Log, n.conf.Staking, n.broker, n.timeService, n.witness, n.ethClient, n.netParams, n.eventForwarder, n.conf.HaveEthClient(), n.ethConfirmations,
 	)
 	n.epochService = epochtime.NewService(n.Log, n.conf.Epoch, n.timeService, n.broker)
-	n.epochService.NotifyOnEpoch(n.topology.OnEpochEvent)
-	n.epochService.NotifyOnEpochRestore(n.topology.OnEpochRestore)
+	n.epochService.NotifyOnEpoch(n.topology.OnEpochEvent, n.topology.OnEpochRestore)
 
 	n.statevar = statevar.New(n.Log, n.conf.StateVar, n.broker, n.topology, n.commander, n.timeService)
 	n.feesTracker = execution.NewFeesTracker(n.epochService)

--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -67,8 +67,7 @@ type StakingAccounts interface {
 }
 
 type EpochEngine interface {
-	NotifyOnEpoch(f func(context.Context, types.Epoch))
-	NotifyOnEpochRestore(f func(context.Context, types.Epoch))
+	NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch))
 }
 
 // party delegation state - how much is delegated by the party to each validator and in total.
@@ -130,8 +129,7 @@ func New(log *logging.Logger, config Config, broker Broker, topology ValidatorTo
 	e.keyToSerialiser[lastReconKey] = e.serialiseLastReconTime
 
 	// register for epoch notifications
-	epochEngine.NotifyOnEpoch(e.onEpochEvent)
-	epochEngine.NotifyOnEpochRestore(e.onEpochRestore)
+	epochEngine.NotifyOnEpoch(e.onEpochEvent, e.onEpochRestore)
 
 	// register for time tick updates
 	ts.NotifyOnTick(e.onChainTimeUpdate)

--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
@@ -165,6 +166,12 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 // update the current epoch at which current pending delegations are recorded
 // regardless if the event is start or stop of the epoch. the sequence is what identifies the epoch.
 func (e *Engine) onEpochEvent(ctx context.Context, epoch types.Epoch) {
+	if epoch.Action == vega.EpochAction_EPOCH_ACTION_RESTORED {
+		e.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
+		e.currentEpoch = epoch
+		return
+	}
+
 	if (e.lastReconciliation == time.Time{}) {
 		e.lastReconciliation = epoch.StartTime
 		e.dss.changed[lastReconKey] = true

--- a/delegation/engine_test.go
+++ b/delegation/engine_test.go
@@ -1919,8 +1919,8 @@ func getEngine(t *testing.T) *testEngine {
 
 type TestEpochEngine struct{}
 
-func (t *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch))        {}
-func (t *TestEpochEngine) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {}
+func (t *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch)) {
+}
 
 type TestStakingAccount struct {
 	partyToStake         map[string]*num.Uint

--- a/delegation/engine_test.go
+++ b/delegation/engine_test.go
@@ -185,7 +185,7 @@ func testActiveSnapshotRoundTrip(t *testing.T) {
 
 	testEngine.engine.ProcessEpochDelegations(context.Background(), types.Epoch{Seq: 0})
 
-	// Move ahead a bit futher
+	// Move ahead a bit further
 	testEngine.engine.onEpochEvent(context.Background(), types.Epoch{Seq: 2, StartTime: time.Now()})
 
 	// get the has and serialised state

--- a/delegation/snapshot.go
+++ b/delegation/snapshot.go
@@ -205,3 +205,7 @@ func (e *Engine) restoreAuto(delegations *types.DelegationAuto) error {
 	e.dss.changed[autoKey] = true
 	return nil
 }
+
+func (e *Engine) onEpochRestore(ctx context.Context, epoch types.Epoch) {
+	e.currentEpoch = epoch
+}

--- a/delegation/snapshot.go
+++ b/delegation/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 
 	"github.com/golang/protobuf/proto"
@@ -207,5 +208,6 @@ func (e *Engine) restoreAuto(delegations *types.DelegationAuto) error {
 }
 
 func (e *Engine) onEpochRestore(ctx context.Context, epoch types.Epoch) {
+	e.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
 	e.currentEpoch = epoch
 }

--- a/epochtime/service.go
+++ b/epochtime/service.go
@@ -24,7 +24,8 @@ type Svc struct {
 	length time.Duration
 	epoch  types.Epoch
 
-	listeners []func(context.Context, types.Epoch)
+	listeners        []func(context.Context, types.Epoch) // for when the epoch state changes
+	restoreListeners []func(context.Context, types.Epoch) // for when the epoch has been restored from a snapshot
 
 	log *logging.Logger
 
@@ -39,7 +40,6 @@ type Svc struct {
 	data             []byte
 	hash             []byte
 	currentTime      time.Time
-	restoreListeners []func(context.Context, types.Epoch)
 	needsFastForward bool
 }
 

--- a/epochtime/service.go
+++ b/epochtime/service.go
@@ -187,10 +187,12 @@ func (s *Svc) fastForward(ctx context.Context) {
 	s.onTick(ctx, tt)
 }
 
-// NotifyOnEpoch allows other services to register a callback function
-// which will be called once we enter a new epoch.
-func (s *Svc) NotifyOnEpoch(f func(context.Context, types.Epoch)) {
+// NotifyOnEpoch allows other services to register 2 callback functions.
+// The first will be called once we enter or leave a new epoch, and the second
+// will be called when the epochserivce has been restored from a snapshot.
+func (s *Svc) NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch)) {
 	s.listeners = append(s.listeners, f)
+	s.restoreListeners = append(s.restoreListeners, r)
 }
 
 func (s *Svc) notify(ctx context.Context, e types.Epoch) {

--- a/epochtime/service.go
+++ b/epochtime/service.go
@@ -39,6 +39,7 @@ type Svc struct {
 	data             []byte
 	hash             []byte
 	currentTime      time.Time
+	restoreListeners []func(context.Context, types.Epoch)
 	needsFastForward bool
 }
 

--- a/epochtime/snapshot.go
+++ b/epochtime/snapshot.go
@@ -82,13 +82,6 @@ func (s *Svc) LoadState(ctx context.Context, payload *types.Payload) ([]types.St
 	}
 }
 
-// NotifyOnRestore allows other services to register a callback function
-// to handle the case where the engine has restored from a snapshot and
-// the other engines need to know about it.
-func (s *Svc) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {
-	s.restoreListeners = append(s.restoreListeners, f)
-}
-
 func (s *Svc) notifyRestore(ctx context.Context, e types.Epoch) {
 	for _, f := range s.restoreListeners {
 		f(ctx, e)

--- a/epochtime/snapshot.go
+++ b/epochtime/snapshot.go
@@ -84,7 +84,7 @@ func (s *Svc) LoadState(ctx context.Context, payload *types.Payload) ([]types.St
 
 // NotifyOnRestore allows other services to register a callback function
 // to handle the case where the engine has restored from a snapshot and
-// the other engines need to know about it
+// the other engines need to know about it.
 func (s *Svc) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {
 	s.restoreListeners = append(s.restoreListeners, f)
 }

--- a/epochtime/snapshot.go
+++ b/epochtime/snapshot.go
@@ -74,8 +74,23 @@ func (s *Svc) LoadState(ctx context.Context, payload *types.Payload) ([]types.St
 		s.readyToEndEpoch = snap.ReadyToEndEpoch
 		s.length = s.epoch.ExpireTime.Sub(s.epoch.StartTime)
 
+		// notify everyone of the restored epoch, this will always be mid epoch since onTick only
+		// happens at the start of a block and an epoch boundary is handle instantaneously. So even at
+		// and epoch boundary the order of events will be
+		// onEndBlock -> snapshot -> OnCommit -> onBeginBlock -> epoch-end + epoch-start events -> notify-new-epoch
+		// and so we can never take a snapshot between an epoch ending and a new one starting.
+		s.notify(ctx, types.Epoch{
+			Seq:        snap.Seq,
+			StartTime:  snap.StartTime,
+			ExpireTime: snap.ExpireTime,
+			Action:     vega.EpochAction_EPOCH_ACTION_RESTORED,
+		})
 		return nil, s.serialise()
 	default:
 		return nil, types.ErrUnknownSnapshotType
 	}
+}
+
+func (s *Svc) NotifyOnRestore(f func(context.Context, types.Epoch)) {
+	s.restoreListeners = append(s.listeners, f)
 }

--- a/epochtime/snapshot_test.go
+++ b/epochtime/snapshot_test.go
@@ -38,6 +38,9 @@ func TestEpochSnapshotFunctionallyAfterReload(t *testing.T) {
 	err = proto.Unmarshal(data, snap)
 	require.Nil(t, err)
 
+	service.NotifyOnEpoch(onEpoch, onEpochRestore)
+	snapService.NotifyOnEpoch(onEpoch, onEpochRestore)
+
 	_, err = snapService.LoadState(
 		ctx,
 		types.PayloadFromProto(snap),
@@ -47,8 +50,6 @@ func TestEpochSnapshotFunctionallyAfterReload(t *testing.T) {
 	// Check functional equivalence by stepping forward in time/blocks
 	// Reset global used in callback so that is doesn't pick up state from another test
 	epochs = []types.Epoch{}
-	service.NotifyOnEpoch(onEpoch)
-	snapService.NotifyOnEpoch(onEpoch)
 
 	// Move time forward in time a small amount that should cause no change
 	nt := now.Add(time.Hour)

--- a/execution/engine_snapshot_test.go
+++ b/execution/engine_snapshot_test.go
@@ -43,7 +43,7 @@ func createEngine(t *testing.T) (*execution.Engine, *gomock.Controller) {
 	statevar.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	epochEngine := mocks.NewMockEpochEngine(ctrl)
-	epochEngine.EXPECT().NotifyOnEpoch(gomock.Any()).Times(1)
+	epochEngine.EXPECT().NotifyOnEpoch(gomock.Any(), gomock.Any()).Times(1)
 	asset := mocks.NewMockAssets(ctrl)
 	asset.EXPECT().Get(gomock.Any()).AnyTimes().DoAndReturn(func(a string) (*assets.Asset, error) {
 		as := NewAssetStub(a, 0)

--- a/execution/fees_tracker.go
+++ b/execution/fees_tracker.go
@@ -11,7 +11,7 @@ import (
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/epoch_service_mock.go -package mocks code.vegaprotocol.io/vega/execution EpochEngine
 type EpochEngine interface {
-	NotifyOnEpoch(f func(context.Context, types.Epoch))
+	NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch))
 }
 
 // assetFeesTracker tracks the amount of fees paid/received by different parties in the asset.
@@ -54,7 +54,7 @@ func NewFeesTracker(epochEngine EpochEngine) *FeesTracker {
 		assetToTracker: map[string]*assetFeesTracker{},
 		ss:             &snapshotState{changed: true},
 	}
-	epochEngine.NotifyOnEpoch(ft.onEpochEvent)
+	epochEngine.NotifyOnEpoch(ft.onEpochEvent, ft.onEpochRestore)
 	return ft
 }
 

--- a/execution/fees_tracker_snapshot.go
+++ b/execution/fees_tracker_snapshot.go
@@ -156,3 +156,8 @@ func (f *FeesTracker) restore(ctx context.Context, data *snapshot.FeesTracker) e
 	f.ss.changed = true
 	return nil
 }
+
+// onEpochEvent is called when the state of the epoch changes, we only care about new epochs starting.
+func (f *FeesTracker) onEpochRestore(_ context.Context, epoch types.Epoch) {
+	f.currentEpoch = epoch.Seq
+}

--- a/execution/fees_tracker_test.go
+++ b/execution/fees_tracker_test.go
@@ -17,7 +17,7 @@ type TestEpochEngine struct {
 	target func(context.Context, types.Epoch)
 }
 
-func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch)) {
+func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch), _ func(context.Context, types.Epoch)) {
 	e.target = f
 }
 

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -183,7 +183,7 @@ func (tm *testMarket) Run(ctx context.Context, mktCfg types.Market) *testMarket 
 
 	statevarEngine := stubs.NewStateVar()
 	epochEngine := mocks.NewMockEpochEngine(tm.ctrl)
-	epochEngine.EXPECT().NotifyOnEpoch(gomock.Any()).Times(1)
+	epochEngine.EXPECT().NotifyOnEpoch(gomock.Any(), gomock.Any()).Times(1)
 	feeTracker := execution.NewFeesTracker(epochEngine)
 	mktEngine, err := execution.NewMarket(ctx,
 		tm.log, riskConfig, positionConfig, settlementConfig, matchingConfig,
@@ -379,7 +379,7 @@ func getTestMarket2WithDP(
 	statevar := stubs.NewStateVar()
 
 	epoch := mocks.NewMockEpochEngine(ctrl)
-	epoch.EXPECT().NotifyOnEpoch(gomock.Any()).Times(1)
+	epoch.EXPECT().NotifyOnEpoch(gomock.Any(), gomock.Any()).Times(1)
 	feeTracker := execution.NewFeesTracker(epoch)
 
 	mktEngine, err := execution.NewMarket(context.Background(),

--- a/execution/mocks/epoch_service_mock.go
+++ b/execution/mocks/epoch_service_mock.go
@@ -36,13 +36,13 @@ func (m *MockEpochEngine) EXPECT() *MockEpochEngineMockRecorder {
 }
 
 // NotifyOnEpoch mocks base method.
-func (m *MockEpochEngine) NotifyOnEpoch(arg0 func(context.Context, types.Epoch)) {
+func (m *MockEpochEngine) NotifyOnEpoch(arg0, arg1 func(context.Context, types.Epoch)) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyOnEpoch", arg0)
+	m.ctrl.Call(m, "NotifyOnEpoch", arg0, arg1)
 }
 
 // NotifyOnEpoch indicates an expected call of NotifyOnEpoch.
-func (mr *MockEpochEngineMockRecorder) NotifyOnEpoch(arg0 interface{}) *gomock.Call {
+func (mr *MockEpochEngineMockRecorder) NotifyOnEpoch(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpoch", reflect.TypeOf((*MockEpochEngine)(nil).NotifyOnEpoch), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOnEpoch", reflect.TypeOf((*MockEpochEngine)(nil).NotifyOnEpoch), arg0, arg1)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module code.vegaprotocol.io/vega
 
 go 1.17
 
+
+replace code.vegaprotocol.io/protos => /Users/wwestgarth/work/protos
+
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
 	code.vegaprotocol.io/protos v0.49.1-0.20220301090519-acdae22a9cac

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module code.vegaprotocol.io/vega
 go 1.17
 
 
-replace code.vegaprotocol.io/protos => /Users/wwestgarth/work/protos
-
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
 	code.vegaprotocol.io/protos v0.49.1-0.20220301090519-acdae22a9cac

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -109,7 +109,7 @@ func newExecutionTestSetup() *executionTestSetup {
 	execsetup.topology = stubs.NewTopologyStub("nodeID", execsetup.broker)
 
 	execsetup.stakingAccount = stubs.NewStakingAccountStub()
-	execsetup.epochEngine.NotifyOnEpoch(execsetup.stakingAccount.OnEpochEvent)
+	execsetup.epochEngine.NotifyOnEpoch(execsetup.stakingAccount.OnEpochEvent, execsetup.stakingAccount.OnEpochRestore)
 
 	feesTracker := execution.NewFeesTracker(execsetup.epochEngine)
 

--- a/integration/stubs/staking_account_stub.go
+++ b/integration/stubs/staking_account_stub.go
@@ -29,6 +29,8 @@ func (t *StakingAccountStub) OnEpochEvent(ctx context.Context, epoch types.Epoch
 	}
 }
 
+func (t *StakingAccountStub) OnEpochRestore(_ context.Context, _ types.Epoch) {}
+
 func (t *StakingAccountStub) IncrementBalance(party string, amount *num.Uint) error {
 	if _, ok := t.partyToStake[party]; !ok {
 		t.partyToStake[party] = num.Zero()

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -35,7 +35,7 @@ type TimeService interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/epoch_service_mock.go -package mocks code.vegaprotocol.io/vega/processor EpochService
 type EpochService interface {
-	NotifyOnEpoch(f func(context.Context, types.Epoch))
+	NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch))
 	OnBlockEnd(ctx context.Context)
 }
 

--- a/rewards/engine.go
+++ b/rewards/engine.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/types/num"
 
 	"code.vegaprotocol.io/vega/events"
@@ -189,8 +190,12 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 func (e *Engine) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 	e.log.Debug("OnEpochEvent")
 
+	if epoch.Action == vega.EpochAction_EPOCH_ACTION_RESTORED {
+		e.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
+	}
+
 	// on new epoch update the epoch seq and update the epoch started flag
-	if (epoch.EndTime == time.Time{}) {
+	if (epoch.EndTime == time.Time{} || epoch.Action == vega.EpochAction_EPOCH_ACTION_RESTORED) {
 		e.epochSeq = num.NewUint(epoch.Seq).String()
 		e.newEpochStarted = true
 		return

--- a/rewards/engine.go
+++ b/rewards/engine.go
@@ -203,6 +203,7 @@ func (e *Engine) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 }
 
 func (e *Engine) OnEpochRestore(ctx context.Context, epoch types.Epoch) {
+	e.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
 	e.epochSeq = num.NewUint(epoch.Seq).String()
 	e.newEpochStarted = true
 }

--- a/rewards/engine.go
+++ b/rewards/engine.go
@@ -36,8 +36,7 @@ type MarketTracker interface {
 
 // EpochEngine notifies the reward engine at the end of an epoch.
 type EpochEngine interface {
-	NotifyOnEpoch(f func(context.Context, types.Epoch))
-	NotifyOnEpochRestore(f func(context.Context, types.Epoch))
+	NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch))
 }
 
 //Delegation engine for getting validation data
@@ -124,8 +123,7 @@ func New(log *logging.Logger, config Config, broker Broker, delegation Delegatio
 	}
 
 	// register for epoch end notifications
-	epochEngine.NotifyOnEpoch(e.OnEpochEvent)
-	epochEngine.NotifyOnEpochRestore(e.OnEpochRestore)
+	epochEngine.NotifyOnEpoch(e.OnEpochEvent, e.OnEpochRestore)
 
 	// register for time tick updates
 	ts.NotifyOnTick(e.onChainTimeUpdate)

--- a/rewards/engine_test.go
+++ b/rewards/engine_test.go
@@ -369,10 +369,7 @@ type TestEpochEngine struct {
 	restore   []func(context.Context, types.Epoch)
 }
 
-func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch)) {
+func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch)) {
 	e.callbacks = append(e.callbacks, f)
-}
-
-func (e *TestEpochEngine) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {
-	e.restore = append(e.restore, f)
+	e.restore = append(e.callbacks, r)
 }

--- a/rewards/engine_test.go
+++ b/rewards/engine_test.go
@@ -287,7 +287,10 @@ func getEngine(t *testing.T) *testEngine {
 	broker := bmock.NewMockBroker(ctrl)
 	logger := logging.NewTestLogger()
 	delegation := mocks.NewMockDelegation(ctrl)
-	epochEngine := &TestEpochEngine{callbacks: []func(context.Context, types.Epoch){}}
+	epochEngine := &TestEpochEngine{
+		callbacks: []func(context.Context, types.Epoch){},
+		restore:   []func(context.Context, types.Epoch){},
+	}
 	ts := mocks.NewMockTimeService(ctrl)
 
 	ts.EXPECT().GetTimeNow().AnyTimes()
@@ -363,8 +366,13 @@ func getEngine(t *testing.T) *testEngine {
 
 type TestEpochEngine struct {
 	callbacks []func(context.Context, types.Epoch)
+	restore   []func(context.Context, types.Epoch)
 }
 
 func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch)) {
 	e.callbacks = append(e.callbacks, f)
+}
+
+func (e *TestEpochEngine) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {
+	e.restore = append(e.restore, f)
 }

--- a/spam/engine.go
+++ b/spam/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/netparams"
 
 	"code.vegaprotocol.io/vega/blockchain/abci"
@@ -152,6 +153,13 @@ func (e *Engine) OnMinValidatorTokensChanged(_ context.Context, minTokens num.De
 // OnEpochEvent is a callback for epoch events.
 func (e *Engine) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 	e.log.Info("Spam protection OnEpochEvent called", logging.Uint64("epoch", epoch.Seq))
+
+	if epoch.Action == vega.EpochAction_EPOCH_ACTION_RESTORED {
+		e.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
+		e.currentEpoch = &epoch
+		return
+	}
+
 	if e.currentEpoch == nil || e.currentEpoch.Seq != epoch.Seq {
 		if e.log.GetLevel() <= logging.DebugLevel {
 			e.log.Debug("Spam protection new epoch started", logging.Uint64("epochSeq", epoch.Seq))

--- a/spam/engine.go
+++ b/spam/engine.go
@@ -27,8 +27,7 @@ type StakingAccounts interface {
 }
 
 type EpochEngine interface {
-	NotifyOnEpoch(f func(context.Context, types.Epoch))
-	NotifyOnEpochRestore(f func(context.Context, types.Epoch))
+	NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch))
 }
 
 type Engine struct {
@@ -100,8 +99,7 @@ func New(log *logging.Logger, config Config, epochEngine EpochEngine, accounting
 	e.transactionTypeToPolicy[txn.AnnounceNodeCommand] = valJoinPolicy
 
 	// register for epoch end notifications
-	epochEngine.NotifyOnEpoch(e.OnEpochEvent)
-	epochEngine.NotifyOnEpochRestore(e.OnEpochRestore)
+	epochEngine.NotifyOnEpoch(e.OnEpochEvent, e.OnEpochRestore)
 	e.log.Info("Spam protection started")
 
 	return e

--- a/spam/engine_test.go
+++ b/spam/engine_test.go
@@ -243,7 +243,10 @@ func getEngine(t *testing.T, balances map[string]*num.Uint) *testEngine {
 	t.Helper()
 	conf := spam.NewDefaultConfig()
 	logger := logging.NewTestLogger()
-	epochEngine := &TestEpochEngine{callbacks: []func(context.Context, types.Epoch){}}
+	epochEngine := &TestEpochEngine{
+		callbacks: []func(context.Context, types.Epoch){},
+		restore:   []func(context.Context, types.Epoch){},
+	}
 	accounts := &testAccounts{balances: balances}
 
 	engine := spam.New(logger, conf, epochEngine, accounts)
@@ -264,8 +267,13 @@ func getEngine(t *testing.T, balances map[string]*num.Uint) *testEngine {
 
 type TestEpochEngine struct {
 	callbacks []func(context.Context, types.Epoch)
+	restore   []func(context.Context, types.Epoch)
 }
 
 func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch)) {
 	e.callbacks = append(e.callbacks, f)
+}
+
+func (e *TestEpochEngine) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {
+	e.restore = append(e.restore, f)
 }

--- a/spam/engine_test.go
+++ b/spam/engine_test.go
@@ -281,10 +281,7 @@ type TestEpochEngine struct {
 	restore   []func(context.Context, types.Epoch)
 }
 
-func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch)) {
+func (e *TestEpochEngine) NotifyOnEpoch(f func(context.Context, types.Epoch), r func(context.Context, types.Epoch)) {
 	e.callbacks = append(e.callbacks, f)
-}
-
-func (e *TestEpochEngine) NotifyOnEpochRestore(f func(context.Context, types.Epoch)) {
-	e.restore = append(e.restore, f)
+	e.restore = append(e.restore, r)
 }

--- a/spam/engine_test.go
+++ b/spam/engine_test.go
@@ -105,46 +105,57 @@ func testEngineReset(t *testing.T) {
 		require.NoError(t, err)
 		snap[k] = data
 	}
+
+	snapEngine := getEngine(t, map[string]*num.Uint{"party1": sufficientPropTokens})
 	for _, bytes := range snap {
 		var p snapshot.Payload
 		proto.Unmarshal(bytes, &p)
 		payload := types.PayloadFromProto(&p)
-		engine.LoadState(context.Background(), payload)
+		snapEngine.engine.LoadState(context.Background(), payload)
 	}
 
-	proposalHash2, err := engine.GetHash("proposal")
+	// restore the epoch we were on
+	snapEngine.engine.OnEpochRestore(context.Background(), types.Epoch{Seq: 0})
+
+	proposalHash2, err := snapEngine.engine.GetHash("proposal")
 	require.Nil(t, err)
 	require.True(t, bytes.Equal(proposalHash, proposalHash2))
 
-	voteHash2, err := engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
+	voteHash2, err := snapEngine.engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
 	require.Nil(t, err)
 	require.True(t, bytes.Equal(voteHash, voteHash2))
 
-	accept, err := engine.PreBlockAccept(tx1)
+	accept, err := snapEngine.engine.PreBlockAccept(tx1)
 	require.Equal(t, false, accept)
 	require.Equal(t, errors.New("party has already proposed the maximum number of proposal requests per epoch"), err)
 
-	accept, err = engine.PreBlockAccept(tx2)
+	accept, err = snapEngine.engine.PreBlockAccept(tx2)
 	require.Equal(t, false, accept)
 	require.Equal(t, spam.ErrTooManyVotes, err)
 
+	// Notify an epoch event for the *same* epoch and a reset should not happen
+	snapEngine.engine.OnEpochEvent(context.Background(), types.Epoch{Seq: 0})
+	proposalHashNoReset, err := snapEngine.engine.GetHash("proposal")
+	require.Nil(t, err)
+	require.True(t, bytes.Equal(proposalHashNoReset, proposalHash2))
+
 	// move to next epoch
-	engine.OnEpochEvent(context.Background(), types.Epoch{Seq: 1})
+	snapEngine.engine.OnEpochEvent(context.Background(), types.Epoch{Seq: 1})
 
 	// expect to be able to submit 3 more votes/proposals successfully
 	for i := 0; i < 3; i++ {
-		accept, _ := engine.PreBlockAccept(tx1)
+		accept, _ := snapEngine.engine.PreBlockAccept(tx1)
 		require.Equal(t, true, accept)
 
-		accept, _ = engine.PreBlockAccept(tx2)
+		accept, _ = snapEngine.engine.PreBlockAccept(tx2)
 		require.Equal(t, true, accept)
 	}
 
-	proposalHash3, err := engine.GetHash("proposal")
+	proposalHash3, err := snapEngine.engine.GetHash("proposal")
 	require.Nil(t, err)
 	require.False(t, bytes.Equal(proposalHash3, proposalHash2))
 
-	voteHash3, err := engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
+	voteHash3, err := snapEngine.engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
 	require.Nil(t, err)
 	require.False(t, bytes.Equal(voteHash3, voteHash2))
 }

--- a/spam/snapshot.go
+++ b/spam/snapshot.go
@@ -55,3 +55,8 @@ func (e *Engine) LoadState(ctx context.Context, p *types.Payload) ([]types.State
 
 	return nil, e.policyNameToPolicy[p.Key()].Deserialise(p)
 }
+
+// OnEpochEvent is a callback for epoch events.
+func (e *Engine) OnEpochRestore(ctx context.Context, epoch types.Epoch) {
+	e.currentEpoch = &epoch
+}

--- a/spam/snapshot.go
+++ b/spam/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 )
 
@@ -58,5 +59,6 @@ func (e *Engine) LoadState(ctx context.Context, p *types.Payload) ([]types.State
 
 // OnEpochEvent is a callback for epoch events.
 func (e *Engine) OnEpochRestore(ctx context.Context, epoch types.Epoch) {
+	e.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
 	e.currentEpoch = &epoch
 }

--- a/validators/topology.go
+++ b/validators/topology.go
@@ -135,10 +135,16 @@ type Topology struct {
 
 func (t *Topology) OnEpochEvent(_ context.Context, epoch types.Epoch) {
 	t.epochSeq = epoch.Seq
-	if epoch.Action == proto.EpochAction_EPOCH_ACTION_START {
+	switch epoch.Action {
+	case proto.EpochAction_EPOCH_ACTION_START:
 		t.newEpochStarted = true
 		t.rng = rand.New(rand.NewSource(epoch.StartTime.Unix()))
 		t.validatorPerformance.Reset()
+	case proto.EpochAction_EPOCH_ACTION_RESTORED:
+		t.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
+		t.newEpochStarted = true
+		t.rng = rand.New(rand.NewSource(epoch.StartTime.Unix()))
+		// we don't want to reset the peformance here, we're mid epoch
 	}
 }
 

--- a/validators/topology.go
+++ b/validators/topology.go
@@ -135,16 +135,10 @@ type Topology struct {
 
 func (t *Topology) OnEpochEvent(_ context.Context, epoch types.Epoch) {
 	t.epochSeq = epoch.Seq
-	switch epoch.Action {
-	case proto.EpochAction_EPOCH_ACTION_START:
+	if epoch.Action == proto.EpochAction_EPOCH_ACTION_START {
 		t.newEpochStarted = true
 		t.rng = rand.New(rand.NewSource(epoch.StartTime.Unix()))
 		t.validatorPerformance.Reset()
-	case proto.EpochAction_EPOCH_ACTION_RESTORED:
-		t.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
-		t.newEpochStarted = true
-		t.rng = rand.New(rand.NewSource(epoch.StartTime.Unix()))
-		// we don't want to reset the peformance here, we're mid epoch
 	}
 }
 

--- a/validators/topology_snapshot.go
+++ b/validators/topology_snapshot.go
@@ -3,6 +3,7 @@ package validators
 import (
 	"context"
 	"encoding/base64"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -248,4 +249,12 @@ func (t *Topology) restore(ctx context.Context, topology *types.Topology) error 
 	t.validatorPerformance.Deserialize(topology.ValidatorPerformance)
 	t.tss.changed = true
 	return nil
+}
+
+// OnEpochRestore is the epochtime service telling us the restored epoch data
+func (t *Topology) OnEpochRestore(_ context.Context, epoch types.Epoch) {
+	t.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
+	t.epochSeq = epoch.Seq
+	t.newEpochStarted = true
+	t.rng = rand.New(rand.NewSource(epoch.StartTime.Unix()))
 }

--- a/validators/topology_snapshot.go
+++ b/validators/topology_snapshot.go
@@ -251,7 +251,7 @@ func (t *Topology) restore(ctx context.Context, topology *types.Topology) error 
 	return nil
 }
 
-// OnEpochRestore is the epochtime service telling us the restored epoch data
+// OnEpochRestore is the epochtime service telling us the restored epoch data.
 func (t *Topology) OnEpochRestore(_ context.Context, epoch types.Epoch) {
 	t.log.Debug("epoch restoration notification received", logging.String("epoch", epoch.String()))
 	t.epochSeq = epoch.Seq


### PR DESCRIPTION
closes #4880 

When an epoch is restored from a snapshot it now notifies all subscribers so that they themselves can set the restored epoch values in their engines.