### PR TITLE
fix: better serialisation for party orders in liquidity snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Fixes
 - [5362](https://github.com/vegaprotocol/vega/issues/5362) - Liquidity and order book point to same underlying order after restore
-
+- [5367](https://github.com/vegaprotocol/vega/issues/5367) - better serialisation for party orders in liquidity snapshot
 ## 0.51.0
 
 ### 🚨 Breaking changes

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3
-	code.vegaprotocol.io/protos v0.51.1-0.20220517145005-fc5e0192af7c
+	code.vegaprotocol.io/protos v0.51.1-0.20220518193313-c80dffa05180
 	code.vegaprotocol.io/quant v0.2.5
 	code.vegaprotocol.io/shared v0.0.0-20220321185018-3b5684b00533
 	code.vegaprotocol.io/vegawallet v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3 h1:/A09Q3EEiJF+/WiJfKiqzp1zvcWphiYR8lf2N/JSJBU=
 code.vegaprotocol.io/oracles-relay v0.0.0-20210201140234-f047e1bf6df3/go.mod h1:1Gwg5D0PbFEE92Vip8EU0/+n80Kx3GwlGvP850S0op8=
-code.vegaprotocol.io/protos v0.51.1-0.20220517145005-fc5e0192af7c h1:UtDLlSEiMHY8gNb4nHtJWhN59mu5GPXVymdAJ7UrQJ0=
-code.vegaprotocol.io/protos v0.51.1-0.20220517145005-fc5e0192af7c/go.mod h1:4BqwDw6jhc/mnwbXq8ZFUtYBFCnk8tBW6zuPsBt8OrQ=
+code.vegaprotocol.io/protos v0.51.1-0.20220518193313-c80dffa05180 h1:f8RSJf+AbQNett2K8tpoQ91RGChZFCbNWt4EZH2t5OI=
+code.vegaprotocol.io/protos v0.51.1-0.20220518193313-c80dffa05180/go.mod h1:4BqwDw6jhc/mnwbXq8ZFUtYBFCnk8tBW6zuPsBt8OrQ=
 code.vegaprotocol.io/quant v0.2.5 h1:8h+TTHdz1LCO4oGXt8mbowXszd8CQP1MHlJOkthUp1E=
 code.vegaprotocol.io/quant v0.2.5/go.mod h1:HEzOoPKj8OIP49r9AZYeo5281M5ygeGWxopwvt8k6Es=
 code.vegaprotocol.io/shared v0.0.0-20220321185018-3b5684b00533 h1:IxTWvyF0i0AgUAS+FTgQKIpbsS6Ki/Y9Ug0GSlgChJw=

--- a/liquidity/snapshot_test.go
+++ b/liquidity/snapshot_test.go
@@ -94,8 +94,8 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 	expectedHashes := map[string]string{
 		"parameters:market-id":             "d663375fd6843a0807d17b10ad8425a6ba45c8c2dd6339f400c5b2426f900c13",
-		"partiesLiquidityOrders:market-id": "0254d8b74441ca3bac8f9b141408502d9b1f297e8ef1054d45775566677a8072",
-		"partiesOrders:market-id":          "f9cb31b1c4c8df91f6a348d43978c302c8887336107c265259bc74fdddf00e19",
+		"partiesLiquidityOrders:market-id": "bfe546e1a60738daedbfd2edb54738dd19bf9ac154490d13395bc0f30d2b120c",
+		"partiesOrders:market-id":          "9bac769916db894ee5f1f78291e7b793a58a9362e6994fc93f1aa3441ad40e4b",
 		"pendingProvisions:market-id":      "6cc4d407a2ea45e37e27993eb6f94134b3f906d080777d94bf99551aa82dc461",
 		"provisions:market-id":             "7c76902e145d0eaf0abb83382575c027097abdb418364c351e2ad085e1c69c3e",
 		"liquiditySupplied:market-id":      "3276bba2a77778ba710ec29e3a6e59212452dbda69eaac8f9160930d1270da1d",
@@ -133,8 +133,8 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 	expectedHashes2 := map[string]string{
 		"parameters:market-id":             "b5eec91c297baf1f06830350dbcb37d79937561ae605d2304eb12680e443775c",
-		"partiesLiquidityOrders:market-id": "c29d0b4d9265cf7951cc396ce8d6350ab7b2e978782423c4090842cbb2619f76",
-		"partiesOrders:market-id":          "f9cb31b1c4c8df91f6a348d43978c302c8887336107c265259bc74fdddf00e19",
+		"partiesLiquidityOrders:market-id": "234f3b3010c174f180fc8a12060b3feb93eefa4026055371843f50cc77676c4b",
+		"partiesOrders:market-id":          "03c49ce221938e53db03110ac4a377de0bd6bc1f8feffbafeec4ddbde11cb247",
 		"pendingProvisions:market-id":      "627ef55af7f36bea0d09b0081b85d66531a01df060d8e9447e17049a4e152b12",
 		"provisions:market-id":             "89335d14e98ca80b144cb6502e9b508d97d63027ba0c7733d6024030cdf102ed",
 		"liquiditySupplied:market-id":      "3276bba2a77778ba710ec29e3a6e59212452dbda69eaac8f9160930d1270da1d",


### PR DESCRIPTION
Closes #5367 