### PR TITLE
fix: do not remove a malperforming validator while it is still a cons…

### DIFF
--- a/protocol/all_services.go
+++ b/protocol/all_services.go
@@ -350,6 +350,10 @@ func (svcs *allServices) setupNetParameters() error {
 			Watcher: svcs.pow.UpdateSpamPoWNumberOfTxPerBlock,
 		},
 		netparams.WatchParam{
+			Param:   netparams.ValidatorsEpochLength,
+			Watcher: svcs.topology.OnEpochLengthUpdate,
+		},
+		netparams.WatchParam{
 			Param:   netparams.NumberOfTendermintValidators,
 			Watcher: svcs.topology.UpdateNumberOfTendermintValidators,
 		},

--- a/validators/topology.go
+++ b/validators/topology.go
@@ -160,6 +160,8 @@ type Topology struct {
 	checkpointLoaded bool
 	notary           Notary
 	signatures       Signatures
+
+	blocksToKeepMalperforming int64
 }
 
 func (t *Topology) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
@@ -216,6 +218,13 @@ func NewTopology(
 	}
 
 	return t
+}
+
+// OnEpochLengthUpdate updates the duration of an epoch - which is used to calculate the number of blocks to keep a malperforming validators.
+// The number of blocks is calculated as 10 epochs x duration of epoch in seconds, assuming block time is 1s.
+func (t *Topology) OnEpochLengthUpdate(ctx context.Context, l time.Duration) error {
+	t.blocksToKeepMalperforming = int64(10 * l.Seconds())
+	return nil
 }
 
 // SetNotary this is not good, the topology depends on the notary


### PR DESCRIPTION
…ensus validator and set the flag correctly to removed and use epoch duration rather than 1m blocks