### PR TITLE
fix: when reconnecting to TM just pass back where we got up to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [4964](https://github.com/vegaprotocol/vega/issues/4964) - Fix price monitoring snapshot
 - [4974](https://github.com/vegaprotocol/vega/issues/4974) - Fix panic when checkpointing staking accounts if there are no events
 - [4888](https://github.com/vegaprotocol/vega/issues/4888) - Fix memory leak when loading snapshots.
+- [4993](https://github.com/vegaprotocol/vega/issues/4993) - Stop snapshots thinking we've loaded via `statesync` when we just lost connection to TM
 - [4981](https://github.com/vegaprotocol/vega/issues/4981) - Fix bug causing LP orders to uncross at auction end.
 
 

--- a/execution/snapshot_test.go
+++ b/execution/snapshot_test.go
@@ -123,7 +123,7 @@ func TestLoadTerminatedMarketFromSnapshot(t *testing.T) {
 	exec2 := getEngine(t, now)
 	exec2.snapshotEngine.ReceiveSnapshot(snap1)
 	exec2.snapshotEngine.ApplySnapshot(ctx)
-	exec2.snapshotEngine.Loaded()
+	exec2.snapshotEngine.CheckLoaded()
 
 	// progress time to trigger any side effect on time ticks
 	exec.timeService.SetTime(now.Add(2 * time.Second))
@@ -303,7 +303,7 @@ func getEngine(t *testing.T, now time.Time) *snapshotTestData {
 	statsData := stats.New(log, stats.NewDefaultConfig(), "", "")
 	snapshotEngine, _ := snp.New(context.Background(), &paths.DefaultPaths{}, snp.NewDefaultConfig(), log, timeService, statsData.Blockchain)
 	snapshotEngine.AddProviders(eng)
-	snapshotEngine.Start()
+	snapshotEngine.ClearAndInitialise()
 
 	return &snapshotTestData{
 		engine:         eng,

--- a/snapshot/engine_test.go
+++ b/snapshot/engine_test.go
@@ -40,7 +40,7 @@ func getTestEngine(t *testing.T) *tstEngine {
 	time := mocks.NewMockTimeService(ctrl)
 	stats := mocks.NewMockStatsService(ctrl)
 	eng, err := snapshot.New(context.Background(), nil, snapshot.NewTestConfig(), logging.NewTestLogger(), time, stats)
-	eng.Start()
+	eng.ClearAndInitialise()
 	require.NoError(t, err)
 	ctx = vegactx.WithTraceID(vegactx.WithBlockHeight(ctx, 1), "0xDEADBEEF")
 	return &tstEngine{
@@ -320,7 +320,7 @@ func testReloadSnapshot(t *testing.T) {
 	// OK, our snapshot is ready to load
 	require.NoError(t, eng2.ApplySnapshot(eng2.ctx))
 
-	loaded, err := eng2.Loaded()
+	loaded, err := eng2.CheckLoaded()
 	require.NoError(t, err)
 	require.True(t, loaded)
 }
@@ -401,7 +401,7 @@ func testReloadReplayProtectors(t *testing.T) {
 	require.True(t, ready)
 	// OK, snapshot is ready to be applied
 	require.NoError(t, e2.ApplySnapshot(e.ctx))
-	loaded, err := e2.Loaded()
+	loaded, err := e2.CheckLoaded()
 	require.NoError(t, err)
 	require.True(t, loaded)
 	// so now we can check if taking a snapshot calls the methods on the replacement provider
@@ -486,7 +486,7 @@ func testReloadRestore(t *testing.T) {
 
 	// OK, our snapshot is ready to load
 	require.NoError(t, eng2.ApplySnapshot(eng2.ctx))
-	loaded, err := eng2.Loaded()
+	loaded, err := eng2.CheckLoaded()
 	require.NoError(t, err)
 	require.True(t, loaded)
 }


### PR DESCRIPTION
closes #4991 

How it looks now:
```
2022-03-14T14:20:19.115Z	DEBUG	processor	processor/abci.go:618	leaving commit	{"at": "2022-03-14T14:20:19.115Z"}
2022-03-14T14:20:20.334Z	ERROR	tm.abci.socket-server	server/socket_server.go:140	Connection was closed by client []
2022-03-14T14:20:20.336Z	ERROR	tm.abci.socket-server	server/socket_server.go:140	Connection was closed by client []
2022-03-14T14:20:20.336Z	ERROR	tm.abci.socket-server	server/socket_server.go:140	Connection was closed by client []
2022-03-14T14:20:20.336Z	ERROR	tm.abci.socket-server	server/socket_server.go:140	Connection was closed by client []
2022-03-14T14:20:20.648Z	INFO	monitoring	monitoring/status.go:198	Blockchain status updated	{"status-old": "CHAIN_STATUS_CONNECTED", "status-new": "CHAIN_STATUS_DISCONNECTED"}
2022-03-14T14:20:20.648Z	INFO	monitoring	monitoring/status.go:218	Chain is disconnected, we'll try to reconnect	{"retries-left": 5}
2022-03-14T14:20:21.145Z	INFO	monitoring	monitoring/status.go:218	Chain is disconnected, we'll try to reconnect	{"retries-left": 4}
2022-03-14T14:20:22.222Z	INFO	tm.abci.socket-server	server/socket_server.go:119	Accepted a new connection []
2022-03-14T14:20:22.222Z	INFO	tm.abci.socket-server	server/socket_server.go:109	Waiting for new connection... []
2022-03-14T14:20:22.224Z	INFO	tm.abci.socket-server	server/socket_server.go:119	Accepted a new connection []
2022-03-14T14:20:22.224Z	INFO	tm.abci.socket-server	server/socket_server.go:109	Waiting for new connection... []
2022-03-14T14:20:22.229Z	INFO	tm.abci.socket-server	server/socket_server.go:119	Accepted a new connection []
2022-03-14T14:20:22.230Z	INFO	tm.abci.socket-server	server/socket_server.go:109	Waiting for new connection... []
2022-03-14T14:20:22.231Z	INFO	tm.abci.socket-server	server/socket_server.go:119	Accepted a new connection []
2022-03-14T14:20:22.231Z	INFO	tm.abci.socket-server	server/socket_server.go:109	Waiting for new connection... []
2022-03-14T14:20:22.558Z	INFO	processor	processor/abci.go:359	ABCI service INFO requested after reconnect	{"height": 35, "hash": "b58b87baa2bbeb7068d7bb7726c66e797ae9edd454ccdcdaca42e34a53a185ab"}
2022-03-14T14:20:22.670Z	INFO	monitoring	monitoring/status.go:166	tendermint info	{"version": "0.34.15"}
2022-03-14T14:20:22.670Z	INFO	monitoring	monitoring/status.go:198	Blockchain status updated	{"status-old": "CHAIN_STATUS_DISCONNECTED", "status-new": "CHAIN_STATUS_REPLAYING"}
```