### PR TITLE
fix: send event in both positions.UpdateNetwork and Update + fix position.AmendOrder implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [4870](https://github.com/vegaprotocol/vega/issues/5870) - Add missing commands to the `TxError` event
 - [5088](https://github.com/vegaprotocol/vega/issues/5088) - Fixed MTM bug where settlement balance would not be zero when loss amount was 1.
 - [5093](https://github.com/vegaprotocol/vega/issues/5093) - Fixed proof of engine end of block callback never called to clear up state
+- [4996](https://github.com/vegaprotocol/vega/issues/4996) - Fix positions engines `vwBuys` and `vwSell` when amending, send events on `Update` and `UpdateNetwork`
 
 
 ## 0.49.8

--- a/execution/market.go
+++ b/execution/market.go
@@ -1542,7 +1542,7 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 			tradeEvts = append(tradeEvts, events.NewTradeEvent(ctx, *trade))
 
 			// Update positions (this communicates with settlement via channel)
-			m.position.Update(trade)
+			m.position.Update(ctx, trade)
 			// Record open interest change
 			if err := m.tsCalc.RecordOpenInterest(m.position.GetOpenInterest(), m.currentTime); err != nil {
 				m.log.Debug("unable record open interest",
@@ -1858,7 +1858,7 @@ func (m *Market) resolveClosedOutParties(ctx context.Context, distressedMarginEv
 
 			// Update positions - this is a special trade involving the network as party
 			// so rather than checking this every time we call Update, call special UpdateNetwork
-			m.position.UpdateNetwork(trade)
+			m.position.UpdateNetwork(ctx, trade)
 			if err := m.tsCalc.RecordOpenInterest(m.position.GetOpenInterest(), m.currentTime); err != nil {
 				m.log.Debug("unable record open interest",
 					logging.String("market-id", m.GetID()),

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -65,7 +65,7 @@ func TestGetOpenInterest(t *testing.T) {
 		SellOrder: "sell_order_id",
 		Timestamp: time.Now().Unix(),
 	}
-	_ = engine.Update(&trade)
+	_ = engine.Update(context.Background(), &trade)
 	trade = types.Trade{
 		Type:      types.TradeTypeDefault,
 		ID:        "trade_id",
@@ -78,7 +78,7 @@ func TestGetOpenInterest(t *testing.T) {
 		SellOrder: "sell_order_id",
 		Timestamp: time.Now().Unix(),
 	}
-	_ = engine.Update(&trade)
+	_ = engine.Update(context.Background(), &trade)
 	// 3 positions
 	// 2 at + 10
 	// 1 at -20
@@ -121,7 +121,7 @@ func testUpdatePositionRegular(t *testing.T) {
 		SellOrder: "sell_order_id",
 		Timestamp: time.Now().Unix(),
 	}
-	positions := engine.Update(&trade)
+	positions := engine.Update(context.Background(), &trade)
 	pos := engine.Positions()
 	assert.Equal(t, 2, len(pos))
 	assert.Equal(t, 2, len(positions))
@@ -153,7 +153,7 @@ func testUpdatePositionNetworkBuy(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 	registerOrder(engine, types.SideSell, seller, num.NewUint(10000), uint64(size))
-	positions := engine.UpdateNetwork(&trade)
+	positions := engine.UpdateNetwork(context.Background(), &trade)
 	pos := engine.Positions()
 	assert.Equal(t, 1, len(pos))
 	assert.Equal(t, 1, len(positions))
@@ -180,7 +180,7 @@ func testUpdatePositionNetworkSell(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 	registerOrder(engine, types.SideBuy, buyer, num.NewUint(10000), uint64(size))
-	positions := engine.UpdateNetwork(&trade)
+	positions := engine.UpdateNetwork(context.Background(), &trade)
 	pos := engine.Positions()
 	assert.Equal(t, 1, len(pos))
 	assert.Equal(t, 1, len(positions))
@@ -467,7 +467,7 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 		for _, tr := range tc.ExistingPositions {
 			registerOrder(e, types.SideBuy, tr.Buyer, tr.Price, tr.Size)
 			registerOrder(e, types.SideSell, tr.Seller, tr.Price, tr.Size)
-			e.Update(tr)
+			e.Update(context.Background(), tr)
 		}
 
 		oiGivenTrades := e.GetOpenInterestGivenTrades(tc.Trades)
@@ -475,7 +475,7 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 		for _, tr := range tc.Trades {
 			registerOrder(e, types.SideBuy, tr.Buyer, tr.Price, tr.Size)
 			registerOrder(e, types.SideSell, tr.Seller, tr.Price, tr.Size)
-			e.Update(tr)
+			e.Update(context.Background(), tr)
 		}
 
 		// Now check it matches ones those trades are registered as positions
@@ -572,7 +572,7 @@ func TestHash(t *testing.T) {
 		SellOrder: "sell_order_id",
 		Timestamp: time.Now().Unix(),
 	}
-	e.Update(&trade)
+	e.Update(context.Background(), &trade)
 
 	hash := e.Hash()
 	require.Equal(t,

--- a/positions/positions_acceptance_criteria_test.go
+++ b/positions/positions_acceptance_criteria_test.go
@@ -93,7 +93,7 @@ func testTradeOccurIncreaseShortAndLong(t *testing.T) {
 		// call an update on the positions with the trade
 		registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 		registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
-		positions := engine.Update(&c.trade)
+		positions := engine.Update(context.Background(), &c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
 		assert.Equal(t, 2, len(positions))
@@ -158,7 +158,7 @@ func testTradeOccurDecreaseShortAndLong(t *testing.T) {
 		// call an update on the positions with the trade
 		registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 		registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
-		positions := engine.Update(&c.trade)
+		positions := engine.Update(context.Background(), &c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
 		assert.Equal(t, 2, len(positions))
@@ -222,7 +222,7 @@ func testTradeOccurClosingShortAndLong(t *testing.T) {
 	for _, c := range cases {
 		registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 		registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
-		positions := engine.Update(&c.trade)
+		positions := engine.Update(context.Background(), &c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
 		assert.Equal(t, 2, len(positions))
@@ -287,7 +287,7 @@ func testTradeOccurShortBecomeLongAndLongBecomeShort(t *testing.T) {
 		registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 		registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
 		// call an update on the positions with the trade
-		positions := engine.Update(&c.trade)
+		positions := engine.Update(context.Background(), &c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
 		assert.Equal(t, 2, len(positions))
@@ -334,7 +334,7 @@ func testNoOpenPositionsTradeOccurOpenLongAndShortPosition(t *testing.T) {
 	// now create a trade an make sure the positions are created an correct
 	registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 	registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
-	positions := engine.Update(&c.trade)
+	positions := engine.Update(context.Background(), &c.trade)
 	pos := engine.Positions()
 	assert.Equal(t, 2, len(pos))
 	assert.Equal(t, 2, len(positions))
@@ -424,7 +424,7 @@ func testOpenPosTradeOccurCloseThanOpenPositioAgain(t *testing.T) {
 	for _, c := range cases {
 		registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 		registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
-		positions := engine.Update(&c.trade)
+		positions := engine.Update(context.Background(), &c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, c.posSize, len(pos), fmt.Sprintf("all pos trade: %v", c.trade.ID))
 		assert.Equal(t, 2, len(positions), fmt.Sprintf("chan trade: %v", c.trade.ID))
@@ -492,7 +492,7 @@ func testWashTradeDoNotChangePosition(t *testing.T) {
 		registerOrder(engine, types.SideBuy, c.trade.Buyer, c.trade.Price, c.trade.Size)
 		registerOrder(engine, types.SideSell, c.trade.Seller, c.trade.Price, c.trade.Size)
 		// call an update on the positions with the trade
-		positions := engine.Update(&c.trade)
+		positions := engine.Update(context.Background(), &c.trade)
 		pos := engine.Positions()
 		assert.Equal(t, 2, len(pos))
 		assert.Equal(t, 2, len(positions))
@@ -660,7 +660,7 @@ func testNewTradePartialAmountOfExistingOrderTraded(t *testing.T) {
 
 	// add the trade
 	// call an update on the positions with the trade
-	positions := engine.Update(&trade)
+	positions := engine.Update(context.Background(), &trade)
 	pos := engine.Positions()
 	assert.Equal(t, 2, len(pos))
 	assert.Equal(t, 2, len(positions))
@@ -754,7 +754,7 @@ func testTradeCauseTheFullAmountOfOrderToTrade(t *testing.T) {
 
 	// add the trade
 	// call an update on the positions with the trade
-	positions := engine.Update(&trade)
+	positions := engine.Update(context.Background(), &trade)
 	pos := engine.Positions()
 	assert.Equal(t, 2, len(pos))
 	assert.Equal(t, 2, len(positions))

--- a/positions/snapshot.go
+++ b/positions/snapshot.go
@@ -58,14 +58,14 @@ func (e *SnapshotEngine) AmendOrder(ctx context.Context, originalOrder, newOrder
 	return e.Engine.AmendOrder(ctx, originalOrder, newOrder)
 }
 
-func (e *SnapshotEngine) UpdateNetwork(trade *types.Trade) []events.MarketPosition {
+func (e *SnapshotEngine) UpdateNetwork(ctx context.Context, trade *types.Trade) []events.MarketPosition {
 	e.changed = true
-	return e.Engine.UpdateNetwork(trade)
+	return e.Engine.UpdateNetwork(ctx, trade)
 }
 
-func (e *SnapshotEngine) Update(trade *types.Trade) []events.MarketPosition {
+func (e *SnapshotEngine) Update(ctx context.Context, trade *types.Trade) []events.MarketPosition {
 	e.changed = true
-	return e.Engine.Update(trade)
+	return e.Engine.Update(ctx, trade)
 }
 
 func (e *SnapshotEngine) RemoveDistressed(parties []events.MarketPosition) []events.MarketPosition {

--- a/positions/snapshot_test.go
+++ b/positions/snapshot_test.go
@@ -65,7 +65,7 @@ func fillTestPositions(e *positions.SnapshotEngine) {
 		SellOrder: "sell_order_id",
 		Timestamp: time.Now().Unix(),
 	}
-	e.Update(&trade)
+	e.Update(context.Background(), &trade)
 }
 
 func TestSnapshotSaveAndLoad(t *testing.T) {


### PR DESCRIPTION
- [x] Adds a test to show we cannot reproduce the initial issue
- [x] Send events in positions.Update and positions.UpdateNetwork with the updated positions
- [x] Fix implementation of the position.Amend method (vwBuy and vwSell were calculated incorrectly)

close #4996    