### PR TITLE
Fix settlement engine handling of truncated MTM win amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [5172](https://github.com/vegaprotocol/vega/issues/5172) - Add replay protection for validator commands
 - [5181](https://github.com/vegaprotocol/vega/issues/5181) - Ensure Oracle specs handle numbers using `num.Decimal` and `num.Int`
 - [5190](https://github.com/vegaprotocol/vega/issues/5190) - Fix settlement at expiry to scale the settlement price from market decimals to asset decimals
+- [5185](https://github.com/vegaprotocol/vega/issues/5185) - Fix MTM settlement where win transfers get truncated resulting in settlement balance not being zero after settlement.
 
 ## 0.49.8
 

--- a/settlement/engine_test.go
+++ b/settlement/engine_test.go
@@ -58,14 +58,15 @@ func TestMarkToMarket(t *testing.T) {
 
 func TestMTMWinDistribution(t *testing.T) {
 	t.Run("A MTM loss party with a loss of value 1, with several parties needing a win", testMTMWinOneExcess)
-	t.Run("A MTM scenario with several parties winning less than 1, and several parties losing 1, to distribute equally", testMTMWinDivideExcess)
+	t.Run("Distribute win excess in a scenario where no transfer amount is < 1", testMTMWinNoZero)
 }
 
-func testMTMWinDivideExcess(t *testing.T) {
+func testMTMWinNoZero(t *testing.T) {
+	// cheat by setting the factor to some specific value, makes it easier to create a scenario where win/loss amounts don't match
 	engine := getTestEngineWithFactor(t, 1)
 	defer engine.Finish()
 
-	price := num.NewUint(10000)
+	price := num.NewUint(100000)
 	one := num.NewUint(1)
 	ctx := context.Background()
 
@@ -78,12 +79,12 @@ func testMTMWinDivideExcess(t *testing.T) {
 		{
 			price: price.Clone(),
 			party: "party2",
-			size:  20,
+			size:  23,
 		},
 		{
 			price: price.Clone(),
 			party: "party3",
-			size:  -29,
+			size:  -32,
 		},
 		{
 			price: price.Clone(),
@@ -93,12 +94,12 @@ func testMTMWinDivideExcess(t *testing.T) {
 		{
 			price: price.Clone(),
 			party: "party5",
-			size:  -1,
+			size:  -29,
 		},
 		{
 			price: price.Clone(),
-			party: "party5",
-			size:  1,
+			party: "party6",
+			size:  27,
 		},
 	}
 
@@ -107,7 +108,8 @@ func testMTMWinDivideExcess(t *testing.T) {
 		init = append(init, p)
 	}
 
-	newPrice := num.Sum(price, one)
+	newPrice := num.Sum(price, one, one, one)
+	somePrice := num.Sum(price, one)
 	newParty := testPos{
 		size:  30,
 		price: newPrice.Clone(),
@@ -119,13 +121,13 @@ func testMTMWinDivideExcess(t *testing.T) {
 			Size:   10,
 			Buyer:  newParty.party,
 			Seller: initPos[0].party,
-			Price:  newPrice.Clone(),
+			Price:  somePrice.Clone(),
 		},
 		{
 			Size:   10,
 			Buyer:  newParty.party,
 			Seller: initPos[1].party,
-			Price:  newPrice.Clone(),
+			Price:  somePrice.Clone(),
 		},
 		{
 			Size:   10,


### PR DESCRIPTION
fixes #5185 

Several issues addressed here:

* largest MTM share was only set if the MTM win party transfer amount was < 1
* loss/win delta amount was distributed incorrectly amongst parties with a MTM share < 1 (delta / zero parties could've been > 1. Parties with a MTM share of 0.x should at most receive an MTM share of 1)
* Removed the weird check for `largestShare == nil` which defaulted the largest share to the first party with a zero amount win. This effectively hid the bug where `largestShare` wasn't being set properly, and could've resulted in a party with an MTM share of 0.x to get a transfer > 1.