### PR TITLE
fix: banking snapshots, restore risk factors from snapshot, remove ti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [5066](https://github.com/vegaprotocol/vega/issues/5066) - Return an error if market decimal place > to asset decimal place
 - [5095](https://github.com/vegaprotocol/vega/issues/5095) - Stabilise state sync restore and restore block height in the topology engine
 - [4870](https://github.com/vegaprotocol/vega/issues/5870) - Add missing commands to the `TxError` event
+- [5136](https://github.com/vegaprotocol/vega/issues/5136) - Fix banking snapshot for transfers, risk factor restoration, and `statevar` handling of settled markets
 - [5088](https://github.com/vegaprotocol/vega/issues/5088) - Fixed MTM bug where settlement balance would not be zero when loss amount was 1.
 - [5093](https://github.com/vegaprotocol/vega/issues/5093) - Fixed proof of engine end of block callback never called to clear up state
 - [4996](https://github.com/vegaprotocol/vega/issues/4996) - Fix positions engines `vwBuys` and `vwSell` when amending, send events on `Update` and `UpdateNetwork`

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -172,7 +172,14 @@ func New(
 		deposits:      map[string]*types.Deposit{},
 		withdrawalCnt: big.NewInt(0),
 		bss: &bankingSnapshotState{
-			changed:    map[string]bool{withdrawalsKey: true, depositsKey: true, seenKey: true, assetActionsKey: true},
+			changed: map[string]bool{
+				withdrawalsKey:        true,
+				depositsKey:           true,
+				seenKey:               true,
+				assetActionsKey:       true,
+				recurringTransfersKey: true,
+				scheduledTransfersKey: true,
+			},
 			hash:       map[string][]byte{},
 			serialised: map[string][]byte{},
 		},

--- a/banking/recurring_transfers.go
+++ b/banking/recurring_transfers.go
@@ -22,7 +22,7 @@ func (e *Engine) recurringTransfer(
 	transfer *types.RecurringTransfer,
 ) (err error) {
 	defer func() {
-		if err != nil {
+		if err == nil {
 			e.bss.changed[recurringTransfersKey] = true
 		}
 		e.broker.Send(events.NewRecurringTransferFundsEvent(ctx, transfer))

--- a/banking/snapshot.go
+++ b/banking/snapshot.go
@@ -244,13 +244,14 @@ func (e *Engine) LoadState(ctx context.Context, p *types.Payload) ([]types.State
 func (e *Engine) restoreRecurringTransfers(ctx context.Context, transfers *checkpoint.RecurringTransfers) error {
 	// ignore events here as we don't need to send them
 	_ = e.loadRecurringTransfers(ctx, transfers)
-
+	e.bss.changed[recurringTransfersKey] = true
 	return nil
 }
 
 func (e *Engine) restoreScheduledTransfers(ctx context.Context, transfers []*checkpoint.ScheduledTransferAtTime) error {
 	// ignore events
 	_, err := e.loadScheduledTransfers(ctx, transfers)
+	e.bss.changed[scheduledTransfersKey] = true
 	return err
 }
 
@@ -296,9 +297,7 @@ func (e *Engine) restoreAssetActions(ctx context.Context, aa *types.BankingAsset
 	for _, v := range aa.AssetAction {
 		asset, err := e.assets.Get(v.Asset)
 		if err != nil {
-			e.log.Error("error restoring asset actions for asset", logging.String("asset", v.Asset))
-
-			continue
+			e.log.Panic("trying to restore an assetAction with no asset", logging.String("asset", v.Asset))
 		}
 
 		aa := &assetAction{

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -510,9 +510,6 @@ func (e *Engine) removeMarket(mktID string) {
 			mkt.liquidity.StopSnapshots()
 			mkt.tsCalc.StopSnapshots()
 
-			asset, _ := mkt.mkt.GetAsset()
-			mkt.stateVarEngine.RemoveTimeTriggers(asset, mkt.GetID())
-
 			copy(e.marketsCpy[i:], e.marketsCpy[i+1:])
 			e.marketsCpy[len(e.marketsCpy)-1] = nil
 			e.marketsCpy = e.marketsCpy[:len(e.marketsCpy)-1]

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -61,6 +61,7 @@ type Collateral interface {
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/state_var_engine_mock.go -package mocks code.vegaprotocol.io/vega/execution StateVarEngine
 type StateVarEngine interface {
 	RegisterStateVariable(asset, market, name string, converter statevar.Converter, startCalculation func(string, statevar.FinaliseCalculation), trigger []statevar.StateVarEventType, result func(context.Context, statevar.StateVariableResult) error) error
+	RemoveTimeTriggers(asset, market string)
 	NewEvent(asset, market string, eventType statevar.StateVarEventType)
 	ReadyForTimeTrigger(asset, mktID string)
 }
@@ -498,14 +499,25 @@ func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) err
 }
 
 func (e *Engine) removeMarket(mktID string) {
+	e.log.Debug("removing market", logging.String("id", mktID))
 	e.stateChanged = true
+
 	delete(e.markets, mktID)
 	for i, mkt := range e.marketsCpy {
 		if mkt.GetID() == mktID {
+			mkt.matching.StopSnapshots()
+			mkt.position.StopSnapshots()
+			mkt.liquidity.StopSnapshots()
+			mkt.tsCalc.StopSnapshots()
+
+			asset, _ := mkt.mkt.GetAsset()
+			mkt.stateVarEngine.RemoveTimeTriggers(asset, mkt.GetID())
+
 			copy(e.marketsCpy[i:], e.marketsCpy[i+1:])
 			e.marketsCpy[len(e.marketsCpy)-1] = nil
 			e.marketsCpy = e.marketsCpy[:len(e.marketsCpy)-1]
 			e.marketTracker.removeMarket(mktID)
+			e.log.Debug("removed in total", logging.String("id", mktID))
 			return
 		}
 	}
@@ -768,21 +780,12 @@ func (e *Engine) onChainTimeUpdate(ctx context.Context, t time.Time) {
 		if closing {
 			e.log.Info("market is closed, removing from execution engine",
 				logging.MarketID(mkt.GetID()))
-			delete(e.markets, mkt.GetID())
 			toDelete = append(toDelete, mkt.GetID())
 		}
 	}
 
 	for _, id := range toDelete {
-		var i int
-		for idx, mkt := range e.marketsCpy {
-			if mkt.GetID() == id {
-				i = idx
-				break
-			}
-		}
-		copy(e.marketsCpy[i:], e.marketsCpy[i+1:])
-		e.marketsCpy = e.marketsCpy[:len(e.marketsCpy)-1]
+		e.removeMarket(id)
 	}
 
 	timer.EngineTimeCounterAdd()

--- a/execution/engine_snapshot.go
+++ b/execution/engine_snapshot.go
@@ -23,6 +23,7 @@ func (e *Engine) marketsStates() ([]*types.ExecMarket, []types.StateProvider, er
 	}
 	e.newGeneratedProviders = make([]types.StateProvider, 0, mkts*4)
 	for _, m := range e.marketsCpy {
+		e.log.Debug("serialising market", logging.String("id", m.mkt.ID))
 		mks = append(mks, m.getState())
 
 		if _, ok := e.generatedProviders[m.GetID()]; !ok {
@@ -65,6 +66,7 @@ func (e *Engine) restoreMarket(ctx context.Context, em *types.ExecMarket) (*Mark
 	}
 
 	// create market auction state
+	e.log.Info("restoring market", logging.String("id", em.Market.ID))
 	mkt, err := NewMarketFromSnapshot(
 		ctx,
 		e.log,

--- a/execution/market.go
+++ b/execution/market.go
@@ -772,6 +772,9 @@ func (m *Market) closeMarket(ctx context.Context, t time.Time) error {
 		return err
 	}
 
+	// stop time triggered events in the statevar engine
+	m.stateVarEngine.RemoveTimeTriggers(asset, m.mkt.ID)
+
 	m.broker.Send(events.NewTransferResponse(ctx, clearMarketTransfers))
 	m.mkt.State = types.MarketStateSettled
 	m.broker.Send(events.NewMarketUpdatedEvent(ctx, *m.mkt))

--- a/execution/market.go
+++ b/execution/market.go
@@ -333,8 +333,9 @@ func NewMarket(
 		mkt.ID,
 		asset,
 		stateVarEngine,
-		false,
 		positionFactor,
+		false,
+		nil,
 	)
 
 	settleEngine := settlement.New(
@@ -3183,11 +3184,6 @@ func (m *Market) cleanupOnReject(ctx context.Context) {
 			logging.Error(err))
 		return
 	}
-
-	m.matching.StopSnapshots()
-	m.position.StopSnapshots()
-	m.liquidity.StopSnapshots()
-	m.tsCalc.StopSnapshots()
 
 	// then send the responses
 	m.broker.Send(events.NewTransferResponse(ctx, tresps))

--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -73,8 +73,9 @@ func NewMarketFromSnapshot(
 		mkt.ID,
 		asset,
 		stateVarEngine,
-		em.RiskFactorConsensusReached,
 		positionFactor,
+		em.RiskFactorConsensusReached,
+		&types.RiskFactor{Market: mkt.ID, Short: em.ShortRiskFactor, Long: em.LongRiskFactor},
 	)
 
 	settleEngine := settlement.New(

--- a/execution/mocks/state_var_engine_mock.go
+++ b/execution/mocks/state_var_engine_mock.go
@@ -72,3 +72,15 @@ func (mr *MockStateVarEngineMockRecorder) RegisterStateVariable(arg0, arg1, arg2
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterStateVariable", reflect.TypeOf((*MockStateVarEngine)(nil).RegisterStateVariable), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
+
+// RemoveTimeTriggers mocks base method.
+func (m *MockStateVarEngine) RemoveTimeTriggers(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveTimeTriggers", arg0, arg1)
+}
+
+// RemoveTimeTriggers indicates an expected call of RemoveTimeTriggers.
+func (mr *MockStateVarEngineMockRecorder) RemoveTimeTriggers(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTimeTriggers", reflect.TypeOf((*MockStateVarEngine)(nil).RemoveTimeTriggers), arg0, arg1)
+}

--- a/integration/stubs/state_var_stub.go
+++ b/integration/stubs/state_var_stub.go
@@ -50,6 +50,9 @@ func (e *StateVarStub) OnFloatingPointUpdatesDurationUpdate(ctx context.Context,
 	return nil
 }
 
+func (e *StateVarStub) RemoveTimeTriggers(asset, market string) {
+}
+
 func (e *StateVarStub) RegisterStateVariable(asset, market, name string, converter statevar.Converter, startCalculation func(string, statevar.FinaliseCalculation), trigger []statevar.StateVarEventType, result func(context.Context, statevar.StateVariableResult) error) error {
 	ID := asset + "_" + market + "_" + name + "_" + strconv.Itoa(e.seq)
 	e.seq++

--- a/risk/engine.go
+++ b/risk/engine.go
@@ -84,8 +84,9 @@ func NewEngine(log *logging.Logger,
 	mktID string,
 	asset string,
 	stateVarEngine StateVarEngine,
-	riskFactorsInitialised bool,
 	positionFactor num.Decimal,
+	riskFactorsInitialised bool,
+	initialisedRiskFactors *types.RiskFactor, // if restored from snapshot, will be nil otherwise
 ) *Engine {
 	// setup logger
 	log = log.Named(namedLogger)
@@ -108,6 +109,10 @@ func NewEngine(log *logging.Logger,
 		factors:                model.DefaultRiskFactors(),
 		riskFactorsInitialised: riskFactorsInitialised,
 		positionFactor:         positionFactor,
+	}
+
+	if initialisedRiskFactors != nil {
+		e.factors = initialisedRiskFactors
 	}
 
 	stateVarEngine.RegisterStateVariable(asset, mktID, RiskFactorStateVarName, RiskFactorConverter{}, e.startRiskFactorsCalculation, []statevar.StateVarEventType{statevar.StateVarEventTypeMarketEnactment, statevar.StateVarEventTypeMarketUpdated}, e.updateRiskFactor)

--- a/risk/engine_test.go
+++ b/risk/engine_test.go
@@ -338,7 +338,7 @@ func testMarginWithOrderInBook(t *testing.T) {
 	statevar := mocks.NewMockStateVarEngine(ctrl)
 	statevar.EXPECT().RegisterStateVariable(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	statevar.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any())
-	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, broker, 0, "mktid", "ETH", statevar, false, num.DecimalFromInt64(1))
+	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, broker, 0, "mktid", "ETH", statevar, num.DecimalFromInt64(1), false, nil)
 	evt := testMargin{
 		party:   "tx",
 		size:    10,
@@ -439,7 +439,7 @@ func testMarginWithOrderInBook2(t *testing.T) {
 	statevar := mocks.NewMockStateVarEngine(ctrl)
 	statevar.EXPECT().RegisterStateVariable(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	statevar.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any())
-	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, broker, 0, "mktid", "ETH", statevar, false, num.DecimalFromInt64(1))
+	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, broker, 0, "mktid", "ETH", statevar, num.DecimalFromInt64(1), false, nil)
 	evt := testMargin{
 		party:   "tx",
 		size:    13,
@@ -544,7 +544,7 @@ func testMarginWithOrderInBookAfterParamsUpdate(t *testing.T) {
 	statevarEngine.EXPECT().RegisterStateVariable(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	statevarEngine.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any())
 	asset := "ETH"
-	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, broker, 0, marketID, asset, statevarEngine, false, num.DecimalFromInt64(1))
+	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, broker, 0, marketID, asset, statevarEngine, num.DecimalFromInt64(1), false, nil)
 
 	evt := testMargin{
 		party:   "tx",
@@ -637,8 +637,9 @@ func getTestEngine(t *testing.T, initialRisk *types.RiskFactor) *testEngine {
 		"mktid",
 		"ETH",
 		statevar,
-		false,
 		num.DecimalFromInt64(1),
+		false,
+		nil,
 	)
 
 	return &testEngine{

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -111,7 +111,7 @@ type Engine struct {
 // order in which snapshots are to be restored.
 var nodeOrder = []types.SnapshotNamespace{
 	types.AppSnapshot,
-	types.AssetsSnapshot,
+	types.AssetsSnapshot,  // needs to happen before banking
 	types.WitnessSnapshot, // needs to happen before banking and governance
 	types.GovernanceSnapshot,
 	types.BankingSnapshot,

--- a/statevar/snapshot.go
+++ b/statevar/snapshot.go
@@ -50,12 +50,13 @@ func (e *Engine) serialiseNextTimeTrigger() []*snapshot.NextTimeTrigger {
 
 	for _, id := range ids {
 		if sv, ok := e.stateVars[id]; ok {
-			timeTriggers = append(timeTriggers, &snapshot.NextTimeTrigger{
+			data := &snapshot.NextTimeTrigger{
 				Asset:       sv.asset,
 				Market:      sv.market,
 				Id:          id,
 				NextTrigger: e.stateVarToNextCalc[id].UnixNano(),
-			})
+			}
+			timeTriggers = append(timeTriggers, data)
 		}
 	}
 

--- a/statevar/state_var_test.go
+++ b/statevar/state_var_test.go
@@ -594,4 +594,20 @@ func testTimeBasedEvent(t *testing.T) {
 		require.Equal(t, "20210221_011050", evt.EventID)
 		require.Equal(t, "consensus_calc_started", evt.State)
 	}
+
+	// Remove time trigger events
+	for _, v := range validators {
+		v.engine.RemoveTimeTriggers("asset", "market")
+	}
+
+	// advance even more to when we should have triggered
+	brokerEvents = []events.Event{}
+	now = now.Add(time.Second * 9)
+	for _, v := range validators {
+		v.engine.OnTimeTick(context.Background(), now)
+	}
+
+	// expected no events
+	brokerEvents = []events.Event{}
+	require.Equal(t, 0, len(brokerEvents))
 }


### PR DESCRIPTION
closes #5136 
closes #5040 

Three main fixes here are:
- banking engine's snapshots for recurring/oneoff transfers weren't quite right
- we never restored risk-factors when we restored a market
- the statevar engine was holding on to time-triggers for settled markets caused issues when restoring, because settled markets don't get restored.