### PR TITLE
fix: store auction state being time as nanosecond in snapshot

### DIFF
--- a/monitor/snapshot_test.go
+++ b/monitor/snapshot_test.go
@@ -173,9 +173,9 @@ func TestChangedState(t *testing.T) {
 // TestAuctionTypeChain checks that if an auction is ended, then started again it is logged as a change.
 func TestAuctionEndsOpens(t *testing.T) {
 	as := createAuctionState()
-
+	now := time.Now()
 	// Perform some updates to the object
-	as.StartOpeningAuction(time.Now(), &types.AuctionDuration{
+	as.StartOpeningAuction(now, &types.AuctionDuration{
 		Duration: 200,
 		Volume:   200,
 	})
@@ -185,10 +185,10 @@ func TestAuctionEndsOpens(t *testing.T) {
 	original := getHash(t, as)
 
 	// Close it down and then start exactly the same auction again
-	as.Left(context.Background(), time.Now())
+	as.Left(context.Background(), now)
 	require.False(t, as.InAuction()) // definitely no auction
 
-	as.StartOpeningAuction(time.Now(), &types.AuctionDuration{
+	as.StartOpeningAuction(now, &types.AuctionDuration{
 		Duration: 200,
 		Volume:   200,
 	})

--- a/types/snapshot_nodes.go
+++ b/types/snapshot_nodes.go
@@ -2380,7 +2380,7 @@ func AuctionStateFromProto(as *snapshot.AuctionState) *AuctionState {
 	return &AuctionState{
 		Mode:        as.Mode,
 		DefaultMode: as.DefaultMode,
-		Begin:       time.Unix(as.Begin, 0).UTC(),
+		Begin:       time.Unix(0, as.Begin).UTC(),
 		Trigger:     as.Trigger,
 		End:         end,
 		Start:       as.Start,
@@ -2398,7 +2398,7 @@ func (a AuctionState) IntoProto() *snapshot.AuctionState {
 		Mode:        a.Mode,
 		DefaultMode: a.DefaultMode,
 		Trigger:     a.Trigger,
-		Begin:       a.Begin.Unix(),
+		Begin:       a.Begin.UnixNano(),
 		End:         end,
 		Start:       a.Start,
 		Stop:        a.Stop,


### PR DESCRIPTION
This is _not_ related to the issue seen on stagnet2, but spotted while reviewing the snapshot code in that area.

We need to store the auction being time as nanoseconds since that loss of precision could result in a difference in the decision to extend an auction if the current-time happens to land in that error bound.

We saw something similar happen in the checkpoint engine a while ago.