### PR TITLE
fix: set refPriceCacheTime so that pricemonitor cache actually works

### DIFF
--- a/monitor/price/statevar.go
+++ b/monitor/price/statevar.go
@@ -45,7 +45,7 @@ func (e *Engine) startCalcPriceRanges(eventID string, endOfCalcCallback statevar
 	}
 
 	for _, b := range e.bounds {
-		ref := e.getRefPrice(b.Trigger.Horizon)
+		ref := e.getRefPrice(b.Trigger.Horizon, false)
 		minPrice, maxPrice := e.riskModel.PriceRange(ref, e.fpHorizons[b.Trigger.Horizon], b.Trigger.Probability)
 		down = append(down, minPrice.Div(ref))
 		up = append(up, maxPrice.Div(ref))


### PR DESCRIPTION
Spotted while chasing a snapshotting bug. `refPriceCacheTime` was never getting set so we always refreshed the cache each call.