### PR TITLE
feat: get rid of getHash for snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🛠 Improvements
 - [5318](https://github.com/vegaprotocol/vega/issues/5318) - Automatically dispatch reward pool into markets in recurring transfers
 - [5333](https://github.com/vegaprotocol/vega/issues/5333) - Run snapshot generation for all providers in parallel 
+- [5343](https://github.com/vegaprotocol/vega/issues/5343) - Snapshot optimisation part II - get rid of `getHash`
 - [5324](https://github.com/vegaprotocol/vega/issues/5324) -  Send event when oracle data doesn't match
 
 ### 🐛 Fixes
@@ -23,6 +24,7 @@
 - [5322](https://github.com/vegaprotocol/vega/issues/5322) - Change vega pub key hashing in topology to fix key rotation submission.
 - [5313](https://github.com/vegaprotocol/vega/issues/5313) - Future update was using oracle spec for settlement price as trading termination spec
 - [5304](https://github.com/vegaprotocol/vega/issues/5304) - Fix bug causing trade events at auction end showing the wrong price.
+- [5345](https://github.com/vegaprotocol/vega/issues/5345) - Fix issue with state variable transactions assumed gone missing
 
 ## 0.50.2
 

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -48,7 +48,7 @@ type Service struct {
 	ethToVega map[string]string
 
 	isValidator bool
-	lock        sync.Mutex
+	lock        sync.RWMutex
 }
 
 func New(
@@ -71,7 +71,6 @@ func New(
 		ethClient:     ethClient,
 		ass: &assetsSnapshotState{
 			changed:    map[string]bool{activeKey: true, pendingKey: true},
-			hash:       map[string][]byte{},
 			serialised: map[string][]byte{},
 		},
 		keyToSerialiser: map[string]func() ([]byte, error){},

--- a/banking/engine.go
+++ b/banking/engine.go
@@ -140,7 +140,7 @@ type Engine struct {
 	// recurring transfers
 	// transfer id to recurringTransfers
 	recurringTransfers map[string]*types.RecurringTransfer
-	lock               sync.Mutex
+	lock               sync.RWMutex
 }
 
 type withdrawalRef struct {
@@ -191,7 +191,6 @@ func New(
 				recurringTransfersKey: true,
 				scheduledTransfersKey: true,
 			},
-			hash:       map[string][]byte{},
 			serialised: map[string][]byte{},
 		},
 		keyToSerialiser:            map[string]func() ([]byte, error){},

--- a/checkpoint/engine.go
+++ b/checkpoint/engine.go
@@ -72,7 +72,6 @@ type Engine struct {
 
 	// snapshot fields
 	state   *types.PayloadCheckpoint
-	hash    []byte
 	data    []byte
 	updated bool
 	snapErr error

--- a/checkpoint/snapshot.go
+++ b/checkpoint/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 
@@ -28,22 +27,12 @@ func (e *Engine) Stopped() bool {
 func (e *Engine) setNextCP(t time.Time) {
 	e.nextCP = t
 	e.state.Checkpoint.NextCp = t.UnixNano()
-	// clear hash/data
-	e.hash = []byte{}
 	e.data = []byte{}
 	e.updated = true
 }
 
-func (e *Engine) GetHash(k string) ([]byte, error) {
-	if k != e.state.Key() {
-		return nil, types.ErrSnapshotKeyDoesNotExist
-	}
-	if len(e.hash) == 0 {
-		if err := e.serialiseState(); err != nil {
-			return nil, err
-		}
-	}
-	return e.hash, nil
+func (e *Engine) HasChanged(k string) bool {
+	return true
 }
 
 func (e *Engine) GetState(k string) ([]byte, []types.StateProvider, error) {
@@ -69,7 +58,6 @@ func (e *Engine) serialiseState() error {
 	}
 
 	e.data = data
-	e.hash = crypto.Hash(data)
 	return nil
 }
 

--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -100,7 +100,7 @@ type Engine struct {
 	dss                      *delegationSnapshotState          // snapshot state
 	keyToSerialiser          map[string]func() ([]byte, error) // snapshot key to serialisation function
 	lastReconciliation       time.Time                         // last time staking balance has been reconciled against delegation balance
-	lock                     sync.Mutex
+	lock                     sync.RWMutex
 }
 
 // New instantiates a new delegation engine.
@@ -118,7 +118,6 @@ func New(log *logging.Logger, config Config, broker Broker, topology ValidatorTo
 		autoDelegationMode:       map[string]struct{}{},
 		dss: &delegationSnapshotState{
 			changed:    map[string]bool{activeKey: true, pendingKey: true, autoKey: true, lastReconKey: true},
-			hash:       map[string][]byte{},
 			serialised: map[string][]byte{},
 		},
 		keyToSerialiser:    map[string]func() ([]byte, error){},

--- a/epochtime/service.go
+++ b/epochtime/service.go
@@ -38,7 +38,6 @@ type Svc struct {
 	state            *types.EpochState
 	pl               types.Payload
 	data             []byte
-	hash             []byte
 	currentTime      time.Time
 	needsFastForward bool
 }

--- a/epochtime/snapshot.go
+++ b/epochtime/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"code.vegaprotocol.io/protos/vega"
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/types"
 
 	"code.vegaprotocol.io/vega/libs/proto"
@@ -23,7 +22,6 @@ func (s *Svc) serialise() error {
 	}
 
 	s.data = data
-	s.hash = crypto.Hash(data)
 	return nil
 }
 
@@ -39,12 +37,8 @@ func (s *Svc) Stopped() bool {
 	return false
 }
 
-func (s *Svc) GetHash(k string) ([]byte, error) {
-	if k != s.pl.Key() {
-		return nil, types.ErrSnapshotKeyDoesNotExist
-	}
-
-	return s.hash, nil
+func (s *Svc) HasChanged(k string) bool {
+	return true
 }
 
 func (s *Svc) GetState(k string) ([]byte, []types.StateProvider, error) {

--- a/epochtime/snapshot_test.go
+++ b/epochtime/snapshot_test.go
@@ -9,6 +9,7 @@ import (
 	snapshot "code.vegaprotocol.io/protos/vega/snapshot/v1"
 	"code.vegaprotocol.io/vega/types"
 
+	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/libs/proto"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -90,24 +91,24 @@ func TestEpochSnapshotHash(t *testing.T) {
 	service.broker.EXPECT().Send(gomock.Any()).Times(3)
 	// Trigger initial block
 	service.cb(ctx, now)
-	h, err := service.GetHash("all")
+	s, _, err := service.GetState("all")
 	require.Nil(t, err)
-	require.Equal(t, "41a9839f4dc60ac14461f58658c0e1bf7542bd54cbd635f3c0402bef2f07f60f", hex.EncodeToString(h))
+	require.Equal(t, "41a9839f4dc60ac14461f58658c0e1bf7542bd54cbd635f3c0402bef2f07f60f", hex.EncodeToString(crypto.Hash(s)))
 
 	// Shuffle time along
 	now = now.Add(25 * time.Hour)
 	service.cb(ctx, now)
 	service.OnBlockEnd(ctx)
-	h, err = service.GetHash("all")
+	s, _, err = service.GetState("all")
 	require.Nil(t, err)
-	require.Equal(t, "074677210f20ebb3427064339ebbd46dbfd5d2381bcd3b3fd126bbdcb05b6697", hex.EncodeToString(h))
+	require.Equal(t, "074677210f20ebb3427064339ebbd46dbfd5d2381bcd3b3fd126bbdcb05b6697", hex.EncodeToString(crypto.Hash(s)))
 
 	// Shuffle time a bit more
 	now = now.Add(25 * time.Hour)
 	service.cb(ctx, now)
-	h, err = service.GetHash("all")
+	s, _, err = service.GetState("all")
 	require.Nil(t, err)
-	require.Equal(t, "2fb572edea4af9154edeff680e23689ed076d08934c60f8a4c1f5743a614954e", hex.EncodeToString(h))
+	require.Equal(t, "2fb572edea4af9154edeff680e23689ed076d08934c60f8a4c1f5743a614954e", hex.EncodeToString(crypto.Hash(s)))
 }
 
 func TestEpochSnapshotCompare(t *testing.T) {
@@ -143,12 +144,4 @@ func TestEpochSnapshotCompare(t *testing.T) {
 	newData, _, err := service.GetState("all")
 	require.Nil(t, err)
 	require.Equal(t, data, newData)
-
-	h1, err := service.GetHash("all")
-	require.Nil(t, err)
-	h2, err := snapService.GetHash("all")
-	require.Nil(t, err)
-
-	// Compare hashes
-	require.Equal(t, h1, h2)
 }

--- a/evtforward/forwarder.go
+++ b/evtforward/forwarder.go
@@ -92,7 +92,6 @@ func New(log *logging.Logger, cfg Config, cmd Commander, time TimeService, top V
 		bcQueueAllowlist: allowlist,
 		efss: &efSnapshotState{
 			changed:    true,
-			hash:       []byte{},
 			serialised: []byte{},
 		},
 	}

--- a/evtforward/forwarder_test.go
+++ b/evtforward/forwarder_test.go
@@ -9,10 +9,16 @@ import (
 	prototypes "code.vegaprotocol.io/protos/vega"
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
 	snapshot "code.vegaprotocol.io/protos/vega/snapshot/v1"
+	"code.vegaprotocol.io/shared/paths"
 	"code.vegaprotocol.io/vega/evtforward"
 	"code.vegaprotocol.io/vega/evtforward/mocks"
+	"code.vegaprotocol.io/vega/integration/stubs"
+	vgcontext "code.vegaprotocol.io/vega/libs/context"
+	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/libs/proto"
 	"code.vegaprotocol.io/vega/logging"
+	snp "code.vegaprotocol.io/vega/snapshot"
+	"code.vegaprotocol.io/vega/stats"
 	"code.vegaprotocol.io/vega/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -132,31 +138,20 @@ func testAckSuccess(t *testing.T) {
 	evtfwd := getTestEvtFwd(t)
 	defer evtfwd.ctrl.Finish()
 	evt := getTestChainEvent("some")
-
-	hash1, err := evtfwd.GetHash("all")
-	require.Nil(t, err)
 	state1, _, err := evtfwd.GetState("all")
 	require.Nil(t, err)
 
 	ok := evtfwd.Ack(evt)
 	assert.True(t, ok)
-	hash2, err := evtfwd.GetHash("all")
-	require.Nil(t, err)
 	state2, _, err := evtfwd.GetState("all")
 	require.Nil(t, err)
-
-	require.False(t, bytes.Equal(hash1, hash2))
 	require.False(t, bytes.Equal(state1, state2))
 
 	// try to ack again the same event
 	ok = evtfwd.Ack(evt)
 	assert.False(t, ok)
-	hash3, err := evtfwd.GetHash("all")
-	require.Nil(t, err)
 	state3, _, err := evtfwd.GetState("all")
 	require.Nil(t, err)
-
-	require.True(t, bytes.Equal(hash3, hash2))
 	require.True(t, bytes.Equal(state3, state2))
 
 	// restore the state
@@ -170,25 +165,17 @@ func testAckSuccess(t *testing.T) {
 	ok = evtfwd.Ack(evt)
 	assert.False(t, ok)
 
-	// expect the hash/state after the reload to equal what it was before
-	hash4, err := evtfwd.GetHash("all")
-	require.Nil(t, err)
+	// expect the state after the reload to equal what it was before
 	state4, _, err := evtfwd.GetState("all")
 	require.Nil(t, err)
-
-	require.True(t, bytes.Equal(hash4, hash3))
 	require.True(t, bytes.Equal(state4, state3))
 
 	// ack a new event for the hash/state to change
 	evt2 := getTestChainEvent("somenew")
 	ok = evtfwd.Ack(evt2)
 	assert.True(t, ok)
-	hash5, err := evtfwd.GetHash("all")
-	require.Nil(t, err)
 	state5, _, err := evtfwd.GetState("all")
 	require.Nil(t, err)
-
-	require.False(t, bytes.Equal(hash5, hash4))
 	require.False(t, bytes.Equal(state5, state4))
 }
 
@@ -218,4 +205,59 @@ func getTestChainEvent(txid string) *commandspb.ChainEvent {
 			},
 		},
 	}
+}
+
+func TestSnapshotRoundtripViaEngine(t *testing.T) {
+	evtfwd := getTestEvtFwd(t)
+	defer evtfwd.ctrl.Finish()
+
+	for i := 0; i < 100; i++ {
+		evtfwd.Ack(getTestChainEvent(crypto.RandomHash()))
+	}
+	ctx := vgcontext.WithTraceID(vgcontext.WithBlockHeight(context.Background(), 100), "0xDEADBEEF")
+	ctx = vgcontext.WithChainID(ctx, "chainid")
+	now := time.Now()
+	log := logging.NewTestLogger()
+	timeService := stubs.NewTimeStub()
+	timeService.SetTime(now)
+	statsData := stats.New(log, stats.NewDefaultConfig(), "", "")
+	config := snp.NewDefaultConfig()
+	config.Storage = "memory"
+	snapshotEngine, _ := snp.New(context.Background(), &paths.DefaultPaths{}, config, log, timeService, statsData.Blockchain)
+	snapshotEngine.AddProviders(evtfwd)
+	snapshotEngine.ClearAndInitialise()
+	defer snapshotEngine.Close()
+
+	_, err := snapshotEngine.Snapshot(ctx)
+	require.NoError(t, err)
+	snaps, err := snapshotEngine.List()
+	require.NoError(t, err)
+	snap1 := snaps[0]
+
+	evtfwdLoad := getTestEvtFwd(t)
+	snapshotEngineLoad, _ := snp.New(context.Background(), &paths.DefaultPaths{}, config, log, timeService, statsData.Blockchain)
+	defer snapshotEngineLoad.Close()
+	snapshotEngineLoad.AddProviders(evtfwdLoad)
+	snapshotEngineLoad.ClearAndInitialise()
+	snapshotEngineLoad.ReceiveSnapshot(snap1)
+	snapshotEngineLoad.ApplySnapshot(ctx)
+	snapshotEngineLoad.CheckLoaded()
+
+	b, err := snapshotEngine.Snapshot(ctx)
+	require.NoError(t, err)
+	bLoad, err := snapshotEngineLoad.Snapshot(ctx)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(b, bLoad))
+
+	for i := 0; i < 10; i++ {
+		txID := crypto.RandomHash()
+		evtfwd.Ack(getTestChainEvent(txID))
+		evtfwdLoad.Ack(getTestChainEvent(txID))
+	}
+
+	b, err = snapshotEngine.Snapshot(ctx)
+	require.NoError(t, err)
+	bLoad, err = snapshotEngineLoad.Snapshot(ctx)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(b, bLoad))
 }

--- a/evtforward/snapshot.go
+++ b/evtforward/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/types"
 	"github.com/jfcg/sorty/v2"
 
@@ -21,7 +20,6 @@ var (
 
 type efSnapshotState struct {
 	changed    bool
-	hash       []byte
 	serialised []byte
 }
 
@@ -68,33 +66,31 @@ func (f *Forwarder) serialise() ([]byte, error) {
 	return proto.Marshal(payload.IntoProto())
 }
 
-// get the serialised form and hash of the given key.
-func (f *Forwarder) getSerialisedAndHash(k string) (data []byte, hash []byte, err error) {
+// get the serialised form of the given key.
+func (f *Forwarder) getSerialised(k string) (data []byte, err error) {
 	if k != key {
-		return nil, nil, types.ErrSnapshotKeyDoesNotExist
+		return nil, types.ErrSnapshotKeyDoesNotExist
 	}
 
 	if !f.efss.changed {
-		return f.efss.serialised, f.efss.hash, nil
+		return f.efss.serialised, nil
 	}
 
 	f.efss.serialised, err = f.serialise()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	f.efss.hash = crypto.Hash(f.efss.serialised)
 	f.efss.changed = false
-	return f.efss.serialised, f.efss.hash, nil
+	return f.efss.serialised, nil
 }
 
-func (f *Forwarder) GetHash(k string) ([]byte, error) {
-	_, hash, err := f.getSerialisedAndHash(k)
-	return hash, err
+func (f *Forwarder) HasChanged(k string) bool {
+	return f.efss.changed
 }
 
 func (f *Forwarder) GetState(k string) ([]byte, []types.StateProvider, error) {
-	state, _, err := f.getSerialisedAndHash(k)
+	state, err := f.getSerialised(k)
 	return state, nil, err
 }
 
@@ -104,13 +100,13 @@ func (f *Forwarder) LoadState(ctx context.Context, p *types.Payload) ([]types.St
 	}
 	// see what we're reloading
 	if pl, ok := p.Data.(*types.PayloadEventForwarder); ok {
-		return nil, f.restore(ctx, pl.Events)
+		return nil, f.restore(ctx, pl.Events, p)
 	}
 
 	return nil, types.ErrUnknownSnapshotType
 }
 
-func (f *Forwarder) restore(ctx context.Context, events []*commandspb.ChainEvent) error {
+func (f *Forwarder) restore(ctx context.Context, events []*commandspb.ChainEvent, p *types.Payload) error {
 	f.ackedEvts = map[string]*commandspb.ChainEvent{}
 	for _, event := range events {
 		key, err := f.getEvtKey(event)
@@ -120,6 +116,8 @@ func (f *Forwarder) restore(ctx context.Context, events []*commandspb.ChainEvent
 		f.ackedEvts[key] = event
 	}
 
-	f.efss.changed = true
-	return nil
+	var err error
+	f.efss.changed = false
+	f.efss.serialised, err = proto.Marshal(p.IntoProto())
+	return err
 }

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -97,7 +97,6 @@ type Engine struct {
 	// Snapshot
 	stateChanged          bool
 	snapshotSerialised    []byte
-	snapshotHash          []byte
 	newGeneratedProviders []types.StateProvider // new providers generated during the last state change
 
 	// Map of all active snapshot providers that the execution engine has generated

--- a/execution/snapshot_test.go
+++ b/execution/snapshot_test.go
@@ -89,6 +89,7 @@ func TestSnapshotOraclesTerminatingMarketFromSnapshot(t *testing.T) {
 func TestLoadTerminatedMarketFromSnapshot(t *testing.T) {
 	now := time.Now()
 	exec := getEngine(t, now)
+	defer exec.snapshotEngine.Close()
 	ctx := vgcontext.WithTraceID(vgcontext.WithBlockHeight(context.Background(), 100), "0xDEADBEEF")
 	ctx = vgcontext.WithChainID(ctx, "chainid")
 
@@ -121,6 +122,7 @@ func TestLoadTerminatedMarketFromSnapshot(t *testing.T) {
 
 	// now let's start from this snapshot
 	exec2 := getEngine(t, now)
+	defer exec2.snapshotEngine.Close()
 	exec2.snapshotEngine.ReceiveSnapshot(snap1)
 	exec2.snapshotEngine.ApplySnapshot(ctx)
 	exec2.snapshotEngine.CheckLoaded()
@@ -299,7 +301,9 @@ func getEngine(t *testing.T, now time.Time) *snapshotTestData {
 	)
 
 	statsData := stats.New(log, stats.NewDefaultConfig(), "", "")
-	snapshotEngine, _ := snp.New(context.Background(), &paths.DefaultPaths{}, snp.NewDefaultConfig(), log, timeService, statsData.Blockchain)
+	config := snp.NewDefaultConfig()
+	config.Storage = "memory"
+	snapshotEngine, _ := snp.New(context.Background(), &paths.DefaultPaths{}, config, log, timeService, statsData.Blockchain)
 	snapshotEngine.AddProviders(eng)
 	snapshotEngine.ClearAndInitialise()
 

--- a/governance/engine.go
+++ b/governance/engine.go
@@ -105,7 +105,7 @@ type Engine struct {
 	// snapshot state
 	gss             *governanceSnapshotState
 	keyToSerialiser map[string]func() ([]byte, error)
-	lock            sync.Mutex
+	lock            sync.RWMutex
 }
 
 func NewEngine(
@@ -136,7 +136,6 @@ func NewEngine(
 		netp:                   netp,
 		gss: &governanceSnapshotState{
 			changed:    map[string]bool{activeKey: true, enactedKey: true, nodeValidationKey: true},
-			hash:       map[string][]byte{},
 			serialised: map[string][]byte{},
 		},
 		keyToSerialiser: map[string]func() ([]byte, error){},

--- a/integration/stubs/state_var_stub.go
+++ b/integration/stubs/state_var_stub.go
@@ -90,7 +90,9 @@ func (e *StateVarStub) NewEvent(asset, market string, eventType statevar.StateVa
 }
 
 func (s *sv) CalculationFinished(eventID string, result statevar.StateVariableResult, err error) {
-	s.result(context.Background(), result)
+	if err == nil {
+		s.result(context.Background(), result)
+	}
 }
 
 func (e *StateVarStub) ReadyForTimeTrigger(asset, mktID string) {

--- a/limits/snapshot_test.go
+++ b/limits/snapshot_test.go
@@ -20,9 +20,9 @@ var allKey = (&types.PayloadLimitState{}).Key()
 func TestLimitSnapshotEmpty(t *testing.T) {
 	l := getLimitsTest(t)
 
-	h, err := l.GetHash(allKey)
+	s, _, err := l.GetState(allKey)
 	require.Nil(t, err)
-	require.NotNil(t, h)
+	require.NotNil(t, s)
 }
 
 func TestLimitSnapshotWrongPayLoad(t *testing.T) {
@@ -37,14 +37,14 @@ func TestLimitSnapshotGenesisState(t *testing.T) {
 		BootstrapBlockCount: 1,
 	}
 	lmt := getLimitsTest(t)
-	h1, err := lmt.GetHash(allKey)
+	s1, _, err := lmt.GetState(allKey)
 	require.Nil(t, err)
 
 	lmt.loadGenesisState(t, gs)
 
-	h2, err := lmt.GetHash(allKey)
+	s2, _, err := lmt.GetState(allKey)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 }
 
 func TestLimitSnapshotBlockCount(t *testing.T) {
@@ -55,16 +55,16 @@ func TestLimitSnapshotBlockCount(t *testing.T) {
 	lmt := getLimitsTest(t)
 	lmt.loadGenesisState(t, gs)
 
-	h1, err := lmt.GetHash(allKey)
+	s1, _, err := lmt.GetState(allKey)
 	require.Nil(t, err)
 
-	// increase block count and hash should change
+	// increase block count and state should change
 	lmt.OnTick(ctx, time.Unix(3000, 0))
 	require.False(t, lmt.BootstrapFinished())
 
-	h2, err := lmt.GetHash(allKey)
+	s2, _, err := lmt.GetState(allKey)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 
 	state, _, err := lmt.GetState(allKey)
 	require.Nil(t, err)
@@ -117,9 +117,9 @@ func TestLimitSnapshotBootstrapFinished(t *testing.T) {
 	require.True(t, lmt.CanProposeMarket())
 	require.True(t, lmt.BootstrapFinished())
 
-	h1, err := lmt.GetHash(allKey)
+	s1, _, err := lmt.GetState(allKey)
 	require.Nil(t, err)
-	h2, err := snapLmt.GetHash(allKey)
+	s2, _, err := snapLmt.GetState(allKey)
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(h1, h2))
+	require.True(t, bytes.Equal(s1, s2))
 }

--- a/liquidity/supplied/statevar.go
+++ b/liquidity/supplied/statevar.go
@@ -60,6 +60,7 @@ func (e *Engine) startCalcProbOfTrading(eventID string, endOfCalcCallback statev
 	bestBid, bestAsk, err := e.getBestStaticPrices()
 	if err != nil {
 		e.log.Error("failed to get static price for probability of trading state var", logging.String("error", err.Error()))
+		endOfCalcCallback.CalculationFinished(eventID, nil, err)
 		return
 	}
 
@@ -151,7 +152,9 @@ func calculateAskRange(bestAsk, maxAsk, tickSize, tauScaled num.Decimal, probabi
 // updatePriceBounds is called back from the state variable consensus engine when consensus is reached for the down/up factors and updates the price bounds.
 func (e *Engine) updateProbabilities(ctx context.Context, res statevar.StateVariableResult) error {
 	e.pot = res.(*probabilityOfTrading)
-	e.log.Info("consensus reached for probability of trading", logging.String("market", e.marketID))
+	if e.log.GetLevel() <= logging.DebugLevel {
+		e.log.Debug("consensus reached for probability of trading", logging.String("market", e.marketID))
+	}
 
 	e.potInitialised = true
 	e.changed = true

--- a/liquidity/target/snapshot.go
+++ b/liquidity/target/snapshot.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	snapshot "code.vegaprotocol.io/protos/vega/snapshot/v1"
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/libs/proto"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
@@ -28,13 +27,12 @@ func (toi timestampedOI) toSnapshotProto() *snapshot.TimestampedOpenInterest {
 
 type SnapshotEngine struct {
 	*Engine
-	hash    []byte
 	data    []byte
 	stopped bool
 	changed bool
 	key     string
 	keys    []string
-	lock    sync.Mutex
+	lock    sync.RWMutex
 }
 
 func NewSnapshotEngine(
@@ -104,13 +102,10 @@ func (e *SnapshotEngine) Stopped() bool {
 	return e.stopped
 }
 
-func (e *SnapshotEngine) GetHash(k string) ([]byte, error) {
-	if k != e.key {
-		return nil, types.ErrSnapshotKeyDoesNotExist
-	}
-
-	_, hash, err := e.serialise()
-	return hash, err
+func (e *SnapshotEngine) HasChanged(k string) bool {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return e.changed
 }
 
 func (e *SnapshotEngine) GetState(k string) ([]byte, []types.StateProvider, error) {
@@ -118,7 +113,7 @@ func (e *SnapshotEngine) GetState(k string) ([]byte, []types.StateProvider, erro
 		return nil, nil, types.ErrSnapshotKeyDoesNotExist
 	}
 
-	state, _, err := e.serialise()
+	state, err := e.serialise()
 	return state, nil, err
 }
 
@@ -145,8 +140,10 @@ func (e *SnapshotEngine) LoadState(_ context.Context, payload *types.Payload) ([
 			e.previous = append(e.previous, newTimestampedOISnapshotFromProto(poi))
 		}
 
-		e.changed = true
-		return nil, nil
+		var err error
+		e.data, err = proto.Marshal(payload.IntoProto())
+		e.changed = false
+		return nil, err
 
 	default:
 		return nil, types.ErrUnknownSnapshotType
@@ -161,17 +158,17 @@ func (e *SnapshotEngine) serialisePrevious() []*snapshot.TimestampedOpenInterest
 	return poi
 }
 
-// serialise marshal the snapshot state, populating the data and hash fields
+// serialise marshal the snapshot state, populating the data fields
 // with updated values.
-func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
+func (e *SnapshotEngine) serialise() ([]byte, error) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	if e.stopped {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	if !e.changed {
-		return e.data, e.hash, nil // we already have what we need
+		return e.data, nil // we already have what we need
 	}
 
 	p := &snapshot.Payload{
@@ -190,11 +187,10 @@ func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
 	var err error
 	e.data, err = proto.Marshal(p)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	e.hash = crypto.Hash(e.data)
 	e.changed = false
 
-	return e.data, e.hash, nil
+	return e.data, nil
 }

--- a/matching/snapshot.go
+++ b/matching/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/libs/proto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
@@ -27,21 +26,8 @@ func (b OrderBook) Namespace() types.SnapshotNamespace {
 	return types.MatchingSnapshot
 }
 
-func (b *OrderBook) GetHash(key string) ([]byte, error) {
-	if key != b.snapshot.Key() {
-		return nil, types.ErrSnapshotKeyDoesNotExist
-	}
-
-	if b.stopped {
-		return nil, nil
-	}
-
-	payload, _, e := b.GetState(key)
-	if e != nil {
-		return nil, e
-	}
-
-	return crypto.Hash(payload), nil
+func (e *OrderBook) HasChanged(k string) bool {
+	return true
 }
 
 func (b *OrderBook) GetState(key string) ([]byte, []types.StateProvider, error) {

--- a/notary/snapshot_test.go
+++ b/notary/snapshot_test.go
@@ -18,15 +18,15 @@ var allKey = (&types.PayloadNotary{}).Key()
 
 func TestNotarySnapshotEmpty(t *testing.T) {
 	notr := getTestNotary(t)
-	h1, err := notr.GetHash(allKey)
+	s, _, err := notr.GetState(allKey)
 	require.Nil(t, err)
-	require.Equal(t, 32, len(h1))
+	require.NotNil(t, s)
 }
 
 func TestNotarySnapshotVotesKinds(t *testing.T) {
 	notr := getTestNotary(t)
 
-	h1, err := notr.GetHash(allKey)
+	s1, _, err := notr.GetState(allKey)
 	require.Nil(t, err)
 
 	resID := "resid"
@@ -36,9 +36,9 @@ func TestNotarySnapshotVotesKinds(t *testing.T) {
 
 	notr.StartAggregate(resID, types.NodeSignatureKindAssetNew, []byte("123456"))
 
-	h2, err := notr.GetHash(allKey)
+	s2, _, err := notr.GetState(allKey)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 }
 
 func populateNotary(t *testing.T, notr *testNotary) {
@@ -121,11 +121,11 @@ func TestNotarySnapshotRoundTrip(t *testing.T) {
 	_, err = snapNotr.LoadState(context.Background(), types.PayloadFromProto(snap))
 	require.Nil(t, err)
 
-	h1, err := notr.GetHash(allKey)
+	s1, _, err := notr.GetState(allKey)
 	require.Nil(t, err)
-	h2, err := notr.GetHash(allKey)
+	s2, _, err := notr.GetState(allKey)
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(h1, h2))
+	require.True(t, bytes.Equal(s1, s2))
 
 	// Check the the loaded in (and original) node signatures exist and are perceived to be ok
 	_, ok1 := snapNotr.IsSigned(context.Background(), "resid1", types.NodeSignatureKindAssetNew)

--- a/positions/snapshot.go
+++ b/positions/snapshot.go
@@ -6,7 +6,6 @@ import (
 
 	"code.vegaprotocol.io/vega/events"
 
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
@@ -17,11 +16,10 @@ import (
 type SnapshotEngine struct {
 	*Engine
 	pl      types.Payload
-	hash    []byte
 	data    []byte
 	changed bool
 	stopped bool
-	lock    sync.Mutex
+	lock    sync.RWMutex
 }
 
 func NewSnapshotEngine(
@@ -93,13 +91,10 @@ func (e *SnapshotEngine) Stopped() bool {
 	return e.stopped
 }
 
-func (e *SnapshotEngine) GetHash(k string) ([]byte, error) {
-	if k != e.marketID {
-		return nil, types.ErrSnapshotKeyDoesNotExist
-	}
-
-	_, hash, err := e.serialise()
-	return hash, err
+func (e *SnapshotEngine) HasChanged(k string) bool {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+	return e.changed
 }
 
 func (e *SnapshotEngine) GetState(k string) ([]byte, []types.StateProvider, error) {
@@ -107,7 +102,7 @@ func (e *SnapshotEngine) GetState(k string) ([]byte, []types.StateProvider, erro
 		return nil, nil, types.ErrSnapshotKeyDoesNotExist
 	}
 
-	state, _, err := e.serialise()
+	state, err := e.serialise()
 	return state, nil, err
 }
 
@@ -116,6 +111,7 @@ func (e *SnapshotEngine) LoadState(_ context.Context, payload *types.Payload) ([
 		return nil, types.ErrInvalidSnapshotNamespace
 	}
 
+	var err error
 	switch pl := payload.Data.(type) {
 	case *types.PayloadMarketPositions:
 
@@ -135,27 +131,27 @@ func (e *SnapshotEngine) LoadState(_ context.Context, payload *types.Payload) ([
 
 			e.positionsCpy = append(e.positionsCpy, pos)
 			e.positions[p.PartyID] = pos
-
-			e.changed = true
 		}
-		return nil, nil
+		e.data, err = proto.Marshal(payload.IntoProto())
+		e.changed = false
+		return nil, err
 
 	default:
 		return nil, types.ErrUnknownSnapshotType
 	}
 }
 
-// serialise marshal the snapshot state, populating the data and hash fields
+// serialise marshal the snapshot state, populating the data field
 // with updated values.
-func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
+func (e *SnapshotEngine) serialise() ([]byte, error) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	if e.stopped {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	if !e.changed {
-		return e.data, e.hash, nil // we already have what we need
+		return e.data, nil // we already have what we need
 	}
 
 	e.log.Debug("serilaising snapshot", logging.Int("positions", len(e.positionsCpy)))
@@ -183,11 +179,10 @@ func (e *SnapshotEngine) serialise() ([]byte, []byte, error) {
 	var err error
 	e.data, err = proto.Marshal(e.pl.IntoProto())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	e.hash = crypto.Hash(e.data)
 	e.changed = false
 
-	return e.data, e.hash, nil
+	return e.data, nil
 }

--- a/positions/snapshot_test.go
+++ b/positions/snapshot_test.go
@@ -12,6 +12,7 @@ import (
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 
+	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/libs/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,13 +77,13 @@ func TestSnapshotSaveAndLoad(t *testing.T) {
 	require.Equal(t, 1, len(keys))
 	require.Equal(t, "test_market", keys[0])
 
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
-	// With no change the hashes are equal
-	require.True(t, bytes.Equal(h1, h2))
+	// With no change the states are equal
+	require.True(t, bytes.Equal(s1, s2))
 
 	data, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
@@ -98,10 +99,10 @@ func TestSnapshotSaveAndLoad(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	// Get hash again
-	h3, err := snapEngine.GetHash(keys[0])
+	// Get state again
+	s3, _, err := snapEngine.GetState(keys[0])
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(h1, h3))
+	require.True(t, bytes.Equal(s1, s3))
 	require.Equal(t, len(engine.Positions()), len(snapEngine.Positions()))
 	for _, p := range engine.Positions() {
 		// find it in the other engine by partyID
@@ -111,29 +112,29 @@ func TestSnapshotSaveAndLoad(t *testing.T) {
 	}
 }
 
-func TestSnapshotHashNoChanges(t *testing.T) {
+func TestSnapshotStateNoChanges(t *testing.T) {
 	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
-	// With no changes we expect the hashes are equal
-	require.True(t, bytes.Equal(h1, h2))
+	// With no changes we expect the states are equal
+	require.True(t, bytes.Equal(s1, s2))
 }
 
-func TestSnapshotHashRegisterOrder(t *testing.T) {
+func TestSnapshotStateRegisterOrder(t *testing.T) {
 	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
-	// Add and order and the hash should change
+	// Add and order and the state should change
 	newOrder := &types.Order{
 		Party:     "test_party_1",
 		Side:      types.SideBuy,
@@ -142,20 +143,20 @@ func TestSnapshotHashRegisterOrder(t *testing.T) {
 		Price:     num.Zero(),
 	}
 	engine.RegisterOrder(context.TODO(), newOrder)
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 }
 
-func TestSnapshotHashUnregisterOrder(t *testing.T) {
+func TestSnapshotStateUnregisterOrder(t *testing.T) {
 	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
-	// Add and order and the hash should change
+	// Add and order and the state should change
 	newOrder := &types.Order{
 		Party:     "test_party_1",
 		Side:      types.SideBuy,
@@ -164,16 +165,16 @@ func TestSnapshotHashUnregisterOrder(t *testing.T) {
 		Price:     num.Zero(),
 	}
 	engine.RegisterOrder(context.TODO(), newOrder)
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 }
 
-func TestSnapshotHashAmendOrder(t *testing.T) {
+func TestSnapshotStateAmendOrder(t *testing.T) {
 	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
-	// Add and order and the hash should change
+	// Add and order and the state should change
 	newOrders := []*types.Order{
 		{
 			Party:     "test_party_1",
@@ -192,57 +193,57 @@ func TestSnapshotHashAmendOrder(t *testing.T) {
 	}
 	engine.RegisterOrder(context.TODO(), newOrders[0])
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
 	// Amend it
 	engine.AmendOrder(context.TODO(), newOrders[0], newOrders[1])
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 
-	// Then amend it back, hash should be the same as originally
+	// Then amend it back, state should be the same as originally
 	engine.AmendOrder(context.TODO(), newOrders[1], newOrders[0])
-	h2, err = engine.GetHash(keys[0])
+	s2, _, err = engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(h1, h2))
+	require.True(t, bytes.Equal(s1, s2))
 }
 
-func TestSnapshotHashRemoveDistressed(t *testing.T) {
+func TestSnapshotStateRemoveDistressed(t *testing.T) {
 	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
 	engine.RemoveDistressed(engine.Positions())
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 }
 
-func TestSnapshotHashUpdateMarkPrice(t *testing.T) {
+func TestSnapshotStaeUpdateMarkPrice(t *testing.T) {
 	engine := getTestEngine(t)
 	fillTestPositions(engine)
 
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
 
 	engine.UpdateMarkPrice(num.NewUint(12))
-	h2, err := engine.GetHash(keys[0])
+	s2, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 }
 
 func TestSnapshotHashNoPositions(t *testing.T) {
 	engine := getTestEngine(t)
 
 	keys := engine.Keys()
-	h1, err := engine.GetHash(keys[0])
+	s1, _, err := engine.GetState(keys[0])
 	require.Nil(t, err)
-	require.Equal(t, "278f2eff5adc1ea5b8365bd04c6e534ef64ca43df737c22ee61db46a8dac5870", hex.EncodeToString(h1))
+	require.Equal(t, "278f2eff5adc1ea5b8365bd04c6e534ef64ca43df737c22ee61db46a8dac5870", hex.EncodeToString(crypto.Hash(s1)))
 }
 
 func TestStopSnapshotTaking(t *testing.T) {
@@ -255,8 +256,5 @@ func TestStopSnapshotTaking(t *testing.T) {
 	s, _, err := engine.GetState(keys[0])
 	assert.NoError(t, err)
 	assert.Nil(t, s)
-	h, err := engine.GetHash(keys[0])
-	assert.NoError(t, err)
-	assert.Nil(t, h)
 	assert.True(t, engine.Stopped())
 }

--- a/pow/engine.go
+++ b/pow/engine.go
@@ -251,9 +251,9 @@ func (e *Engine) verify(tx abci.Tx) (byte, error) {
 	idx := tx.BlockHeight() % e.spamPoWNumberOfPastBlocks
 	if e.blockHeight[idx] != tx.BlockHeight() {
 		if e.log.IsDebug() {
-			e.log.Debug("unknown block height", logging.String("tx-hash", txHash), logging.String("tid", tx.GetPoWTID()), logging.Uint64("tx-block-height", tx.BlockHeight()), logging.Uint64("index", idx), logging.Uint64("indexed-height", e.blockHeight[idx]), logging.String("command", tx.Command().String()), logging.String("party", tx.Party()))
+			e.log.Debug("unknown block height", logging.Uint64("current-block-height", e.currentBlock), logging.String("tx-hash", txHash), logging.String("tid", tx.GetPoWTID()), logging.Uint64("tx-block-height", tx.BlockHeight()), logging.Uint64("index", idx), logging.Uint64("indexed-height", e.blockHeight[idx]), logging.String("command", tx.Command().String()), logging.String("party", tx.Party()))
 		}
-		return h, errors.New("unknown block height")
+		return h, errors.New("unknown block height for tx:" + txHash + ", command:" + tx.Command().String() + ", party:" + tx.Party())
 	}
 
 	if _, ok := e.seenTx[txHash]; ok {

--- a/pow/engine_test.go
+++ b/pow/engine_test.go
@@ -218,9 +218,6 @@ func TestCheckTx(t *testing.T) {
 	e.UpdateSpamPoWHashFunction(context.Background(), crypto.Sha3)
 	e.UpdateSpamPoWNumberOfTxPerBlock(context.Background(), num.NewUint(1))
 
-	// incorrect block
-	require.Equal(t, errors.New("unknown block height"), e.CheckTx(&testTx{blockHeight: 100}))
-
 	e.currentBlock = 100
 	e.blockHeight[0] = 100
 	e.blockHash[0] = "113EB390CBEB921433BDBA832CCDFD81AC4C77C3748A41B1AF08C96BC6C7BCD9"

--- a/pow/snapshot.go
+++ b/pow/snapshot.go
@@ -3,7 +3,6 @@ package pow
 import (
 	"context"
 
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/types"
 	"github.com/golang/protobuf/proto"
 )
@@ -21,7 +20,7 @@ func (e *Engine) Stopped() bool {
 }
 
 // get the serialised form and hash of the given key.
-func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+func (e *Engine) serialise(k string) ([]byte, error) {
 	payload := types.Payload{
 		Data: &types.PayloadProofOfWork{
 			BlockHeight:   e.blockHeight,
@@ -34,20 +33,18 @@ func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
 
 	data, err := proto.Marshal(payload.IntoProto())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	hash := crypto.Hash(data)
-	return data, hash, nil
+	return data, nil
 }
 
-func (e *Engine) GetHash(k string) ([]byte, error) {
-	_, hash, err := e.getSerialisedAndHash(k)
-	return hash, err
+func (e *Engine) HasChanged(k string) bool {
+	return true
 }
 
 func (e *Engine) GetState(k string) ([]byte, []types.StateProvider, error) {
-	state, _, err := e.getSerialisedAndHash(k)
+	state, err := e.serialise(k)
 	return state, nil, err
 }
 

--- a/pow/snapshot_test.go
+++ b/pow/snapshot_test.go
@@ -110,9 +110,6 @@ func TestSnapshot(t *testing.T) {
 	e.BeginBlock(102, "2E289FB9CEF7234E2C08F34CCD66B330229067CE47E22F76EF0595B3ABA9968F")
 
 	key := (&types.PayloadProofOfWork{}).Key()
-	hash1, err := e.GetHash(key)
-	require.NoError(t, err)
-
 	state1, _, err := e.GetState(key)
 	require.NoError(t, err)
 
@@ -125,10 +122,6 @@ func TestSnapshot(t *testing.T) {
 	pl := snapshotpb.Payload{}
 	require.NoError(t, proto.Unmarshal(state1, &pl))
 	eLoaded.LoadState(context.Background(), gtypes.PayloadFromProto(&pl))
-
-	hash2, err := eLoaded.GetHash(key)
-	require.NoError(t, err)
-	require.True(t, bytes.Equal(hash1, hash2))
 
 	state2, _, err := eLoaded.GetState(key)
 	require.NoError(t, err)

--- a/snapshot/engine_test.go
+++ b/snapshot/engine_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	vegactx "code.vegaprotocol.io/vega/libs/context"
-	"code.vegaprotocol.io/vega/libs/crypto"
-	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/snapshot"
 	"code.vegaprotocol.io/vega/snapshot/mocks"
@@ -190,12 +188,14 @@ func testAddProvidersDuplicateKeys(t *testing.T) {
 		[]byte("bar2"),
 	}
 	data2 := hash2
+	prov1.EXPECT().Stopped().Times(2).Return(false)
 	for i, k := range keys1 {
-		prov1.EXPECT().GetHash(k).Times(1).Return(hash1[i], nil)
+		prov1.EXPECT().HasChanged(k).Times(1).Return(true)
 		prov1.EXPECT().GetState(k).Times(1).Return(data1[i], nil, nil)
 	}
 	// duplicate key is skipped
-	prov2.EXPECT().GetHash(keys2[1]).Times(1).Return(hash2[0], nil)
+	prov2.EXPECT().Stopped().Times(1).Return(false)
+	prov2.EXPECT().HasChanged(gomock.Any()).Times(1).Return(true)
 	prov2.EXPECT().GetState(keys2[1]).Times(1).Return(data2[0], nil, nil)
 
 	engine.time.EXPECT().GetTimeNow().Times(1).Return(time.Now())
@@ -231,15 +231,20 @@ func testTakeSnapshot(t *testing.T) {
 		pl := state[k]
 		data, err := proto.Marshal(pl.IntoProto())
 		require.NoError(t, err)
-		hash := crypto.Hash(data)
-		prov.EXPECT().GetHash(k).Times(2).Return(hash, nil)
+		prov.EXPECT().HasChanged(k).Times(1).Return(true)
 		prov.EXPECT().GetState(k).Times(1).Return(data, nil, nil)
 	}
+	prov.EXPECT().Stopped().Times(len(keys)).Return(false)
 
 	// take the snapshot knowing state has changed:
 	// we need the ctx that goes with the mock, because that has block height and hash set
 	hash, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
+
+	for _, k := range keys {
+		prov.EXPECT().HasChanged(k).Times(1).Return(false)
+	}
+	prov.EXPECT().Stopped().Times(len(keys)).Return(false)
 	secondHash, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.EqualValues(t, hash, secondHash)
@@ -271,10 +276,10 @@ func testReloadSnapshot(t *testing.T) {
 		pl := state[k]
 		data, err := proto.Marshal(pl.IntoProto())
 		require.NoError(t, err)
-		hash := crypto.Hash(data)
-		prov.EXPECT().GetHash(k).Times(1).Return(hash, nil)
 		prov.EXPECT().GetState(k).Times(1).Return(data, nil, nil)
+		prov.EXPECT().HasChanged(k).Times(1).Return(true)
 	}
+	prov.EXPECT().Stopped().Times(len(keys)).Return(false)
 	hash, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, hash)
@@ -349,10 +354,10 @@ func testReloadRestore(t *testing.T) {
 		pl := state[k]
 		data, err := proto.Marshal(pl.IntoProto())
 		require.NoError(t, err)
-		hash := crypto.Hash(data)
-		prov.EXPECT().GetHash(k).Times(1).Return(hash, nil)
 		prov.EXPECT().GetState(k).Times(1).Return(data, nil, nil)
+		prov.EXPECT().HasChanged(k).Times(1).Return(true)
 	}
+	prov.EXPECT().Stopped().Times(len(keys)).Return(false)
 	hash, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, hash)
@@ -429,7 +434,6 @@ func testRejectSnapshot(t *testing.T) {
 
 func testRemovingMutlipleKeysSingleNamespace(t *testing.T) {
 	someState := []byte("hello-i-am-state")
-	someHash := vgcrypto.Hash(someState)
 	engine := getTestEngine(t)
 	defer engine.Finish()
 
@@ -439,7 +443,8 @@ func testRemovingMutlipleKeysSingleNamespace(t *testing.T) {
 	prov := engine.getNewProviderMock()
 	prov.EXPECT().Keys().AnyTimes().Return([]string{"key1"})
 	prov.EXPECT().Namespace().AnyTimes().Return(types.PositionsSnapshot)
-	prov.EXPECT().GetHash(gomock.Any()).Times(2).Return(someHash, nil) // called twice, first to store and second to change for no change
+	prov.EXPECT().HasChanged(gomock.Any()).Times(1).Return(true)
+	prov.EXPECT().Stopped().Times(1).Return(false)
 	prov.EXPECT().GetState(gomock.Any()).Times(1).Return(someState, nil, nil)
 	engine.AddProviders(prov)
 
@@ -447,14 +452,20 @@ func testRemovingMutlipleKeysSingleNamespace(t *testing.T) {
 	prov2 := engine.getNewProviderMock()
 	prov2.EXPECT().Keys().AnyTimes().Return([]string{"key2"})
 	prov2.EXPECT().Namespace().AnyTimes().Return(types.PositionsSnapshot)
-	prov2.EXPECT().GetHash(gomock.Any()).Times(3).Return(someHash, nil)
+	prov2.EXPECT().HasChanged(gomock.Any()).Times(1).Return(true)
 	prov2.EXPECT().GetState(gomock.Any()).Times(1).Return(someState, nil, nil)
+	prov2.EXPECT().Stopped().Times(1).Return(false)
 	engine.AddProviders(prov2)
 
 	// initial snapshot
 	b1, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.NotNil(t, b1)
+
+	prov.EXPECT().HasChanged(gomock.Any()).Times(1).Return(false)
+	prov.EXPECT().Stopped().Times(1).Return(false)
+	prov2.EXPECT().HasChanged(gomock.Any()).Times(1).Return(false)
+	prov2.EXPECT().Stopped().Times(1).Return(false)
 
 	// call again to confirm no state changes
 	b2, err := engine.Snapshot(engine.ctx)
@@ -463,15 +474,17 @@ func testRemovingMutlipleKeysSingleNamespace(t *testing.T) {
 	require.Equal(t, b1, b2)
 
 	// Now the only change is we signal remove of a single provider, check the snapshot changes
-	prov.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, nil)
+	prov.EXPECT().HasChanged(gomock.Any()).Times(1).Return(true)
 	prov.EXPECT().Stopped().Times(1).Return(true)
+	prov2.EXPECT().HasChanged(gomock.Any()).Times(1).Return(false)
+	prov2.EXPECT().Stopped().Times(1).Return(false)
 	b3, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)
 	require.NotNil(t, b3)
 	require.NotEqual(t, b1, b3)
 
 	// remove the second provider
-	prov2.EXPECT().GetHash(gomock.Any()).Times(1).Return(nil, nil)
+	prov2.EXPECT().HasChanged(gomock.Any()).Times(1).Return(true)
 	prov2.EXPECT().Stopped().Times(1).Return(true)
 	b4, err := engine.Snapshot(engine.ctx)
 	require.NoError(t, err)

--- a/spam/engine_test.go
+++ b/spam/engine_test.go
@@ -93,9 +93,9 @@ func testEngineReset(t *testing.T) {
 	// move to next block, we've voted/proposed everything already so shouldn't be allowed to make more
 	engine.EndOfBlock(1)
 
-	proposalHash, err := engine.GetHash("proposal")
+	proposalState, _, err := engine.GetState("proposal")
 	require.Nil(t, err)
-	voteHash, err := engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
+	voteState, _, err := engine.GetState((&types.PayloadVoteSpamPolicy{}).Key())
 	require.Nil(t, err)
 
 	keys := engine.Keys()
@@ -117,13 +117,13 @@ func testEngineReset(t *testing.T) {
 	// restore the epoch we were on
 	snapEngine.engine.OnEpochRestore(context.Background(), types.Epoch{Seq: 0})
 
-	proposalHash2, err := snapEngine.engine.GetHash("proposal")
+	proposalState2, _, err := snapEngine.engine.GetState("proposal")
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(proposalHash, proposalHash2))
+	require.True(t, bytes.Equal(proposalState, proposalState2))
 
-	voteHash2, err := snapEngine.engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
+	voteState2, _, err := snapEngine.engine.GetState((&types.PayloadVoteSpamPolicy{}).Key())
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(voteHash, voteHash2))
+	require.True(t, bytes.Equal(voteState, voteState2))
 
 	accept, err := snapEngine.engine.PreBlockAccept(tx1)
 	require.Equal(t, false, accept)
@@ -135,9 +135,9 @@ func testEngineReset(t *testing.T) {
 
 	// Notify an epoch event for the *same* epoch and a reset should not happen
 	snapEngine.engine.OnEpochEvent(context.Background(), types.Epoch{Seq: 0})
-	proposalHashNoReset, err := snapEngine.engine.GetHash("proposal")
+	proposalStateNoReset, _, err := snapEngine.engine.GetState("proposal")
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(proposalHashNoReset, proposalHash2))
+	require.True(t, bytes.Equal(proposalStateNoReset, proposalState2))
 
 	// move to next epoch
 	snapEngine.engine.OnEpochEvent(context.Background(), types.Epoch{Seq: 1})
@@ -151,13 +151,13 @@ func testEngineReset(t *testing.T) {
 		require.Equal(t, true, accept)
 	}
 
-	proposalHash3, err := snapEngine.engine.GetHash("proposal")
+	proposalState3, _, err := snapEngine.engine.GetState("proposal")
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(proposalHash3, proposalHash2))
+	require.False(t, bytes.Equal(proposalState3, proposalState2))
 
-	voteHash3, err := snapEngine.engine.GetHash((&types.PayloadVoteSpamPolicy{}).Key())
+	voteState3, _, err := snapEngine.engine.GetState((&types.PayloadVoteSpamPolicy{}).Key())
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(voteHash3, voteHash2))
+	require.False(t, bytes.Equal(voteState3, voteState2))
 }
 
 func testPreBlockAccept(t *testing.T) {

--- a/spam/snapshot.go
+++ b/spam/snapshot.go
@@ -3,7 +3,6 @@ package spam
 import (
 	"context"
 
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 )
@@ -21,27 +20,24 @@ func (e *Engine) Stopped() bool {
 }
 
 // get the serialised form and hash of the given key.
-func (e *Engine) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+func (e *Engine) serialise(k string) ([]byte, error) {
 	if _, ok := e.policyNameToPolicy[k]; !ok {
-		return nil, nil, types.ErrSnapshotKeyDoesNotExist
+		return nil, types.ErrSnapshotKeyDoesNotExist
 	}
 
 	data, err := e.policyNameToPolicy[k].Serialise()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	hash := crypto.Hash(data)
-	return data, hash, nil
+	return data, nil
 }
 
-func (e *Engine) GetHash(k string) ([]byte, error) {
-	_, hash, err := e.getSerialisedAndHash(k)
-	return hash, err
+func (e *Engine) HasChanged(k string) bool {
+	return true
 }
 
 func (e *Engine) GetState(k string) ([]byte, []types.StateProvider, error) {
-	state, _, err := e.getSerialisedAndHash(k)
+	state, err := e.serialise(k)
 	return state, nil, err
 }
 

--- a/staking/accounting_snapshot_test.go
+++ b/staking/accounting_snapshot_test.go
@@ -20,9 +20,9 @@ func TestAccountsSnapshotEmpty(t *testing.T) {
 	acc := getAccountingTest(t)
 	defer acc.ctrl.Finish()
 
-	h, err := acc.GetHash(allKey)
+	s, _, err := acc.GetState(allKey)
 	require.Nil(t, err)
-	require.NotNil(t, h)
+	require.NotNil(t, s)
 }
 
 func TestAccountsSnapshotRoundTrip(t *testing.T) {
@@ -31,7 +31,7 @@ func TestAccountsSnapshotRoundTrip(t *testing.T) {
 	defer acc.ctrl.Finish()
 	acc.broker.EXPECT().Send(gomock.Any()).Times(1)
 
-	h1, err := acc.GetHash(allKey)
+	s1, _, err := acc.GetState(allKey)
 	require.Nil(t, err)
 
 	evt := &types.StakeLinking{
@@ -47,10 +47,10 @@ func TestAccountsSnapshotRoundTrip(t *testing.T) {
 	}
 	acc.AddEvent(ctx, evt)
 
-	// Check hash has change now an event as been added
-	h2, err := acc.GetHash(allKey)
+	// Check state has change now an event as been added
+	s2, _, err := acc.GetState(allKey)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 
 	// Get state ready to load in a new instance of the engine
 	state, _, err := acc.GetState(allKey)
@@ -70,7 +70,7 @@ func TestAccountsSnapshotRoundTrip(t *testing.T) {
 	require.Nil(t, provs)
 	require.Equal(t, acc.GetAllAvailableBalances(), snapAcc.GetAllAvailableBalances())
 
-	h3, err := snapAcc.GetHash(allKey)
+	s3, _, err := snapAcc.GetState(allKey)
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(h2, h3))
+	require.True(t, bytes.Equal(s2, s3))
 }

--- a/staking/stake_verifier.go
+++ b/staking/stake_verifier.go
@@ -75,7 +75,7 @@ type StakeVerifier struct {
 	svss            *stakeVerifierSnapshotState
 	keyToSerialiser map[string]func() ([]byte, error)
 
-	lock sync.Mutex
+	lock sync.RWMutex
 }
 
 type pendingSD struct {
@@ -119,7 +119,6 @@ func NewStakeVerifier(
 		svss: &stakeVerifierSnapshotState{
 			changed:    map[string]bool{depositedKey: true, removedKey: true},
 			serialised: map[string][]byte{},
-			hash:       map[string][]byte{},
 		},
 		keyToSerialiser: map[string]func() ([]byte, error){},
 	}

--- a/staking/stake_verifier_snapshot_test.go
+++ b/staking/stake_verifier_snapshot_test.go
@@ -27,13 +27,13 @@ func TestSVSnapshotEmpty(t *testing.T) {
 
 	assert.Equal(t, 2, len(sv.Keys()))
 
-	h, err := sv.GetHash(depositedKey)
+	s, _, err := sv.GetState(depositedKey)
 	require.Nil(t, err)
-	require.NotNil(t, h)
+	require.NotNil(t, s)
 
-	h, err = sv.GetHash(removedKey)
+	s, _, err = sv.GetState(removedKey)
 	require.Nil(t, err)
-	require.NotNil(t, h)
+	require.NotNil(t, s)
 }
 
 func TestSVSnapshotDeposited(t *testing.T) {
@@ -45,9 +45,9 @@ func TestSVSnapshotDeposited(t *testing.T) {
 	sv.broker.EXPECT().Send(gomock.Any()).Times(1)
 	sv.witness.EXPECT().StartCheck(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
-	h1, err := sv.GetHash(key)
+	s1, _, err := sv.GetState(key)
 	require.Nil(t, err)
-	require.NotNil(t, h1)
+	require.NotNil(t, s1)
 
 	event := &types.StakeDeposited{
 		BlockNumber:     42,
@@ -63,9 +63,9 @@ func TestSVSnapshotDeposited(t *testing.T) {
 	err = sv.ProcessStakeDeposited(ctx, event)
 	require.Nil(t, err)
 
-	h2, err := sv.GetHash(key)
+	s2, _, err := sv.GetState(key)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 
 	state, _, err := sv.GetState(key)
 	require.Nil(t, err)
@@ -95,9 +95,9 @@ func TestSVSnapshotRemoved(t *testing.T) {
 	sv.broker.EXPECT().Send(gomock.Any()).Times(1)
 	sv.witness.EXPECT().StartCheck(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
-	h1, err := sv.GetHash(key)
+	s1, _, err := sv.GetState(key)
 	require.Nil(t, err)
-	require.NotNil(t, h1)
+	require.NotNil(t, s1)
 
 	event := &types.StakeRemoved{
 		BlockNumber:     42,
@@ -113,9 +113,9 @@ func TestSVSnapshotRemoved(t *testing.T) {
 	err = sv.ProcessStakeRemoved(ctx, event)
 	require.Nil(t, err)
 
-	h2, err := sv.GetHash(key)
+	s2, _, err := sv.GetState(key)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h2))
+	require.False(t, bytes.Equal(s1, s2))
 
 	state, _, err := sv.GetState(key)
 	require.Nil(t, err)

--- a/statevar/engine.go
+++ b/statevar/engine.go
@@ -187,7 +187,7 @@ func (e *Engine) OnTimeTick(ctx context.Context, t time.Time) {
 		sv := e.stateVars[ID]
 
 		if e.log.GetLevel() <= logging.DebugLevel {
-			e.log.Debug("New time based event for state variable received", logging.String("eventID", eventID))
+			e.log.Debug("New time based event for state variable received", logging.String("state-var", ID), logging.String("eventID", eventID))
 		}
 		sv.eventTriggered(eventID)
 		e.stateVarToNextCalc[ID] = t.Add(e.updateFrequency)
@@ -229,6 +229,7 @@ func (e *Engine) RegisterStateVariable(asset, market, name string, converter sta
 	}
 
 	sv := NewStateVar(e.log, e.broker, e.top, e.cmd, e.currentTime, ID, asset, market, converter, startCalculation, trigger, result)
+	sv.currentTime = e.currentTime
 	e.stateVars[ID] = sv
 	for _, t := range trigger {
 		if _, ok := e.eventTypeToStateVar[t]; !ok {

--- a/statevar/snapshot_test.go
+++ b/statevar/snapshot_test.go
@@ -25,10 +25,6 @@ func TestSnapshot(t *testing.T) {
 	engine1.ReadyForTimeTrigger("asset1", "market2")
 
 	key := (&gtypes.PayloadFloatingPointConsensus{}).Key()
-
-	hash1, err := engine1.GetHash(key)
-	require.NoError(t, err)
-
 	state1, _, err := engine1.GetState(key)
 	require.NoError(t, err)
 
@@ -44,10 +40,6 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(state1, &pl))
 	engine2.LoadState(context.Background(), gtypes.PayloadFromProto(&pl))
 
-	hash2, err := engine2.GetHash(key)
-	require.NoError(t, err)
-	require.True(t, bytes.Equal(hash1, hash2))
-
 	state2, _, err := engine2.GetState(key)
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(state1, state2))
@@ -59,13 +51,13 @@ func TestSnapshotChangeFlagSet(t *testing.T) {
 
 	engine1.RegisterStateVariable("asset1", "market1", "var1", converter{}, defaultStartCalc(), []types.StateVarEventType{types.StateVarEventTypeMarketEnactment, types.StateVarEventTypeTimeTrigger}, defaultResultBack())
 
-	hash1, err := engine1.GetHash(key)
+	state1, _, err := engine1.GetState(key)
 	require.NoError(t, err)
 
 	// this should hit the change flag causing us to reserialise at the next hash
 	engine1.ReadyForTimeTrigger("asset1", "market1")
 
-	hash2, err := engine1.GetHash(key)
+	state2, _, err := engine1.GetState(key)
 	require.NoError(t, err)
-	require.NotEqual(t, hash1, hash2)
+	require.False(t, bytes.Equal(state1, state2))
 }

--- a/types/mocks/restore_state_provider_mock.go
+++ b/types/mocks/restore_state_provider_mock.go
@@ -35,21 +35,6 @@ func (m *MockPostRestore) EXPECT() *MockPostRestoreMockRecorder {
 	return m.recorder
 }
 
-// GetHash mocks base method.
-func (m *MockPostRestore) GetHash(arg0 string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHash", arg0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHash indicates an expected call of GetHash.
-func (mr *MockPostRestoreMockRecorder) GetHash(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHash", reflect.TypeOf((*MockPostRestore)(nil).GetHash), arg0)
-}
-
 // GetState mocks base method.
 func (m *MockPostRestore) GetState(arg0 string) ([]byte, []types.StateProvider, error) {
 	m.ctrl.T.Helper()
@@ -64,6 +49,20 @@ func (m *MockPostRestore) GetState(arg0 string) ([]byte, []types.StateProvider, 
 func (mr *MockPostRestoreMockRecorder) GetState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockPostRestore)(nil).GetState), arg0)
+}
+
+// HasChanged mocks base method.
+func (m *MockPostRestore) HasChanged(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasChanged", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasChanged indicates an expected call of HasChanged.
+func (mr *MockPostRestoreMockRecorder) HasChanged(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasChanged", reflect.TypeOf((*MockPostRestore)(nil).HasChanged), arg0)
 }
 
 // Keys mocks base method.

--- a/types/mocks/state_provider_mock.go
+++ b/types/mocks/state_provider_mock.go
@@ -35,21 +35,6 @@ func (m *MockStateProvider) EXPECT() *MockStateProviderMockRecorder {
 	return m.recorder
 }
 
-// GetHash mocks base method.
-func (m *MockStateProvider) GetHash(arg0 string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHash", arg0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHash indicates an expected call of GetHash.
-func (mr *MockStateProviderMockRecorder) GetHash(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHash", reflect.TypeOf((*MockStateProvider)(nil).GetHash), arg0)
-}
-
 // GetState mocks base method.
 func (m *MockStateProvider) GetState(arg0 string) ([]byte, []types.StateProvider, error) {
 	m.ctrl.T.Helper()
@@ -64,6 +49,20 @@ func (m *MockStateProvider) GetState(arg0 string) ([]byte, []types.StateProvider
 func (mr *MockStateProviderMockRecorder) GetState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockStateProvider)(nil).GetState), arg0)
+}
+
+// HasChanged mocks base method.
+func (m *MockStateProvider) HasChanged(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasChanged", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasChanged indicates an expected call of HasChanged.
+func (mr *MockStateProviderMockRecorder) HasChanged(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasChanged", reflect.TypeOf((*MockStateProvider)(nil).HasChanged), arg0)
 }
 
 // Keys mocks base method.

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -20,8 +20,8 @@ import (
 type StateProvider interface {
 	Namespace() SnapshotNamespace
 	Keys() []string
-	// NB: GetHash must be threadsafe as it may be called from multiple goroutines concurrently!
-	GetHash(key string) ([]byte, error)
+	// HasChanged indicates if the key state has changed and needs to be updated in the snapshot
+	HasChanged(key string) bool
 	// NB: GetState must be threadsafe as it may be called from multiple goroutines concurrently!
 	GetState(key string) ([]byte, []StateProvider, error)
 	LoadState(ctx context.Context, pl *Payload) ([]StateProvider, error)

--- a/validators/erc20multisig/topology.go
+++ b/validators/erc20multisig/topology.go
@@ -81,7 +81,7 @@ type Topology struct {
 	keyToSerialiser map[string]func() ([]byte, error)
 
 	ethEventSource EthereumEventSource
-	lock           sync.Mutex
+	lock           sync.RWMutex
 }
 
 type pendingSigner struct {
@@ -123,7 +123,6 @@ func NewTopology(
 		witnessedThresholds: map[string]struct{}{},
 		witnessedSigners:    map[string]struct{}{},
 		tss: &topologySnapshotState{
-			hash:       map[string][]byte{},
 			serialised: map[string][]byte{},
 			changed: map[string]bool{
 				verifiedStateKey: true,

--- a/validators/topology_snapshot_test.go
+++ b/validators/topology_snapshot_test.go
@@ -27,10 +27,6 @@ func TestEmptySnapshot(t *testing.T) {
 	top := getTestTopology(t)
 	defer top.ctrl.Finish()
 
-	h, err := top.GetHash(topKey)
-	assert.Nil(t, err)
-	assert.NotEmpty(t, h)
-
 	s, p, err := top.GetState(topKey)
 	assert.Nil(t, err)
 	assert.Empty(t, p)
@@ -43,16 +39,16 @@ func TestChangeOnValidatorPerfUpdate(t *testing.T) {
 	top := getTestTopology(t)
 	defer top.ctrl.Finish()
 
-	h, err := top.GetHash(topKey)
+	s, _, err := top.GetState(topKey)
 	assert.Nil(t, err)
-	assert.NotEmpty(t, h)
+	assert.NotEmpty(t, s)
 
 	updateValidatorPerformanceToNonDefaultState(t, top.Topology)
 
-	h2, err := top.GetHash(topKey)
+	s2, _, err := top.GetState(topKey)
 	assert.Nil(t, err)
-	assert.NotEmpty(t, h2)
-	require.NotEqual(t, h, h2)
+	assert.NotEmpty(t, s2)
+	require.False(t, bytes.Equal(s, s2))
 }
 
 func TestTopologySnapshot(t *testing.T) {
@@ -60,7 +56,7 @@ func TestTopologySnapshot(t *testing.T) {
 	updateValidatorPerformanceToNonDefaultState(t, top.Topology)
 	defer top.ctrl.Finish()
 
-	h1, err := top.GetHash(topKey)
+	s1, _, err := top.GetState(topKey)
 	require.Nil(t, err)
 
 	tmPubKeys := []string{"2w5hxsVqWFTV6/f0swyNVqOhY1vWI42MrfO0xkUqsiA=", "67g7+123M0kfMR35U7LLq09eEU1dVr6jHBEgEtPzkrs="}
@@ -119,9 +115,9 @@ func TestTopologySnapshot(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check the hashes have changed after each state change
-	h3, err := top.GetHash(topKey)
+	s3, _, err := top.GetState(topKey)
 	require.Nil(t, err)
-	require.False(t, bytes.Equal(h1, h3))
+	require.False(t, bytes.Equal(s1, s3))
 
 	// Get the state ready to load into a new instance of the engine
 	state, _, _ := top.GetState(topKey)
@@ -137,9 +133,9 @@ func TestTopologySnapshot(t *testing.T) {
 	require.Nil(t, err)
 
 	// Check the new reloaded engine is the same as the original
-	h4, err := snapTop.GetHash(topKey)
+	s4, _, err := snapTop.GetState(topKey)
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(h3, h4))
+	require.True(t, bytes.Equal(s3, s4))
 	assert.ElementsMatch(t, top.AllNodeIDs(), snapTop.AllNodeIDs())
 	assert.ElementsMatch(t, top.AllVegaPubKeys(), snapTop.AllVegaPubKeys())
 	assert.Equal(t, top.IsValidator(), snapTop.IsValidator())

--- a/validators/witness.go
+++ b/validators/witness.go
@@ -162,7 +162,6 @@ func NewWitness(log *logging.Logger, cfg Config, top ValidatorTopology, cmd Comm
 		validatorVotesRequired: defaultValidatorsVoteRequired,
 		wss: &witnessSnapshotState{
 			changed:    true,
-			hash:       []byte{},
 			serialised: []byte{},
 		},
 	}

--- a/validators/witness_snapshot.go
+++ b/validators/witness_snapshot.go
@@ -9,7 +9,6 @@ import (
 
 	"code.vegaprotocol.io/vega/libs/proto"
 
-	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/types"
 )
@@ -26,7 +25,6 @@ var (
 
 type witnessSnapshotState struct {
 	changed    bool
-	hash       []byte
 	serialised []byte
 	mu         sync.Mutex
 }
@@ -39,7 +37,7 @@ func (w *Witness) Keys() []string {
 	return hashKeys
 }
 
-func (w *Witness) serialise() ([]byte, error) {
+func (w *Witness) serialiseWitness() ([]byte, error) {
 	w.log.Debug("serialising witness resources", logging.Int("n", len(w.resources)))
 	resources := make([]*types.Resource, 0, len(w.resources))
 	for id, r := range w.resources {
@@ -71,39 +69,38 @@ func (w *Witness) serialise() ([]byte, error) {
 	return proto.Marshal(x)
 }
 
-// get the serialised form and hash of the given key.
-func (w *Witness) getSerialisedAndHash(k string) ([]byte, []byte, error) {
+// get the serialised form of the given key.
+func (w *Witness) serialise(k string) ([]byte, error) {
 	if k != key {
-		return nil, nil, ErrSnapshotKeyDoesNotExist
+		return nil, ErrSnapshotKeyDoesNotExist
 	}
 
 	w.wss.mu.Lock()
 	defer w.wss.mu.Unlock()
 	if !w.wss.changed {
-		return w.wss.serialised, w.wss.hash, nil
+		return w.wss.serialised, nil
 	}
 
-	data, err := w.serialise()
+	data, err := w.serialiseWitness()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	hash := crypto.Hash(data)
 	w.wss.serialised = data
-	w.wss.hash = hash
 	w.wss.changed = false
-	return data, hash, nil
+	return data, nil
 }
 
 func (w *Witness) Stopped() bool { return false }
 
-func (w *Witness) GetHash(k string) ([]byte, error) {
-	_, hash, err := w.getSerialisedAndHash(k)
-	return hash, err
+func (w *Witness) HasChanged(k string) bool {
+	w.wss.mu.Lock()
+	defer w.wss.mu.Unlock()
+	return w.wss.changed
 }
 
 func (w *Witness) GetState(k string) ([]byte, []types.StateProvider, error) {
-	state, _, err := w.getSerialisedAndHash(k)
+	state, err := w.serialise(k)
 	return state, nil, err
 }
 
@@ -114,13 +111,13 @@ func (w *Witness) LoadState(ctx context.Context, p *types.Payload) ([]types.Stat
 	// see what we're reloading
 	switch pl := p.Data.(type) {
 	case *types.PayloadWitness:
-		return nil, w.restore(ctx, pl.Witness)
+		return nil, w.restore(ctx, pl.Witness, p)
 	default:
 		return nil, types.ErrUnknownSnapshotType
 	}
 }
 
-func (w *Witness) restore(ctx context.Context, witness *types.Witness) error {
+func (w *Witness) restore(ctx context.Context, witness *types.Witness, p *types.Payload) error {
 	w.resources = map[string]*res{}
 	w.needResendRes = map[string]struct{}{}
 
@@ -149,9 +146,11 @@ func (w *Witness) restore(ctx context.Context, witness *types.Witness) error {
 	}
 
 	w.wss.mu.Lock()
-	w.wss.changed = true
+	var err error
+	w.wss.changed = false
+	w.wss.serialised, err = proto.Marshal(p.IntoProto())
 	w.wss.mu.Unlock()
-	return nil
+	return err
 }
 
 func (w *Witness) RestoreResource(r Resource, cb func(interface{}, bool)) error {


### PR DESCRIPTION
Closes #5343 #5342 #5337 #5345

Summary of changes included here:
1. Get rid of unnecessary getHash in all snapshot engines 
2. This is replaced by hasChanged implemented in all engines
3. This comes with a change in the semantics of resetting the changed flags after restore 
4. Fixes for determinism in processing the results of snapshot nodes in the snapshot engine
5. Fix for concurrency issue reported by Jake
6. Fix for a long standing bug in removing a tree key from the snapshot

Two additional issues fixed, related to state variable and the error message found in logs saying "failed to send command for x"