### PR TITLE
Bring indicative trades in line with actual uncrossing trade price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [3362](https://github.com/vegaprotocol/vega/issues/3362) - Stop non-persistent orders from triggering auctions
 - [5388](https://github.com/vegaprotocol/vega/issues/5388) - Use `UnixNano()` to snapshot price monitor times
 - [5237](https://github.com/vegaprotocol/vega/issues/5237) - Trigger state variable calculation first time indicative uncrossing price is available
+- [5397](https://github.com/vegaprotocol/vega/issues/5397) - Bring indicative trades price inline with that of actual auction uncrossing trades
 
 ## 0.51.0
 

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -437,14 +437,6 @@ func (b *OrderBook) GetIndicativeTrades() ([]*types.Trade, error) {
 
 	// Remove all the orders from that side of the book up to the given volume
 	uncrossOrders = uncrossingSide.ExtractOrders(price, volume, false)
-	if len(uncrossOrders) == 0 {
-		return nil, nil
-	}
-	// get price factor, if price is 10,000, but market price is 100, this is 10,000/100 -> 100
-	// so we can get the market price simply by doing price / (order.Price/ order.OriginalPrice)
-	mPrice := num.Zero().Div(uncrossOrders[0].Price, uncrossOrders[0].OriginalPrice)
-	mPrice.Div(price, mPrice)
-
 	opSide := b.getOppositeSide(uncrossSide)
 	output := make([]*types.Trade, 0, len(uncrossOrders))
 	for _, o := range uncrossOrders {
@@ -455,7 +447,6 @@ func (b *OrderBook) GetIndicativeTrades() ([]*types.Trade, error) {
 		// Update all the trades to have the correct uncrossing price
 		for index := 0; index < len(trades); index++ {
 			trades[index].Price = price.Clone()
-			trades[index].MarketPrice = mPrice.Clone()
 		}
 		output = append(output, trades...)
 	}

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -2596,11 +2596,23 @@ func TestOrderBook_IndicativePriceAndVolume1(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, price.Uint64(), uint64(101))
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, len(uncrossedOrders), 1)
 	assert.Equal(t, len(cancels), 0)
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_IndicativePriceAndVolume2(t *testing.T) {
@@ -2635,11 +2647,24 @@ func TestOrderBook_IndicativePriceAndVolume2(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, uint64(100), price.Uint64())
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(uncrossedOrders))
 	assert.Equal(t, 0, len(cancels))
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_IndicativePriceAndVolume3(t *testing.T) {
@@ -2671,11 +2696,24 @@ func TestOrderBook_IndicativePriceAndVolume3(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, 100, int(price.Uint64()))
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(uncrossedOrders))
 	assert.Equal(t, 0, len(cancels))
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_IndicativePriceAndVolume4(t *testing.T) {
@@ -2707,11 +2745,24 @@ func TestOrderBook_IndicativePriceAndVolume4(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, uint64(0), price.Uint64())
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, len(uncrossedOrders), 0)
 	assert.Equal(t, len(cancels), 0)
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_IndicativePriceAndVolume5(t *testing.T) {
@@ -2757,11 +2808,24 @@ func TestOrderBook_IndicativePriceAndVolume5(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, uint64(99), price.Uint64())
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(uncrossedOrders))
 	assert.Equal(t, 0, len(cancels))
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 // Set up an auction so that the sell side is processed when we uncross.
@@ -2796,11 +2860,24 @@ func TestOrderBook_IndicativePriceAndVolume6(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, 101, int(price.Uint64()))
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, len(uncrossedOrders), 1)
 	assert.Equal(t, len(cancels), 0)
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 // Check that multiple orders per price level work.
@@ -2839,11 +2916,24 @@ func TestOrderBook_IndicativePriceAndVolume7(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, uint64(99), price.Uint64())
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(uncrossedOrders))
 	assert.Equal(t, 0, len(cancels))
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_IndicativePriceAndVolume8(t *testing.T) {
@@ -2881,11 +2971,24 @@ func TestOrderBook_IndicativePriceAndVolume8(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, 99, int(price.Uint64()))
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, 8, len(uncrossedOrders))
 	assert.Equal(t, 0, len(cancels))
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_IndicativePriceAndVolume9(t *testing.T) {
@@ -2920,11 +3023,24 @@ func TestOrderBook_IndicativePriceAndVolume9(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, 303, int(price.Uint64()))
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(uncrossedOrders))
 	assert.Equal(t, 0, len(cancels))
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 func TestOrderBook_UncrossTest1(t *testing.T) {
@@ -2962,11 +3078,24 @@ func TestOrderBook_UncrossTest1(t *testing.T) {
 	price = book.ob.GetIndicativePrice()
 	assert.Equal(t, price.Uint64(), uint64(100))
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	for _, x := range trades {
+		assert.Equal(t, price, x.Price)
+	}
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, len(uncrossedOrders), 1)
 	assert.Equal(t, len(cancels), 2)
+
+	for _, o := range uncrossedOrders {
+		for _, x := range o.Trades {
+			assert.Equal(t, price, x.Price)
+		}
+	}
 }
 
 // this is a test for issue 2060 to ensure we process FOK orders properly.


### PR DESCRIPTION
~Bring changes from https://github.com/vegaprotocol/vega/pull/5309 to `orderbook.GetIndicativeTrades()` so that it's in line with `orderbook.uncrossBookSide(...)` + extend unit tests to assure the two result in equivalent trade prices.~

Bring `orderbook.GetIndicativeTrades()` in line with `orderbook.uncrossBookSide(...)` by overwriting the uncrossing price. Otherwise it cannot be reliably used in auction monitoring trigger evaluation. 

Closes #5397 

