### PR TITLE
Bug when making market order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [5444](https://github.com/vegaprotocol/vega/issues/5444) - Merge both checkpoints and genesis asset on startup
 - [5446](https://github.com/vegaprotocol/vega/issues/5446) - Cover liquidity monitoring acceptance criteria relating to aggressive order removing best bid or ask from the book
 - [5457](https://github.com/vegaprotocol/vega/issues/5457) - Fix sorting of validators for demotion check
+- [5460](https://github.com/vegaprotocol/vega/issues/5460) - Fix theoretical open interest calculation
 
 ## 0.51.1
 

--- a/integration/features/auctions/5460-market-order-cannot-trade-due-to-auction.feature
+++ b/integration/features/auctions/5460-market-order-cannot-trade-due-to-auction.feature
@@ -1,4 +1,4 @@
-Feature: Test interactions between different auction types with Market Orders
+Feature: Test for issue 5460
 
   Background:
     Given the following network parameters are set:
@@ -35,7 +35,7 @@ Feature: Test interactions between different auction types with Market Orders
       | party_r  | ETH | 10000000000000000  |
       | party_r1 | ETH | 10000000000000000  |
 
-  Scenario: 001 Once market is in continuous trading mode: post a non-persistent order that should trigger liquidity auction (not enough target stake), appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS (0026-AUCT-001, 0026-AUCT-005)
+  Scenario: 001 post market order
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -60,17 +60,17 @@ Feature: Test interactions between different auction types with Market Orders
     
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 100000000  | TRADING_MODE_CONTINUOUS | 43200   | 82056031  | 121701233 | 54210000     | 100000000      | 1000000            |
+      | 100000000  | TRADING_MODE_CONTINUOUS | 43200   | 82056031  | 121701233 | 54210000     | 100000000      | 1000000       |
 
     Then the parties place the following orders:
-      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
-      | party1 | ETH/DEC21 | buy  | 2000000| 101000000  | 4           | TYPE_MARKET| TIF_GFN | ref-ref   | 
+      | party  | market id | side | volume | price     | resulting trades | type        | tif     | reference | 
+      | party1 | ETH/DEC21 | buy  | 2000000| 101000000 | 4                | TYPE_MARKET | TIF_GFN | ref-ref   | 
 
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 110000000  | TRADING_MODE_MONITORING_AUCTION | 43200   | 82056031  | 121701233      | 84115906        | 100000000           | 1410607            |
+      | 110000000  | TRADING_MODE_MONITORING_AUCTION | 43200   | 82056031  | 121701233 | 84115906     | 100000000      | 1410607       |
 
-Scenario: 002 replicate bug from Galen
+Scenario: 002 replicate bug
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -97,7 +97,6 @@ Scenario: 002 replicate bug from Galen
      | party_r  | ETH/DEC21 | buy  | 100000 | 29977    | 0                | TYPE_LIMIT | TIF_GTC |
      | party_r  | ETH/DEC21 | buy  | 100000 | 29967    | 0                | TYPE_LIMIT | TIF_GTC |
      | party_r  | ETH/DEC21 | buy  | 100000 | 29957    | 0                | TYPE_LIMIT | TIF_GTC |
-     #| party_r  | ETH/DEC21 | sell | 100000 | 30210    | 0                | TYPE_LIMIT | TIF_GTC |
 
     Then the market state should be "STATE_ACTIVE" for the market "ETH/DEC21"
     
@@ -106,12 +105,8 @@ Scenario: 002 replicate bug from Galen
       | 30000      | TRADING_MODE_CONTINUOUS | 43200   | 24617     | 36510     | 1626         | 200000000      | 100000        |
 
     And the parties place the following orders: 
-     | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
-     | party_r1 | ETH/DEC21 | buy  | 300000  | 400000  |       2         | TYPE_MARKET | TIF_IOC | 
-
-    # And the parties place the following orders: 
-    #  | party    | market id | side | volume  | price   |resulting trades | type       | tif     | error                           |
-    #  | party_r1 | ETH/DEC21 | sell | 300000  | 200000  |       0         | TYPE_MARKET| TIF_IOC | OrderError: Invalid Persistence |
+     | party    | market id | side | volume  | price   | resulting trades | type        | tif     | 
+     | party_r1 | ETH/DEC21 | buy  | 300000  | 400000  | 2                | TYPE_MARKET | TIF_IOC | 
 
     And the order book should have the following volumes for market "ETH/DEC21":
       | side | price  | volume      |
@@ -127,14 +122,12 @@ Scenario: 002 replicate bug from Galen
     Then the market state should be "STATE_SUSPENDED" for the market "ETH/DEC21"
 
    And the parties place the following orders: 
-     | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
-     | party_r  | ETH/DEC21 | sell | 100000  | 30002  |       0         | TYPE_LIMIT| TIF_GTC | 
+     | party    | market id | side | volume  | price  | resulting trades | type       | tif     | 
+     | party_r  | ETH/DEC21 | sell | 100000  | 30002  | 0                | TYPE_LIMIT | TIF_GTC | 
 
    Then the network moves ahead "10" blocks
 
    Then the market state should be "STATE_ACTIVE" for the market "ETH/DEC21"
-
-  #Then the network moves ahead "1" blocks
 
    And the order book should have the following volumes for market "ETH/DEC21":
       | side | price  | volume      |
@@ -149,7 +142,7 @@ Scenario: 002 replicate bug from Galen
 
    And the parties place the following orders: 
      | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
-     | party_r  | ETH/DEC21 | buy  | 100000  | 29700   |       0         | TYPE_LIMIT| TIF_GTC | 
+     | party_r  | ETH/DEC21 | buy  | 100000  | 29700   |       0         | TYPE_LIMIT | TIF_GTC | 
 
   And the order book should have the following volumes for market "ETH/DEC21":
       | side | price  | volume      |
@@ -169,8 +162,8 @@ Scenario: 002 replicate bug from Galen
      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 6549         | 200000000      | 400000        |
 
    And the parties place the following orders: 
-     | party    | market id | side | volume  | price   | resulting trades | type       | tif     |
-     | party_r1 | ETH/DEC21 | sell | 600000  | 29000   | 6                | TYPE_MARKET| TIF_IOC |
+     | party    | market id | side | volume  | price   | resulting trades | type        | tif     |
+     | party_r1 | ETH/DEC21 | sell | 600000  | 29000   | 6                | TYPE_MARKET | TIF_IOC |
 
   And the market data for the market "ETH/DEC21" should be:
      | trading mode            | auction trigger             | target stake | supplied stake | open interest |

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -83,6 +83,15 @@ Feature: Test interactions between different auction types with Market Orders
       | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | buy  | MID              | 2          | 1      | amendment |
       | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | sell | ASK              | 1          | 2      | amendment |
       | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | sell | MID              | 2          | 1      | amendment |
+
+   And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price | volume |
+      | buy  | 999   | 14     |
+      | buy  | 990   | 8      |
+      | buy  | 900   | 1      |
+      | sell | 1001  | 14     |
+      | sell | 1010  | 8      |
+      | sell | 1100  | 1      |
     
    And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -90,7 +99,7 @@ Feature: Test interactions between different auction types with Market Orders
 
    Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
-      | party1 | ETH/DEC21 | buy  | 20     | 1010  | 3                | TYPE_MARKET | TIF_GFN | ref-ref   | 
+      | party1 | ETH/DEC21 | buy  | 22     | 1010  | 3                | TYPE_MARKET | TIF_GFN | ref-ref   | 
 
    And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -104,5 +113,6 @@ Feature: Test interactions between different auction types with Market Orders
   #  And the market data for the market "ETH/DEC21" should be:
   #     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
   #     | 1001       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1201         | 1000           | 12            |
+
 
 

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -79,27 +79,32 @@ Feature: Test interactions between different auction types with Market Orders
       | sell | 1011  | 0      |
       | sell | 1100  | 1      |
 
+   #increaase supply stake
+   And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | buy  | BID              | 1          | 2      | amendment |
+      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | buy  | MID              | 2          | 1      | amendment |
+      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | sell | ASK              | 1          | 2      | amendment |
+      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | sell | MID              | 2          | 1      | amendment |
     
-    #try different trader
+   And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 10000           | 10            |
 
-    # Then the parties place the following orders:
-    #   | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error                           |
-    #   | party3 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
+   Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
+      | party1 | ETH/DEC21 | buy  | 20     | 1010  | 3                | TYPE_LIMIT | TIF_GFN | ref-ref   | 
 
-    # And the market data for the market "ETH/DEC21" should be:
-    #   | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-    #   | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1000         | 1000           | 10            |
-  
-    # And the market data for the market "ETH/DEC21" should be:
-    #   | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-    #   | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+   And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1010       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 3030         | 10000           | 30            |
 
     # try different price 
-      Then the parties place the following orders:
-      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
-      | party1 | ETH/DEC21 | buy  | 20     | 1005  | 1                | TYPE_LIMIT | TIF_GFN | ref-ref   | 
+  #  Then the parties place the following orders:
+  #     | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
+  #     | party1 | ETH/DEC21 | buy  | 20     | 1005  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | 
 
-    And the market data for the market "ETH/DEC21" should be:
-      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1001       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1201         | 1000           | 12            |
+  #  And the market data for the market "ETH/DEC21" should be:
+  #     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+  #     | 1001       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1201         | 1000           | 12            |
 

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -67,18 +67,18 @@ Feature: Test interactions between different auction types with Market Orders
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error                           |
       | party1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
 
+   # is there supposed to be some vol on line 75 and 79?
    And the order book should have the following volumes for market "ETH/DEC21":
       | side | price | volume |
-      | buy  | 900   | 1      |
-      | buy  | 990   | 2      |
-      | buy  | 989   | 0      |
       | buy  | 999   | 2      |
-      | sell | 1002  | 0      |
+      | buy  | 990   | 2      |
+      | buy  | 988   | 0      |
+      | buy  | 900   | 1      |
+      | sell | 1001  | 2      |
       | sell | 1010  | 2      |
+      | sell | 1012  | 0      |
       | sell | 1100  | 1      |
-      | sell | 1011  | 0      |
-      | sell | 1100  | 1      |
-
+  
    #increaase supply stake
    And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -65,18 +65,15 @@ Feature: Test interactions between different auction types with Market Orders
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error                           |
-      | party1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
+      | party1 | ETH/DEC21 | buy  | 3      | 1010  | 0                | TYPE_MARKET | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
 
-   # is there supposed to be some vol on line 75 and 79?
    And the order book should have the following volumes for market "ETH/DEC21":
       | side | price | volume |
       | buy  | 999   | 2      |
       | buy  | 990   | 2      |
-      | buy  | 988   | 0      |
       | buy  | 900   | 1      |
       | sell | 1001  | 2      |
       | sell | 1010  | 2      |
-      | sell | 1012  | 0      |
       | sell | 1100  | 1      |
   
    #increaase supply stake
@@ -93,7 +90,7 @@ Feature: Test interactions between different auction types with Market Orders
 
    Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
-      | party1 | ETH/DEC21 | buy  | 20     | 1010  | 3                | TYPE_LIMIT | TIF_GFN | ref-ref   | 
+      | party1 | ETH/DEC21 | buy  | 20     | 1010  | 3                | TYPE_MARKET | TIF_GFN | ref-ref   | 
 
    And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -107,4 +104,5 @@ Feature: Test interactions between different auction types with Market Orders
   #  And the market data for the market "ETH/DEC21" should be:
   #     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
   #     | 1001       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1201         | 1000           | 12            |
+
 

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -107,7 +107,7 @@ Scenario: 002 replicate bug from Galen
 
     And the parties place the following orders: 
      | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
-     | party_r1 | ETH/DEC21 | buy  | 300000  | 400000  |       2         | TYPE_MARKET| TIF_IOC | 
+     | party_r1 | ETH/DEC21 | buy  | 300000  | 400000  |       2         | TYPE_MARKET | TIF_IOC | 
 
     # And the parties place the following orders: 
     #  | party    | market id | side | volume  | price   |resulting trades | type       | tif     | error                           |
@@ -151,11 +151,25 @@ Scenario: 002 replicate bug from Galen
      | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
      | party_r  | ETH/DEC21 | buy  | 100000  | 29700   |       0         | TYPE_LIMIT| TIF_GTC | 
 
+  And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price  | volume      |
+      | buy  | 29998  | 100000      |
+      | buy  | 29987  | 100000      |
+      | buy  | 29977  | 100000      |
+      | buy  | 29967  | 100000      |
+      | buy  | 29957  | 100000      |
+      | buy  | 29795  | 1345237966  |
+      | buy  | 400000 | 0           |
+      | buy  | 29700  | 100000      |
+      | sell | 30002  | 100000      |
+      | sell | 30205  | 1326977824  |
+
    And the parties place the following orders: 
      | party    | market id | side | volume  | price   |resulting trades | type       | tif     | error                           |
-     | party_r1 | ETH/DEC21 | sell | 600000  | 20000   |       0         | TYPE_MARKET| TIF_IOC | OrderError: Invalid Persistence |
+     | party_r1 | ETH/DEC21 | sell | 600000  | 29000   |       0         | TYPE_MARKET| TIF_IOC | OrderError: Invalid Persistence |
 
- 
+   And the parties place the following orders: 
+     | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
+     | party_r1 | ETH/DEC21 | sell | 600000  | 20000   |       0         | TYPE_LIMIT | TIF_GTC |
 
-     
-      
+  

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -5,114 +5,92 @@ Feature: Test interactions between different auction types with Market Orders
       | name                                          | value |
       | market.stake.target.timeWindow                | 24h   |
       | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.targetstake.triggering.ratio | 0     |
+      | market.liquidity.targetstake.triggering.ratio | 1     |
       | network.floatingPointUpdates.delay            | 5s    |
       | market.auction.minimumDuration                | 10    |
+    And the following assets are registered:
+      | id  | decimal places |
+      | ETH | 5              |
     And the average block duration is "1"
-    And the simple risk model named "simple-risk-model-1":
-      | long | short | max move up | min move down | probability of trading |
-      | 0.1  | 0.1   | 10          | 10            | 0.1                    |
     And the log normal risk model named "log-normal-risk-model-1":
       | risk aversion | tau                    | mu | r     | sigma |
-      | 0.001         | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
+      | 0.000001      | 0.00011407711613050422 | 0  | 0     | 1.0   |
     And the fees configuration named "fees-config-1":
       | maker fee | infrastructure fee |
-      | 0.004     | 0.001              |
+      | 0.001     | 0.001              |
     And the price monitoring updated every "1" seconds named "price-monitoring-1":
       | horizon | probability | auction extension |
-      | 1       | 0.99        | 300               |
-    And the price monitoring updated every "1" seconds named "price-monitoring-2":
-      | horizon | probability | auction extension |
-      | 2       | 0.999995    | 200               |
-      | 1       | 0.999999    | 300               |
+      | 43200   | 0.9999999   | 60                |
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | oracle config          |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1     | default-margin-calculator | 10               | fees-config-1 | price-monitoring-1 | default-eth-for-future |
-      | ETH/DEC22 | ETH        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 10               | fees-config-1 | price-monitoring-2 | default-eth-for-future |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | oracle config          |decimal places | position decimal places |
+      | ETH/DEC21 | ETH        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 10               | fees-config-1 | price-monitoring-1 | default-eth-for-future |       5       |           5             |
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount     |
-      | party0 | ETH   | 1000000000 |
-      | party1 | ETH   | 100000000  |
-      | party2 | ETH   | 100000000  |
-      | party3 | ETH   | 100000000  |
+      | party0 | ETH   | 100000000000000 |
+      | party1 | ETH   | 10000000000000  |
+      | party2 | ETH   | 10000000000000  |
+      | party3 | ETH   | 10000000000000  |
+      | party_a1 | ETH | 10000000000000  |
+      | party_a2 | ETH | 10000000000000  |
+      | party_r  | ETH | 10000000000000  |
+  
 
-  Scenario: Once market is in continuous trading mode: post a non-persistent order that should trigger liquidity auction (not enough target stake), appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS (0026-AUCT-001, 0026-AUCT-005)
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+  Scenario: 001 Once market is in continuous trading mode: post a non-persistent order that should trigger liquidity auction (not enough target stake), appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS (0026-AUCT-001, 0026-AUCT-005)
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
-      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | buy  | BID              | 1          | 2      | submission |
-      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | buy  | MID              | 2          | 1      | submission |
-      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | sell | ASK              | 1          | 2      | submission |
-      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | sell | MID              | 2          | 1      | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | buy  | BID              | 1          | 200000 | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | buy  | MID              | 2          | 100000 | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | sell | ASK              | 1          | 200000 | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | sell | MID              | 2          | 100000 | submission |
 
     And the parties place the following orders:
-      | party  | market id | side | volume | price | resulting trades | type       | tif     |
-      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-      | party1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
-      | party1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | party2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
-      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-      | party2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 100000 | 90000000   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 100000 | 99000000   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 1000000| 100000000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 100000 | 101000000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 100000 | 110000000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1000000| 100000000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the network moves ahead "4" blocks
 
     When the opening auction period ends for market "ETH/DEC21"
-    Then the auction ends with a traded volume of "10" at a price of "1000"
+    Then the auction ends with a traded volume of "1000000" at a price of "100000000"
+    
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+      | 100000000  | TRADING_MODE_CONTINUOUS | 43200   | 82056031  | 121701233 | 54210000     | 100000000      | 1000000            |
 
     Then the parties place the following orders:
-      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error                           |
-      | party1 | ETH/DEC21 | buy  | 3      | 1010  | 0                | TYPE_MARKET | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
-
-   And the order book should have the following volumes for market "ETH/DEC21":
-      | side | price | volume |
-      | buy  | 999   | 2      |
-      | buy  | 990   | 2      |
-      | buy  | 900   | 1      |
-      | sell | 1001  | 2      |
-      | sell | 1010  | 2      |
-      | sell | 1100  | 1      |
-  
-   #increaase supply stake
-   And the parties submit the following liquidity provision:
-      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
-      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | buy  | BID              | 1          | 2      | amendment |
-      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | buy  | MID              | 2          | 1      | amendment |
-      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | sell | ASK              | 1          | 2      | amendment |
-      | lp1 | party0 | ETH/DEC21 | 10000              | 0.001 | sell | MID              | 2          | 1      | amendment |
-
-   And the order book should have the following volumes for market "ETH/DEC21":
-      | side | price | volume |
-      | buy  | 999   | 14     |
-      | buy  | 990   | 8      |
-      | buy  | 900   | 1      |
-      | sell | 1001  | 14     |
-      | sell | 1010  | 8      |
-      | sell | 1100  | 1      |
-    
-   And the market data for the market "ETH/DEC21" should be:
-      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 10000           | 10            |
-
-   Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
-      | party1 | ETH/DEC21 | buy  | 22     | 1010  | 3                | TYPE_MARKET | TIF_GFN | ref-ref   | 
+      | party1 | ETH/DEC21 | buy  | 2000000| 101000000  | 4           | TYPE_MARKET| TIF_GFN | ref-ref   | 
 
-   And the market data for the market "ETH/DEC21" should be:
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 110000000  | TRADING_MODE_MONITORING_AUCTION | 43200   | 82056031  | 121701233      | 84115906        | 100000000           | 1410607            |
+
+Scenario: 002 replicate bug from Galen
+
+    # And the parties submit the following liquidity provision:
+    #   | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+    #   | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | buy  | BID              | 1          | 200000 | submission |
+    #   | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | buy  | MID              | 2          | 100000 | submission |
+    #   | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | sell | ASK              | 1          | 200000 | submission |
+    #   | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | sell | MID              | 2          | 100000 | submission |
+
+    And the parties place the following orders:
+      | party    | market id | side | volume | price    | resulting trades | type       | tif     |
+      | party_a1 | ETH/DEC21 | buy  | 100000 | 30000    | 0                | TYPE_LIMIT | TIF_GTC |
+      | party_a2 | ETH/DEC21 | sell | 100000 | 30000    | 0                | TYPE_LIMIT | TIF_GTC |
+      | party_r  | ETH/DEC21 | buy  | 100000 | 29998    | 0                | TYPE_LIMIT | TIF_GTC |
+      | party_r  | ETH/DEC21 | sell | 100000 | 30002    | 0                | TYPE_LIMIT | TIF_GTC |
+      
+    When the opening auction period ends for market "ETH/DEC21"
+    Then the auction ends with a traded volume of "100000" at a price of "30000"
+
+    And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1010       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 3030         | 10000           | 30            |
-
-    # try different price 
-  #  Then the parties place the following orders:
-  #     | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
-  #     | party1 | ETH/DEC21 | buy  | 20     | 1005  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | 
-
-  #  And the market data for the market "ETH/DEC21" should be:
-  #     | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-  #     | 1001       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1201         | 1000           | 12            |
-
+      | 30000       | TRADING_MODE_CONTINUOUS | 43200   | 24617     | 36510     | 1626        | 100000000           | 100000            |
 
 

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -1,0 +1,105 @@
+Feature: Test interactions between different auction types with Market Orders
+
+  Background:
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.targetstake.triggering.ratio | 0     |
+      | network.floatingPointUpdates.delay            | 5s    |
+      | market.auction.minimumDuration                | 10    |
+    And the average block duration is "1"
+    And the simple risk model named "simple-risk-model-1":
+      | long | short | max move up | min move down | probability of trading |
+      | 0.1  | 0.1   | 10          | 10            | 0.1                    |
+    And the log normal risk model named "log-normal-risk-model-1":
+      | risk aversion | tau                    | mu | r     | sigma |
+      | 0.001         | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
+    And the fees configuration named "fees-config-1":
+      | maker fee | infrastructure fee |
+      | 0.004     | 0.001              |
+    And the price monitoring updated every "1" seconds named "price-monitoring-1":
+      | horizon | probability | auction extension |
+      | 1       | 0.99        | 300               |
+    And the price monitoring updated every "1" seconds named "price-monitoring-2":
+      | horizon | probability | auction extension |
+      | 2       | 0.999995    | 200               |
+      | 1       | 0.999999    | 300               |
+    And the markets:
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | oracle config          |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1     | default-margin-calculator | 10               | fees-config-1 | price-monitoring-1 | default-eth-for-future |
+      | ETH/DEC22 | ETH        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 10               | fees-config-1 | price-monitoring-2 | default-eth-for-future |
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | party0 | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
+      | party3 | ETH   | 100000000  |
+
+  Scenario: Once market is in continuous trading mode: post a non-persistent order that should trigger liquidity auction (not enough target stake), appropriate event is sent and market remains in TRADING_MODE_CONTINUOUS (0026-AUCT-001, 0026-AUCT-005)
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | buy  | BID              | 1          | 2      | submission |
+      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | buy  | MID              | 2          | 1      | submission |
+      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | sell | ASK              | 1          | 2      | submission |
+      | lp1 | party0 | ETH/DEC21 | 1000              | 0.001 | sell | MID              | 2          | 1      | submission |
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    When the opening auction period ends for market "ETH/DEC21"
+    Then the auction ends with a traded volume of "10" at a price of "1000"
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error                           |
+      | party1 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
+
+   And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price | volume |
+      | buy  | 900   | 1      |
+      | buy  | 990   | 2      |
+      | buy  | 989   | 0      |
+      | buy  | 999   | 2      |
+      | sell | 1002  | 0      |
+      | sell | 1010  | 2      |
+      | sell | 1100  | 1      |
+      | sell | 1011  | 0      |
+      | sell | 1100  | 1      |
+
+    
+    #try different trader
+
+    # Then the parties place the following orders:
+    #   | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | error                           |
+    #   | party3 | ETH/DEC21 | buy  | 20     | 1010  | 0                | TYPE_LIMIT | TIF_GFN | ref-ref   | OrderError: Invalid Persistence |
+
+    # And the market data for the market "ETH/DEC21" should be:
+    #   | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+    #   | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1000         | 1000           | 10            |
+  
+    # And the market data for the market "ETH/DEC21" should be:
+    #   | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+    #   | 1000       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1000         | 1000           | 10            |
+
+    # try different price 
+      Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference | 
+      | party1 | ETH/DEC21 | buy  | 20     | 1005  | 1                | TYPE_LIMIT | TIF_GFN | ref-ref   | 
+
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1001       | TRADING_MODE_CONTINUOUS | 1       | 990       | 1010      | 1201         | 1000           | 12            |
+

--- a/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
+++ b/integration/features/verified/0026-AUCT-auction_MarketOrder.feature
@@ -164,12 +164,14 @@ Scenario: 002 replicate bug from Galen
       | sell | 30002  | 100000      |
       | sell | 30205  | 1326977824  |
 
-   And the parties place the following orders: 
-     | party    | market id | side | volume  | price   |resulting trades | type       | tif     | error                           |
-     | party_r1 | ETH/DEC21 | sell | 600000  | 29000   |       0         | TYPE_MARKET| TIF_IOC | OrderError: Invalid Persistence |
+   And the market data for the market "ETH/DEC21" should be:
+     | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+     | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 6549         | 200000000      | 400000        |
 
    And the parties place the following orders: 
-     | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
-     | party_r1 | ETH/DEC21 | sell | 600000  | 20000   |       0         | TYPE_LIMIT | TIF_GTC |
+     | party    | market id | side | volume  | price   | resulting trades | type       | tif     |
+     | party_r1 | ETH/DEC21 | sell | 600000  | 29000   | 6                | TYPE_MARKET| TIF_IOC |
 
-  
+  And the market data for the market "ETH/DEC21" should be:
+     | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+     | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 8075         | 200000000      | 500000        |

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -459,6 +459,65 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 300,
 		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 300,
+		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 400,
+		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "A", Buyer: "B", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 400,
+		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "D", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 400,
+		},
 	}
 
 	for _, tc := range cases {
@@ -478,7 +537,7 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			e.Update(context.Background(), tr)
 		}
 
-		// Now check it matches ones those trades are registered as positions
+		// Now check it matches once those trades are registered as positions
 		oiAfterUpdatingPositions := e.GetOpenInterest()
 		t.Run("", func(t *testing.T) {
 			require.Equal(t, tc.ExpectedOI, oiGivenTrades)


### PR DESCRIPTION
When market maker assigns a market order to the market, they get "Invalid Persistence" error message, and order is rejected despite the fact that:

1. there is enough supplied stake
2. there is enough liquidity left after the trade  

[issue](https://github.com/vegaprotocol/vega/issues/5460)