### PR TITLE
chore: log why a proposal was declined

### DIFF
--- a/governance/engine.go
+++ b/governance/engine.go
@@ -782,7 +782,7 @@ func (e *Engine) closeProposal(ctx context.Context, proposal *proposal) {
 	if proposal.IsPassed() {
 		e.log.Debug("Proposal passed", logging.ProposalID(proposal.ID))
 	} else if proposal.IsDeclined() {
-		e.log.Debug("Proposal declined", logging.ProposalID(proposal.ID))
+		e.log.Debug("Proposal declined", logging.ProposalID(proposal.ID), logging.String("details", proposal.ErrorDetails), logging.String("reason", proposal.Reason.String()))
 	}
 
 	e.broker.Send(events.NewProposalEvent(ctx, *proposal.Proposal))


### PR DESCRIPTION
So you can helpfully search in the logs for your proposal ID and see why vega said no.