### PR TITLE
Modify price monitoring engine to receive time update via a separate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [5284](https://github.com/vegaprotocol/vega/issues/5284) - price monitoring past prices are now included in the snapshot
 - [5294](https://github.com/vegaprotocol/vega/issues/5294) - Parse timestamps oracle in market proposal validation
 - [5292](https://github.com/vegaprotocol/vega/issues/5292) - Internal time oracle broadcasts timestamp without nanoseconds
-
+- [5297](https://github.com/vegaprotocol/vega/issues/5297) - Assure min/max price always accurate
 
 ## 0.50.2
 

--- a/execution/auction.go
+++ b/execution/auction.go
@@ -29,7 +29,7 @@ func (m *Market) checkAuction(ctx context.Context, now time.Time) {
 		if endTS := m.as.ExpiresAt(); endTS == nil || !endTS.Before(now) {
 			return
 		}
-		if err := m.pMonitor.CheckPrice(ctx, m.as, p.Clone(), v, now, true); err != nil {
+		if err := m.pMonitor.CheckPrice(ctx, m.as, p.Clone(), v, true); err != nil {
 			m.log.Panic("unable to run check price with price monitor",
 				logging.String("market-id", m.GetID()),
 				logging.Error(err))
@@ -75,7 +75,7 @@ func (m *Market) checkAuction(ctx context.Context, now time.Time) {
 			m.checkLiquidity(ctx, ft)
 		}
 		if isPrice || m.as.CanLeave() {
-			if err := m.pMonitor.CheckPrice(ctx, m.as, p.Clone(), v, now, true); err != nil {
+			if err := m.pMonitor.CheckPrice(ctx, m.as, p.Clone(), v, true); err != nil {
 				m.log.Panic("unable to run check price with price monitor",
 					logging.String("market-id", m.GetID()),
 					logging.Error(err))

--- a/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
+++ b/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
@@ -77,15 +77,30 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     When the network moves ahead "2" blocks
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference     |
-      | party2 | ETH/DEC21 | sell | 1500   | 1030  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell-1 |
       | party3 | ETH/DEC21 | buy  | 1000   | 1022  | 2                | TYPE_LIMIT | TIF_GTC | party3-buy-1  |
       | party3 | ETH/DEC21 | buy  | 300    | 1020  | 0                | TYPE_LIMIT | TIF_GTC | party3-buy-2  |
       | party2 | ETH/DEC21 | sell | 500    | 1030  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell-2 |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 0      | 0       | 0    |
-    And the insurance pool balance should be "6250" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 1864      | 0       | 0    |
+    And the insurance pool balance should be "4571" for the market "ETH/DEC21"
+    
+    Then the liquidity provisions should have the following states:
+      | id  | party  | market    | commitment amount | status           |
+      | lp1 | party0 | ETH/DEC21 | 5000              | STATUS_CANCELLED |
+  
+    # existing LP position not liquidated as there isn't enough volume on the book
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party0 | -700   | 0              | 0            |
 
+    And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price | volume |
+      | sell | 1100  | 100    |
+      | sell | 1030  | 500    |
+      | buy  | 1020  | 300    |
+      | buy  | 990   | 100    |
+      | buy  | 900   | 100    |
 
   Scenario: LP gets distressed after auction
 

--- a/integration/features/liquidity-provision/lp-distressed-closeout.feature
+++ b/integration/features/liquidity-provision/lp-distressed-closeout.feature
@@ -77,14 +77,32 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     When the network moves ahead "2" blocks
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference     |
-      | party2 | ETH/DEC21 | sell | 15     | 1030  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell-1 |
       | party3 | ETH/DEC21 | buy  | 10     | 1022  | 2                | TYPE_LIMIT | TIF_GTC | party3-buy-1  |
       | party3 | ETH/DEC21 | buy  | 3      | 1020  | 0                | TYPE_LIMIT | TIF_GTC | party3-buy-2  |
       | party2 | ETH/DEC21 | sell | 5      | 1030  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell-2 |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 0      | 0       | 0    |
-    And the insurance pool balance should be "6250" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 2816      | 0       | 0    |
+    And the insurance pool balance should be "3619" for the market "ETH/DEC21"
+
+    Then the liquidity provisions should have the following states:
+      | id  | party  | market    | commitment amount | status           |
+      | lp1 | party0 | ETH/DEC21 | 5000              | STATUS_CANCELLED |
+
+    # existing LP position not liquidated as there isn't enough volume on the book
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party0 | -7     | 0              | 0            |
+
+    Then debug detailed orderbook volumes for market "ETH/DEC21"
+
+    And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price | volume |
+      | sell | 1100  | 1      |
+      | sell | 1030  | 5      |
+      | buy  | 1020  | 3      |
+      | buy  | 990   | 1      |
+      | buy  | 900   | 1      |
 
   Scenario: LP gets distressed after auction
 

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -222,8 +222,13 @@ func (e *Engine) GetCurrentBounds() []*types.PriceMonitoringBounds {
 	return ret
 }
 
-// CheckPrice checks how current price, volume and time should impact the auction state and modifies it accordingly: start auction, end auction, extend ongoing auction.
-func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v uint64, now time.Time, persistent bool) error {
+func (e *Engine) OnTimeUpdate(now time.Time) {
+	e.recordTimeChange(now)
+}
+
+// CheckPrice checks how current price, volume and time should impact the auction state and modifies it accordingly: start auction, end auction, extend ongoing auction,
+// "true" gets returned if non-persistent order should be rejected.
+func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v uint64, persistent bool) error {
 	// initialise with the first price & time provided, otherwise there won't be any bounds
 	wasInitialised := e.initialised
 	if !wasInitialised {
@@ -231,7 +236,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 		if v == 0 {
 			return nil
 		}
-		e.reset(p, v, now)
+		e.reset(p, v)
 		e.initialised = true
 		e.stateChanged = true
 	}
@@ -246,9 +251,6 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 
 	// market is not in auction, or in batch auction
 	if fba := as.IsFBA(); !as.InAuction() || fba {
-		if err := e.recordTimeChange(now); err != nil {
-			return err
-		}
 		bounds := e.checkBounds(ctx, p, v)
 		// no bounds violations - update price, and we're done (unless we initialised as part of this call, then price has alrady been updated)
 		if len(bounds) == 0 {
@@ -259,7 +261,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 		}
 		if !persistent {
 			// we're going to stay in continuous trading, make sure we still have bounds
-			e.reset(last.Price, last.Volume, now)
+			e.reset(last.Price, last.Volume)
 			return proto.ErrNonPersistentOrderOutOfBounds
 		}
 		duration := types.AuctionDuration{}
@@ -276,7 +278,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 			duration.Duration = min
 		}
 
-		as.StartPriceAuction(now, &duration)
+		as.StartPriceAuction(e.now, &duration)
 		return nil
 	}
 	// market is in auction
@@ -284,10 +286,6 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 	// opening auction -> ignore
 	if as.IsOpeningAuction() {
 		return nil
-	}
-
-	if err := e.recordTimeChange(now); err != nil {
-		return err
 	}
 
 	bounds := e.checkBounds(ctx, p, v)
@@ -299,18 +297,18 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 			if end == nil {
 				return ErrExpiresAtNotSet
 			}
-			if !now.After(*end) {
+			if !e.now.After(*end) {
 				return nil
 			}
 			// auction can be terminated
 			as.SetReadyToLeave()
 			// reset the engine
-			e.reset(p, v, now)
+			e.reset(p, v)
 			return nil
 		}
 		// liquidity auction, and it was safe to end -> book is OK, price was OK, reset the engine
 		if as.CanLeave() {
-			e.reset(p, v, now)
+			e.reset(p, v)
 		}
 		return nil
 	}
@@ -329,9 +327,8 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v
 }
 
 // reset restarts price monitoring with a new price. All previously recorded prices and previously obtained bounds get deleted.
-func (e *Engine) reset(price *num.Uint, volume uint64, now time.Time) {
-	e.now = now
-	e.update = now
+func (e *Engine) reset(price *num.Uint, volume uint64) {
+	e.update = e.now
 	if volume > 0 {
 		e.pricesNow = []currentPrice{{Price: price, Volume: volume}}
 		e.pricesPast = []pastPrice{}
@@ -423,11 +420,13 @@ func (e *Engine) checkBounds(ctx context.Context, p *num.Uint, v uint64) []*type
 
 // getCurrentPriceRanges calculates price ranges from current reference prices and bound down/up factors.
 func (e *Engine) getCurrentPriceRanges(force bool) map[*bound]priceRange {
-	if e.priceRangeCacheTime == e.now && !force {
+	if e.priceRangeCacheTime == e.now && e.priceRangesCache != nil && len(e.priceRangesCache) > 0 && !force {
 		return e.priceRangesCache
 	}
-	e.priceRangesCache = make(map[*bound]priceRange, len(e.priceRangesCache))
-
+	ranges := make(map[*bound]priceRange, len(e.priceRangesCache))
+	if len(e.pricesPast) == 0 && len(e.pricesNow) == 0 {
+		return ranges
+	}
 	for _, b := range e.bounds {
 		if !b.Active {
 			continue
@@ -446,12 +445,13 @@ func (e *Engine) getCurrentPriceRanges(force bool) map[*bound]priceRange {
 		minUint, _ := num.UintFromDecimal(min.Ceil())
 		maxUint, _ := num.UintFromDecimal(max.Floor())
 
-		e.priceRangesCache[b] = priceRange{
+		ranges[b] = priceRange{
 			MinPrice:       num.NewWrappedDecimal(minUint, min),
 			MaxPrice:       num.NewWrappedDecimal(maxUint, max),
 			ReferencePrice: ref,
 		}
 	}
+	e.priceRangesCache = ranges
 	e.priceRangeCacheTime = e.now
 	e.stateChanged = true
 	return e.priceRangesCache
@@ -484,7 +484,7 @@ func (e *Engine) clearStalePrices() {
 func (e *Engine) getRefPrice(horizon int64, force bool) num.Decimal {
 	e.refPriceLock.Lock()
 	defer e.refPriceLock.Unlock()
-	if e.refPriceCacheTime != e.now || force {
+	if e.refPriceCache == nil || e.refPriceCacheTime != e.now || force {
 		e.refPriceCache = make(map[int64]num.Decimal, len(e.refPriceCache))
 		e.stateChanged = true
 		e.refPriceCacheTime = e.now

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -226,8 +226,7 @@ func (e *Engine) OnTimeUpdate(now time.Time) {
 	e.recordTimeChange(now)
 }
 
-// CheckPrice checks how current price, volume and time should impact the auction state and modifies it accordingly: start auction, end auction, extend ongoing auction,
-// "true" gets returned if non-persistent order should be rejected.
+// CheckPrice checks how current price, volume and time should impact the auction state and modifies it accordingly: start auction, end auction, extend ongoing auction.
 func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, p *num.Uint, v uint64, persistent bool) error {
 	// initialise with the first price & time provided, otherwise there won't be any bounds
 	wasInitialised := e.initialised

--- a/monitor/price/pricemonitoring.go
+++ b/monitor/price/pricemonitoring.go
@@ -3,6 +3,7 @@ package price
 import (
 	"context"
 	"errors"
+	"log"
 	"sort"
 	"sync"
 	"time"
@@ -367,12 +368,13 @@ func (e *Engine) recordPriceChange(price *num.Uint, volume uint64) {
 }
 
 // recordTimeChange updates the current time and moves prices from current prices to past prices by calculating their corresponding vwp.
-func (e *Engine) recordTimeChange(now time.Time) error {
+func (e *Engine) recordTimeChange(now time.Time) {
 	if now.Before(e.now) {
-		return ErrTimeSequence // This shouldn't happen, but if it does there's something fishy going on
+		log.Panic("invalid state enecountered in price monitoring engine",
+			logging.Error(ErrTimeSequence))
 	}
 	if now.Equal(e.now) {
-		return nil
+		return
 	}
 
 	if len(e.pricesNow) > 0 {
@@ -392,8 +394,6 @@ func (e *Engine) recordTimeChange(now time.Time) error {
 	e.now = now
 	e.clearStalePrices()
 	e.stateChanged = true
-
-	return nil
 }
 
 // checkBounds checks if the price is within price range for each of the bound and return trigger for each bound that it's not.

--- a/monitor/price/pricemonitoring_test.go
+++ b/monitor/price/pricemonitoring_test.go
@@ -40,16 +40,20 @@ func TestEmptyParametersList(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now.Add(time.Second), true)
+	pm.OnTimeUpdate(now.Add(time.Second))
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now.Add(time.Minute), true)
+	pm.OnTimeUpdate(now.Add(time.Minute))
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now.Add(time.Hour), true)
+	pm.OnTimeUpdate(now.Add(time.Hour))
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 }
 
@@ -124,16 +128,17 @@ func TestRecordPriceChange(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 	one := num.NewUint(1)
 	cp1 := num.Sum(currentPrice, one)      // plus 1
 	cp2 := num.Sum(currentPrice, one, one) // plus 2
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cp2, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cp2, 1, true)
 	require.NoError(t, err)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cp1, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cp1, 1, true)
 	require.NoError(t, err)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 }
 
@@ -180,24 +185,25 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactors, upFactors)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	cPrice := num.Sum(currentPrice, maxUp1)
 	cPrice = cPrice.Sub(cPrice, one)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	cPrice = num.Sum(currentPrice, one)
 	cPrice = cPrice.Sub(cPrice, maxDown1)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	cPrice = num.Sum(one, cPrice.Sub(currentPrice, maxDown1)) // add one bc price bounds are now using Ceil for min price
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	// set the min duration to equal auction extension 1
@@ -207,7 +213,7 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 
 	delta := num.Sum(maxUp1, maxUp2)
 	cPrice = num.Sum(currentPrice, delta.Div(delta, num.Sum(one, one)))
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	// Reinstantiate price monitoring after auction to reset internal state
@@ -216,13 +222,14 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactors, upFactors)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	auctionStateMock.EXPECT().StartPriceAuction(now, &end).Times(1)
 	delta = num.Sum(maxDown1, maxDown2)
 	cPrice = cPrice.Sub(currentPrice, delta.Div(delta, num.Sum(one, one)))
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	// Reinstantiate price monitoring after auction to reset internal state
@@ -231,12 +238,13 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactors, upFactors)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err, currentPrice.String())
 
 	auctionStateMock.EXPECT().StartPriceAuction(now, &end).Times(1)
 	cPrice = num.Sum(currentPrice, num.Zero().Sub(maxUp2, one)) // max price bound is now floored, so sub 1 to stay below second price bound
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	// Reinstantiate price monitoring after auction to reset internal state
@@ -245,12 +253,13 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactors, upFactors)
 
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	auctionStateMock.EXPECT().StartPriceAuction(now, &end).Times(1)
 	cPrice = num.Sum(cPrice.Sub(currentPrice, maxDown2), one) // add 1 back, avoid breaching both down limits
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	// Reinstantiate price monitoring after auction to reset internal state
@@ -258,13 +267,14 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactors, upFactors)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	end = types.AuctionDuration{Duration: t1.AuctionExtension + t2.AuctionExtension}
 	auctionStateMock.EXPECT().StartPriceAuction(now, &end).Times(1)
 	cPrice = num.Sum(currentPrice, maxUp2, maxUp2)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	// Reinstantiate price monitoring after auction to reset internal state
@@ -272,13 +282,14 @@ func TestCheckBoundViolationsWithinCurrentTimeWith2HorizonProbabilityPairs(t *te
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactors, upFactors)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	auctionStateMock.EXPECT().StartPriceAuction(now, &end).Times(1)
 	delta = num.Sum(maxDown2, maxDown2)
 	cPrice = cPrice.Sub(currentPrice, delta)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 }
 
@@ -538,7 +549,8 @@ func TestAuctionStartedAndEndendBy1Trigger(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 	pm.UpdateTestFactors(downFactorsP1, upFactorsP1)
-	err = pm.CheckPrice(ctx, auctionStateMock, price1, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, price1, 1, true)
 	require.NoError(t, err)
 
 	end := types.AuctionDuration{Duration: t1.AuctionExtension}
@@ -547,7 +559,8 @@ func TestAuctionStartedAndEndendBy1Trigger(t *testing.T) {
 
 	delta := num.Sum().Sub(maxUp2, maxUp1)
 	cPrice := num.Sum(price1, delta)
-	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, now, true) // t1 violated only
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(context.TODO(), auctionStateMock, cPrice, 1, true) // t1 violated only
 	require.NoError(t, err)
 
 	initialAuctionEnd := now.Add(time.Duration(t1.AuctionExtension) * time.Second)
@@ -560,7 +573,8 @@ func TestAuctionStartedAndEndendBy1Trigger(t *testing.T) {
 	auctionStateMock.EXPECT().SetReadyToLeave().Times(1)
 
 	afterInitialAuction := initialAuctionEnd.Add(time.Nanosecond)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, afterInitialAuction, true) // price should be accepted now
+	pm.OnTimeUpdate(afterInitialAuction)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true) // price should be accepted now
 	require.NoError(t, err)
 }
 
@@ -594,7 +608,8 @@ func TestAuctionStartedAndEndendBy2Triggers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, price1, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, price1, 1, true)
 	require.NoError(t, err)
 
 	end := types.AuctionDuration{Duration: t1.AuctionExtension + t2.AuctionExtension}
@@ -605,7 +620,7 @@ func TestAuctionStartedAndEndendBy2Triggers(t *testing.T) {
 	// decPrice, pMin1, pMax1, _, _ := getPriceBounds(cPrice, 1, 2)
 	// _, pMin2, pMax2, _, _ = getPriceBounds(cPrice, 1*4, 2*4)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true) // t1 violated only
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true) // t1 violated only
 	require.NoError(t, err)
 
 	initialAuctionEnd := now.Add(time.Duration(t1.AuctionExtension+t2.AuctionExtension) * time.Second)
@@ -618,7 +633,8 @@ func TestAuctionStartedAndEndendBy2Triggers(t *testing.T) {
 	auctionStateMock.EXPECT().SetReadyToLeave().Times(1)
 
 	afterInitialAuction := initialAuctionEnd.Add(time.Nanosecond)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, afterInitialAuction, true) // price should be accepted now
+	pm.OnTimeUpdate(afterInitialAuction)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true) // price should be accepted now
 	require.NoError(t, err)
 }
 
@@ -666,7 +682,8 @@ func TestAuctionStartedAndEndendBy1TriggerAndExtendedBy2nd(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, price1, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, price1, 1, true)
 	require.NoError(t, err)
 
 	bounds := pm.GetCurrentBounds()
@@ -686,7 +703,7 @@ func TestAuctionStartedAndEndendBy1TriggerAndExtendedBy2nd(t *testing.T) {
 
 	cPrice := num.Sum(price1, maxUp2)
 	cPrice.Sub(cPrice, maxUp1)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true) // t1 violated only
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true) // t1 violated only
 	require.NoError(t, err)
 
 	initialAuctionEnd := now.Add(time.Duration(t1.AuctionExtension) * time.Second)
@@ -710,7 +727,8 @@ func TestAuctionStartedAndEndendBy1TriggerAndExtendedBy2nd(t *testing.T) {
 	cPrice = num.Sum(price1, maxUp2, maxUp1)
 	end2 := types.AuctionDuration{Duration: t2.AuctionExtension}
 	auctionStateMock.EXPECT().ExtendAuctionPrice(end2).Times(1)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, afterInitialAuction, true) // price should violated 2nd trigger and result in auction extension
+	pm.OnTimeUpdate(afterInitialAuction)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true) // price should violated 2nd trigger and result in auction extension
 	require.NoError(t, err)
 
 	bounds = pm.GetCurrentBounds()
@@ -737,7 +755,8 @@ func TestAuctionStartedAndEndendBy1TriggerAndExtendedBy2nd(t *testing.T) {
 	auctionStateMock.EXPECT().SetReadyToLeave().Times(1)
 
 	afterExtendedAuction := extendedAuctionEnd.Add(time.Nanosecond)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, afterExtendedAuction, true) // price should be accepted now
+	pm.OnTimeUpdate(afterExtendedAuction)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true) // price should be accepted now
 	require.NoError(t, err)
 }
 
@@ -769,7 +788,8 @@ func TestMarketInOpeningAuction(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 }
 
@@ -807,28 +827,29 @@ func TestMarketInGenericAuction(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pm)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	cPrice := num.Sum(currentPrice, maxUp)
 	cPrice.Sub(cPrice, one)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	cPrice.Sub(num.Sum(currentPrice, one), maxDown)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	extension := types.AuctionDuration{Duration: t1.AuctionExtension}
 	auctionStateMock.EXPECT().ExtendAuctionPrice(extension).MinTimes(1).MaxTimes(1)
 
 	cPrice = num.Sum(currentPrice, maxUp, maxUp)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	cPrice = num.Sum(maxDown, maxDown)
 	cPrice.Sub(currentPrice, cPrice)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 }
 
@@ -862,7 +883,8 @@ func TestGetValidPriceRange_NoTriggers(t *testing.T) {
 	require.True(t, min.Representation().IsZero())
 	require.Equal(t, expMax.String(), max.Representation().String())
 
-	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	min, max = pm.GetValidPriceRange()
@@ -907,68 +929,74 @@ func TestGetValidPriceRange_2triggers(t *testing.T) {
 
 	pm.UpdateTestFactors(downFactors, upFactors)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	_, _ = pm.GetValidPriceRange()
 	now = now.Add(time.Second)
 	cPrice := num.Sum(currentPrice, maxUp1)
 	cPrice.Sub(cPrice, one)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	_, _ = pm.GetValidPriceRange()
 	now = now.Add(time.Minute)
 	cPrice = num.Sum(currentPrice, one)
 	cPrice.Sub(cPrice, maxDown1)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	_, _ = pm.GetValidPriceRange()
 	now = now.Add(time.Hour)
 	cPrice = num.Sum(currentPrice, maxUp1)
 	cPrice.Sub(cPrice, one)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	_, _ = pm.GetValidPriceRange()
 	now = now.Add(time.Minute)
 	cPrice.Sub(currentPrice, maxDown1)
 	cPrice.AddSum(one)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	min, max := pm.GetValidPriceRange()
 
-	err = pm.CheckPrice(ctx, auctionStateMock, min.Representation(), 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, min.Representation(), 1, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, max.Representation(), 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, max.Representation(), 1, true)
 	require.NoError(t, err)
 
 	// Should trigger an auction
 	auctionStateMock.EXPECT().StartPriceAuction(now, gomock.Any()).Times(1)
 
 	cPrice.Sub(min.Representation(), one)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 
 	now = now.Add(time.Second)
-	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, now, true)
+	pm.OnTimeUpdate(now)
+	err = pm.CheckPrice(ctx, auctionStateMock, currentPrice, 1, true)
 	require.NoError(t, err)
 
 	min, max = pm.GetValidPriceRange()
 
-	err = pm.CheckPrice(ctx, auctionStateMock, min.Representation(), 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, min.Representation(), 1, true)
 	require.NoError(t, err)
 
-	err = pm.CheckPrice(ctx, auctionStateMock, max.Representation(), 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, max.Representation(), 1, true)
 	require.NoError(t, err)
 
 	// Should trigger an auction
 	auctionStateMock.EXPECT().StartPriceAuction(now, gomock.Any()).Times(1)
 	cPrice.Add(max.Representation(), one)
-	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, now, true)
+	err = pm.CheckPrice(ctx, auctionStateMock, cPrice, 1, true)
 	require.NoError(t, err)
 }
 

--- a/monitor/price/snapshot_test.go
+++ b/monitor/price/snapshot_test.go
@@ -100,8 +100,9 @@ func TestChangedState(t *testing.T) {
 	now := time.Now()
 
 	for i := 0; i < 10; i++ {
-		err := pm1.CheckPrice(context.Background(), as, num.NewUint(uint64(100+i)), uint64(100+i), now, true)
-		now = now.Add(time.Minute * 1)
+		pm1.OnTimeUpdate(now)
+		err := pm1.CheckPrice(context.Background(), as, num.NewUint(uint64(100+i)), uint64(100+i), true)
+		now.Add(time.Minute * 1)
 		assert.NoError(t, err)
 	}
 

--- a/monitor/price/snapshot_test.go
+++ b/monitor/price/snapshot_test.go
@@ -102,7 +102,7 @@ func TestChangedState(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pm1.OnTimeUpdate(now)
 		err := pm1.CheckPrice(context.Background(), as, num.NewUint(uint64(100+i)), uint64(100+i), true)
-		now.Add(time.Minute * 1)
+		now = now.Add(time.Minute * 1)
 		assert.NoError(t, err)
 	}
 


### PR DESCRIPTION
Modify price monitoring engine so that time update is injected via a dedicated call rather than as part of `CheckPrice(...)` call. Please see description of the issue #5297 for details of why the current design was not correct. 

Closes https://github.com/vegaprotocol/vega/issues/5297 

Modified integration tests:
Modified tests pass in the current version of `develop` too. The difference in their previous versions was down to the fact that bounds would only get updated following a potential trade, hence LP would still shift the orders when best bid gets updated and closeout was more "spectacular" in old case. 