### PR TITLE
4981 panic on auction end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [4964](https://github.com/vegaprotocol/vega/issues/4964) - Fix price monitoring snapshot
 - [4974](https://github.com/vegaprotocol/vega/issues/4974) - Fix panic when checkpointing staking accounts if there are no events
 - [4888](https://github.com/vegaprotocol/vega/issues/4888) - Fix memory leak when loading snapshots.
+- [4981](https://github.com/vegaprotocol/vega/issues/4981) - Fix bug causing LP orders to uncross at auction end.
 
 
 ## 0.49.1

--- a/execution/liquidity_provision_test.go
+++ b/execution/liquidity_provision_test.go
@@ -1127,11 +1127,11 @@ func TestSubmit(t *testing.T) {
 				size  uint64
 				found bool
 			}{
-				{119, false},
+				{139, false},
 				{2, false},
 				{2, false},
 				{3, false},
-				{112, false},
+				{194, false},
 			}
 
 			for _, v := range found {

--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -109,7 +109,7 @@ func NewMarketFromSnapshot(
 	priceFactor := num.Zero().Exp(num.NewUint(10), num.NewUint(exp))
 	lMonitor := lmon.NewMonitor(tsCalc, mkt.LiquidityMonitoringParameters)
 
-	liqEngine := liquidity.NewSnapshotEngine(liquidityConfig, log, broker, tradableInstrument.RiskModel, pMonitor, asset, mkt.ID, stateVarEngine, mkt.TickSize(), positionFactor)
+	liqEngine := liquidity.NewSnapshotEngine(liquidityConfig, log, broker, tradableInstrument.RiskModel, pMonitor, asset, mkt.ID, stateVarEngine, priceFactor.Clone(), positionFactor)
 	// call on chain time update straight away, so
 	// the time in the engine is being updatedat creation
 	liqEngine.OnChainTimeUpdate(ctx, now)

--- a/execution/special_orders.go
+++ b/execution/special_orders.go
@@ -45,12 +45,15 @@ func (m *Market) repricePeggedOrders(
 					order.UpdatedAt = m.currentTime.UnixNano()
 					order.Status = types.OrderStatusParked
 					order.Price = num.Zero()
+					order.OriginalPrice = num.Zero()
 					m.broker.Send(events.NewOrderEvent(ctx, order))
 					parked = append(parked, order)
 				}
 			} else {
 				// Repriced so all good make sure status is correct
 				order.Price = price.Clone()
+				order.OriginalPrice = price.Clone()
+				order.OriginalPrice.Div(order.OriginalPrice, m.priceFactor)
 				order.Status = types.OrderStatusParked
 				toSubmit = append(toSubmit, order)
 			}

--- a/integration/features/auctions/liquidity-uncross.feature
+++ b/integration/features/auctions/liquidity-uncross.feature
@@ -1,0 +1,59 @@
+Feature: Ensure we don't uncross when leaving liquidity auction
+
+   Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | ETH | 5              |
+    And the markets:
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | oracle config          | decimal places |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 2              |
+    And the following network parameters are set:
+      | name                           | value |
+      | market.auction.minimumDuration | 1     |
+
+  @Panic
+  Scenario:
+    Given the parties deposit on asset's general account the following amount:
+      | party            | asset | amount    |
+      | party1           | ETH   | 100000000 |
+      | party2           | ETH   | 100000000 |
+      | sellSideProvider | ETH   | 100000000 |
+      | buySideProvider  | ETH   | 100000000 |
+      | auxiliary        | ETH   | 100000000 |
+      | aux2             | ETH   | 100000000 |
+
+# submit our LP
+    Then the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | party1 | ETH/DEC19 | 300000            | 0.1 | buy  | MID              | 1          | 21     | submission |
+      | lp1 | party1 | ETH/DEC19 | 300000            | 0.1 | sell | MID              | 1          | 21     | amendment  |
+
+# get out of auction
+    When the parties place the following orders:
+      | party     | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | auxiliary | ETH/DEC19 | buy  | 1      | 80    | 0                | TYPE_LIMIT | TIF_GTC | oa-b-1    |
+      | auxiliary | ETH/DEC19 | sell | 1      | 120   | 0                | TYPE_LIMIT | TIF_GTC | oa-s-1    |
+      | aux2      | ETH/DEC19 | buy  | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | oa-b-2    |
+      | auxiliary | ETH/DEC19 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC | oa-s-2    |
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+# now consume all the volume on the sell side
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC19 | buy  | 1      | 120   | 1                | TYPE_LIMIT | TIF_GTC | t1-1      |
+
+   # enter price monitoring auction
+    Then the market state should be "STATE_SUSPENDED" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    
+
+# now we move add back some volume
+    When the parties place the following orders:
+      | party     | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | auxiliary | ETH/DEC19 | sell | 10     | 120   | 0                | TYPE_LIMIT | TIF_GTC | t1-2      |
+# now update the time to get the market out of auction
+    And time is updated to "2019-12-01T00:00:00Z"
+     # leave price monitoring auction
+    Then the market state should be "STATE_ACTIVE" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"

--- a/liquidity/engine.go
+++ b/liquidity/engine.go
@@ -87,7 +87,8 @@ type Engine struct {
 	maxShapesSize int64
 
 	// this is the max fee that can be specified
-	maxFee num.Decimal
+	maxFee   num.Decimal
+	tickSize *num.Uint
 }
 
 // NewEngine returns a new Liquidity Engine.
@@ -114,6 +115,7 @@ func NewEngine(config Config,
 		stakeToObligationFactor: num.DecimalFromInt64(1),
 		maxShapesSize:           100, // set it to the same default than the netparams
 		maxFee:                  num.DecimalFromInt64(1),
+		tickSize:                tickSize,
 		// provisions related state
 		provisions: newSnapshotableProvisionsPerParty(),
 		pendings:   newSnapshotablePendingProvisions(),
@@ -649,10 +651,13 @@ func (e *Engine) createOrUpdateForParty(
 }
 
 func (e *Engine) buildOrder(side types.Side, price *num.Uint, partyID, marketID string, size uint64, ref string, lpID string) *types.Order {
+	op := price.Clone()
+	op.Div(op, e.tickSize)
 	order := &types.Order{
 		MarketID:             marketID,
 		Side:                 side,
 		Price:                price.Clone(),
+		OriginalPrice:        op,
 		Party:                partyID,
 		Size:                 size,
 		Remaining:            size,


### PR DESCRIPTION
LP orders are priced based on asset decimals, this price was interpreted as being in market precision, and incorrectly multiplied by the price factor (market tick size) a second time, causing LP buy orders to be deployed at 1000x the intended price point, and thus generating trades

Closes #4981 