### PR TITLE
fix: non-validators must still invoke notary.StartAggregate even if t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [4798](https://github.com/vegaprotocol/vega/issues/4978) - Set market pending timestamp to the time at which the market is created.
 - [5222](https://github.com/vegaprotocol/vega/issues/5222) - Do not panic when admin server stops.
 - [5103](https://github.com/vegaprotocol/vega/issues/5103) - Fix invalid http status set in faucet
+- [5239](https://github.com/vegaprotocol/vega/issues/5239) - Always call `StartAggregate()` when signing validators joining and leaving even if not a validator
 - [5128](https://github.com/vegaprotocol/vega/issues/5128) - Fix wrong http rate limit for faucet
 - [5231](https://github.com/vegaprotocol/vega/issues/5231) - Fix pegged orders to be reset to the order pointer after snapshot loading
 

--- a/validators/signatures.go
+++ b/validators/signatures.go
@@ -198,7 +198,6 @@ func (s *ERC20Signatures) EmitRemoveValidatorsSignatures(
 	for _, oldSigner := range remove {
 		submitters := []*eventspb.ERC20MulistSigSignerRemovedSubmitter{}
 		for _, validator := range validators {
-
 			var sig []byte
 			// Here resid is a concat of the oldsigner, the submitter and the nonce
 			resid := hex.EncodeToString(

--- a/validators/signatures_test.go
+++ b/validators/signatures_test.go
@@ -31,14 +31,17 @@ func getTestSignatures(t *testing.T) *testSignatures {
 	ctrl := gomock.NewController(t)
 	notary := mocks.NewMockNotary(ctrl)
 	broker := bmocks.NewMockBroker(ctrl)
+	nodewallet := mocks.NewMockNodeWallets(ctrl)
 	tsigner := testSigner{}
+	nodewallet.EXPECT().GetEthereum().AnyTimes().Return(tsigner)
 
 	return &testSignatures{
 		ERC20Signatures: validators.NewSignatures(
 			logging.NewTestLogger(),
 			notary,
-			tsigner,
+			nodewallet,
 			broker,
+			true,
 		),
 		ctrl:   ctrl,
 		notary: notary,

--- a/validators/topology.go
+++ b/validators/topology.go
@@ -224,10 +224,7 @@ func NewTopology(
 // anyway we may want to extract the code requiring the notary somewhere
 // else or have different pattern somehow...
 func (t *Topology) SetNotary(notary Notary) {
-	// if we are not even setup as a validator, no need for this.
-	if t.isValidatorSetup {
-		t.signatures = NewSignatures(t.log, notary, t.wallets.GetEthereum(), t.broker)
-	}
+	t.signatures = NewSignatures(t.log, notary, t.wallets, t.broker, t.isValidatorSetup)
 	t.notary = notary
 }
 
@@ -237,8 +234,8 @@ func (t *Topology) SetSignatures(signatures Signatures) {
 	t.signatures = signatures
 }
 
-// SetSignatures this is not good, same issue as for SetNotary method.
-// This is only used as a helper for testing..
+// SetIsValidator will set the flag for `self` so that it is considered a real validator
+// for example, when a node has announced itself and is accepted as a PENDING validator
 func (t *Topology) SetIsValidator() {
 	t.isValidator = true
 }

--- a/validators/topology.go
+++ b/validators/topology.go
@@ -235,7 +235,7 @@ func (t *Topology) SetSignatures(signatures Signatures) {
 }
 
 // SetIsValidator will set the flag for `self` so that it is considered a real validator
-// for example, when a node has announced itself and is accepted as a PENDING validator
+// for example, when a node has announced itself and is accepted as a PENDING validator.
 func (t *Topology) SetIsValidator() {
 	t.isValidator = true
 }

--- a/validators/validator_set.go
+++ b/validators/validator_set.go
@@ -140,11 +140,8 @@ func (t *Topology) RecalcValidatorSet(ctx context.Context, epochSeq string, dele
 		}
 	}
 
-	// do this only if we are a validator, not need otherwise
-	if t.IsValidator() {
-		t.signatures.EmitPromotionsSignatures(
-			ctx, t.currentTime, currentState, newState)
-	}
+	t.signatures.EmitPromotionsSignatures(
+		ctx, t.currentTime, currentState, newState)
 
 	// prepare and send the events
 	evts := make([]events.Event, 0, len(currentState))


### PR DESCRIPTION
closes #5239 

We need non-validator nodes to still call `notary.StartAggregate()` so that the resource ID is logged ready for when the node-sig transactions come in.