### PR TITLE
5388 statevar snapshot

### DIFF
--- a/banking/erc20.go
+++ b/banking/erc20.go
@@ -34,6 +34,7 @@ func (e *Engine) EnableERC20(
 		hash:        txHash,
 	}
 	e.assetActs[aa.id] = aa
+	e.bss.changedAssetActions = true
 	return e.witness.StartCheck(aa, e.onCheckDone, e.currentTime.Add(defaultValidationDuration))
 }
 

--- a/statevar/snapshot.go
+++ b/statevar/snapshot.go
@@ -162,9 +162,6 @@ func (e *Engine) postRestore(stateVariablesInternalState []*snapshot.StateVarInt
 			kvb, _ := statevar.KeyValueBundleFromProto(fpvr.Bundle)
 			sv.validatorResults[fpvr.Id] = kvb
 		}
-		if sv.eventID != "" {
-			sv.startCalculation(sv.eventID, sv)
-		}
 	}
 }
 


### PR DESCRIPTION
part of #5388 

We need to not kick off a new state-var calculation when we restore from a snapshot. The reason is because the state of core is not the same as when it was originally calculated. I have seen a case where we have this chain of events: 
```
block N: 
    - state-var-calculation happens with a healthy order book
block N+1: 
    - all orders are remove from the book
    - we take a snapshot
block N+2:
    - the state-var bundle comes in, consensus is reached
```
when we restore from the snapshot and restart the calculation we have
```
block N+1:
    - restore order book (which is now empty)
    - restore state-var, and start the calculation
    - the orderbook is empty so the calculation fails (because it should), and we set eventID = ""
block N+2:
    - the state-var bundles comes in during replay, it is rejected because the eventID is now stale
```
the state is then different at the next snapshot, we crash a burn.
