### PR TITLE
fix: reset pegged orders to the order pointer after snapshot loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [5222](https://github.com/vegaprotocol/vega/issues/5222) - Do not panic when admin server stops.
 - [5103](https://github.com/vegaprotocol/vega/issues/5103) - Fix invalid http status set in faucet
 - [5128](https://github.com/vegaprotocol/vega/issues/5128) - Fix wrong http rate limit for faucet
-
+- [5231](https://github.com/vegaprotocol/vega/issues/5231) - Fix pegged orders to be reset to the order pointer after snapshot loading
 
 ## 0.50.1
 

--- a/execution/market.go
+++ b/execution/market.go
@@ -647,6 +647,8 @@ func (m *Market) PostRestore(ctx context.Context) error {
 	m.settlement.Update(m.position.Positions())
 
 	pps := m.position.Parties()
+	m.peggedOrders.ReconcileWithOrderBook(m.matching)
+
 	peggedOrder := m.peggedOrders.GetAll()
 	parties := make(map[string]struct{}, len(pps)+len(peggedOrder))
 

--- a/execution/pegged_orders.go
+++ b/execution/pegged_orders.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/events"
+	"code.vegaprotocol.io/vega/matching"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 )
@@ -27,6 +28,16 @@ func NewPeggedOrdersFromSnapshot(orders []*types.Order) *PeggedOrders {
 	return &PeggedOrders{
 		orders: orders,
 	}
+}
+
+func (p *PeggedOrders) ReconcileWithOrderBook(orderbook *matching.CachedOrderBook) {
+	o := make([]*types.Order, 0, len(p.orders))
+	for _, ord := range p.orders {
+		if order, err := orderbook.GetOrderByID(ord.ID); err == nil {
+			o = append(o, order)
+		}
+	}
+	p.orders = o
 }
 
 func (p *PeggedOrders) Changed() bool {

--- a/execution/pegged_orders_test.go
+++ b/execution/pegged_orders_test.go
@@ -1,10 +1,15 @@
 package execution_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"code.vegaprotocol.io/vega/config"
 	"code.vegaprotocol.io/vega/execution"
+	"code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/matching"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +22,7 @@ func getTestOrders() []*types.Order {
 		p, _ := num.UintFromString(fmt.Sprintf("%d", i*10), 10)
 
 		o = append(o, &types.Order{
-			ID:          fmt.Sprintf("id-%d", i),
+			ID:          crypto.RandomHash(),
 			MarketID:    "market-1",
 			Party:       "party-1",
 			Side:        types.SideBuy,
@@ -62,8 +67,6 @@ func testPeggedOrdersSnapshot(t *testing.T) {
 	a.False(p.Changed())
 
 	// Test amend
-	testOrders[0].ID = "id-changed"
-
 	p.Amend(testOrders[0])
 	a.True(p.Changed())
 	a.Equal(testOrders, p.GetState())
@@ -91,6 +94,22 @@ func testPeggedOrdersSnapshot(t *testing.T) {
 	// Test restore state
 	s = p.GetState()
 
+	ob := matching.NewCachedOrderBook(logging.NewTestLogger(), config.NewDefaultConfig().Execution.Matching, "market-1", false)
+	pl := &types.Payload{
+		Data: &types.PayloadMatchingBook{
+			MatchingBook: &types.MatchingBook{
+				MarketID:        "market-1",
+				Buy:             testOrders,
+				Sell:            nil,
+				LastTradedPrice: num.NewUint(100),
+				Auction:         false,
+				BatchID:         1,
+			},
+		},
+	}
+	ob.LoadState(context.Background(), pl)
+
 	newP := execution.NewPeggedOrdersFromSnapshot(s)
+	newP.ReconcileWithOrderBook(ob)
 	a.Equal(s, newP.GetState())
 }


### PR DESCRIPTION
Closes #5231 