### PR TITLE
fix: fix notary snapshot determinism when no signature are generated yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🛠 Improvements
+- [5415](https://github.com/vegaprotocol/vega/issues/5421) - Fix notary snapshot determinism when no signature are generated yet
 - [5415](https://github.com/vegaprotocol/vega/issues/5415) - Regenerate smart contracts code
 
 ### 🐛 Fixes

--- a/notary/snapshot.go
+++ b/notary/snapshot.go
@@ -161,6 +161,14 @@ func (n *SnapshotNotary) serialiseNotary() ([]byte, error) {
 	}
 
 	sort.SliceStable(sigs, func(i, j int) bool {
+		// sigs could be "" so we need to sort on ID as well
+		switch strings.Compare(sigs[i].ID, sigs[j].ID) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+
 		return sigs[i].Sig < sigs[j].Sig
 	})
 


### PR DESCRIPTION
closes #5421 (probably)

I managed to catch it failing when I had enough logs on in the snapshot engine to tell me where the problem was. This issue is in `notary` where we sort the node-signatures only by the signature strings. In the case where we take a snapshot before any signatures have come in, [the signatures are set to `""`](https://github.com/vegaprotocol/vega/blob/develop/notary/snapshot.go#L157) and its possible that we could have two separate withdrawls happening where we haven't yet had signatures in. So we'll sort two `""`'s in an non-deterministic way since their source is an iteration over a map.