### PR TITLE
Fix GetOpenInterestGivenTrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [5444](https://github.com/vegaprotocol/vega/issues/5444) - Merge both checkpoints and genesis asset on startup
 - [5446](https://github.com/vegaprotocol/vega/issues/5446) - Cover liquidity monitoring acceptance criteria relating to aggressive order removing best bid or ask from the book
 - [5457](https://github.com/vegaprotocol/vega/issues/5457) - Fix sorting of validators for demotion check
+- [5460](https://github.com/vegaprotocol/vega/issues/5460) - Fix theoretical open interest calculation
 
 ## 0.51.1
 

--- a/integration/features/auctions/5460-market-order-cannot-trade-due-to-auction.feature
+++ b/integration/features/auctions/5460-market-order-cannot-trade-due-to-auction.feature
@@ -1,0 +1,170 @@
+Feature: Test for issue 5460
+
+  Background:
+    Given the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.targetstake.triggering.ratio | 1     |
+      | network.floatingPointUpdates.delay            | 5s    |
+      | market.auction.minimumDuration                | 1    |
+    And the following assets are registered:
+      | id  | decimal places |
+      | ETH | 5              |
+    And the average block duration is "1"
+    And the log normal risk model named "log-normal-risk-model-1":
+      | risk aversion | tau                    | mu | r     | sigma |
+      | 0.000001      | 0.00011407711613050422 | 0  | 0     | 1.0   |
+    And the fees configuration named "fees-config-1":
+      | maker fee | infrastructure fee |
+      | 0.001     | 0.001              |
+    And the price monitoring updated every "1" seconds named "price-monitoring-1":
+      | horizon | probability | auction extension |
+      | 43200   | 0.9999999   | 60                |
+    And the markets:
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | oracle config          |decimal places | position decimal places |
+      | ETH/DEC21 | ETH        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 10               | fees-config-1 | price-monitoring-1 | default-eth-for-future |       5       |           5             |
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | party0 | ETH   | 100000000000000 |
+      | party1 | ETH   | 10000000000000  |
+      | party2 | ETH   | 10000000000000  |
+      | party3 | ETH   | 10000000000000  |
+      | party_a1 | ETH | 10000000000000  |
+      | party_a2 | ETH | 10000000000000  |
+      | party_r  | ETH | 10000000000000000  |
+      | party_r1 | ETH | 10000000000000000  |
+
+  Scenario: 001 post market order
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | buy  | BID              | 1          | 200000 | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | buy  | MID              | 2          | 100000 | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | sell | ASK              | 1          | 200000 | submission |
+      | lp1 | party0 | ETH/DEC21 | 100000000         | 0.001 | sell | MID              | 2          | 100000 | submission |
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price      | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 100000 | 90000000   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 100000 | 99000000   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 1000000| 100000000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 100000 | 101000000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 100000 | 110000000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1000000| 100000000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the network moves ahead "4" blocks
+
+    When the opening auction period ends for market "ETH/DEC21"
+    Then the auction ends with a traded volume of "1000000" at a price of "100000000"
+    
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 100000000  | TRADING_MODE_CONTINUOUS | 43200   | 82056031  | 121701233 | 54210000     | 100000000      | 1000000       |
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price     | resulting trades | type        | tif     | reference | 
+      | party1 | ETH/DEC21 | buy  | 2000000| 101000000 | 4                | TYPE_MARKET | TIF_GFN | ref-ref   | 
+
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 110000000  | TRADING_MODE_MONITORING_AUCTION | 43200   | 82056031  | 121701233 | 84115906     | 100000000      | 1410607       |
+
+Scenario: 002 replicate bug
+
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | party0 | ETH/DEC21 | 200000000         | 0.001 | buy  | MID              | 2          | 205    | submission |
+      | lp1 | party0 | ETH/DEC21 | 200000000         | 0.001 | sell | MID              | 2          | 205    | submission |
+
+    And the parties place the following orders:
+      | party    | market id | side | volume | price    | resulting trades | type       | tif     |
+      | party_a1 | ETH/DEC21 | buy  | 100000 | 30000    | 0                | TYPE_LIMIT | TIF_GTC |
+      | party_a2 | ETH/DEC21 | sell | 100000 | 30000    | 0                | TYPE_LIMIT | TIF_GTC |
+      | party_r  | ETH/DEC21 | buy  | 100000 | 29998    | 0                | TYPE_LIMIT | TIF_GTC |
+      | party_r  | ETH/DEC21 | sell | 100000 | 30002    | 0                | TYPE_LIMIT | TIF_GTC |
+      
+    When the opening auction period ends for market "ETH/DEC21"
+    Then the auction ends with a traded volume of "100000" at a price of "30000"
+
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 30000      | TRADING_MODE_CONTINUOUS | 43200   | 24617     | 36510     | 1626        | 200000000      | 100000        |
+
+   And the parties place the following orders: 
+     | party    | market id | side | volume | price    | resulting trades | type       | tif     |
+     | party_r  | ETH/DEC21 | buy  | 100000 | 29987    | 0                | TYPE_LIMIT | TIF_GTC |
+     | party_r  | ETH/DEC21 | buy  | 100000 | 29977    | 0                | TYPE_LIMIT | TIF_GTC |
+     | party_r  | ETH/DEC21 | buy  | 100000 | 29967    | 0                | TYPE_LIMIT | TIF_GTC |
+     | party_r  | ETH/DEC21 | buy  | 100000 | 29957    | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the market state should be "STATE_ACTIVE" for the market "ETH/DEC21"
+    
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 30000      | TRADING_MODE_CONTINUOUS | 43200   | 24617     | 36510     | 1626         | 200000000      | 100000        |
+
+    And the parties place the following orders: 
+     | party    | market id | side | volume  | price   | resulting trades | type        | tif     | 
+     | party_r1 | ETH/DEC21 | buy  | 300000  | 400000  | 2                | TYPE_MARKET | TIF_IOC | 
+
+    And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price  | volume      |
+      | buy  | 29998  | 100000      |
+      | buy  | 29987  | 100000      |
+      | buy  | 29977  | 100000      |
+      | buy  | 29967  | 100000      |
+      | buy  | 29957  | 100000      |
+      | buy  | 29795  | 0           |
+      | sell | 30002  | 0           |
+      | sell | 30205  | 0           |
+    
+    Then the market state should be "STATE_SUSPENDED" for the market "ETH/DEC21"
+
+   And the parties place the following orders: 
+     | party    | market id | side | volume  | price  | resulting trades | type       | tif     | 
+     | party_r  | ETH/DEC21 | sell | 100000  | 30002  | 0                | TYPE_LIMIT | TIF_GTC | 
+
+   Then the network moves ahead "10" blocks
+
+   Then the market state should be "STATE_ACTIVE" for the market "ETH/DEC21"
+
+   And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price  | volume      |
+      | buy  | 29998  | 100000      |
+      | buy  | 29987  | 100000      |
+      | buy  | 29977  | 100000      |
+      | buy  | 29967  | 100000      |
+      | buy  | 29957  | 100000      |
+      | buy  | 29795  | 1345237966  |
+      | sell | 30002  | 100000      |
+      | sell | 30205  | 1326977824  |
+
+   And the parties place the following orders: 
+     | party    | market id | side | volume  | price   |resulting trades | type       | tif     | 
+     | party_r  | ETH/DEC21 | buy  | 100000  | 29700   |       0         | TYPE_LIMIT | TIF_GTC | 
+
+  And the order book should have the following volumes for market "ETH/DEC21":
+      | side | price  | volume      |
+      | buy  | 29998  | 100000      |
+      | buy  | 29987  | 100000      |
+      | buy  | 29977  | 100000      |
+      | buy  | 29967  | 100000      |
+      | buy  | 29957  | 100000      |
+      | buy  | 29795  | 1345237966  |
+      | buy  | 400000 | 0           |
+      | buy  | 29700  | 100000      |
+      | sell | 30002  | 100000      |
+      | sell | 30205  | 1326977824  |
+
+   And the market data for the market "ETH/DEC21" should be:
+     | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+     | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 6549         | 200000000      | 400000        |
+
+   And the parties place the following orders: 
+     | party    | market id | side | volume  | price   | resulting trades | type        | tif     |
+     | party_r1 | ETH/DEC21 | sell | 600000  | 29000   | 6                | TYPE_MARKET | TIF_IOC |
+
+  And the market data for the market "ETH/DEC21" should be:
+     | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+     | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 8075         | 200000000      | 500000        |

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -459,6 +459,65 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 300,
 		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 300,
+		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 400,
+		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "A", Buyer: "B", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 400,
+		},
+		{
+			ExistingPositions: []*types.Trade{
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "C", Buyer: "B", Size: 300, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "A", Buyer: "C", Size: 100, Price: num.Zero()},
+				{Seller: "D", Buyer: "A", Size: 100, Price: num.Zero()},
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			ExpectedOI: 400,
+		},
 	}
 
 	for _, tc := range cases {
@@ -478,7 +537,7 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			e.Update(context.Background(), tr)
 		}
 
-		// Now check it matches ones those trades are registered as positions
+		// Now check it matches once those trades are registered as positions
 		oiAfterUpdatingPositions := e.GetOpenInterest()
 		t.Run("", func(t *testing.T) {
 			require.Equal(t, tc.ExpectedOI, oiGivenTrades)


### PR DESCRIPTION
From original [PR](https://github.com/vegaprotocol/vega/pull/5459): 

> When market maker assigns a market order to the market, they get "Invalid Persistence" error message, and order is rejected despite the fact that:
> 
> there is enough supplied stake
> there is enough liquidity left after the trade

Logic in `GetOpenInterestGivenTrades` didn't cover the case where party's open position changed over multiple trades from long to short resulting in uint underflow. 

Closes #5460 