### PR TITLE
chore: uncapitilise country flag in annouce node so that it matches the other args

### DIFF
--- a/cmd/vega/announce_node.go
+++ b/cmd/vega/announce_node.go
@@ -22,7 +22,7 @@ type AnnounceNodeCmd struct {
 	config.Passphrase `long:"passphrase-file"`
 
 	InfoURL   string `short:"i" long:"info-url" required:"true" description:"An url to the website / information about this validator"`
-	Country   string `short:"c" long:"Country" required:"true" description:"The country from which the validator is operating"`
+	Country   string `short:"c" long:"country" required:"true" description:"The country from which the validator is operating"`
 	Name      string `short:"n" long:"name" required:"true" description:"The name of this validator"`
 	AvatarURL string `short:"a" long:"avatar-url" required:"true" description:"A link to an avatar picture for this validator"`
 	FromEpoch uint64 `short:"f" long:"from-epoch" required:"true" description:"The epoch from which this validator should be ready to validate blocks" `

--- a/validators/validator_performance.go
+++ b/validators/validator_performance.go
@@ -62,7 +62,7 @@ func (vp *validatorPerformance) ValidatorPerformanceScore(tmPubKey string, power
 	expected := num.DecimalFromInt64(power).Div(num.DecimalFromInt64(totalPower))
 
 	score := num.MaxD(minPerfScore, num.MinD(decimalOne, actual.Div(expected)))
-	vp.log.Info("loooking up performance for", logging.String("address", address), logging.String("perf-score", score.String()))
+	vp.log.Info("looking up performance for", logging.String("address", address), logging.String("perf-score", score.String()))
 	return score
 }
 


### PR DESCRIPTION
Before it was like `vega announce_node --name blah --Country whatever` and its a bit unusual to have caps in CLI args.