### PR TITLE
Ignore new checks introduced in golangci-lint 1.45

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -50,6 +50,17 @@ disable = [
     "funlen",
     "gocyclo",
     "errname",
+    # New in golangci-lint 1.45 but would be nice to address
+    "maintidx",
+    "contextcheck",
+    "containedctx",
+    "varnamelen",
+    "ireturn",
+    "nilnil",
+    "errchkjson",
+    "ifshort",
+    "predeclared",
+    "nolintlint",
 ]
 
 [[issues.exclude-rules]]

--- a/api/core.go
+++ b/api/core.go
@@ -470,7 +470,8 @@ func (s *coreService) getGenesisTimeAndChainID(ctx context.Context) error {
 }
 
 func (s *coreService) ObserveEventBus(
-	stream protoapi.CoreService_ObserveEventBusServer) error {
+	stream protoapi.CoreService_ObserveEventBusServer,
+) error {
 	defer metrics.StartAPIRequestAndTimeGRPC("ObserveEventBus")()
 
 	ctx, cfunc := context.WithCancel(stream.Context())

--- a/banking/builtin_assets.go
+++ b/banking/builtin_assets.go
@@ -14,7 +14,8 @@ import (
 )
 
 func (e *Engine) WithdrawBuiltinAsset(
-	ctx context.Context, id, party, assetID string, amount *num.Uint) error {
+	ctx context.Context, id, party, assetID string, amount *num.Uint,
+) error {
 	// build the withdrawal type
 	w, ref := e.newWithdrawal(id, party, assetID, amount, time.Time{}, nil)
 	w.Status = types.WithdrawalStatusRejected // default
@@ -38,7 +39,8 @@ func (e *Engine) WithdrawBuiltinAsset(
 }
 
 func (e *Engine) DepositBuiltinAsset(
-	ctx context.Context, d *types.BuiltinAssetDeposit, id string, nonce uint64) error {
+	ctx context.Context, d *types.BuiltinAssetDeposit, id string, nonce uint64,
+) error {
 	now := e.currentTime
 	dep := e.newDeposit(id, d.PartyID, d.VegaAssetID, d.Amount, "") // no hash
 	e.broker.Send(events.NewDepositEvent(ctx, *dep))

--- a/banking/checkpoint.go
+++ b/banking/checkpoint.go
@@ -69,7 +69,8 @@ func (e *Engine) loadScheduledTransfers(
 }
 
 func (e *Engine) loadRecurringTransfers(
-	ctx context.Context, r *checkpoint.RecurringTransfers) []events.Event {
+	ctx context.Context, r *checkpoint.RecurringTransfers,
+) []events.Event {
 	evts := []events.Event{}
 	for _, v := range r.RecurringTransfers {
 		transfer := types.RecurringTransferFromEvent(v)

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -381,7 +381,8 @@ func (e *Engine) finalizeDeposit(ctx context.Context, d *types.Deposit) error {
 }
 
 func (e *Engine) finalizeWithdraw(
-	ctx context.Context, w *types.Withdrawal) error {
+	ctx context.Context, w *types.Withdrawal,
+) error {
 	// always send the withdrawal event, don't delete it from the map because we
 	// may still receive events
 	defer func() {

--- a/client/eth/ethereum_confirmations.go
+++ b/client/eth/ethereum_confirmations.go
@@ -70,7 +70,8 @@ func (e *EthereumConfirmations) Check(block uint64) error {
 }
 
 func (e *EthereumConfirmations) currentHeight(
-	_ context.Context) (uint64, error) {
+	_ context.Context,
+) (uint64, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 

--- a/cmd/vega/node/app_wrapper.go
+++ b/cmd/vega/node/app_wrapper.go
@@ -65,21 +65,25 @@ func (app *appW) EndBlock(req types.RequestEndBlock) types.ResponseEndBlock {
 }
 
 func (app *appW) ListSnapshots(
-	req types.RequestListSnapshots) types.ResponseListSnapshots {
+	req types.RequestListSnapshots,
+) types.ResponseListSnapshots {
 	return app.impl.ListSnapshots(req)
 }
 
 func (app *appW) OfferSnapshot(
-	req types.RequestOfferSnapshot) types.ResponseOfferSnapshot {
+	req types.RequestOfferSnapshot,
+) types.ResponseOfferSnapshot {
 	return app.impl.OfferSnapshot(req)
 }
 
 func (app *appW) LoadSnapshotChunk(
-	req types.RequestLoadSnapshotChunk) types.ResponseLoadSnapshotChunk {
+	req types.RequestLoadSnapshotChunk,
+) types.ResponseLoadSnapshotChunk {
 	return app.impl.LoadSnapshotChunk(req)
 }
 
 func (app *appW) ApplySnapshotChunk(
-	req types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk {
+	req types.RequestApplySnapshotChunk,
+) types.ResponseApplySnapshotChunk {
 	return app.impl.ApplySnapshotChunk(req)
 }

--- a/events/validator_score.go
+++ b/events/validator_score.go
@@ -20,7 +20,8 @@ type ValidatorScore struct {
 }
 
 func NewValidatorScore(ctx context.Context, nodeID, epochSeq string, score, normalisedScore, rawValidatorScore,
-	validatorPerformance num.Decimal, multisigScore num.Decimal, validatorStatus string) *ValidatorScore {
+	validatorPerformance num.Decimal, multisigScore num.Decimal, validatorStatus string,
+) *ValidatorScore {
 	return &ValidatorScore{
 		Base:                 newBase(ctx, ValidatorScoreEvent),
 		NodeID:               nodeID,

--- a/execution/collateral.go
+++ b/execution/collateral.go
@@ -16,7 +16,8 @@ var ErrBondSlashing = errors.New("bond slashing")
 // this will transfer funds calculated for a party amending a liquidity
 // provision during auction.
 func (m *Market) transferMarginsLiquidityProvisionAmendAuction(
-	ctx context.Context, risk events.Risk) error {
+	ctx context.Context, risk events.Risk,
+) error {
 	market := m.GetID()
 	// This is ultimately the same behaviour than update on order
 	// all or nothing of margin needsto be transferred

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -280,7 +280,8 @@ func (e *Engine) IsEligibleForProposerBonus(marketID string, value *num.Uint) bo
 // the usual governance process.
 func (e *Engine) SubmitMarketWithLiquidityProvision(ctx context.Context, marketConfig *types.Market, lp *types.LiquidityProvisionSubmission, party,
 	lpID,
-	deterministicId string) error {
+	deterministicId string,
+) error {
 	if e.log.IsDebug() {
 		e.log.Debug("submit market with liquidity provision",
 			logging.Market(*marketConfig),
@@ -555,7 +556,8 @@ func (e *Engine) SubmitOrder(
 // AmendOrder takes order amendment details and attempts to amend the order
 // if it exists and is in a editable state.
 func (e *Engine) AmendOrder(ctx context.Context, amendment *types.OrderAmendment, party string,
-	deterministicId string) (confirmation *types.OrderConfirmation, returnedErr error) {
+	deterministicId string,
+) (confirmation *types.OrderConfirmation, returnedErr error) {
 	timer := metrics.NewTimeCounter(amendment.MarketID, "execution", "AmendOrder")
 	defer func() {
 		timer.EngineTimeCounterAdd()
@@ -706,7 +708,8 @@ func (e *Engine) SubmitLiquidityProvision(
 }
 
 func (e *Engine) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string,
-	deterministicId string) (returnedErr error) {
+	deterministicId string,
+) (returnedErr error) {
 	timer := metrics.NewTimeCounter(lpa.MarketID, "execution", "LiquidityProvisionAmendment")
 	defer func() {
 		timer.EngineTimeCounterAdd()
@@ -989,7 +992,8 @@ func (e *Engine) OnMarketLiquidityProvidersFeeDistributionTimeStep(_ context.Con
 }
 
 func (e *Engine) OnMarketLiquidityProvisionShapesMaxSizeUpdate(
-	_ context.Context, v int64) error {
+	_ context.Context, v int64,
+) error {
 	if e.log.IsDebug() {
 		e.log.Debug("update liquidity provision max shape",
 			logging.Int64("max-shape", v),
@@ -1006,7 +1010,8 @@ func (e *Engine) OnMarketLiquidityProvisionShapesMaxSizeUpdate(
 }
 
 func (e *Engine) OnMarketLiquidityMaximumLiquidityFeeFactorLevelUpdate(
-	_ context.Context, d num.Decimal) error {
+	_ context.Context, d num.Decimal,
+) error {
 	if e.log.IsDebug() {
 		e.log.Debug("update liquidity provision max liquidity fee factor",
 			logging.Decimal("max-liquidity-fee", d),

--- a/execution/expiring_orders.go
+++ b/execution/expiring_orders.go
@@ -32,7 +32,8 @@ func (a *ExpiringOrders) GetExpiryingOrderCount() int {
 }
 
 func (a *ExpiringOrders) Insert(
-	orderID string, ts int64) {
+	orderID string, ts int64,
+) {
 	item := &ordersAtTS{ts: ts}
 	if item := a.orders.Get(item); item != nil {
 		item.(*ordersAtTS).orders = append(item.(*ordersAtTS).orders, orderID)

--- a/execution/liquidity_provision.go
+++ b/execution/liquidity_provision.go
@@ -685,7 +685,8 @@ func (m *Market) rollBackMargin(
 
 // repriceFuncW is an adapter for getNewPeggedPrice.
 func (m *Market) repriceLiquidityOrder(
-	po *types.PeggedOrder, side types.Side) (*num.Uint, *types.PeggedOrder, error) {
+	po *types.PeggedOrder, side types.Side,
+) (*num.Uint, *types.PeggedOrder, error) {
 	if m.as.InAuction() {
 		return num.Zero(), nil, ErrCannotRepriceDuringAuction
 	}
@@ -884,7 +885,8 @@ func (m *Market) adjustPriceRange(po *types.PeggedOrder, side types.Side, price 
 }
 
 func (m *Market) cancelLiquidityProvision(
-	ctx context.Context, party string, isDistressed bool) error {
+	ctx context.Context, party string, isDistressed bool,
+) error {
 	// cancel the liquidity provision
 	cancelOrders, err := m.liquidity.CancelLiquidityProvision(ctx, party)
 	if err != nil {

--- a/execution/market.go
+++ b/execution/market.go
@@ -1514,7 +1514,8 @@ func (m *Market) applyFees(ctx context.Context, order *types.Order, trades []*ty
 
 func (m *Market) handleConfirmationPassiveOrders(
 	ctx context.Context,
-	conf *types.OrderConfirmation) {
+	conf *types.OrderConfirmation,
+) {
 	if conf.PassiveOrdersAffected != nil {
 		var (
 			evts        = make([]events.Event, 0, len(conf.PassiveOrdersAffected))
@@ -1607,7 +1608,8 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 }
 
 func (m *Market) confirmMTM(
-	ctx context.Context, order *types.Order) (orderUpdates []*types.Order) {
+	ctx context.Context, order *types.Order,
+) (orderUpdates []*types.Order) {
 	// now let's get the transfers for MTM settlement
 	markPrice := m.getCurrentMarkPrice()
 	evts := m.position.UpdateMarkPrice(markPrice)
@@ -2877,7 +2879,8 @@ func (m *Market) orderAmendWhenParked(originalOrder, amendOrder *types.Order) *t
 // RemoveExpiredOrders remove all expired orders from the order book
 // and also any pegged orders that are parked.
 func (m *Market) RemoveExpiredOrders(
-	ctx context.Context, timestamp int64) ([]*types.Order, error) {
+	ctx context.Context, timestamp int64,
+) ([]*types.Order, error) {
 	timer := metrics.NewTimeCounter(m.mkt.ID, "market", "RemoveExpiredOrders")
 	defer timer.EngineTimeCounterAdd()
 

--- a/execution/market_test.go
+++ b/execution/market_test.go
@@ -263,7 +263,8 @@ func getTestMarketWithDP(
 	closingAt time.Time,
 	pMonitorSettings *types.PriceMonitoringSettings,
 	openingAuctionDuration *types.AuctionDuration,
-	decimalPlaces uint64) *testMarket {
+	decimalPlaces uint64,
+) *testMarket {
 	t.Helper()
 	return getTestMarket2WithDP(t, now, closingAt, pMonitorSettings, openingAuctionDuration, true, decimalPlaces)
 }
@@ -529,7 +530,8 @@ func addAccountWithAmount(market *testMarket, party string, amnt uint64) *types.
 
 // WithSubmittedLiquidityProvision Submits a Liquidity Provision and asserts that it was created without errors.
 func (tm *testMarket) WithSubmittedLiquidityProvision(t *testing.T, party, id string, amount uint64, fee string,
-	buys, sells []*types.LiquidityOrder) *testMarket {
+	buys, sells []*types.LiquidityOrder,
+) *testMarket {
 	t.Helper()
 	ctx := vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash())
 
@@ -2981,7 +2983,8 @@ func getMarketOrder(tm *testMarket,
 	side types.Side,
 	partyID string,
 	size uint64,
-	price uint64) *types.Order {
+	price uint64,
+) *types.Order {
 	order := &types.Order{
 		Type:        orderType,
 		TimeInForce: orderTIF,

--- a/execution/order_test.go
+++ b/execution/order_test.go
@@ -593,7 +593,8 @@ func getAmend(market string, orderID string, sizeDelta int64, price uint64, tif 
 }
 
 func amendOrder(t *testing.T, tm *testMarket, party string, orderID string, sizeDelta int64, price uint64,
-	tif types.OrderTimeInForce, expiresAt int64, pass bool) {
+	tif types.OrderTimeInForce, expiresAt int64, pass bool,
+) {
 	t.Helper()
 	amend := getAmend(tm.market.GetID(), orderID, sizeDelta, price, tif, expiresAt)
 
@@ -605,7 +606,8 @@ func amendOrder(t *testing.T, tm *testMarket, party string, orderID string, size
 }
 
 func getOrder(t *testing.T, tm *testMarket, now *time.Time, orderType types.OrderType, tif types.OrderTimeInForce,
-	expiresAt int64, side types.Side, party string, size uint64, price uint64) types.Order {
+	expiresAt int64, side types.Side, party string, size uint64, price uint64,
+) types.Order {
 	t.Helper()
 	order := types.Order{
 		Status:      types.OrderStatusActive,
@@ -628,7 +630,8 @@ func getOrder(t *testing.T, tm *testMarket, now *time.Time, orderType types.Orde
 }
 
 func sendOrder(t *testing.T, tm *testMarket, now *time.Time, orderType types.OrderType, tif types.OrderTimeInForce, expiresAt int64, side types.Side, party string,
-	size uint64, price uint64) string {
+	size uint64, price uint64,
+) string {
 	t.Helper()
 	order := &types.Order{
 		Status:      types.OrderStatusActive,

--- a/governance/netparams.go
+++ b/governance/netparams.go
@@ -113,7 +113,8 @@ func (e *Engine) getProposalParametersFromNetParams(
 }
 
 func validateNetworkParameterUpdate(
-	netp NetParams, np *types.NetworkParameter) (types.ProposalError, error) {
+	netp NetParams, np *types.NetworkParameter,
+) (types.ProposalError, error) {
 	if len(np.Key) <= 0 {
 		return types.ProposalErrorNetworkParameterInvalidKey, ErrEmptyNetParamKey
 	}

--- a/integration/execution_test.go
+++ b/integration/execution_test.go
@@ -49,7 +49,8 @@ func (e *exEng) CancelOrder(ctx context.Context, cancel *types.OrderCancellation
 }
 
 func (e *exEng) SubmitLiquidityProvision(ctx context.Context, sub *types.LiquidityProvisionSubmission, party, lpID,
-	deterministicId string) error {
+	deterministicId string,
+) error {
 	if err := e.Engine.SubmitLiquidityProvision(ctx, sub, party, deterministicId); err != nil {
 		e.broker.Send(events.NewTxErrEvent(ctx, err, party, sub.IntoProto()))
 		return err

--- a/liquidity/types.go
+++ b/liquidity/types.go
@@ -226,7 +226,8 @@ func (o *SnapshotablePartiesOrders) Get(party, orderID string) (*types.Order, bo
 
 // GetForParty expects to read through them, not do any write operation.
 func (o *SnapshotablePartiesOrders) GetForParty(
-	party string) (map[string]*types.Order, bool) {
+	party string,
+) (map[string]*types.Order, bool) {
 	orders, ok := o.m[party]
 	return orders, ok
 }

--- a/logging/fields.go
+++ b/logging/fields.go
@@ -217,42 +217,50 @@ func LiquidityID(id string) zap.Field {
 }
 
 func LiquidityProvisionSubmissionProto(
-	lp *commandspb.LiquidityProvisionSubmission) zap.Field {
+	lp *commandspb.LiquidityProvisionSubmission,
+) zap.Field {
 	return zap.String("liquidity-provision-submission", lp.String())
 }
 
 func LiquidityProvisionSubmission(
-	lp types.LiquidityProvisionSubmission) zap.Field {
+	lp types.LiquidityProvisionSubmission,
+) zap.Field {
 	return zap.String("liquidity-provision-submission", lp.String())
 }
 
 func LiquidityProvisionCancellationProto(
-	lp *commandspb.LiquidityProvisionCancellation) zap.Field {
+	lp *commandspb.LiquidityProvisionCancellation,
+) zap.Field {
 	return zap.String("liquidity-provision-cancellation", lp.String())
 }
 
 func LiquidityProvisionCancellation(
-	lp types.LiquidityProvisionCancellation) zap.Field {
+	lp types.LiquidityProvisionCancellation,
+) zap.Field {
 	return zap.String("liquidity-provision-cancellation", lp.String())
 }
 
 func LiquidityProvisionAmendmentProto(
-	lp *commandspb.LiquidityProvisionAmendment) zap.Field {
+	lp *commandspb.LiquidityProvisionAmendment,
+) zap.Field {
 	return zap.String("liquidity-provision-amendment", lp.String())
 }
 
 func LiquidityProvisionAmendment(
-	lp types.LiquidityProvisionAmendment) zap.Field {
+	lp types.LiquidityProvisionAmendment,
+) zap.Field {
 	return zap.String("liquidity-provision-amendment", lp.String())
 }
 
 func WithdrawSubmissionProto(
-	lp *commandspb.WithdrawSubmission) zap.Field {
+	lp *commandspb.WithdrawSubmission,
+) zap.Field {
 	return zap.String("withdraw-submission", lp.String())
 }
 
 func WithdrawSubmission(
-	lp types.WithdrawSubmission) zap.Field {
+	lp types.WithdrawSubmission,
+) zap.Field {
 	return zap.String("withdraw-submission", lp.String())
 }
 

--- a/matching/cached_orderbook.go
+++ b/matching/cached_orderbook.go
@@ -29,13 +29,15 @@ func (b *CachedOrderBook) EnterAuction() []*types.Order {
 }
 
 func (b *CachedOrderBook) LeaveAuction(
-	at time.Time) ([]*types.OrderConfirmation, []*types.Order, error) {
+	at time.Time,
+) ([]*types.OrderConfirmation, []*types.Order, error) {
 	b.cache.Invalidate()
 	return b.OrderBook.LeaveAuction(at)
 }
 
 func (b *CachedOrderBook) CancelAllOrders(
-	party string) ([]*types.OrderCancellationConfirmation, error) {
+	party string,
+) ([]*types.OrderCancellationConfirmation, error) {
 	b.cache.Invalidate()
 	return b.OrderBook.CancelAllOrders(party)
 }
@@ -82,7 +84,8 @@ func (b *CachedOrderBook) RemoveOrder(order *types.Order) error {
 }
 
 func (b *CachedOrderBook) AmendOrder(
-	originalOrder, amendedOrder *types.Order) error {
+	originalOrder, amendedOrder *types.Order,
+) error {
 	if !b.InAuction() {
 		b.cache.Invalidate()
 	} else {
@@ -92,7 +95,8 @@ func (b *CachedOrderBook) AmendOrder(
 }
 
 func (b *CachedOrderBook) SubmitOrder(
-	order *types.Order) (*types.OrderConfirmation, error) {
+	order *types.Order,
+) (*types.OrderConfirmation, error) {
 	if !b.InAuction() {
 		b.cache.Invalidate()
 	} else {
@@ -102,7 +106,8 @@ func (b *CachedOrderBook) SubmitOrder(
 }
 
 func (b *CachedOrderBook) DeleteOrder(
-	order *types.Order) (*types.Order, error) {
+	order *types.Order,
+) (*types.Order, error) {
 	if !b.InAuction() {
 		b.cache.Invalidate()
 	} else {

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -799,7 +799,8 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 
 // DeleteOrder remove a given order on a given side from the book.
 func (b *OrderBook) DeleteOrder(
-	order *types.Order) (*types.Order, error) {
+	order *types.Order,
+) (*types.Order, error) {
 	dorder, err := b.getSide(order.Side).RemoveOrder(order)
 	if err != nil {
 		if b.log.GetLevel() == logging.DebugLevel {

--- a/monitor/liquidity/engine.go
+++ b/monitor/liquidity/engine.go
@@ -68,7 +68,8 @@ func (e *Engine) UpdateTargetStakeTriggerRatio(ctx context.Context, ratio num.De
 // CheckLiquidity Starts or Ends a Liquidity auction given the current and target stakes along with best static bid and ask volumes.
 // The constant c1 represents the netparam `MarketLiquidityTargetStakeTriggeringRatio`.
 func (e *Engine) CheckLiquidity(as AuctionState, t time.Time, currentStake *num.Uint, trades []*types.Trade,
-	rf types.RiskFactor, markPrice *num.Uint, bestStaticBidVolume, bestStaticAskVolume uint64) {
+	rf types.RiskFactor, markPrice *num.Uint, bestStaticBidVolume, bestStaticAskVolume uint64,
+) {
 	exp := as.ExpiresAt()
 	if exp != nil && exp.After(t) {
 		// we're in auction, and the auction isn't expiring yet, so we don't have to do anything yet

--- a/positions/snapshot.go
+++ b/positions/snapshot.go
@@ -23,7 +23,8 @@ type SnapshotEngine struct {
 }
 
 func NewSnapshotEngine(
-	log *logging.Logger, config Config, marketID string, broker Broker) *SnapshotEngine {
+	log *logging.Logger, config Config, marketID string, broker Broker,
+) *SnapshotEngine {
 	return &SnapshotEngine{
 		Engine:  New(log, config, marketID, broker),
 		pl:      types.Payload{},

--- a/processor/abci.go
+++ b/processor/abci.go
@@ -1077,7 +1077,8 @@ func (app *App) DeliverAmendOrder(ctx context.Context, tx abci.Tx, deterministic
 }
 
 func (app *App) DeliverWithdraw(
-	ctx context.Context, tx abci.Tx, id string) error {
+	ctx context.Context, tx abci.Tx, id string,
+) error {
 	w := &commandspb.WithdrawSubmission{}
 	if err := tx.Unmarshal(w); err != nil {
 		return err

--- a/risk/engine.go
+++ b/risk/engine.go
@@ -301,7 +301,8 @@ func (e *Engine) UpdateMarginOnNewOrder(ctx context.Context, evt events.Margin, 
 // move monies later, we'll need to close out the party but that cannot be figured out
 // now only in later when we try to move monies from the general account.
 func (e *Engine) UpdateMarginsOnSettlement(
-	ctx context.Context, evts []events.Margin, markPrice *num.Uint) []events.Risk {
+	ctx context.Context, evts []events.Margin, markPrice *num.Uint,
+) []events.Risk {
 	ret := make([]events.Risk, 0, len(evts))
 	// var err error
 	// this will keep going until we've closed this channel

--- a/staking/accounting.go
+++ b/staking/accounting.go
@@ -299,7 +299,8 @@ func (a *Accounting) GetAvailableBalance(party string) (*num.Uint, error) {
 }
 
 func (a *Accounting) GetAvailableBalanceAt(
-	party string, at time.Time) (*num.Uint, error) {
+	party string, at time.Time,
+) (*num.Uint, error) {
 	acc, ok := a.accounts[party]
 	if !ok {
 		return num.Zero(), ErrNoBalanceForParty
@@ -309,7 +310,8 @@ func (a *Accounting) GetAvailableBalanceAt(
 }
 
 func (a *Accounting) GetAvailableBalanceInRange(
-	party string, from, to time.Time) (*num.Uint, error) {
+	party string, from, to time.Time,
+) (*num.Uint, error) {
 	acc, ok := a.accounts[party]
 	if !ok {
 		return num.Zero(), ErrNoBalanceForParty

--- a/staking/on_chain_verifier.go
+++ b/staking/on_chain_verifier.go
@@ -60,7 +60,8 @@ func (o *OnChainVerifier) UpdateStakingBridgeAddresses(stakingBridgeAddresses []
 }
 
 func (o *OnChainVerifier) CheckStakeDeposited(
-	event *types.StakeDeposited) error {
+	event *types.StakeDeposited,
+) error {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 

--- a/staking/stake_verifier.go
+++ b/staking/stake_verifier.go
@@ -151,7 +151,8 @@ func (s *StakeVerifier) ensureNotDuplicate(id, h string) bool {
 // }
 
 func (s *StakeVerifier) ProcessStakeRemoved(
-	ctx context.Context, event *types.StakeRemoved) error {
+	ctx context.Context, event *types.StakeRemoved,
+) error {
 	if ok := s.ensureNotDuplicate(event.ID, event.IntoStakeLinking().Hash()); !ok {
 		s.log.Error("stake removed event already exists",
 			logging.String("event", event.String()))
@@ -177,7 +178,8 @@ func (s *StakeVerifier) ProcessStakeRemoved(
 }
 
 func (s *StakeVerifier) ProcessStakeDeposited(
-	ctx context.Context, event *types.StakeDeposited) error {
+	ctx context.Context, event *types.StakeDeposited,
+) error {
 	if ok := s.ensureNotDuplicate(event.ID, event.IntoStakeLinking().Hash()); !ok {
 		s.log.Error("stake deposited event already exists",
 			logging.String("event", event.String()))

--- a/types/snapshot_nodes.go
+++ b/types/snapshot_nodes.go
@@ -878,7 +878,8 @@ func (p Payload) GetAppState() *PayloadAppState {
 }
 
 func PayloadERC20MultiSigTopologyVerifiedFromProto(
-	s *snapshot.Payload_Erc20MultisigTopologyVerified) *PayloadERC20MultiSigTopologyVerified {
+	s *snapshot.Payload_Erc20MultisigTopologyVerified,
+) *PayloadERC20MultiSigTopologyVerified {
 	return &PayloadERC20MultiSigTopologyVerified{
 		Verified: s.Erc20MultisigTopologyVerified,
 	}
@@ -901,7 +902,8 @@ func (p *PayloadERC20MultiSigTopologyVerified) Key() string {
 }
 
 func PayloadERC20MultiSigTopologyPendingFromProto(
-	s *snapshot.Payload_Erc20MultisigTopologyPending) *PayloadERC20MultiSigTopologyPending {
+	s *snapshot.Payload_Erc20MultisigTopologyPending,
+) *PayloadERC20MultiSigTopologyPending {
 	return &PayloadERC20MultiSigTopologyPending{
 		Pending: s.Erc20MultisigTopologyPending,
 	}

--- a/validators/announce_node.go
+++ b/validators/announce_node.go
@@ -14,7 +14,8 @@ import (
 var ErrMissingRequiredAnnounceNodeFields = errors.New("missing required announce node fields")
 
 func (t *Topology) ProcessAnnounceNode(
-	ctx context.Context, an *commandspb.AnnounceNode) error {
+	ctx context.Context, an *commandspb.AnnounceNode,
+) error {
 	if err := VerifyAnnounceNode(an); err != nil {
 		return err
 	}

--- a/validators/erc20multisig/on_chain_verifier.go
+++ b/validators/erc20multisig/on_chain_verifier.go
@@ -104,7 +104,8 @@ func (o *OnChainVerifier) CheckSignerEvent(event *types.SignerEvent) error {
 }
 
 func (o *OnChainVerifier) CheckThresholdSetEvent(
-	event *types.SignerThresholdSetEvent) error {
+	event *types.SignerThresholdSetEvent,
+) error {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 

--- a/validators/erc20multisig/topology.go
+++ b/validators/erc20multisig/topology.go
@@ -305,7 +305,8 @@ func (t *Topology) updateThreshold(ctx context.Context) {
 }
 
 func (t *Topology) setThresholdSetEvent(
-	ctx context.Context, event *types.SignerThresholdSetEvent) {
+	ctx context.Context, event *types.SignerThresholdSetEvent,
+) {
 	// if it's out first time here
 	if t.threshold == nil || event.BlockTime > t.threshold.BlockTime {
 		t.threshold = event

--- a/validators/erc20multisig/topology_snapshot_state.go
+++ b/validators/erc20multisig/topology_snapshot_state.go
@@ -67,7 +67,8 @@ func (s *Topology) LoadState(ctx context.Context, payload *types.Payload) ([]typ
 }
 
 func (t *Topology) restoreVerifiedState(
-	_ context.Context, s *snapshotpb.ERC20MultiSigTopologyVerified) error {
+	_ context.Context, s *snapshotpb.ERC20MultiSigTopologyVerified,
+) error {
 	t.log.Debug("restoring snapshot verified state")
 	if s.Threshold != nil {
 		t.log.Debug("restoring threshold")
@@ -99,7 +100,8 @@ func (t *Topology) restoreVerifiedState(
 }
 
 func (t *Topology) restorePendingState(
-	_ context.Context, s *snapshotpb.ERC20MultiSigTopologyPending) error {
+	_ context.Context, s *snapshotpb.ERC20MultiSigTopologyPending,
+) error {
 	t.log.Debug("restoring snapshot pending state")
 	t.log.Debug("restoring witness signers", logging.Int("n", len(s.WitnessedSigners)))
 	for _, v := range s.WitnessedSigners {

--- a/validators/heartbeat.go
+++ b/validators/heartbeat.go
@@ -46,7 +46,8 @@ func (v *validatorHeartbeatTracker) recordHeartbeatResult(status bool) {
 // ProcessValidatorHeartbeat is verifying the signatures from a validator's transaction and records the status.
 func (t *Topology) ProcessValidatorHeartbeat(ctx context.Context, vh *commandspb.ValidatorHeartbeat,
 	verifyVegaSig func(message, signature, pubkey []byte) error,
-	verifyEthSig func(message, signature []byte, hexAddress string) error) error {
+	verifyEthSig func(message, signature []byte, hexAddress string) error,
+) error {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	validator, ok := t.validators[vh.NodeId]


### PR DESCRIPTION
Previous golangci-lint gives nonsense warnings with go 1.18
So we upgraded to golangci-lint@latest, but it has a bunch of new check in it which we are failing. Ignore those for now, but we should take a look.
It also seems to have a new version of gofumpt that has a slightly different view of what things look like so I allowed it to auto fix a few files.