### PR TITLE
fix: when restoring pegged orders, they might not be in the orderbook

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -647,7 +647,9 @@ func (m *Market) PostRestore(ctx context.Context) error {
 	m.settlement.Update(m.position.Positions())
 
 	pps := m.position.Parties()
-	m.peggedOrders.ReconcileWithOrderBook(m.matching)
+	if err := m.peggedOrders.ReconcileWithOrderBook(m.matching); err != nil {
+		return err
+	}
 
 	peggedOrder := m.peggedOrders.GetAll()
 	parties := make(map[string]struct{}, len(pps)+len(peggedOrder))

--- a/execution/pegged_orders_test.go
+++ b/execution/pegged_orders_test.go
@@ -112,4 +112,14 @@ func testPeggedOrdersSnapshot(t *testing.T) {
 	newP := execution.NewPeggedOrdersFromSnapshot(s)
 	newP.ReconcileWithOrderBook(ob)
 	a.Equal(s, newP.GetState())
+	a.Equal(len(p.GetAll()), len(newP.GetAll()))
+
+	// if market is in a auction we'll have pegged orders on the market but not the orderbook
+	ob2 := matching.NewCachedOrderBook(logging.NewTestLogger(), config.NewDefaultConfig().Execution.Matching, "market-1", false)
+	newP2 := execution.NewPeggedOrdersFromSnapshot(s)
+	for _, o := range newP2.GetAll() {
+		newP2.Park(o)
+	}
+	newP2.ReconcileWithOrderBook(ob2)
+	a.Equal(len(p.GetAll()), len(newP2.GetAll()))
 }


### PR DESCRIPTION
Talking to @peterbarrow this morning, its expected that when a market is in auction that the pegged orders are removed from the orderbook but persist in the market slice. This confirms what I was seeing in real-life too, which is always a bonus! So we need to handle that case in `ReconcileWithOrderBook`

I have a _feeling_ this isn't the last pegged-order issue, but its a step forward...