### PR TITLE
Small fixes to AmendOrder flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [5052](https://github.com/vegaprotocol/vega/issues/5052) - Adding acceptance criteria tests for market decimal places
 - [5138](https://github.com/vegaprotocol/vega/issues/5038) - Adding feature test for "0032-PRIM-price_monitoring.md"
 - [4753](https://github.com/vegaprotocol/vega/issues/4753) - Adding feature test for oracle spec public key validation
+- [4559](https://github.com/vegaprotocol/vega/issues/4559) - Small fixes to the amend order flow
 
 ### 🐛 Fixes
 - [5064](https://github.com/vegaprotocol/vega/issues/5064) - Send order event on settlement

--- a/execution/market.go
+++ b/execution/market.go
@@ -2762,27 +2762,18 @@ func (m *Market) applyOrderAmendment(
 	}
 
 	// apply size changes
-	if amendment.SizeDelta != 0 {
-		neg := false
-		delta := uint64(amendment.SizeDelta)
-		newRemaining := existingOrder.Remaining
-		if amendment.SizeDelta < 0 {
-			neg = true
-			delta = uint64(-amendment.SizeDelta)
-		}
-		if neg {
-			order.Size -= delta
-			if delta > newRemaining {
-				newRemaining = 0
+	if delta := amendment.SizeDelta; delta != 0 {
+		if delta < 0 {
+			order.Size -= uint64(-delta)
+			if order.Remaining > uint64(-delta) {
+				order.Remaining -= uint64(-delta)
 			} else {
-				newRemaining -= delta
+				order.Remaining = 0
 			}
 		} else {
-			order.Size += delta
-			newRemaining += delta
+			order.Size += uint64(delta)
+			order.Remaining += uint64(delta)
 		}
-
-		order.Remaining = newRemaining
 	}
 
 	// apply tif

--- a/execution/market.go
+++ b/execution/market.go
@@ -2663,16 +2663,6 @@ func (m *Market) amendOrder(
 	// if decrease in size or change in expiration date
 	// ---> DO amend in place in matching engine
 	if expiryChange || sizeDecrease || timeInForceChange {
-		// @TODO how is this even possible? size decrease subtracts from remaining, or sets it to 0
-		// IMO, this should be removed
-		if sizeDecrease && amendedOrder.Remaining >= existingOrder.Remaining {
-			_ = m.position.AmendOrder(ctx, amendedOrder, existingOrder)
-
-			if m.log.GetLevel() == logging.DebugLevel {
-				m.log.Debug("Order amendment not allowed when reducing to a larger amount", logging.Order(*existingOrder))
-			}
-			return nil, nil, ErrInvalidAmendRemainQuantity
-		}
 		// we not doing anything in case of error here as its
 		// pretty much impossible at this point for an order not to be
 		// amended in place. Maybe a panic would be better

--- a/types/matching.go
+++ b/types/matching.go
@@ -58,6 +58,11 @@ func (o Order) Clone() *Order {
 	} else {
 		cpy.Price = num.Zero()
 	}
+	// this isn't really needed, to original order is about to be replaced, or the original price is getting reassinged
+	// but in case something goes wrong, we don't want a pointer to this field in 2 places
+	if o.OriginalPrice != nil {
+		cpy.OriginalPrice = o.OriginalPrice.Clone()
+	}
 	if o.PeggedOrder != nil {
 		cpy.PeggedOrder = o.PeggedOrder.Clone()
 	}


### PR DESCRIPTION
Fixes #4559

Some small changes after going through the amend order flow:

* Take the `OriginalPrice` field into consideration when cloning an order object
* If the market ID for an order doesn't match, we should panic
* Left a comment on a strange check when amendment has a negative size delta, but could somehow result in Remaining increasing (only possible in case of overflow, which has been addressed). The code is, AFAIK, unreachable and can be deleted.