### PR TITLE
Allow wash trades in opening auction 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [5446](https://github.com/vegaprotocol/vega/issues/5446) - Cover liquidity monitoring acceptance criteria relating to aggressive order removing best bid or ask from the book
 - [5457](https://github.com/vegaprotocol/vega/issues/5457) - Fix sorting of validators for demotion check
 - [5460](https://github.com/vegaprotocol/vega/issues/5460) - Fix theoretical open interest calculation
+- [5468](https://github.com/vegaprotocol/vega/issues/5468) - Bring indicative trades inline with actual auction uncrossing trades in presence of wash trades
 
 ## 0.51.1
 

--- a/integration/features/auctions/5468-opening-auction-uncross-with-wash-trades.feature
+++ b/integration/features/auctions/5468-opening-auction-uncross-with-wash-trades.feature
@@ -1,0 +1,52 @@
+Feature: Set up a market, with an opening auction, then uncross the book in presence of wash trades
+
+  Background:
+
+    And the markets:
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | oracle config          |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future |
+
+  Scenario: Set up opening auction with wash trades and uncross
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | BTC   | 100000000 |
+      | party2 | BTC   | 100000000 |
+      | party3 | BTC   | 100000000 |
+      | party4 | BTC   | 100000000 |
+
+    # place orders and generate trades
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party1 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-s-1    |
+      | party1 | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-2    |
+      | party2 | ETH/DEC19 | sell | 3      | 12000 | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
+    Then the opening auction period ends for market "ETH/DEC19"
+
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | target stake | supplied stake | open interest |
+      | 10000      | TRADING_MODE_CONTINUOUS | 50000        | 0              | 5             |
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 10000 | 5    | party1 |
+      | party1 | 10000 | 5    | party2 |
+
+    Then the orders should have the following status:
+      | party  | reference | status           |
+      | party3 | t3-b-1    | STATUS_ACTIVE    |
+      | party4 | t4-s-1    | STATUS_ACTIVE    |
+      | party1 | t1-b-1    | STATUS_FILLED    |
+      | party1 | t1-s-1    | STATUS_FILLED    |
+      | party1 | t1-b-2    | STATUS_FILLED    |
+      | party2 | t2-s-2    | STATUS_FILLED    |
+      | party2 | t2-s-3    | STATUS_CANCELLED |
+
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party1 |  5     | 0              | 0            |
+      | party2 | -5     | 0              | 0            |

--- a/integration/features/price_monitoring/price-monitoring-lognormal2.feature
+++ b/integration/features/price_monitoring/price-monitoring-lognormal2.feature
@@ -187,6 +187,131 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
     And the mark price should be "104252" for the market "ETH/DEC20"
 
+  Scenario: Non-opening auction can end with washtrades
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount       |
+      | party1 | ETH   | 10000000000  |
+      | party2 | ETH   | 10000000000  |
+      | party3 | ETH   | 10000000000  |
+      | party4 | ETH   | 10000000000  |
+      | aux    | ETH   | 100000000000 |
+
+     # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+    When the parties place the following orders:
+      | party | market id | side | volume | price  | resulting trades | type       | tif     |
+      | aux   | ETH/DEC20 | buy  | 1      | 1      | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC20 | sell | 1      | 200000 | 0                | TYPE_LIMIT | TIF_GTC |
+
+    # Trigger an auction to set the mark price
+    Then the trading mode should be "TRADING_MODE_OPENING_AUCTION" for the market "ETH/DEC20"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party3 | ETH/DEC20 | sell | 1      | 200000 | 0                | TYPE_LIMIT | TIF_GTC | party3-1  |
+      | party4 | ETH/DEC20 | buy  | 1      | 80000  | 0                | TYPE_LIMIT | TIF_GTC | party4-1  |
+      | party3 | ETH/DEC20 | sell | 1      | 100000 | 0                | TYPE_LIMIT | TIF_GFA | party3-2  |
+      | party4 | ETH/DEC20 | buy  | 1      | 100000 | 0                | TYPE_LIMIT | TIF_GFA | party4-2  |
+    Then the opening auction period ends for market "ETH/DEC20"
+    And the mark price should be "100000" for the market "ETH/DEC20"
+
+    When the parties cancel the following orders:
+      | party  | reference |
+      | party3 | party3-1  |
+      | party4 | party4-1  |
+
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    # T0
+    Then time is updated to "2020-10-16T02:00:00Z"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | sell | 1      | 100000 | 0                | TYPE_LIMIT | TIF_GTC | ref-1     |
+      | party2 | ETH/DEC20 | buy  | 1      | 100000 | 1                | TYPE_LIMIT | TIF_GTC | ref-2     |
+    Then the mark price should be "100000" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | sell | 1      | 95878 | 0                | TYPE_LIMIT | TIF_GTC | ref-1     |
+      | party2 | ETH/DEC20 | buy  | 1      | 95878 | 1                | TYPE_LIMIT | TIF_GTC | ref-2     |
+
+    Then the mark price should be "95878" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | sell | 1      | 104251 | 0                | TYPE_LIMIT | TIF_GTC | ref-1     |
+      | party2 | ETH/DEC20 | buy  | 1      | 104251 | 1                | TYPE_LIMIT | TIF_GTC | ref-2     |
+    Then the mark price should be "104251" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode            | horizon | min bound | max bound |
+      | 104251     | TRADING_MODE_CONTINUOUS | 3600    | 95878     | 104251    |
+      | 104251     | TRADING_MODE_CONTINUOUS | 7200    | 90497     | 110401    |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | sell | 1      | 104252 | 0                | TYPE_LIMIT | TIF_GTC | ref-3     |
+      | party2 | ETH/DEC20 | buy  | 1      | 104252 | 0                | TYPE_LIMIT | TIF_GTC | ref-4     |
+
+    Then the parties cancel the following orders:
+      | party  | reference |
+      | party2 | ref-4     |
+
+     And the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode                    | auction trigger       | open interest |
+      | 104251     | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 4             |
+
+    #T0 + 4min
+    Then time is updated to "2020-10-16T02:04:00Z"
+
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
+
+    # Assure no change in target stake due to wash trade
+    And the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode                    | auction trigger       | open interest |
+      | 104251     | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 4             |
+
+
+    # Submit trade so that auction uncrosses with wash trade
+    And the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | buy  | 1      | 104252 | 0                | TYPE_LIMIT | TIF_GTC | ref-5     |
+  
+    # Assure no change in target stake due to wash trade
+    And the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode                    | auction trigger       | open interest |
+      | 104251     | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE | 4             |
+
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party1 | -3     | -12624         | 0            |
+      | party2 |  3     |  12624         | 0            |
+      | party3 | -1     | -4251          | 0            |
+      | party4 |  1     |  4251          | 0            |
+      | aux    |  0     |  0             | 0            |
+
+    #T0 + 4min04s
+    Then time is updated to "2020-10-16T03:04:04Z"
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    # Assure uncrossing trade was indeed a wash trade
+    And the following trades should be executed:
+      | buyer  | price  | size | seller |
+      | party1 | 104252 | 1    | party1 |
+
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party1 | -3     | -8418          | -4209        |
+      | party2 |  3     |  12627         | 0            |
+      | party3 | -1     | -4252          | 0            |
+      | party4 |  1     |  4252          | 0            |
+      | aux    |  0     |  0             | 0            |
+
+    And the mark price should be "104252" for the market "ETH/DEC20"
+
   Scenario: Auction triggered by 1 trigger (upper bound breached)
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |

--- a/integration/features/price_monitoring/price-monitoring-lognormal2.feature
+++ b/integration/features/price_monitoring/price-monitoring-lognormal2.feature
@@ -187,7 +187,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
 
     And the mark price should be "104252" for the market "ETH/DEC20"
 
-  Scenario: Non-opening auction can end with washtrades
+  Scenario: Non-opening auction can end with wash trades
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |
       | party1 | ETH   | 10000000000  |

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -440,7 +440,7 @@ func (b *OrderBook) GetIndicativeTrades() ([]*types.Trade, error) {
 	opSide := b.getOppositeSide(uncrossSide)
 	output := make([]*types.Trade, 0, len(uncrossOrders))
 	for _, o := range uncrossOrders {
-		trades, err := opSide.fakeUncross(o)
+		trades, err := opSide.fakeUncross(o, false)
 		if err != nil {
 			return nil, err
 		}
@@ -709,7 +709,7 @@ func (b *OrderBook) GetTrades(order *types.Order) ([]*types.Trade, error) {
 		b.latestTimestamp = order.CreatedAt
 	}
 
-	trades, err := b.getOppositeSide(order.Side).fakeUncross(order)
+	trades, err := b.getOppositeSide(order.Side).fakeUncross(order, true)
 	// it's fine for the error to be a wash trade here,
 	// it's just be stopped when really uncrossing.
 	if err != nil && err != ErrWashTrade {

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -3257,11 +3257,28 @@ func TestOrderBook_AuctionUncrossWashTrades(t *testing.T) {
 	assert.Equal(t, volume, uint64(5))
 	assert.Equal(t, side, types.SideBuy)
 
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	assert.Equal(t, len(trades), 1)
+
 	// Leave auction and uncross the book
 	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
 	assert.Nil(t, err)
 	assert.Equal(t, len(uncrossedOrders), 1)
+	assert.Equal(t, len(uncrossedOrders[0].Trades), 1)
 	assert.Equal(t, len(cancels), 0)
+
+	// Assure indicative trade has same (relevant) data as the actual trade
+	assert.Equal(t, uncrossedOrders[0].Trades[0].Aggressor, trades[0].Aggressor)
+	assert.Equal(t, uncrossedOrders[0].Trades[0].Buyer, trades[0].Buyer)
+	assert.Equal(t, uncrossedOrders[0].Trades[0].Seller, trades[0].Seller)
+	assert.Equal(t, uncrossedOrders[0].Trades[0].Size, trades[0].Size)
+	assert.Equal(t, uncrossedOrders[0].Trades[0].Price, trades[0].Price)
+
+	// Assure trade is indeed a wash trade
+	assert.Equal(t, trades[0].Buyer, trades[0].Seller)
+
 }
 
 func TestOrderBook_AuctionUncrossTamlyn(t *testing.T) {

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -3278,7 +3278,6 @@ func TestOrderBook_AuctionUncrossWashTrades(t *testing.T) {
 
 	// Assure trade is indeed a wash trade
 	assert.Equal(t, trades[0].Buyer, trades[0].Seller)
-
 }
 
 func TestOrderBook_AuctionUncrossTamlyn(t *testing.T) {

--- a/matching/pricelevel.go
+++ b/matching/pricelevel.go
@@ -72,7 +72,7 @@ func (l *PriceLevel) fakeUncross(o *types.Order, checkWashTrades bool) (agg *typ
 		if checkWashTrades {
 			if order.Party == agg.Party {
 				err = ErrWashTrade
-				break
+				return
 			}
 		}
 

--- a/matching/pricelevel.go
+++ b/matching/pricelevel.go
@@ -59,7 +59,7 @@ func (l *PriceLevel) removeOrder(index int) {
 }
 
 // fakeUncross - this updates a copy of the order passed to it, the copied order is returned.
-func (l *PriceLevel) fakeUncross(o *types.Order) (agg *types.Order, trades []*types.Trade, err error) {
+func (l *PriceLevel) fakeUncross(o *types.Order, checkWashTrades bool) (agg *types.Order, trades []*types.Trade, err error) {
 	// work on a copy of the order, so we can submit it a second time
 	// after we've done the price monitoring and fees checks
 	cpy := *o
@@ -69,9 +69,11 @@ func (l *PriceLevel) fakeUncross(o *types.Order) (agg *types.Order, trades []*ty
 	}
 
 	for _, order := range l.orders {
-		if order.Party == agg.Party {
-			err = ErrWashTrade
-			return
+		if checkWashTrades {
+			if order.Party == agg.Party {
+				err = ErrWashTrade
+				break
+			}
 		}
 
 		// Get size and make newTrade

--- a/matching/side.go
+++ b/matching/side.go
@@ -324,7 +324,7 @@ func (s *OrderBookSide) GetVolume(price *num.Uint) (uint64, error) {
 }
 
 // fakeUncross returns hypotehetical trades if the order book side were to be uncrossed with the agg order supplied,
-// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades)
+// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades).
 func (s *OrderBookSide) fakeUncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, error) {
 	var (
 		trades            []*types.Trade
@@ -402,7 +402,7 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order, checkWashTrades bool) ([]*
 }
 
 // uncross returns trades after order book side gets uncrossed with the agg order supplied,
-// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades)
+// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades).
 func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, []*types.Order, *num.Uint, error) {
 	var (
 		trades            []*types.Trade

--- a/matching/side.go
+++ b/matching/side.go
@@ -323,7 +323,9 @@ func (s *OrderBookSide) GetVolume(price *num.Uint) (uint64, error) {
 	return priceLevel.volume, nil
 }
 
-func (s *OrderBookSide) fakeUncross(agg *types.Order) ([]*types.Trade, error) {
+// fakeUncross returns hypotehetical trades if the order book side were to be uncrossed with the agg order supplied,
+// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades)
+func (s *OrderBookSide) fakeUncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, error) {
 	var (
 		trades            []*types.Trade
 		totalVolumeToFill uint64
@@ -386,7 +388,7 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order) ([]*types.Trade, error) {
 		if agg.Type != types.OrderTypeMarket && checkPrice(s.levels[idx].price) {
 			break
 		}
-		fake, ntrades, err = s.levels[idx].fakeUncross(fake)
+		fake, ntrades, err = s.levels[idx].fakeUncross(fake, checkWashTrades)
 		trades = append(trades, ntrades...)
 		// break if a wash trade is detected
 		if err != nil && err == ErrWashTrade {
@@ -396,9 +398,11 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order) ([]*types.Trade, error) {
 		idx--
 	}
 
-	return trades, nil
+	return trades, err
 }
 
+// uncross returns trades after order book side gets uncrossed with the agg order supplied,
+// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades)
 func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, []*types.Order, *num.Uint, error) {
 	var (
 		trades            []*types.Trade

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -332,7 +332,8 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 90,
 		},
-		{ // A: + 100 + 10, B: -100 - 10 => OI: 110
+		{
+			// A: + 100 + 10, B: -100 - 10 => OI: 110
 			ExistingPositions: []*types.Trade{
 				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
 			},
@@ -341,9 +342,20 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 110,
 		},
-
+		{
+			// Same as above + wash trade -> should leave OI unchanged
+			ExistingPositions: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
+			},
+			Trades: []*types.Trade{
+				{Seller: "B", Buyer: "A", Size: 10, Price: num.Zero()},
+				{Seller: "A", Buyer: "A", Size: 13, Price: num.Zero()},
+			},
+			ExpectedOI: 110,
+		},
 		// There at least 1 new party
-		{ // A: + 100 + 10, B: -100, C: -10 => OI: 110
+		{
+			// A: + 100 + 10, B: -100, C: -10 => OI: 110
 			ExistingPositions: []*types.Trade{
 				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
 			},
@@ -352,7 +364,8 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 110,
 		},
-		{ // A: + 100 - 10, B: -100, C: +10 => OI: 100
+		{
+			// A: + 100 - 10, B: -100, C: +10 => OI: 100
 			ExistingPositions: []*types.Trade{
 				{Seller: "B", Buyer: "A", Size: 100, Price: num.Zero()},
 			},
@@ -361,9 +374,9 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 100,
 		},
-
 		// None of the parties have positions yet
-		{ // C: +10, D:-10 => OI: 10
+		{
+			// C: +10, D:-10 => OI: 10
 			Trades: []*types.Trade{
 				{Seller: "D", Buyer: "C", Size: 10, Price: num.Zero()},
 			},


### PR DESCRIPTION
While wash trades were allowed in opening  auction, the usage of GetIndicativeTrades() to check if auction will uncross resulting in trades prevented it from uncrossing at that function wouldn't return trades if these were wash trades.

Closes #5468 