### PR TITLE
fix: check accounts events is not empty before looking for blockheights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [4956](https://github.com/vegaprotocol/vega/issues/4956) - Fix concurrent write to price monitoring ref price cache
 - [4957](https://github.com/vegaprotocol/vega/issues/4957) - Fix `vega announce_node` to work with `--home` and `--passphrase-file`
 - [4964](https://github.com/vegaprotocol/vega/issues/4964) - Fix price monitoring snapshot
+- [4974](https://github.com/vegaprotocol/vega/issues/4974) - Fix panic when checkpointing staking accounts if there are no events
 
 
 ## 0.49.1

--- a/staking/checkpoint.go
+++ b/staking/checkpoint.go
@@ -117,6 +117,9 @@ func (c *Checkpoint) getLastBlockSeen() uint64 {
 	// the newest block verified then instead ...
 	if block == 0 {
 		for _, acc := range c.accounting.hashableAccounts {
+			if len(acc.Events) == 0 {
+				continue
+			}
 			height := acc.Events[len(acc.Events)-1].BlockHeight
 			if block < height {
 				block = height


### PR DESCRIPTION
closes #4973 