### PR TITLE
4943 amend open auction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [5181](https://github.com/vegaprotocol/vega/issues/5181) - Ensure Oracle specs handle numbers using `num.Decimal` and `num.Int`
 - [5190](https://github.com/vegaprotocol/vega/issues/5190) - Fix settlement at expiry to scale the settlement price from market decimals to asset decimals
 - [5185](https://github.com/vegaprotocol/vega/issues/5185) - Fix MTM settlement where win transfers get truncated resulting in settlement balance not being zero after settlement.
+- [4943](https://github.com/vegaprotocol/vega/issues/4943) - Fix bug where amending orders in opening auctions did not work as expected
 
 ## 0.49.8
 

--- a/integration/features/orders/amend-order-opening-auction.feature
+++ b/integration/features/orders/amend-order-opening-auction.feature
@@ -1,0 +1,42 @@
+Feature: Amend orders
+
+  Background:
+
+    Given the following network parameters are set:
+      | name                           | value |
+      | market.auction.minimumDuration | 1     |
+    And the average block duration is "1"
+    And the markets:
+      | id        | quote name | asset | risk model                  | margin calculator                  | auction duration | fees         | price monitoring | oracle config          |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-2 | default-overkill-margin-calculator | 1                | default-none | default-none     | default-eth-for-future |
+
+  @AmendOA
+  Scenario: Amend an order during opening auction, we should leave the auction the next time update
+# setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party | asset | amount    |
+      | myboi | BTC   | 10000000  |
+      | aux   | BTC   | 100000000 |
+      | aux2  | BTC   | 100000000 |
+
+    # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | aux   | ETH/DEC19 | buy  | 100    | 9900  | 0                | TYPE_LIMIT | TIF_GTC | aux-b-9   |
+      | aux   | ETH/DEC19 | sell | 100    | 10010 | 0                | TYPE_LIMIT | TIF_GTC | aux2-s-10 |
+      | aux2  | ETH/DEC19 | buy  | 1      | 10000 | 0                | TYPE_LIMIT | TIF_GTC | aux2-b-k  |
+      | aux   | ETH/DEC19 | sell | 1      | 10001 | 0                | TYPE_LIMIT | TIF_GTC | aux-s-1   |
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_OPENING_AUCTION" for the market "ETH/DEC19"
+    #And the mark price should be "10000" for the market "ETH/DEC19"
+    
+    # Amend order, we remain in auction
+    When the parties amend the following orders:
+      | party | reference | price | size delta | tif     |
+      | aux   | aux-s-1   | 10000 | 0          | TIF_GTC |
+    Then the trading mode should be "TRADING_MODE_OPENING_AUCTION" for the market "ETH/DEC19"
+
+    # next block
+    When the network moves ahead "1" blocks
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the mark price should be "10000" for the market "ETH/DEC19"

--- a/matching/cached_orderbook.go
+++ b/matching/cached_orderbook.go
@@ -94,6 +94,15 @@ func (b *CachedOrderBook) AmendOrder(
 	return b.OrderBook.AmendOrder(originalOrder, amendedOrder)
 }
 
+func (b *CachedOrderBook) ReplaceOrder(rm, rpl *types.Order) (*types.OrderConfirmation, error) {
+	if !b.InAuction() {
+		b.cache.Invalidate()
+	} else {
+		b.maybeInvalidateDuringAuction(rpl)
+	}
+	return b.OrderBook.ReplaceOrder(rm, rpl)
+}
+
 func (b *CachedOrderBook) SubmitOrder(
 	order *types.Order,
 ) (*types.OrderConfirmation, error) {


### PR DESCRIPTION
Fixes #4943 

After changes to the order amend flow, the cached orderbook remained stale so the indicative price & volume remained 0 when checking whether we could leave auction. 