### PR TITLE
fix: actually restore market parties

### DIFF
--- a/execution/market.go
+++ b/execution/market.go
@@ -666,6 +666,7 @@ func (m *Market) PostRestore(ctx context.Context) error {
 	for _, o := range m.peggedOrders.GetAll() {
 		parties[o.Party] = struct{}{}
 	}
+	m.parties = parties
 	return nil
 }
 

--- a/execution/market_snapshot.go
+++ b/execution/market_snapshot.go
@@ -122,7 +122,7 @@ func NewMarketFromSnapshot(
 		broker:                     broker,
 		fee:                        feeEngine,
 		liquidity:                  liqEngine,
-		parties:                    map[string]struct{}{}, // parties will be restored on chain time update
+		parties:                    map[string]struct{}{}, // parties will be restored on PostRestore
 		lMonitor:                   lMonitor,
 		tsCalc:                     tsCalc,
 		feeSplitter:                NewFeeSplitterFromSnapshot(em.FeeSplitter, now),


### PR DESCRIPTION
Was causing _a lot_ of issues trying to settle a market after a snapshot restore.