### PR TITLE
Do not panic when node is interrupted before snapshot engine gets cleared and initialised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [5313](https://github.com/vegaprotocol/vega/issues/5313) - Future update was using oracle spec for settlement price as trading termination spec
 - [5304](https://github.com/vegaprotocol/vega/issues/5304) - Fix bug causing trade events at auction end showing the wrong price.
 - [5345](https://github.com/vegaprotocol/vega/issues/5345) - Fix issue with state variable transactions assumed gone missing
+- [5351](https://github.com/vegaprotocol/vega/issues/5351) - Fix panic when node is interrupted before snapshot engine gets cleared and initialised
 
 ## 0.50.2
 

--- a/snapshot/engine.go
+++ b/snapshot/engine.go
@@ -292,8 +292,8 @@ func (e *Engine) populateLocalVersions(versions []int) {
 	}
 }
 
-// Loaded will return whether we have loaded from a snapshot. If we have loaded
-// via stat-sync we will already know, if we are loading from local store then we do that
+// CheckLoaded will return whether we have loaded from a snapshot. If we have loaded
+// via stat-sync we will already know if we are loading from local store, then we do that
 // node.
 func (e *Engine) CheckLoaded() (bool, error) {
 	// if the avl has been initialised we must have loaded it earlier via using state-sync
@@ -1054,7 +1054,10 @@ func (e *Engine) Close() error {
 			p.Sync()
 		}
 	}
-	return e.db.Close()
+	if e.db != nil {
+		return e.db.Close()
+	}
+	return nil
 }
 
 func (e *Engine) OnSnapshotIntervalUpdate(ctx context.Context, interval int64) error {


### PR DESCRIPTION
Close #5351 