### PR TITLE
Set market pending timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🐛 Fixes
+- [4798](https://github.com/vegaprotocol/vega/issues/4978) - Set market pending timestamp to the time at which the market is created.
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ## 0.50.1

--- a/execution/market.go
+++ b/execution/market.go
@@ -376,6 +376,7 @@ func NewMarket(
 	// Populate the market timestamps
 	ts := &types.MarketTimestamps{
 		Proposed: now.UnixNano(),
+		Pending:  now.UnixNano(),
 	}
 
 	if mkt.OpeningAuction != nil {


### PR DESCRIPTION
Closes #4978 

We just never set this field, set it to the time at which the market was created and we should be good.