### PR TITLE
fix: set from_epoch in validator-update event so that data-node knows…

### DIFF
--- a/validators/validator_set.go
+++ b/validators/validator_set.go
@@ -198,6 +198,7 @@ func (t *Topology) RecalcValidatorSet(ctx context.Context, epochSeq string, dele
 		// if the node hasn't had a positive score for more than 10 epochs it is dropped
 		if int64(t.currentBlockHeight)-t.validators[k].lastBlockWithPositiveRanking > t.blocksToKeepMalperforming {
 			t.log.Info("removing validator with 0 positive ranking for too long", logging.String("node-id", k))
+			t.validators[k].data.FromEpoch = t.epochSeq
 			t.sendValidatorUpdateEvent(ctx, t.validators[k].data, false)
 			delete(t.validators, k)
 		}


### PR DESCRIPTION
… when nodes were removed

related to https://github.com/vegaprotocol/data-node/issues/627, we need the epoch that a node was removed for the data-node to be able to robustly determine which epochs a node existed/didn't exist in.