### PR TITLE
Fix witness key usage

### DIFF
--- a/validators/mocks/validator_topology_mock.go
+++ b/validators/mocks/validator_topology_mock.go
@@ -89,16 +89,16 @@ func (mr *MockValidatorTopologyMockRecorder) Len() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockValidatorTopology)(nil).Len))
 }
 
-// SelfNodeID mocks base method.
-func (m *MockValidatorTopology) SelfNodeID() string {
+// SelfVegaPubKey mocks base method.
+func (m *MockValidatorTopology) SelfVegaPubKey() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelfNodeID")
+	ret := m.ctrl.Call(m, "SelfVegaPubKey")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// SelfNodeID indicates an expected call of SelfNodeID.
-func (mr *MockValidatorTopologyMockRecorder) SelfNodeID() *gomock.Call {
+// SelfVegaPubKey indicates an expected call of SelfVegaPubKey.
+func (mr *MockValidatorTopologyMockRecorder) SelfVegaPubKey() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfNodeID", reflect.TypeOf((*MockValidatorTopology)(nil).SelfNodeID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfVegaPubKey", reflect.TypeOf((*MockValidatorTopology)(nil).SelfVegaPubKey))
 }

--- a/validators/witness.go
+++ b/validators/witness.go
@@ -43,7 +43,7 @@ type Commander interface {
 type ValidatorTopology interface {
 	Len() int
 	IsValidator() bool
-	SelfNodeID() string
+	SelfVegaPubKey() string
 	AllNodeIDs() []string
 	IsValidatorVegaPubKey(string) bool
 }
@@ -371,7 +371,7 @@ func (w *Witness) OnTick(ctx context.Context, t time.Time) {
 			// set new state so we do not try to validate again
 			atomic.StoreUint32(&v.state, voteSent)
 		} else if (isValidator && state == voteSent) && t.After(v.lastSentVote.Add(10*time.Second)) {
-			if v.selfVoteReceived(w.top.SelfNodeID()) {
+			if v.selfVoteReceived(w.top.SelfVegaPubKey()) {
 				continue
 			}
 			w.onCommandSent(v.res.GetID())(errors.New("no self votes received after 10 seconds"))

--- a/validators/witness_snapshot.go
+++ b/validators/witness_snapshot.go
@@ -133,7 +133,7 @@ func (w *Witness) restore(ctx context.Context, witness *types.Witness) error {
 		selfVoted := false
 		for _, v := range r.Votes {
 			w.resources[r.ID].votes[v] = struct{}{}
-			if r.ID == w.top.SelfNodeID() {
+			if r.ID == w.top.SelfVegaPubKey() {
 				selfVoted = true
 			}
 		}

--- a/validators/witness_snapshot.go
+++ b/validators/witness_snapshot.go
@@ -133,7 +133,7 @@ func (w *Witness) restore(ctx context.Context, witness *types.Witness) error {
 		selfVoted := false
 		for _, v := range r.Votes {
 			w.resources[r.ID].votes[v] = struct{}{}
-			if r.ID == w.top.SelfVegaPubKey() {
+			if v == w.top.SelfVegaPubKey() {
 				selfVoted = true
 			}
 		}

--- a/validators/witness_snapshot_test.go
+++ b/validators/witness_snapshot_test.go
@@ -54,7 +54,7 @@ func TestSnapshot(t *testing.T) {
 		defer erc2.ctrl.Finish()
 		defer erc2.Stop()
 		erc2.top.EXPECT().IsValidator().AnyTimes().Return(true)
-		erc2.top.EXPECT().SelfNodeID().AnyTimes().Return("1234")
+		erc2.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("1234")
 
 		_, err = erc2.LoadState(context.Background(), payload)
 		require.Nil(t, err)
@@ -85,7 +85,7 @@ func TestSnapshot(t *testing.T) {
 		defer erc3.ctrl.Finish()
 		defer erc3.Stop()
 		erc3.top.EXPECT().IsValidator().AnyTimes().Return(true)
-		erc3.top.EXPECT().SelfNodeID().AnyTimes().Return("1234")
+		erc3.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("1234")
 
 		_, err = erc3.LoadState(context.Background(), payload)
 		require.Nil(t, err)

--- a/validators/witness_test.go
+++ b/validators/witness_test.go
@@ -207,12 +207,10 @@ func testOnChainTimeUpdate(t *testing.T) {
 	defer erc.ctrl.Finish()
 	defer erc.Stop()
 
-	selfNodeID := "a5ee437dc100d629"
 	selfPubKey := "b7ee437dc100d642"
 
 	erc.top.EXPECT().Len().AnyTimes().Return(2)
 	erc.top.EXPECT().IsValidator().AnyTimes().Return(true)
-	erc.top.EXPECT().SelfNodeID().AnyTimes().Return(selfNodeID)
 
 	ch := make(chan struct{}, 1)
 	res := testRes{"resource-id-1", func() error {
@@ -261,12 +259,10 @@ func testOnChainTimeUpdateNonValidator(t *testing.T) {
 	defer erc.ctrl.Finish()
 	defer erc.Stop()
 
-	selfNodeID := "a5ee437dc100d629"
 	selfPubKey := "b7ee437dc100d642"
 
 	erc.top.EXPECT().Len().AnyTimes().Return(2)
 	erc.top.EXPECT().IsValidator().AnyTimes().Return(false)
-	erc.top.EXPECT().SelfNodeID().AnyTimes().Return(selfNodeID)
 
 	res := testRes{"resource-id-1", func() error {
 		return nil


### PR DESCRIPTION
Recent merge into develop had some issue in it where we switch from `nodeID` to `VegaPubKey` for node validation, but didn't change it everywhere.