### PR TITLE
Add integration test checking margin release is correct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🛠 Improvements
 - [5001](https://github.com/vegaprotocol/vega/issues/5001) - Set and increment LP version field correctly
+- [3372](https://github.com/vegaprotocol/vega/issues/3372) - Add integration test making sure margin is released when an LP is cancelled.
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🐛 Fixes

--- a/integration/features/liquidity-provision/margin-release-cancel.feature
+++ b/integration/features/liquidity-provision/margin-release-cancel.feature
@@ -1,0 +1,77 @@
+Feature: Replicate unexpected margin issues - no mid price pegs
+
+  Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | DAI | 5              |
+    And the log normal risk model named "dai-lognormal-risk":
+      | risk aversion | tau         | mu | r | sigma |
+      | 0.00001       | 0.000114077 | 0  | 0 | 0.41  |
+    And the markets:
+      | id        | quote name | asset | risk model         | margin calculator         | auction duration | fees         | price monitoring | oracle config          | decimal places |
+      | DAI/DEC22 | DAI        | DAI   | dai-lognormal-risk | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 5              |
+    And the following network parameters are set:
+      | name                              | value |
+      | market.auction.minimumDuration    | 1     |
+      | market.stake.target.scalingFactor | 10    |
+
+  @LPRelease
+  Scenario: Mid price works as expected
+    Given the parties deposit on asset's general account the following amount:
+      | party           | asset | amount       |
+      | party1          | DAI   | 110000000000 |
+      | party2          | DAI   | 110000000000 |
+      | party3          | DAI   | 110000000000 |
+      | party4          | DAI   | 110000000000 |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | buy  | MID              | 1          | 10     | lp-1      | submission |
+      | lp1 | party1 | DAI/DEC22 | 20000000000       | 0.01 | sell | MID              | 1          | 10     | lp-1      | submission |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     | reference |
+      | party2 | DAI/DEC22 | buy  | 1      | 800000000  | 0                | TYPE_LIMIT | TIF_GTC | party2-1  |
+      | party2 | DAI/DEC22 | buy  | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party2-2  |
+      | party3 | DAI/DEC22 | sell | 1      | 3500000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party3 | DAI/DEC22 | sell | 1      | 8200000000 | 0                | TYPE_LIMIT | TIF_GTC | party3-2  |
+
+    And the opening auction period ends for market "DAI/DEC22"
+    Then the following trades should be executed:
+      | buyer  | price      | size | seller |
+      | party2 | 3500000000 | 1    | party3 |
+    And the mark price should be "3500000000" for the market "DAI/DEC22"
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4500000010 | 9      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4499999990 | 9      |
+      | buy  | 800000000  | 1      |
+
+    When the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee  | side | pegged reference | proportion | offset | reference | lp type    |
+      | lp2 | party4 | DAI/DEC22 | 10000000000       | 0.01 | buy  | BID              | 1          | 12     | lp-2      | submission |
+      | lp2 | party4 | DAI/DEC22 | 10000000000       | 0.01 | sell | ASK              | 1          | 12     | lp-2      | submission |
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin     | general     | bond        |
+      | party4 | DAI   | DAI/DEC22 | 2121827800 | 97878172200 | 10000000000 |
+    And the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4500000010 | 9      |
+      | sell | 8200000000 | 1      |
+      | sell | 8200000012 | 3      |
+      | buy  | 4499999990 | 9      |
+      | buy  | 800000000  | 1      |
+      | buy  | 799999988  | 26     |
+
+    # LP cancel -> orders are gone from the book + margin balance is released
+    When party "party4" cancels their liquidity provision for market "DAI/DEC22"
+    Then the order book should have the following volumes for market "DAI/DEC22":
+      | side | price      | volume |
+      | sell | 4500000010 | 9      |
+      | sell | 8200000000 | 1      |
+      | buy  | 4499999990 | 9      |
+      | buy  | 800000000  | 1      |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general      | bond |
+      | party4 | DAI   | DAI/DEC22 | 0      | 110000000000 | 0    |

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -190,6 +190,9 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^the parties submit the following liquidity provision:$`, func(table *godog.Table) error {
 		return steps.PartiesSubmitLiquidityProvision(execsetup.executionEngine, table)
 	})
+	s.Step(`^party "([^"]+)" cancels their liquidity provision for market "([^"]+)"$`, func(party, marketID string) error {
+		return steps.PartyCancelsTheirLiquidityProvision(execsetup.executionEngine, marketID, party)
+	})
 	s.Step(`^the parties submit the following one off transfers:$`, func(table *godog.Table) error {
 		return steps.PartiesSubmitTransfers(execsetup.banking, table)
 	})

--- a/integration/steps/parties_submit_liquidity_provision.go
+++ b/integration/steps/parties_submit_liquidity_provision.go
@@ -24,6 +24,16 @@ type LPUpdate struct {
 	LpType           string
 }
 
+func PartyCancelsTheirLiquidityProvision(exec Execution, marketID, party string) error {
+	cancel := types.LiquidityProvisionCancellation{
+		MarketID: marketID,
+	}
+	if err := exec.CancelLiquidityProvision(context.Background(), &cancel, party); err != nil {
+		return errCancelLiquidityProvision(party, marketID, err)
+	}
+	return nil
+}
+
 func PartiesSubmitLiquidityProvision(exec Execution, table *godog.Table) error {
 	lps := map[string]*LPUpdate{}
 	parties := map[string]string{}
@@ -107,6 +117,10 @@ func PartiesSubmitLiquidityProvision(exec Execution, table *godog.Table) error {
 
 func errSubmittingLiquidityProvision(lp *types.LiquidityProvisionSubmission, party, id string, err error) error {
 	return fmt.Errorf("failed to submit [%v] for party %s and id %s: %v", lp, party, id, err)
+}
+
+func errCancelLiquidityProvision(party, market string, err error) error {
+	return fmt.Errorf("failed to cancel LP for party %s on market %s: %v", party, market, err)
 }
 
 func errAmendingLiquidityProvision(lp *types.LiquidityProvisionAmendment, party string, err error) error {


### PR DESCRIPTION
Closes #3372

Added an integration test (+ step to cancel an LP from a scenario) to ensure margin and bond balances are correctly released if an LP cancels their commitment.