### PR TITLE
Set checkpoint in genesis file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### 🛠 Improvements
 - [2585](https://github.com/vegaprotocol/vega/issues/2585) - Adding position state event to event bus
 - [4952](https://github.com/vegaprotocol/vega/issues/4952) - Add checkpoints for staking and `multisig control`
+- [4923](https://github.com/vegaprotocol/vega/issues/4923) - Add checkpoint state in the genesis file + add subcommand to do it.
 
 ### 🐛 Fixes
 - [4983](https://github.com/vegaprotocol/vega/issues/4983) - Set correct event type for positions state event

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -142,7 +142,7 @@ func (e *Engine) UponGenesis(ctx context.Context, data []byte) (err error) {
 
 		buf, err := base64.StdEncoding.DecodeString(state.CheckpointState)
 		if err != nil {
-			return fmt.Errorf("invalid genesis file checkpoint.state", logging.Error(err))
+			return fmt.Errorf("invalid genesis file checkpoint.state: %w", err)
 		}
 
 		cpt := &types.CheckpointState{}

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -3,6 +3,7 @@ package checkpoint
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -117,6 +118,8 @@ func (e *Engine) UponGenesis(ctx context.Context, data []byte) (err error) {
 	if err != nil {
 		return err
 	}
+
+	// first is there a hash
 	if state != nil && len(state.CheckpointHash) != 0 {
 		e.loadHash, err = hex.DecodeString(state.CheckpointHash)
 		e.log.Warn("Checkpoint restore enabled",
@@ -128,6 +131,28 @@ func (e *Engine) UponGenesis(ctx context.Context, data []byte) (err error) {
 			e.log.Panic("Malformed restore hash in genesis file",
 				logging.Error(err),
 			)
+		}
+	}
+
+	if state != nil && len(state.CheckpointState) > 0 {
+		// no loadHash but a state specified.
+		if len(e.loadHash) <= 0 {
+			e.log.Panic("invalid genesis file, state specified without hash")
+		}
+
+		buf, err := base64.StdEncoding.DecodeString(state.CheckpointState)
+		if err != nil {
+			return fmt.Errorf("invalid genesis file checkpoint.state", logging.Error(err))
+		}
+
+		cpt := &types.CheckpointState{}
+		if err := cpt.SetState(buf); err != nil {
+			return fmt.Errorf("invalid restore checkpoint command: %w", err)
+		}
+
+		// now we can proceed with loading it.
+		if err := e.Load(ctx, cpt); err != nil {
+			return fmt.Errorf("could not load checkpoint: %w", err)
 		}
 	}
 

--- a/checkpoint/genesis_state.go
+++ b/checkpoint/genesis_state.go
@@ -3,7 +3,8 @@ package checkpoint
 import "encoding/json"
 
 type GenesisState struct {
-	CheckpointHash string `json:"load_hash"`
+	CheckpointHash  string `json:"load_hash"`
+	CheckpointState string `json:"state"`
 }
 
 func DefaultGenesisState() GenesisState {

--- a/cmd/vega/genesis/genesis.go
+++ b/cmd/vega/genesis/genesis.go
@@ -13,10 +13,11 @@ type Cmd struct {
 	config.PassphraseFlag
 
 	// Subcommands
-	Generate generateCmd `command:"generate" description:"Generates the genesis file"`
-	Update   updateCmd   `command:"update" description:"Update the genesis file with the app_state, useful if the genesis generation is not done using \"vega genesis generate\""`
-	Sign     signCmd     `command:"sign" description:"Sign a subset of the network parameters"`
-	Verify   verifyCmd   `command:"verify" description:"Verify the signature of the network parameter against local genesis file"`
+	Generate       generateCmd       `command:"generate" description:"Generates the genesis file"`
+	Update         updateCmd         `command:"update" description:"Update the genesis file with the app_state, useful if the genesis generation is not done using \"vega genesis generate\""`
+	Sign           signCmd           `command:"sign" description:"Sign a subset of the network parameters"`
+	Verify         verifyCmd         `command:"verify" description:"Verify the signature of the network parameter against local genesis file"`
+	LoadCheckpoint loadCheckpointCmd `command:"load_checkpoint" description:"Load the given checkpoint file in the genesis file"`
 }
 
 var genesisCmd Cmd
@@ -33,6 +34,9 @@ func Genesis(ctx context.Context, parser *flags.Parser) error {
 			TmHome: "$HOME/.tendermint",
 		},
 		Update: updateCmd{
+			TmHome: "$HOME/.tendermint",
+		},
+		LoadCheckpoint: loadCheckpointCmd{
 			TmHome: "$HOME/.tendermint",
 		},
 	}

--- a/cmd/vega/genesis/load_checkpoint.go
+++ b/cmd/vega/genesis/load_checkpoint.go
@@ -1,0 +1,94 @@
+package genesis
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"code.vegaprotocol.io/vega/genesis"
+	"code.vegaprotocol.io/vega/logging"
+	vgtm "code.vegaprotocol.io/vega/tendermint"
+	"code.vegaprotocol.io/vega/types"
+	"github.com/jessevdk/go-flags"
+)
+
+type loadCheckpointCmd struct {
+	DryRun         bool   `long:"dry-run" description:"Display the genesis file without writing it"`
+	TmHome         string `short:"t" long:"tm-home" description:"The home path of tendermint"`
+	CheckpointPath string `long:"checkpoint-path" required:"true" description:"The path to the checkpoint file to load"`
+}
+
+func (opts *loadCheckpointCmd) Execute(_ []string) error {
+	log := logging.NewLoggerFromConfig(
+		logging.NewDefaultConfig(),
+	)
+	defer log.AtExit()
+
+	if _, err := flags.NewParser(opts, flags.Default|flags.IgnoreUnknown).Parse(); err != nil {
+		return err
+	}
+
+	tmConfig := vgtm.NewConfig(opts.TmHome)
+
+	genesisDoc, _, err := tmConfig.Genesis()
+	if err != nil {
+		return fmt.Errorf("couldn't get genesis file: %w", err)
+	}
+
+	appState := genesis.GenesisState{}
+	err = json.Unmarshal(genesisDoc.AppState, &appState)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(opts.CheckpointPath)
+	if err != nil {
+		return err
+	}
+
+	splits := strings.Split(f.Name(), "-")
+	if len(splits) != 3 {
+		return fmt.Errorf("invalid checkpoint file name: `%v`", f.Name())
+	}
+
+	expectHash := strings.TrimSuffix(splits[2], ".cp")
+	f.Close()
+
+	buf, err := ioutil.ReadFile(opts.CheckpointPath)
+	if err != nil {
+		return err
+	}
+
+	cpt := &types.CheckpointState{}
+	if err := cpt.SetState(buf); err != nil {
+		return fmt.Errorf("invalid restore checkpoint command: %w", err)
+	}
+
+	if hex.EncodeToString(cpt.Hash) != expectHash {
+		return fmt.Errorf("invalid hash, file name have hash `%s` but content hash is `%s`", expectHash, hex.EncodeToString(cpt.Hash))
+	}
+
+	appState.Checkpoint.CheckpointHash = expectHash
+	appState.Checkpoint.CheckpointState = base64.StdEncoding.EncodeToString(buf)
+
+	if err := vgtm.AddAppStateToGenesis(genesisDoc, &appState); err != nil {
+		return fmt.Errorf("couldn't add app_state to genesis: %w", err)
+	}
+
+	if !opts.DryRun {
+		if err := tmConfig.SaveGenesis(genesisDoc); err != nil {
+			return fmt.Errorf("couldn't save genesis: %w", err)
+		}
+	}
+
+	prettifiedDoc, err := vgtm.Prettify(genesisDoc)
+	if err != nil {
+		return err
+	}
+	fmt.Println(prettifiedDoc)
+	return nil
+}

--- a/epochtime/service.go
+++ b/epochtime/service.go
@@ -98,12 +98,12 @@ func (s *Svc) onTick(ctx context.Context, t time.Time) {
 		return
 	}
 
+	s.currentTime = t
+
 	if s.needsFastForward {
 		s.needsFastForward = false
 		s.fastForward(ctx)
 	}
-
-	s.currentTime = t
 
 	if s.epoch.StartTime.IsZero() {
 		// First block so let's create our first epoch

--- a/epochtime/service.go
+++ b/epochtime/service.go
@@ -2,6 +2,7 @@ package epochtime
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"code.vegaprotocol.io/protos/vega"
@@ -176,15 +177,21 @@ func (s *Svc) Load(ctx context.Context, data []byte) error {
 // fastForward advances time and expires/starts any epoch that would have expired/started during the time period. It would trigger the epoch events naturally
 // so will have a side effect of delegations getting promoted and rewards getting calculated and potentially paid.
 func (s *Svc) fastForward(ctx context.Context) {
+	fmt.Printf("\n\nFAST FORWARDING START\n\n")
 	tt := s.currentTime
+	fmt.Printf("\n\n FAST FORWARDING CURRENT TIME: %s\n\n", tt.Format(time.RFC3339))
 	for {
 		if !s.epoch.ExpireTime.Before(tt) {
 			break
 		}
+
+		fmt.Printf("\n\n\nFAST FORWARDING: %v\n\n\n", s.epoch.String())
 		s.OnBlockEnd(ctx)
 		s.onTick(ctx, s.epoch.ExpireTime.Add(1*time.Second))
 	}
+	fmt.Printf("\n\nFAST FORWARDING DONE\n\n")
 	s.onTick(ctx, tt)
+	fmt.Printf("\n\n FAST FORWARDING CURRENT EPOCH %v\n\n", s.epoch.String())
 }
 
 // NotifyOnEpoch allows other services to register 2 callback functions.

--- a/epochtime/service_test.go
+++ b/epochtime/service_test.go
@@ -152,6 +152,7 @@ func TestEpochServiceCheckpointLoading(t *testing.T) {
 	println(now.String())
 	loadService.cb(ctx, now)
 	loadService.Load(ctx, cp)
+	loadService.cb(ctx, now.Add(time.Second))
 	// after the load we expect an event regardless of what epoch we were in before
 	require.Equal(t, 2, len(loadEpochs))
 
@@ -216,7 +217,7 @@ func TestEpochServiceCheckpointFastForward(t *testing.T) {
 	loadService.Load(ctx, cp)
 
 	// new block should trigger fast forward
-	loadService.cb(ctx, now)
+	loadService.cb(ctx, now.Add(time.Second))
 	require.Equal(t, 8, len(loadEpochs))
 
 	// to advance to the first block after the expiry we need advance by for 11h and 4 seconds

--- a/evtforward/engine.go
+++ b/evtforward/engine.go
@@ -51,7 +51,7 @@ func (e *Engine) UpdateStakingStartingBlock(b uint64) {
 	e.ethEngine.UpdateStakingStartingBlock(b)
 }
 
-func (e *Engine) UpdateMultiSigControlStartingBlock(b uint64) {
+func (e *Engine) UpdateMultisigControlStartingBlock(b uint64) {
 	e.multisigControlStartingBlock = b
 	e.ethEngine.UpdateMultiSigControlStartingBlock(b)
 }
@@ -154,7 +154,7 @@ func (e *NoopEngine) ReloadConf(_ Config) {
 
 func (e *NoopEngine) UpdateStakingStartingBlock(b uint64) {}
 
-func (e *NoopEngine) UpdateMultiSigControlStartingBlock(b uint64) {}
+func (e *NoopEngine) UpdateMultisigControlStartingBlock(b uint64) {}
 
 func (e *NoopEngine) SetupEthereumEngine(
 	_ ethereum.Client,

--- a/protocol/all_services.go
+++ b/protocol/all_services.go
@@ -197,6 +197,9 @@ func newServices(
 		svcs.eventForwarderEngine = evtforward.NewNoopEngine(svcs.log, svcs.conf.EvtForward)
 	}
 
+	// this is done to go around circular deps again...
+	svcs.erc20MultiSigTopology.SetEthereumEventSource(svcs.eventForwarderEngine)
+
 	svcs.stakingAccounts, svcs.stakeVerifier, svcs.stakeCheckpoint = staking.New(
 		svcs.log, svcs.conf.Staking, svcs.broker, svcs.timeService, svcs.witness, svcs.ethClient, svcs.netParams, svcs.eventForwarder, svcs.conf.HaveEthClient(), svcs.ethConfirmations, svcs.eventForwarderEngine,
 	)
@@ -231,7 +234,7 @@ func newServices(
 	svcs.banking = banking.New(svcs.log, svcs.conf.Banking, svcs.collateral, svcs.witness, svcs.timeService, svcs.assets, svcs.notary, svcs.broker, svcs.topology, svcs.epochService)
 
 	// checkpoint engine
-	svcs.checkpoint, err = checkpoint.New(svcs.log, svcs.conf.Checkpoint, svcs.assets, svcs.collateral, svcs.governance, svcs.netParams, svcs.delegation, svcs.epochService, svcs.topology, svcs.banking, svcs.stakeCheckpoint)
+	svcs.checkpoint, err = checkpoint.New(svcs.log, svcs.conf.Checkpoint, svcs.assets, svcs.collateral, svcs.governance, svcs.netParams, svcs.delegation, svcs.epochService, svcs.topology, svcs.banking, svcs.stakeCheckpoint, svcs.erc20MultiSigTopology)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/engines.go
+++ b/protocol/engines.go
@@ -14,5 +14,5 @@ type EventForwarderEngine interface {
 
 	// methods used to update starting blocks of the eef
 	UpdateStakingStartingBlock(uint64)
-	UpdateMultiSigControlStartingBlock(uint64)
+	UpdateMultisigControlStartingBlock(uint64)
 }

--- a/validators/erc20multisig/checkpoint.go
+++ b/validators/erc20multisig/checkpoint.go
@@ -60,7 +60,7 @@ func (t *Topology) Load(ctx context.Context, data []byte) error {
 
 	// 0 is default value, we assume that it was then not set
 	if mc.LastBlockSeen != 0 {
-		t.ethEventSource.UpdateMultisigControlLastBlockSeen(mc.LastBlockSeen)
+		t.ethEventSource.UpdateMultisigControlStartingBlock(mc.LastBlockSeen)
 	}
 
 	return nil

--- a/validators/erc20multisig/checkpoint_test.go
+++ b/validators/erc20multisig/checkpoint_test.go
@@ -148,7 +148,7 @@ func TestMultisigTopologySheckpoint(t *testing.T) {
 	top2 := getTestTopology(t)
 
 	top2.broker.EXPECT().Send(gomock.Any()).Times(2)
-	top2.ethEventSource.EXPECT().UpdateMultisigControlLastBlockSeen(gomock.Any()).Do(
+	top2.ethEventSource.EXPECT().UpdateMultisigControlStartingBlock(gomock.Any()).Do(
 		func(block uint64) {
 			// ensure we restart at the right block
 			assert.Equal(t, int(block), 101)

--- a/validators/erc20multisig/mocks/ethereum_event_source_mock.go
+++ b/validators/erc20multisig/mocks/ethereum_event_source_mock.go
@@ -33,14 +33,14 @@ func (m *MockEthereumEventSource) EXPECT() *MockEthereumEventSourceMockRecorder 
 	return m.recorder
 }
 
-// UpdateMultisigControlLastBlockSeen mocks base method.
-func (m *MockEthereumEventSource) UpdateMultisigControlLastBlockSeen(arg0 uint64) {
+// UpdateMultisigControlStartingBlock mocks base method.
+func (m *MockEthereumEventSource) UpdateMultisigControlStartingBlock(arg0 uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateMultisigControlLastBlockSeen", arg0)
+	m.ctrl.Call(m, "UpdateMultisigControlStartingBlock", arg0)
 }
 
-// UpdateMultisigControlLastBlockSeen indicates an expected call of UpdateMultisigControlLastBlockSeen.
-func (mr *MockEthereumEventSourceMockRecorder) UpdateMultisigControlLastBlockSeen(arg0 interface{}) *gomock.Call {
+// UpdateMultisigControlStartingBlock indicates an expected call of UpdateMultisigControlStartingBlock.
+func (mr *MockEthereumEventSourceMockRecorder) UpdateMultisigControlStartingBlock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMultisigControlLastBlockSeen", reflect.TypeOf((*MockEthereumEventSource)(nil).UpdateMultisigControlLastBlockSeen), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMultisigControlStartingBlock", reflect.TypeOf((*MockEthereumEventSource)(nil).UpdateMultisigControlStartingBlock), arg0)
 }

--- a/validators/erc20multisig/topology.go
+++ b/validators/erc20multisig/topology.go
@@ -39,7 +39,7 @@ type MultiSigOnChainVerifier interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/ethereum_event_source_mock.go -package mocks code.vegaprotocol.io/vega/validators/erc20multisig EthereumEventSource
 type EthereumEventSource interface {
-	UpdateMultisigControlLastBlockSeen(uint64)
+	UpdateMultisigControlStartingBlock(uint64)
 }
 
 // Topology keeps track of all the validators


### PR DESCRIPTION
feat: add load checkpoint subcommand to add a checkpoint in a genesis file
if a checkpoint is specified in genesis, load it straight away.

tested locally and seems to work well so far. Just one issue with a mainnet one is that staking balances and validators set is not store in checkpoints for now.


close #4977  