### PR TITLE
fix: set assetDP field in market when restoring from snapshot

### DIFF
--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -147,10 +147,10 @@ func NewMarketFromSnapshot(
 		stateVarEngine:             stateVarEngine,
 	}
 
+	market.assetDP = uint32(assetDetails.DecimalPlaces())
 	market.tradableInstrument.Instrument.Product.NotifyOnTradingTerminated(market.tradingTerminated)
 	market.tradableInstrument.Instrument.Product.NotifyOnSettlementPrice(market.settlementPrice)
 	liqEngine.SetGetStaticPricesFunc(market.getBestStaticPricesDecimal)
-
 	return market, nil
 }
 


### PR DESCRIPTION
Easily done because `NewMarket()` and `NewMarketFromSnapshot()` are two distinct code paths. I'm going to open a tech-debt ticket to try to combine the code paths a little more so that it is harder for this sort of bug to slip in.