### PR TITLE
Fix snapshot memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [4957](https://github.com/vegaprotocol/vega/issues/4957) - Fix `vega announce_node` to work with `--home` and `--passphrase-file`
 - [4964](https://github.com/vegaprotocol/vega/issues/4964) - Fix price monitoring snapshot
 - [4974](https://github.com/vegaprotocol/vega/issues/4974) - Fix panic when checkpointing staking accounts if there are no events
+- [4888](https://github.com/vegaprotocol/vega/issues/4888) - Fix memory leak when loading snapshots.
 
 
 ## 0.49.1

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -70,6 +70,7 @@ type Engine struct {
 
 	ctx          context.Context
 	cfunc        context.CancelFunc
+	initialised  bool
 	timeService  TimeService
 	statsService StatsService
 	db           db.DB
@@ -347,6 +348,10 @@ func (e *Engine) Loaded() (bool, error) {
 // initialiseTree connects to the snapshotdb and sets the engine's state to
 // point to the latest version of the tree.
 func (e *Engine) initialiseTree() error {
+	// prevent re-initialising the tree several times over
+	if e.initialised {
+		return nil
+	}
 	switch e.Config.Storage {
 	case memDB:
 		e.db = db.NewMemDB()
@@ -369,6 +374,7 @@ func (e *Engine) initialiseTree() error {
 		e.log.Error("Failed to load AVL version", logging.Error(err))
 		return err
 	}
+	e.initialised = true
 	return nil
 }
 


### PR DESCRIPTION
Closes #4888 

When reloading from snapshot, we initialised the AVL tree up to 3 times. The version loaded in the `avl` field was a mutable tree, which in the AVL package translates to a DB transaction that never gets released. The net result is that the first 2 trees were loaded into memory and never released.