### PR TITLE
5088 settlement non zero panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [5034](https://github.com/vegaprotocol/vega/issues/5034) - Ensure to / from in transfers payloads are vega public keys
 - [5066](https://github.com/vegaprotocol/vega/issues/5066) - Return an error if market decimal place > to asset decimal place
 - [4870](https://github.com/vegaprotocol/vega/issues/5870) - Add missing commands to the `TxError` event
+- [5088](https://github.com/vegaprotocol/vega/issues/5088) - Fixed MTM bug where settlement balance would not be zero when loss amount was 1.
 
 
 ## 0.49.8

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -875,6 +875,7 @@ func (e *Engine) MarkToMarket(ctx context.Context, marketID string, transfers []
 	// needs to be propagated forward so we return now.
 	if winidx == 0 {
 		if !settle.Balance.IsZero() {
+			e.log.Panic("No win transfers, settlement balance non-zero", logging.BigUint("settlement-balance", settle.Balance))
 			return nil, nil, ErrSettlementBalanceNotZero
 		}
 		return marginEvts, responses, nil
@@ -976,6 +977,7 @@ func (e *Engine) MarkToMarket(ctx context.Context, marketID string, transfers []
 	}
 
 	if !settle.Balance.IsZero() {
+		e.log.Panic("Settlement balance non-zero at the end of MTM settlement", logging.BigUint(settle.Balance))
 		return nil, nil, ErrSettlementBalanceNotZero
 	}
 	return marginEvts, responses, nil

--- a/collateral/engine.go
+++ b/collateral/engine.go
@@ -977,7 +977,7 @@ func (e *Engine) MarkToMarket(ctx context.Context, marketID string, transfers []
 	}
 
 	if !settle.Balance.IsZero() {
-		e.log.Panic("Settlement balance non-zero at the end of MTM settlement", logging.BigUint(settle.Balance))
+		e.log.Panic("Settlement balance non-zero at the end of MTM settlement", logging.BigUint("settlement-balance", settle.Balance))
 		return nil, nil, ErrSettlementBalanceNotZero
 	}
 	return marginEvts, responses, nil

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -56,7 +56,7 @@ func TestCollateralMarkToMarket(t *testing.T) {
 	t.Run("Mark to Market distribution, insufficient funcs - complex scenario", testProcessBothProRatedMTM)
 	t.Run("Mark to Market successful", testMTMSuccess)
 	// we panic if settlement account is non-zero, this test doesn't pass anymore
-	// t.Run("Mark to Market wins and losses do not match up, settlement not drained", testSettleBalanceNotZero)
+	t.Run("Mark to Market wins and losses do not match up, settlement not drained", testSettleBalanceNotZero)
 }
 
 func TestAddPartyToMarket(t *testing.T) {
@@ -1053,10 +1053,12 @@ func testSettleBalanceNotZero(t *testing.T) {
 	eng.broker.EXPECT().Send(gomock.Any()).AnyTimes()
 	eng.broker.EXPECT().SendBatch(gomock.Any()).AnyTimes()
 	transfers := eng.getTestMTMTransfer(pos)
-	_, _, err = eng.MarkToMarket(context.Background(), testMarketID, transfers, "BTC")
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+	}()
+	_, _, _ = eng.MarkToMarket(context.Background(), testMarketID, transfers, "BTC")
 	// this should return an error
-	assert.Error(t, err)
-	assert.Equal(t, collateral.ErrSettlementBalanceNotZero, err)
 }
 
 func testProcessBothProRated(t *testing.T) {

--- a/collateral/engine_test.go
+++ b/collateral/engine_test.go
@@ -55,7 +55,8 @@ func TestCollateralTransfer(t *testing.T) {
 func TestCollateralMarkToMarket(t *testing.T) {
 	t.Run("Mark to Market distribution, insufficient funcs - complex scenario", testProcessBothProRatedMTM)
 	t.Run("Mark to Market successful", testMTMSuccess)
-	t.Run("Mark to Market wins and losses do not match up, settlement not drained", testSettleBalanceNotZero)
+	// we panic if settlement account is non-zero, this test doesn't pass anymore
+	// t.Run("Mark to Market wins and losses do not match up, settlement not drained", testSettleBalanceNotZero)
 }
 
 func TestAddPartyToMarket(t *testing.T) {

--- a/settlement/engine_test.go
+++ b/settlement/engine_test.go
@@ -220,7 +220,6 @@ func testMTMWinOneExcess(t *testing.T) {
 		price: newPrice.Clone(),
 		party: "party4",
 	}
-	// the updated position (new possition to settle, already at mark price)
 
 	trades := []*types.Trade{
 		{

--- a/settlement/engine_test.go
+++ b/settlement/engine_test.go
@@ -3,6 +3,7 @@ package settlement_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -53,6 +54,227 @@ func TestMarkToMarket(t *testing.T) {
 	// add this test case because we had a runtime panic on the trades map earlier
 	t.Run("Trade adds new party, immediately closing out with themselves", testAddNewPartySelfTrade)
 	t.Run("Test MTM settle when the network is closed out", testMTMNetworkZero)
+}
+
+func TestMTMWinDistribution(t *testing.T) {
+	t.Run("A MTM loss party with a loss of value 1, with several parties needing a win", testMTMWinOneExcess)
+	t.Run("A MTM scenario with several parties winning less than 1, and several parties losing 1, to distribute equally", testMTMWinDivideExcess)
+}
+
+func testMTMWinDivideExcess(t *testing.T) {
+	engine := getTestEngineWithFactor(t, 1)
+	defer engine.Finish()
+
+	price := num.NewUint(10000)
+	one := num.NewUint(1)
+	ctx := context.Background()
+
+	initPos := []testPos{
+		{
+			price: price.Clone(),
+			party: "party1",
+			size:  10,
+		},
+		{
+			price: price.Clone(),
+			party: "party2",
+			size:  20,
+		},
+		{
+			price: price.Clone(),
+			party: "party3",
+			size:  -29,
+		},
+		{
+			price: price.Clone(),
+			party: "party4",
+			size:  1,
+		},
+		{
+			price: price.Clone(),
+			party: "party5",
+			size:  -1,
+		},
+		{
+			price: price.Clone(),
+			party: "party5",
+			size:  1,
+		},
+	}
+
+	init := make([]events.MarketPosition, 0, len(initPos))
+	for _, p := range initPos {
+		init = append(init, p)
+	}
+
+	newPrice := num.Sum(price, one)
+	newParty := testPos{
+		size:  30,
+		price: newPrice.Clone(),
+		party: "party4",
+	}
+	// the updated position (new possition to settle, already at mark price)
+
+	trades := []*types.Trade{
+		{
+			Size:   10,
+			Buyer:  newParty.party,
+			Seller: initPos[0].party,
+			Price:  newPrice.Clone(),
+		},
+		{
+			Size:   10,
+			Buyer:  newParty.party,
+			Seller: initPos[1].party,
+			Price:  newPrice.Clone(),
+		},
+		{
+			Size:   10,
+			Buyer:  newParty.party,
+			Seller: initPos[2].party,
+			Price:  newPrice.Clone(),
+		},
+	}
+	updates := make([]events.MarketPosition, 0, len(initPos)+2)
+	for _, trade := range trades {
+		for i, p := range initPos {
+			if p.party == trade.Seller {
+				p.size -= int64(trade.Size)
+			}
+			p.price = trade.Price.Clone()
+			initPos[i] = p
+		}
+	}
+	for _, p := range initPos {
+		updates = append(updates, p)
+	}
+	updates = append(updates, newParty)
+	engine.Update(init)
+	for _, trade := range trades {
+		engine.AddTrade(trade)
+	}
+	transfers := engine.SettleMTM(ctx, newPrice.Clone(), updates)
+	require.NotEmpty(t, transfers)
+	for _, tr := range transfers {
+		if tr == nil {
+			fmt.Println("NIL")
+			continue
+		}
+		t := tr.Transfer()
+		if t == nil {
+			fmt.Println("NIL TRANSFER")
+			continue
+		}
+		fmt.Printf("Transfer for party %s: %s\n%s -%#v", tr.Party(), t.Amount.Amount.String(), t.String(), t)
+	}
+}
+
+func testMTMWinOneExcess(t *testing.T) {
+	engine := getTestEngineWithFactor(t, 1)
+	defer engine.Finish()
+
+	price := num.NewUint(10000)
+	one := num.NewUint(1)
+	ctx := context.Background()
+
+	initPos := []testPos{
+		{
+			price: price.Clone(),
+			party: "party1",
+			size:  10,
+		},
+		{
+			price: price.Clone(),
+			party: "party2",
+			size:  20,
+		},
+		{
+			price: price.Clone(),
+			party: "party3",
+			size:  -29,
+		},
+		{
+			price: price.Clone(),
+			party: "party4",
+			size:  1,
+		},
+		{
+			price: price.Clone(),
+			party: "party5",
+			size:  -1,
+		},
+		{
+			price: price.Clone(),
+			party: "party5",
+			size:  1,
+		},
+	}
+
+	init := make([]events.MarketPosition, 0, len(initPos))
+	for _, p := range initPos {
+		init = append(init, p)
+	}
+
+	newPrice := num.Sum(price, one)
+	newParty := testPos{
+		size:  30,
+		price: newPrice.Clone(),
+		party: "party4",
+	}
+	// the updated position (new possition to settle, already at mark price)
+
+	trades := []*types.Trade{
+		{
+			Size:   10,
+			Buyer:  newParty.party,
+			Seller: initPos[0].party,
+			Price:  newPrice.Clone(),
+		},
+		{
+			Size:   10,
+			Buyer:  newParty.party,
+			Seller: initPos[1].party,
+			Price:  newPrice.Clone(),
+		},
+		{
+			Size:   10,
+			Buyer:  newParty.party,
+			Seller: initPos[2].party,
+			Price:  newPrice.Clone(),
+		},
+	}
+	updates := make([]events.MarketPosition, 0, len(initPos)+2)
+	for _, trade := range trades {
+		for i, p := range initPos {
+			if p.party == trade.Seller {
+				p.size -= int64(trade.Size)
+			}
+			p.price = trade.Price.Clone()
+			initPos[i] = p
+		}
+	}
+	for _, p := range initPos {
+		updates = append(updates, p)
+	}
+	updates = append(updates, newParty)
+	engine.Update(init)
+	for _, trade := range trades {
+		engine.AddTrade(trade)
+	}
+	transfers := engine.SettleMTM(ctx, newPrice.Clone(), updates)
+	require.NotEmpty(t, transfers)
+	for _, tr := range transfers {
+		if tr == nil {
+			fmt.Println("NIL")
+			continue
+		}
+		t := tr.Transfer()
+		if t == nil {
+			fmt.Println("NIL TRANSFER")
+			continue
+		}
+		fmt.Printf("Transfer for party %s: %s\n%s -%#v", tr.Party(), t.Amount.Amount.String(), t.String(), t)
+	}
 }
 
 func testSettleExpiredSuccess(t *testing.T) {
@@ -590,7 +812,7 @@ func (t testPos) VWSell() *num.Uint {
 
 func (t testPos) ClearPotentials() {}
 
-func getTestEngine(t *testing.T) *testEngine {
+func getTestEngineWithFactor(t *testing.T, f float64) *testEngine {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	conf := settlement.NewDefaultConfig()
@@ -600,13 +822,18 @@ func getTestEngine(t *testing.T) *testEngine {
 	market := "BTC/DEC19"
 	prod.EXPECT().GetAsset().AnyTimes().Do(func() string { return "BTC" })
 	return &testEngine{
-		Engine:    settlement.New(logging.NewTestLogger(), conf, prod, market, broker, num.DecimalFromInt64(1)),
+		Engine:    settlement.New(logging.NewTestLogger(), conf, prod, market, broker, num.NewDecimalFromFloat(f)),
 		ctrl:      ctrl,
 		prod:      prod,
 		broker:    broker,
 		positions: nil,
 		market:    market,
 	}
+}
+
+func getTestEngine(t *testing.T) *testEngine {
+	t.Helper()
+	return getTestEngineWithFactor(t, 1)
 } // }}}
 
 func (m marginVal) Asset() string {

--- a/settlement/engine_test.go
+++ b/settlement/engine_test.go
@@ -113,7 +113,6 @@ func testMTMWinDivideExcess(t *testing.T) {
 		price: newPrice.Clone(),
 		party: "party4",
 	}
-	// the updated position (new possition to settle, already at mark price)
 
 	trades := []*types.Trade{
 		{


### PR DESCRIPTION
Ensure MTM loss transfers of 1 don't end up on settlement account if the MTM win transfers are all for amounts < 1 (== amount 0, nil transfers).

Fixes #5088   