### PR TITLE
stop double netparam update after snapshot restore

### DIFF
--- a/netparams/snapshot.go
+++ b/netparams/snapshot.go
@@ -153,5 +153,6 @@ func (s *Store) LoadState(ctx context.Context, pl *types.Payload) ([]types.State
 		}
 	}
 
+	s.paramUpdates = map[string]struct{}{}
 	return nil, nil
 }


### PR DESCRIPTION
When loading netparams from a snapshot and dispatching them everywhere, we weren't clearing `s.paramUpdates`. This meant at the start of the first block after the snapshot restore, we'd dispatch them all again.

Its harmless, but not right.