### PR TITLE
fix: undelegating everything should update active change flag

### DIFF
--- a/delegation/engine.go
+++ b/delegation/engine.go
@@ -502,6 +502,7 @@ func (e *Engine) decreaseBalanceAndFireEvent(ctx context.Context, party, nodeID 
 			e.sendDelegatedBalanceEvent(ctx, party, nodeID, epoch, partyState.nodeToAmount[nodeID])
 		}
 		if cleanup && partyState.nodeToAmount[nodeID].IsZero() {
+			e.dss.changedActive = true
 			delete(partyState.nodeToAmount, nodeID)
 		}
 	}


### PR DESCRIPTION
Found during one of my daily snapshot-soak-test's on the overnight run (which I think really needs to be on the CI)

When undelegating everything from a node we missed hitting the change flag for the active delegations.