### PR TITLE
fix: liquidity parameters set in the market take precedence over netw…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [5362](https://github.com/vegaprotocol/vega/issues/5362) - Liquidity and order book point to same underlying order after restore
 - [5367](https://github.com/vegaprotocol/vega/issues/5367) - better serialisation for party orders in liquidity snapshot
 - [5377](https://github.com/vegaprotocol/vega/issues/5377) - Serialise state var internal state 
+- [5203](https://github.com/vegaprotocol/vega/issues/5203) - Market liquidity monitor parameters trump network parameters on market creation
 
 ## 0.51.0
 

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -453,12 +453,6 @@ func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) err
 		}
 	}
 
-	if !e.npv.targetStakeScalingFactor.Equal(num.DecimalFromInt64(-1)) {
-		if err := mkt.OnMarketTargetStakeScalingFactorUpdate(e.npv.targetStakeScalingFactor); err != nil {
-			return err
-		}
-	}
-
 	if !e.npv.infrastructureFee.Equal(num.DecimalFromInt64(-1)) {
 		if err := mkt.OnFeeFactorsInfrastructureFeeUpdate(ctx, e.npv.infrastructureFee); err != nil {
 			return err
@@ -479,10 +473,6 @@ func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) err
 
 	if e.npv.feeDistributionTimeStep != -1 {
 		mkt.OnMarketLiquidityProvidersFeeDistribitionTimeStep(e.npv.feeDistributionTimeStep)
-	}
-
-	if e.npv.timeWindowUpdate != -1 {
-		mkt.OnMarketTargetStakeTimeWindowUpdate(e.npv.timeWindowUpdate)
 	}
 
 	if e.npv.marketValueWindowLength != -1 {

--- a/execution/engine.go
+++ b/execution/engine.go
@@ -106,8 +106,6 @@ type Engine struct {
 type netParamsValues struct {
 	shapesMaxSize                   int64
 	feeDistributionTimeStep         time.Duration
-	timeWindowUpdate                time.Duration
-	targetStakeScalingFactor        num.Decimal
 	marketValueWindowLength         time.Duration
 	suppliedStakeToObligationFactor num.Decimal
 	infrastructureFee               num.Decimal
@@ -115,7 +113,6 @@ type netParamsValues struct {
 	scalingFactors                  *types.ScalingFactors
 	maxLiquidityFee                 num.Decimal
 	bondPenaltyFactor               num.Decimal
-	targetStakeTriggeringRatio      num.Decimal
 	auctionMinDuration              time.Duration
 	probabilityOfTradingTauScaling  num.Decimal
 	minProbabilityOfTradingLPOrders num.Decimal
@@ -126,8 +123,6 @@ func defaultNetParamsValues() netParamsValues {
 	return netParamsValues{
 		shapesMaxSize:                   -1,
 		feeDistributionTimeStep:         -1,
-		timeWindowUpdate:                -1,
-		targetStakeScalingFactor:        num.DecimalFromInt64(-1),
 		marketValueWindowLength:         -1,
 		suppliedStakeToObligationFactor: num.DecimalFromInt64(-1),
 		infrastructureFee:               num.DecimalFromInt64(-1),
@@ -135,7 +130,6 @@ func defaultNetParamsValues() netParamsValues {
 		scalingFactors:                  nil,
 		maxLiquidityFee:                 num.DecimalFromInt64(-1),
 		bondPenaltyFactor:               num.DecimalFromInt64(-1),
-		targetStakeTriggeringRatio:      num.DecimalFromInt64(-1),
 		auctionMinDuration:              -1,
 		probabilityOfTradingTauScaling:  num.DecimalFromInt64(-1),
 		minProbabilityOfTradingLPOrders: num.DecimalFromInt64(-1),
@@ -485,9 +479,7 @@ func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *Market) err
 	if !e.npv.bondPenaltyFactor.Equal(num.DecimalFromInt64(-1)) {
 		mkt.BondPenaltyFactorUpdate(ctx, e.npv.bondPenaltyFactor)
 	}
-	if !e.npv.targetStakeTriggeringRatio.Equal(num.DecimalFromInt64(-1)) {
-		mkt.OnMarketLiquidityTargetStakeTriggeringRatio(ctx, e.npv.targetStakeTriggeringRatio)
-	}
+
 	if !e.npv.maxLiquidityFee.Equal(num.DecimalFromInt64(-1)) {
 		mkt.OnMarketLiquidityMaximumLiquidityFeeFactorLevelUpdate(e.npv.maxLiquidityFee)
 	}
@@ -948,9 +940,6 @@ func (e *Engine) OnMarketTargetStakeScalingFactorUpdate(_ context.Context, d num
 			return err
 		}
 	}
-
-	e.npv.targetStakeScalingFactor = d
-
 	return nil
 }
 
@@ -964,9 +953,6 @@ func (e *Engine) OnMarketTargetStakeTimeWindowUpdate(_ context.Context, d time.D
 	for _, mkt := range e.marketsCpy {
 		mkt.OnMarketTargetStakeTimeWindowUpdate(d)
 	}
-
-	e.npv.timeWindowUpdate = d
-
 	return nil
 }
 
@@ -1032,9 +1018,6 @@ func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context
 	for _, mkt := range e.marketsCpy {
 		mkt.OnMarketLiquidityTargetStakeTriggeringRatio(ctx, d)
 	}
-
-	e.npv.targetStakeTriggeringRatio = d
-
 	return nil
 }
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -125,7 +125,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		return steps.TheMarginCalculator(marketConfig, name, table)
 	})
 	s.Step(`^the markets:$`, func(table *godog.Table) error {
-		markets, err := steps.TheMarkets(marketConfig, execsetup.executionEngine, execsetup.collateralEngine, table)
+		markets, err := steps.TheMarkets(marketConfig, execsetup.executionEngine, execsetup.collateralEngine, execsetup.netParams, table)
 		execsetup.markets = markets
 		return err
 	})

--- a/integration/steps/the_markets.go
+++ b/integration/steps/the_markets.go
@@ -9,6 +9,7 @@ import (
 	proto "code.vegaprotocol.io/protos/vega"
 	"code.vegaprotocol.io/vega/collateral"
 	"code.vegaprotocol.io/vega/integration/steps/market"
+	"code.vegaprotocol.io/vega/netparams"
 	"code.vegaprotocol.io/vega/types"
 	"code.vegaprotocol.io/vega/types/num"
 )
@@ -17,12 +18,14 @@ func TheMarkets(
 	config *market.Config,
 	executionEngine Execution,
 	collateralEngine *collateral.Engine,
+	netparams *netparams.Store,
 	table *godog.Table,
 ) ([]types.Market, error) {
 	rows := parseMarketsTable(table)
 	markets := make([]types.Market, 0, len(rows))
+
 	for _, row := range rows {
-		mkt := newMarket(config, marketRow{row: row})
+		mkt := newMarket(config, netparams, marketRow{row: row})
 		markets = append(markets, mkt)
 	}
 
@@ -95,7 +98,7 @@ func enableVoteAsset(collateralEngine *collateral.Engine) error {
 	return nil
 }
 
-func newMarket(config *market.Config, row marketRow) types.Market {
+func newMarket(config *market.Config, netparams *netparams.Store, row marketRow) types.Market {
 	fees, err := config.FeesConfig.Get(row.fees())
 	if err != nil {
 		panic(err)
@@ -124,6 +127,19 @@ func newMarket(config *market.Config, row marketRow) types.Market {
 	marginCalculator, err := config.MarginCalculators.Get(row.marginCalculator())
 	if err != nil {
 		panic(err)
+	}
+
+	// the governance engine would fill in the liquidity monitor parameters from the network parameters (unless set explicitly)
+	// so we need to do this here by hand. If the network parameters weren't set we use the below defaults
+	timeWindow := int64(3600)
+	scalingFactor := num.MustDecimalFromString("10")
+
+	if tw, err := netparams.GetDuration("market.stake.target.timeWindow"); err == nil {
+		timeWindow = int64(tw.Seconds())
+	}
+
+	if sf, err := netparams.GetDecimal("market.stake.target.scalingFactor"); err == nil {
+		scalingFactor = sf
 	}
 
 	m := types.Market{
@@ -161,8 +177,8 @@ func newMarket(config *market.Config, row marketRow) types.Market {
 		PriceMonitoringSettings: types.PriceMonitoringSettingsFromProto(priceMonitoring),
 		LiquidityMonitoringParameters: &types.LiquidityMonitoringParameters{
 			TargetStakeParameters: &types.TargetStakeParameters{
-				TimeWindow:    3600,
-				ScalingFactor: num.DecimalFromInt64(10),
+				TimeWindow:    timeWindow,
+				ScalingFactor: scalingFactor,
 			},
 			TriggeringRatio: num.DecimalFromInt64(0),
 		},

--- a/integration/steps/the_markets.go
+++ b/integration/steps/the_markets.go
@@ -132,7 +132,8 @@ func newMarket(config *market.Config, netparams *netparams.Store, row marketRow)
 	// the governance engine would fill in the liquidity monitor parameters from the network parameters (unless set explicitly)
 	// so we need to do this here by hand. If the network parameters weren't set we use the below defaults
 	timeWindow := int64(3600)
-	scalingFactor := num.MustDecimalFromString("10")
+	scalingFactor := num.DecimalFromInt64(10)
+	triggeringRatio := num.DecimalFromInt64(0)
 
 	if tw, err := netparams.GetDuration("market.stake.target.timeWindow"); err == nil {
 		timeWindow = int64(tw.Seconds())
@@ -140,6 +141,10 @@ func newMarket(config *market.Config, netparams *netparams.Store, row marketRow)
 
 	if sf, err := netparams.GetDecimal("market.stake.target.scalingFactor"); err == nil {
 		scalingFactor = sf
+	}
+
+	if tr, err := netparams.GetDecimal("market.liquidity.targetstake.triggering.ratio"); err == nil {
+		triggeringRatio = tr
 	}
 
 	m := types.Market{
@@ -180,7 +185,7 @@ func newMarket(config *market.Config, netparams *netparams.Store, row marketRow)
 				TimeWindow:    timeWindow,
 				ScalingFactor: scalingFactor,
 			},
-			TriggeringRatio: num.DecimalFromInt64(0),
+			TriggeringRatio: triggeringRatio,
 		},
 	}
 


### PR DESCRIPTION
closes #5203 also related to #5232

The issue was that no matter what values you set in your market proposal for `TargetStakeParameters` we would *always* create the market setting those value from the equivalent global network parameters.

Why did this also cause a problem with snapshots, I hear you ask? The same code that was overwriting the market's `TargetStakeParameters` value with the netparams is also called when restoring a market. So in the case where a market-update would move the time-window away from the network parameter value, on restore we would repopulate that value correctly but then reset it to the network parameter in `propagateInitialNetParams()` and then we'd fall out of consensus.

There is a related system-test issue that will hopefully result in us getting some good coverage on this: https://github.com/vegaprotocol/system-tests/issues/783 but its actually quite hard to test because through the API it looks like we've used the values in the marketConfig, but they actually aren't what have been propagated into the engines.