### PR TITLE
fix: set market price at auction end on trades to the correct value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [5286](https://github.com/vegaprotocol/vega/issues/5286) - Ensure liquidity fees are updated when updating the market
 - [5322](https://github.com/vegaprotocol/vega/issues/5322) - Change vega pub key hashing in topology to fix key rotation submission.
 - [5313](https://github.com/vegaprotocol/vega/issues/5313) - Future update was using oracle spec for settlement price as trading termination spec
+- [5304](https://github.com/vegaprotocol/vega/issues/5304) - Fix bug causing trade events at auction end showing the wrong price.
 
 ## 0.50.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module code.vegaprotocol.io/vega
 
-go 1.17
+go 1.18
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.50.4-0.20220428192224-eedc5d5fe8c5
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20220321185018-3b5684b00533
 	code.vegaprotocol.io/vegawallet v0.14.2-pre1.0.20220425142700-ee9cd43c568d
@@ -52,6 +51,7 @@ require (
 )
 
 require (
+	code.vegaprotocol.io/protos v0.50.4-0.20220428192224-eedc5d5fe8c5 // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
 	github.com/DataDog/zstd v1.4.1 // indirect

--- a/integration/features/auctions/opening-auction-indicative-price.feature
+++ b/integration/features/auctions/opening-auction-indicative-price.feature
@@ -1,0 +1,87 @@
+Feature: Set up a market, create indiciative price different to actual opening auction uncross price
+
+  Background:
+
+    Given the markets:
+      | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring | oracle config          |
+      | ETH/DEC19 | BTC        | BTC   | default-log-normal-risk-model | default-margin-calculator | 8                | default-none | default-basic    | default-eth-for-future |
+    And the following network parameters are set:
+      | name                               | value |
+      | market.auction.minimumDuration     | 8     |
+      #| network.floatingPointUpdates.delay | 30s   |
+
+  @IPOTest
+  Scenario: Simple test with different indicative price before auction uncross
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | BTC   | 100000000 |
+      | party2 | BTC   | 100000000 |
+      | party3 | BTC   | 100000000 |
+      | party4 | BTC   | 100000000 |
+      | party5 | BTC   | 100000000 |
+      | party6 | BTC   | 100000000 |
+
+    When the network moves ahead "3" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    # start with submitting trades that produce an indicative uncrossing price
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party6 | ETH/DEC19 | buy  | 100    | 10900 | 0                | TYPE_LIMIT | TIF_GFA | t6-b-1    |
+      | party5 | ETH/DEC19 | sell | 100    | 10900 | 0                | TYPE_LIMIT | TIF_GFA | t5-s-1    |
+    # continue opening auction
+    When the network moves ahead "4" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    And the parties cancel the following orders:
+      | party  | reference |
+      | party6 | t6-b-1    |
+      | party5 | t5-s-1    |
+    # place orders to set the actual price point at which we'll uncross to be 10000
+    # When the network moves ahead "1" blocks
+    # Then the market data for the market "ETH/DEC19" should be:
+    #   | trading mode                 |
+    #   | TRADING_MODE_OPENING_AUCTION |
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party2 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC19 | sell | 5      | 10001 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-2    |
+      | party1 | ETH/DEC19 | buy  | 4      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t1-b-3    |
+      | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
+
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode            |
+      | TRADING_MODE_CONTINUOUS |
+    ## We're seeing these events twice for some reason
+    Then debug trades
+    Then the following trades should be executed:
+      | buyer   | price | size | seller |
+      | party1  | 10000 | 3    | party2 |
+      | party1  | 10000 | 2    | party2 |
+      | party1  | 10000 | 3    | party2 |
+    And the mark price should be "10000" for the market "ETH/DEC19"
+    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
+    And the orders should have the following status:
+      | party  | reference | status           |
+      | party1 | t1-b-1    | STATUS_FILLED    |
+      | party2 | t2-s-1    | STATUS_FILLED    |
+      | party1 | t1-b-2    | STATUS_CANCELLED |
+      | party2 | t2-s-2    | STATUS_CANCELLED |
+      | party1 | t1-b-3    | STATUS_CANCELLED |
+      | party2 | t2-s-3    | STATUS_FILLED    |
+      | party5 | t5-s-1    | STATUS_CANCELLED |
+      | party6 | t6-b-1    | STATUS_CANCELLED |
+      #| party6 | t6-b-1    | STATUS_FILLED    |
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | ref price |
+      | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9985      | 10015     | 10000     |
+
+

--- a/integration/features/auctions/opening-auction-price.feature
+++ b/integration/features/auctions/opening-auction-price.feature
@@ -1,0 +1,332 @@
+Feature: Set up a market, create indiciative price different to actual opening auction uncross price
+
+  Background:
+
+    Given the markets:
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | oracle config          |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 5                | default-none | default-basic    | default-eth-for-future |
+    And the following network parameters are set:
+      | name                               | value |
+      | market.auction.minimumDuration     | 5     |
+      | network.floatingPointUpdates.delay | 10s   |
+
+  @OpenIP
+  Scenario: Simple test with different indicative price before auction uncross
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | BTC   | 100000000 |
+      | party2 | BTC   | 100000000 |
+      | party3 | BTC   | 100000000 |
+      | party4 | BTC   | 100000000 |
+      | party5 | BTC   | 100000000 |
+      | party6 | BTC   | 100000000 |
+
+    # Start market with some dead time
+    When the network moves ahead "2" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    # Ensure an indicative price/volume of 10, although we will not uncross at this price point
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party6 | ETH/DEC19 | buy  | 1      | 10    | 0                | TYPE_LIMIT | TIF_GFA | t6-b-1    |
+    When the network moves ahead "1" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party5 | ETH/DEC19 | sell | 1      | 10    | 0                | TYPE_LIMIT | TIF_GFA | t5-s-1    |
+    # place orders to set the actual price point at which we'll uncross to be 10000
+    When the network moves ahead "1" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party2 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC19 | sell | 5      | 10001 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-2    |
+      | party1 | ETH/DEC19 | buy  | 4      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t1-b-3    |
+      | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release |
+      | party1 | ETH/DEC19 | 25200       | 27720  | 30240   | 65520   |
+      | party2 | ETH/DEC19 | 23900       | 26290  | 28680   | 57460   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party1 | BTC   | ETH/DEC19 | 30240  | 99969760 |
+      | party2 | BTC   | ETH/DEC19 | 28680  | 99971320 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
+    When the opening auction period ends for market "ETH/DEC19"
+    ## We're seeing these events twice for some reason
+    Then debug trades
+    Then the following trades should be executed:
+      | buyer   | price | size | seller |
+      | party1  | 10000 | 1    | party5 |
+      | party1  | 10000 | 3    | party2 |
+      | party1  | 10000 | 1    | party2 |
+      | party1  | 10000 | 4    | party2 |
+    And the mark price should be "10000" for the market "ETH/DEC19"
+    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
+    And the orders should have the following status:
+      | party  | reference | status           |
+      | party1 | t1-b-1    | STATUS_FILLED    |
+      | party2 | t2-s-1    | STATUS_FILLED    |
+      | party1 | t1-b-2    | STATUS_CANCELLED |
+      | party2 | t2-s-2    | STATUS_CANCELLED |
+      | party1 | t1-b-3    | STATUS_CANCELLED |
+      | party2 | t2-s-3    | STATUS_FILLED    |
+      | party5 | t5-s-1    | STATUS_FILLED    |
+      | party6 | t6-b-1    | STATUS_CANCELLED |
+
+    Then the following transfers should happen:
+      | from   | to     | from account        | to account           | market id | amount | asset |
+      | party2 | party2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 9480   | BTC   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
+      | party1 | BTC   | ETH/DEC19 | 108000 | 99892000 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | ref price |
+      | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9999      | 9999      | 10000     |
+
+  @OpenIP
+  Scenario: Same test as above, but without the initial indicative price/volume
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | BTC   | 100000000 |
+      | party2 | BTC   | 100000000 |
+      | party3 | BTC   | 100000000 |
+      | party4 | BTC   | 100000000 |
+
+    # Start opening auction with some dead time...
+    When the network moves ahead "1" blocks
+    # place orders to set the actual price point at which we'll uncross to be 10000
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party2 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC19 | sell | 5      | 10001 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-2    |
+      | party1 | ETH/DEC19 | buy  | 4      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t1-b-3    |
+      | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release |
+      | party1 | ETH/DEC19 | 25200       | 27720  | 30240   | 65520   |
+      | party2 | ETH/DEC19 | 23900       | 26290  | 28680   | 57460   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party1 | BTC   | ETH/DEC19 | 30240  | 99969760 |
+      | party2 | BTC   | ETH/DEC19 | 28680  | 99971320 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
+    # moves forwards several blocks
+    When the opening auction period ends for market "ETH/DEC19"
+    ## We're seeing these events twice for some reason
+    Then the following trades should be executed:
+      | buyer   | price | size | seller |
+      | party1  | 10000 | 3    | party2 |
+      | party1  | 10000 | 2    | party2 |
+      | party1  | 10000 | 3    | party2 |
+    And the mark price should be "10000" for the market "ETH/DEC19"
+    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
+    And the orders should have the following status:
+      | party  | reference | status           |
+      | party1 | t1-b-1    | STATUS_FILLED    |
+      | party2 | t2-s-1    | STATUS_FILLED    |
+      | party1 | t1-b-2    | STATUS_CANCELLED |
+      | party2 | t2-s-2    | STATUS_CANCELLED |
+      | party1 | t1-b-3    | STATUS_CANCELLED |
+      | party2 | t2-s-3    | STATUS_FILLED    |
+
+    Then the following transfers should happen:
+      | from   | to     | from account        | to account           | market id | amount | asset |
+      | party2 | party2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 9480   | BTC   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
+      | party1 | BTC   | ETH/DEC19 | 96000  | 99904000 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | ref price |
+      | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9999      | 9999      | 10000     |
+
+  @OpenIPT
+  Scenario: Simple test with different indicative price before auction uncross
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | BTC   | 100000000 |
+      | party2 | BTC   | 100000000 |
+      | party3 | BTC   | 100000000 |
+      | party4 | BTC   | 100000000 |
+      | party5 | BTC   | 100000000 |
+      | party6 | BTC   | 100000000 |
+
+    # Start market with some dead time
+    When the network moves ahead "3" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    # Ensure an indicative price/volume of 10, although we will not uncross at this price point
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party5 | ETH/DEC19 | sell | 1      | 10    | 0                | TYPE_LIMIT | TIF_GFA | t5-s-1    |
+      | party6 | ETH/DEC19 | buy  | 1      | 10    | 0                | TYPE_LIMIT | TIF_GFA | t6-b-1    |
+    When the network moves ahead "1" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party2 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC19 | sell | 5      | 10001 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-2    |
+      | party1 | ETH/DEC19 | buy  | 4      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t1-b-3    |
+      | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release |
+      | party1 | ETH/DEC19 | 25200       | 27720  | 30240   | 65520   |
+      | party2 | ETH/DEC19 | 23900       | 26290  | 28680   | 57460   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party1 | BTC   | ETH/DEC19 | 30240  | 99969760 |
+      | party2 | BTC   | ETH/DEC19 | 28680  | 99971320 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
+    When the opening auction period ends for market "ETH/DEC19"
+    ## We're seeing these events twice for some reason
+    Then the following trades should be executed:
+      | buyer   | price | size | seller |
+      | party1  | 10000 | 1    | party5 |
+      | party1  | 10000 | 3    | party2 |
+      | party1  | 10000 | 1    | party2 |
+      | party1  | 10000 | 4    | party2 |
+    And the mark price should be "10000" for the market "ETH/DEC19"
+    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
+    And the orders should have the following status:
+      | party  | reference | status           |
+      | party1 | t1-b-1    | STATUS_FILLED    |
+      | party2 | t2-s-1    | STATUS_FILLED    |
+      | party1 | t1-b-2    | STATUS_CANCELLED |
+      | party2 | t2-s-2    | STATUS_CANCELLED |
+      | party1 | t1-b-3    | STATUS_CANCELLED |
+      | party2 | t2-s-3    | STATUS_FILLED    |
+      | party5 | t5-s-1    | STATUS_FILLED    |
+      | party6 | t6-b-1    | STATUS_CANCELLED |
+
+    Then the following transfers should happen:
+      | from   | to     | from account        | to account           | market id | amount | asset |
+      | party2 | party2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 9480   | BTC   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
+      | party1 | BTC   | ETH/DEC19 | 108000 | 99892000 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | ref price |
+      | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9999      | 9999      | 10000     |
+
+
+  @OpenIPO
+  Scenario: Same again, but higher indicative price
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | BTC   | 100000000 |
+      | party2 | BTC   | 100000000 |
+      | party3 | BTC   | 100000000 |
+      | party4 | BTC   | 100000000 |
+      | party5 | BTC   | 100000000 |
+      | party6 | BTC   | 100000000 |
+
+    # Start market with some dead time
+    When the network moves ahead "3" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    # Ensure an indicative price/volume of 10, although we will not uncross at this price point
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party5 | ETH/DEC19 | sell | 1      | 10900 | 0                | TYPE_LIMIT | TIF_GFA | t5-s-1    |
+      | party6 | ETH/DEC19 | buy  | 1      | 10900 | 0                | TYPE_LIMIT | TIF_GFA | t6-b-1    |
+    When the network moves ahead "1" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode                 |
+      | TRADING_MODE_OPENING_AUCTION |
+    And the parties cancel the following orders:
+      | party  | reference |
+      | party5 | t5-s-1    |
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party2 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC19 | sell | 5      | 10001 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-2    |
+      | party1 | ETH/DEC19 | buy  | 4      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t1-b-3    |
+      | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release |
+      | party1 | ETH/DEC19 | 25200       | 27720  | 30240   | 65520   |
+      | party2 | ETH/DEC19 | 23900       | 26290  | 28680   | 57460   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party1 | BTC   | ETH/DEC19 | 30240  | 99969760 |
+      | party2 | BTC   | ETH/DEC19 | 28680  | 99971320 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
+    When the opening auction period ends for market "ETH/DEC19"
+    Then the market data for the market "ETH/DEC19" should be:
+      | trading mode            |
+      | TRADING_MODE_CONTINUOUS |
+    Then debug trades
+    ## We're seeing these events twice for some reason
+    Then the following trades should be executed:
+      | buyer   | price | size | seller |
+      | party1  | 10000 | 3    | party2 |
+      | party1  | 10000 | 2    | party2 |
+      | party1  | 10000 | 2    | party2 |
+    And the mark price should be "10000" for the market "ETH/DEC19"
+    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
+    And the orders should have the following status:
+      | party  | reference | status           |
+      | party1 | t1-b-1    | STATUS_FILLED    |
+      | party2 | t2-s-1    | STATUS_FILLED    |
+      | party1 | t1-b-2    | STATUS_CANCELLED |
+      | party2 | t2-s-2    | STATUS_CANCELLED |
+      | party1 | t1-b-3    | STATUS_CANCELLED |
+      | party2 | t2-s-3    | STATUS_FILLED    |
+      | party5 | t5-s-1    | STATUS_CANCELLED |
+      | party6 | t6-b-1    | STATUS_FILLED    |
+
+    Then the following transfers should happen:
+      | from   | to     | from account        | to account           | market id | amount | asset |
+      | party2 | party2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 9480   | BTC   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general  |
+      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
+      #| party1 | BTC   | ETH/DEC19 | 108000 | 99892000 |
+      # values before uint
+      #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | ref price |
+      | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9999      | 9999      | 10000     |
+

--- a/integration/features/liquidity-provision/unexpected-auction.feature
+++ b/integration/features/liquidity-provision/unexpected-auction.feature
@@ -42,7 +42,7 @@ Feature: Replicate unexpected margin issues.
     And the opening auction period ends for market "DAI/DEC22"
     Then the following trades should be executed:
       | buyer  | price      | size | seller |
-      | party2 | 3500000000 | 1    | party3 |
+      | party2 | 3500000005 | 1    | party3 |
     And the mark price should be "3500000005" for the market "DAI/DEC22"
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search    | initial   | release    |

--- a/integration/features/verified/0032-PRIM-price_monitoring_horizon.feature
+++ b/integration/features/verified/0032-PRIM-price_monitoring_horizon.feature
@@ -50,12 +50,12 @@ Feature: 0032-PRIM-price-mornitoring, test horizon trigger.
       | party2 | ETH/MAR22 | sell | 100000 | 10000000000| 0                | TYPE_LIMIT | TIF_GTC | sell-ref-3 |
 
     When the opening auction period ends for market "ETH/MAR22"
-    Then the auction ends with a traded volume of "500000" at a price of "95100000"
+    Then the auction ends with a traded volume of "500000" at a price of "97600000"
     # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1001 x 5 x 1 x 0.1
     And the insurance pool balance should be "0" for the market "ETH/MAR22"
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 97600000   | TRADING_MODE_CONTINUOUS | 3600    | 93642254  | 101698911  | 25224720     | 390500000000   | 500000        |
+      | 97600000   | TRADING_MODE_CONTINUOUS | 3600    | 93642254  | 101698911 | 25224720     | 390500000000   | 500000        |
  
     #check the volume on the order book
     Then the order book should have the following volumes for market "ETH/MAR22":
@@ -128,7 +128,7 @@ Scenario: 002, horizon set to 360000 in price monitoring model.  0032-PRIM-001, 
       | party2 | ETH/MAR22 | sell | 100000 | 10000000000| 0                | TYPE_LIMIT | TIF_GTC | sell-ref-3 |
 
     When the opening auction period ends for market "ETH/MAR22"
-    Then the auction ends with a traded volume of "500000" at a price of "95100000"
+    Then the auction ends with a traded volume of "500000" at a price of "97600000"
     # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1001 x 5 x 1 x 0.1
     And the insurance pool balance should be "0" for the market "ETH/MAR22"
     
@@ -208,7 +208,7 @@ Scenario: 003, horizon set to 360000 in price monitoring model.  0032-PRIM-001, 
       | party2 | ETH/MAR22 | sell | 1      | 1000000| 0                | TYPE_LIMIT | TIF_GTC | sell-ref-3 |
 
     When the opening auction period ends for market "ETH/MAR22"
-    Then the auction ends with a traded volume of "5" at a price of "9510"
+    Then the auction ends with a traded volume of "5" at a price of "9760"
     # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1001 x 5 x 1 x 0.1
     And the insurance pool balance should be "0" for the market "ETH/MAR22"
   


### PR DESCRIPTION
Closes #5304 

As it turns out, we didn't produce trades at the wrong price level, but rather the trade events were using an incorrect value (`trade.MarketPrice` was incorrectly set).

This change gets the price factor from any order, and calculates the correct market price for the trade events accordingly