### PR TITLE
fix: non-tendermint validators send in node votes, but they are not c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [5124](https://github.com/vegaprotocol/vega/issues/5124) - Ensure update market proposal compute a proper auction duration
 - [5172](https://github.com/vegaprotocol/vega/issues/5172) - Add replay protection for validator commands
 - [5181](https://github.com/vegaprotocol/vega/issues/5181) - Ensure Oracle specs handle numbers using `num.Decimal` and `num.Int`
+- [5059](https://github.com/vegaprotocol/vega/issues/5059) - Validators without tendermint status vote in the witness and notary engine but their votes do not count
 - [5190](https://github.com/vegaprotocol/vega/issues/5190) - Fix settlement at expiry to scale the settlement price from market decimals to asset decimals
 - [5185](https://github.com/vegaprotocol/vega/issues/5185) - Fix MTM settlement where win transfers get truncated resulting in settlement balance not being zero after settlement.
 - [4943](https://github.com/vegaprotocol/vega/issues/4943) - Fix bug where amending orders in opening auctions did not work as expected

--- a/integration/stubs/topology_stub.go
+++ b/integration/stubs/topology_stub.go
@@ -55,6 +55,10 @@ func (ts *TopologyStub) IsValidatorVegaPubKey(pubKey string) bool {
 	return true
 }
 
+func (ts *TopologyStub) IsTendermintValidator(pubKey string) bool {
+	return true
+}
+
 func (ts *TopologyStub) IsValidatorNodeID(nodeID string) bool {
 	_, ok := ts.validators[nodeID]
 	return ok

--- a/notary/mocks/validator_topology_mock.go
+++ b/notary/mocks/validator_topology_mock.go
@@ -33,6 +33,20 @@ func (m *MockValidatorTopology) EXPECT() *MockValidatorTopologyMockRecorder {
 	return m.recorder
 }
 
+// IsTendermintValidator mocks base method.
+func (m *MockValidatorTopology) IsTendermintValidator(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsTendermintValidator", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTendermintValidator indicates an expected call of IsTendermintValidator.
+func (mr *MockValidatorTopologyMockRecorder) IsTendermintValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTendermintValidator", reflect.TypeOf((*MockValidatorTopology)(nil).IsTendermintValidator), arg0)
+}
+
 // IsValidator mocks base method.
 func (m *MockValidatorTopology) IsValidator() bool {
 	m.ctrl.T.Helper()

--- a/notary/notary.go
+++ b/notary/notary.go
@@ -34,6 +34,7 @@ var (
 type ValidatorTopology interface {
 	IsValidator() bool
 	IsValidatorVegaPubKey(string) bool
+	IsTendermintValidator(string) bool
 	SelfVegaPubKey() string
 	Len() int
 }
@@ -205,11 +206,10 @@ func (n *Notary) IsSigned(
 	sig := map[string]struct{}{}
 	out := []commandspb.NodeSignature{}
 	for k := range n.sigs[idkind] {
-		// is node sig is part of the registered nodes,
+		// is node sig is part of the registered nodes, and is a tendermint validator
 		// add it to the map
-		// we may have a node which have been unregistered there, hence
-		// us checkung
-		if n.top.IsValidatorVegaPubKey(k.node) {
+		// we may have a node are validators but with a lesser status sending in votes
+		if n.top.IsTendermintValidator(k.node) {
 			sig[k.node] = struct{}{}
 			out = append(out, commandspb.NodeSignature{
 				Id:   resource,

--- a/notary/snapshot_test.go
+++ b/notary/snapshot_test.go
@@ -93,9 +93,11 @@ func populateNotary(t *testing.T, notr *testNotary) {
 
 func TestNotarySnapshotRoundTrip(t *testing.T) {
 	notr := getTestNotary(t)
+	defer notr.ctrl.Finish()
 
 	notr.top.EXPECT().Len().AnyTimes().Return(1)
 	notr.top.EXPECT().IsValidatorVegaPubKey(gomock.Any()).AnyTimes().Return(true)
+	notr.top.EXPECT().IsTendermintValidator(gomock.Any()).AnyTimes().Return(true)
 	notr.top.EXPECT().IsValidator().AnyTimes().Return(true)
 	notr.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("123456")
 
@@ -109,10 +111,12 @@ func TestNotarySnapshotRoundTrip(t *testing.T) {
 	require.Nil(t, err)
 
 	snapNotr := getTestNotary(t)
+	defer snapNotr.ctrl.Finish()
 	snapNotr.top.EXPECT().Len().AnyTimes().Return(1)
 	snapNotr.top.EXPECT().IsValidator().AnyTimes().Return(true)
 	snapNotr.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("123456")
 	snapNotr.top.EXPECT().IsValidatorVegaPubKey(gomock.Any()).AnyTimes().Return(true)
+	snapNotr.top.EXPECT().IsTendermintValidator(gomock.Any()).AnyTimes().Return(true)
 
 	_, err = snapNotr.LoadState(context.Background(), types.PayloadFromProto(snap))
 	require.Nil(t, err)

--- a/validators/announce_node.go
+++ b/validators/announce_node.go
@@ -21,6 +21,11 @@ func (t *Topology) ProcessAnnounceNode(
 	}
 
 	t.AddNewNode(ctx, an, ValidatorStatusPending)
+
+	// if it is use that has annouce, we can now set our flag to be a validator. How exciting.
+	if an.Id == t.SelfNodeID() {
+		t.SetIsValidator()
+	}
 	return nil
 }
 

--- a/validators/mocks/validator_topology_mock.go
+++ b/validators/mocks/validator_topology_mock.go
@@ -47,6 +47,20 @@ func (mr *MockValidatorTopologyMockRecorder) AllNodeIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllNodeIDs", reflect.TypeOf((*MockValidatorTopology)(nil).AllNodeIDs))
 }
 
+// IsTendermintValidator mocks base method.
+func (m *MockValidatorTopology) IsTendermintValidator(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsTendermintValidator", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTendermintValidator indicates an expected call of IsTendermintValidator.
+func (mr *MockValidatorTopologyMockRecorder) IsTendermintValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTendermintValidator", reflect.TypeOf((*MockValidatorTopology)(nil).IsTendermintValidator), arg0)
+}
+
 // IsValidator mocks base method.
 func (m *MockValidatorTopology) IsValidator() bool {
 	m.ctrl.T.Helper()

--- a/validators/witness_snapshot_test.go
+++ b/validators/witness_snapshot_test.go
@@ -68,6 +68,7 @@ func TestSnapshot(t *testing.T) {
 		// add a vote
 		pubkey := newPublicKey("1234")
 		erc2.top.EXPECT().IsValidatorVegaPubKey(pubkey.Hex()).Times(1).Return(true)
+		erc2.top.EXPECT().IsTendermintValidator(pubkey.Hex()).AnyTimes().Return(true)
 		err = erc2.AddNodeCheck(context.Background(), &commandspb.NodeVote{Reference: res.id}, pubkey)
 
 		assert.NoError(t, err)

--- a/validators/witness_test.go
+++ b/validators/witness_test.go
@@ -248,6 +248,7 @@ func testOnChainTimeUpdate(t *testing.T) {
 
 	// call onTick again to get the callback called
 	newNow = newNow.Add(1 * time.Second)
+	erc.top.EXPECT().IsTendermintValidator(gomock.Any()).Times(2).Return(true)
 	erc.OnTick(context.Background(), newNow)
 
 	// block to wait for the result
@@ -293,6 +294,7 @@ func testOnChainTimeUpdateNonValidator(t *testing.T) {
 
 	// call onTick again to get the callback called
 	newNow = newNow.Add(1 * time.Second)
+	erc.top.EXPECT().IsTendermintValidator(gomock.Any()).Times(2).Return(true)
 	erc.OnTick(context.Background(), newNow)
 }
 


### PR DESCRIPTION
closes #5059 

The idea now is that when a node annouces itself it goes through the motions of sending in node-votes regardless of its state, but when we come to count we only count votes from those of `ValidatorStatusTendermint`