### PR TITLE
Snapshot performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🛠 Improvements
 - [5318](https://github.com/vegaprotocol/vega/issues/5318) - Automatically dispatch reward pool into markets in recurring transfers
+- [5333](https://github.com/vegaprotocol/vega/issues/5333) - Run snapshot generation for all providers in parallel 
 
 ### 🐛 Fixes
 - [5277](https://github.com/vegaprotocol/vega/issues/5277) - Updating a market should default auction extension to 1

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -48,6 +48,7 @@ type Service struct {
 	ethToVega map[string]string
 
 	isValidator bool
+	lock        sync.Mutex
 }
 
 func New(

--- a/assets/snapshot.go
+++ b/assets/snapshot.go
@@ -69,6 +69,8 @@ func (s *Service) serialisePending() ([]byte, error) {
 
 // get the serialised form and hash of the given key.
 func (s *Service) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	if _, ok := s.keyToSerialiser[k]; !ok {
 		return nil, nil, ErrSnapshotKeyDoesNotExist
 	}

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -139,6 +139,7 @@ type Engine struct {
 	// recurring transfers
 	// transfer id to recurringTransfers
 	recurringTransfers map[string]*types.RecurringTransfer
+	lock               sync.Mutex
 }
 
 type withdrawalRef struct {

--- a/banking/snapshot.go
+++ b/banking/snapshot.go
@@ -188,6 +188,8 @@ func (e *Engine) serialiseDeposits() ([]byte, error) {
 
 // get the serialised form and hash of the given key.
 func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 	if _, ok := e.keyToSerialiser[k]; !ok {
 		return nil, nil, ErrSnapshotKeyDoesNotExist
 	}

--- a/collateral/snapshot.go
+++ b/collateral/snapshot.go
@@ -3,6 +3,7 @@ package collateral
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"code.vegaprotocol.io/vega/events"
 	"code.vegaprotocol.io/vega/libs/crypto"
@@ -22,6 +23,7 @@ type accState struct {
 	updates    map[string]bool
 	serialised map[string][]byte
 	hashKeys   []string
+	lock       sync.Mutex
 }
 
 var (
@@ -201,6 +203,8 @@ func (a *accState) hashAccounts() error {
 }
 
 func (a *accState) getState(k string) ([]byte, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
 	update, exist := a.updates[k]
 	if !exist {
 		return nil, ErrSnapshotKeyDoesNotExist
@@ -221,6 +225,8 @@ func (a *accState) getState(k string) ([]byte, error) {
 }
 
 func (a *accState) getHash(k string) ([]byte, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
 	update, exist := a.updates[k]
 	if !exist {
 		return nil, ErrSnapshotKeyDoesNotExist

--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"sort"
+	"sync"
 	"time"
 
 	"code.vegaprotocol.io/vega/events"
@@ -99,6 +100,7 @@ type Engine struct {
 	dss                      *delegationSnapshotState          // snapshot state
 	keyToSerialiser          map[string]func() ([]byte, error) // snapshot key to serialisation function
 	lastReconciliation       time.Time                         // last time staking balance has been reconciled against delegation balance
+	lock                     sync.Mutex
 }
 
 // New instantiates a new delegation engine.

--- a/delegation/snapshot.go
+++ b/delegation/snapshot.go
@@ -109,6 +109,8 @@ func (e *Engine) serialiseAuto() ([]byte, error) {
 
 // get the serialised form and hash of the given key.
 func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 	if _, ok := e.keyToSerialiser[k]; !ok {
 		return nil, nil, types.ErrSnapshotKeyDoesNotExist
 	}

--- a/governance/engine.go
+++ b/governance/engine.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"code.vegaprotocol.io/vega/assets"
@@ -104,6 +105,7 @@ type Engine struct {
 	// snapshot state
 	gss             *governanceSnapshotState
 	keyToSerialiser map[string]func() ([]byte, error)
+	lock            sync.Mutex
 }
 
 func NewEngine(

--- a/governance/snapshot.go
+++ b/governance/snapshot.go
@@ -104,6 +104,8 @@ func (e *Engine) serialiseNodeProposals() ([]byte, error) {
 
 // get the serialised form and hash of the given key.
 func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 	if _, ok := e.keyToSerialiser[k]; !ok {
 		return nil, nil, types.ErrSnapshotKeyDoesNotExist
 	}

--- a/liquidity/snapshot.go
+++ b/liquidity/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"strconv"
+	"sync"
 
 	typespb "code.vegaprotocol.io/protos/vega"
 	snapshotpb "code.vegaprotocol.io/protos/vega/snapshot/v1"
@@ -36,6 +37,8 @@ type SnapshotEngine struct {
 	pendingProvisionsKey      string
 	provisionsKey             string
 	suppliedKey               string
+
+	lock sync.Mutex
 }
 
 func NewSnapshotEngine(config Config,
@@ -238,6 +241,9 @@ func (e *SnapshotEngine) loadProvisions(
 }
 
 func (e *SnapshotEngine) serialise(k string) ([]byte, []byte, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
 	var (
 		buf     []byte
 		changed bool

--- a/liquidity/target/snapshot.go
+++ b/liquidity/target/snapshot.go
@@ -2,6 +2,7 @@ package target
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	snapshot "code.vegaprotocol.io/protos/vega/snapshot/v1"
@@ -33,6 +34,7 @@ type SnapshotEngine struct {
 	changed bool
 	key     string
 	keys    []string
+	lock    sync.Mutex
 }
 
 func NewSnapshotEngine(
@@ -162,6 +164,8 @@ func (e *SnapshotEngine) serialisePrevious() []*snapshot.TimestampedOpenInterest
 // serialise marshal the snapshot state, populating the data and hash fields
 // with updated values.
 func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 	if e.stopped {
 		return nil, nil, nil
 	}

--- a/positions/snapshot.go
+++ b/positions/snapshot.go
@@ -2,6 +2,7 @@ package positions
 
 import (
 	"context"
+	"sync"
 
 	"code.vegaprotocol.io/vega/events"
 
@@ -20,6 +21,7 @@ type SnapshotEngine struct {
 	data    []byte
 	changed bool
 	stopped bool
+	lock    sync.Mutex
 }
 
 func NewSnapshotEngine(
@@ -146,6 +148,8 @@ func (e *SnapshotEngine) LoadState(_ context.Context, payload *types.Payload) ([
 // serialise marshal the snapshot state, populating the data and hash fields
 // with updated values.
 func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 	if e.stopped {
 		return nil, nil, nil
 	}

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -712,16 +712,17 @@ func (e *Engine) Snapshot(ctx context.Context) (b []byte, errlol error) {
 	updated := false
 
 	for _, tkRes := range results {
-		e.log.Debug("State updated",
-			logging.String("node-key", string(tkRes.input.treeKey)),
-			logging.String("state-hash", hex.EncodeToString(tkRes.hash)),
-		)
 		treeKey := tkRes.input.treeKey
 		treeKeyStr := string(treeKey)
 
 		if !tkRes.updated || tkRes.toRemove {
 			continue
 		}
+
+		e.log.Debug("State updated",
+			logging.String("node-key", string(tkRes.input.treeKey)),
+			logging.String("state-hash", hex.EncodeToString(tkRes.hash)),
+		)
 
 		e.keyHashes[treeKeyStr] = tkRes.hash
 		if len(tkRes.state) == 0 && len(treeKey) == 0 {

--- a/staking/stake_verifier.go
+++ b/staking/stake_verifier.go
@@ -74,6 +74,8 @@ type StakeVerifier struct {
 	// snapshot data
 	svss            *stakeVerifierSnapshotState
 	keyToSerialiser map[string]func() ([]byte, error)
+
+	lock sync.Mutex
 }
 
 type pendingSD struct {

--- a/staking/stake_verifier_snapshot.go
+++ b/staking/stake_verifier_snapshot.go
@@ -59,6 +59,8 @@ func (s *StakeVerifier) serialisePendingSR() ([]byte, error) {
 
 // get the serialised form and hash of the given key.
 func (s *StakeVerifier) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	if _, ok := s.keyToSerialiser[k]; !ok {
 		return nil, nil, types.ErrSnapshotKeyDoesNotExist
 	}

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -20,7 +20,9 @@ import (
 type StateProvider interface {
 	Namespace() SnapshotNamespace
 	Keys() []string
+	// NB: GetHash must be threadsafe as it may be called from multiple goroutines concurrently!
 	GetHash(key string) ([]byte, error)
+	// NB: GetState must be threadsafe as it may be called from multiple goroutines concurrently!
 	GetState(key string) ([]byte, []StateProvider, error)
 	LoadState(ctx context.Context, pl *Payload) ([]StateProvider, error)
 	Stopped() bool

--- a/validators/erc20multisig/topology.go
+++ b/validators/erc20multisig/topology.go
@@ -81,6 +81,7 @@ type Topology struct {
 	keyToSerialiser map[string]func() ([]byte, error)
 
 	ethEventSource EthereumEventSource
+	lock           sync.Mutex
 }
 
 type pendingSigner struct {

--- a/validators/erc20multisig/topology_snapshot_state.go
+++ b/validators/erc20multisig/topology_snapshot_state.go
@@ -250,6 +250,8 @@ func (t *Topology) serialisePendingState() ([]byte, error) {
 
 // get the serialised form and hash of the given key.
 func (t *Topology) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
 	if _, ok := t.keyToSerialiser[k]; !ok {
 		return nil, nil, types.ErrSnapshotKeyDoesNotExist
 	}


### PR DESCRIPTION
Closes #5333 

The PR contains two types of changes:
1. Making the snapshot engine run all providers snapshot in parallel - that's the main change here and its in one file - the snapshot engine. 
2. Making all the snapshots thread-safe as they are called concurrently.