### PR TITLE
Verify impact of wash trades on target stake

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
                 "--godog.format",
                 "pretty",
                 "-test.run",
-                "${workspaceFolder}/integration/features/settlement/settlement_at_expiry.feature"
+                "${workspaceFolder}/integration/features/verified/0041-TSK-target_stake.feature:233"
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
                 "--godog.format",
                 "pretty",
                 "-test.run",
-                "${workspaceFolder}/integration/features/verified/0041-TSK-target_stake.feature:233"
+                "${workspaceFolder}/integration/features/settlement/settlement_at_expiry.feature"
             ]
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@
 - [5546](https://github.com/vegaprotocol/vega/issues/5546) - Fix collateral checkpoint to unlock locked reward account balance
 - [5194](https://github.com/vegaprotocol/vega/issues/5194) - Fix market trading mode vs market state
 - [5432](https://github.com/vegaprotocol/vega/issues/5431) - Do not accept transaction with unexpected public keys
-- [5478](https://github.com/vegaprotocol/vega/issues/5478) - Assure uncross and fakeUncross are in line with each other
-- [5480](https://github.com/vegaprotocol/vega/issues/5480) - Assure GetIndicativeTrades is in line with actual uncrossing trades
+- [5478](https://github.com/vegaprotocol/vega/issues/5478) - Assure uncross and fake uncross are in line with each other
+- [5480](https://github.com/vegaprotocol/vega/issues/5480) - Assure indicative trades are in line with actual uncrossing trades
 
 ## 0.52.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - [5546](https://github.com/vegaprotocol/vega/issues/5546) - Fix collateral checkpoint to unlock locked reward account balance
 - [5194](https://github.com/vegaprotocol/vega/issues/5194) - Fix market trading mode vs market state
 - [5432](https://github.com/vegaprotocol/vega/issues/5431) - Do not accept transaction with unexpected public keys
+- [5478](https://github.com/vegaprotocol/vega/issues/5478) - Assure uncross and fakeUncross are in line with each other
+- [5480](https://github.com/vegaprotocol/vega/issues/5480) - Assure GetIndicativeTrades is in line with actual uncrossing trades
 
 ## 0.52.0
 

--- a/integration/features/verified/0041-TSK-target_stake.feature
+++ b/integration/features/verified/0041-TSK-target_stake.feature
@@ -292,8 +292,8 @@ Scenario: Max open interest changes over time, testing change of timewindow (004
 
     # # Check that target stake is unchanged
     Then the market data for the market "ETH/DEC21" should be:
-      | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | 110        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 550          | 2000           | 50            |
+      | mark price | trading mode                 | auction trigger         | target stake | supplied stake | open interest |
+      | 0          | TRADING_MODE_OPENING_AUCTION | AUCTION_TRIGGER_OPENING | 550          | 2000           | 0             |
 
     Then the opening auction period ends for market "ETH/DEC21"
 

--- a/integration/features/verified/0041-TSK-target_stake.feature
+++ b/integration/features/verified/0041-TSK-target_stake.feature
@@ -230,3 +230,73 @@ Scenario: Max open interest changes over time, testing change of timewindow (004
     # target_stake = 110 x (140+30) x 170 x 1 x 0.1=1870
     And the target stake should be "1870" for the market "ETH/DEC21"
 
+ Scenario: Target stake is calculate correctly during auction in presence of wash trades
+  Background:
+    Given the following network parameters are set:
+      | name                              | value |
+      | market.stake.target.timeWindow    | 168h  |
+      | market.stake.target.scalingFactor | 1     |
+    And the simple risk model named "simple-risk-model-1":
+      | long | short | max move up | min move down | probability of trading |
+      | 0.1  | 0.1   | 10          | -10           | 0.1                    |
+    And the log normal risk model named "log-normal-risk-model-1":
+      | risk aversion | tau                    | mu | r  | sigma |
+      | 0.000001      | 0.00011407711613050422 | -1 | -1 | -1    |
+    And the fees configuration named "fees-config-1":
+      | maker fee | infrastructure fee |
+      | 0.00025   | 0.0005             |
+    And the margin calculator named "margin-calculator-1":
+      | search factor | initial factor | release factor |
+      | 1.1           | 1.2            | 1.4            |
+    And the markets:
+      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | oracle config          |
+      | ETH/DEC21 | BTC        | BTC   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | default-none     | default-eth-for-future |
+
+    And time is updated to "2021-03-08T00:00:00Z"
+
+    Given the parties deposit on asset's general account the following amount:
+      | party | asset | amount    |
+      | tt_0  | BTC   | 100000000 |
+      | tt_1  | BTC   | 100000000 |
+      | tt_2  | BTC   | 100000000 |
+      | tt_3  | BTC   | 100000000 |
+      | tt_4  | BTC   | 100000000 |
+
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | tt_0  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | tt_0_0    |
+      | tt_0  | ETH/DEC21 | sell | 1000   | 200   | 0                | TYPE_LIMIT | TIF_GTC | tt_0_1    |
+
+    Then the mark price should be "0" for the market "ETH/DEC21"
+
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | tt_1  | ETH/DEC21 | sell | 50     | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_1_0    |
+      | tt_2  | ETH/DEC21 | buy  | 20     | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_2_0    |
+      | tt_3  | ETH/DEC21 | buy  | 30     | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_2_0    |
+
+    And the market data for the market "ETH/DEC21" should be:
+      | trading mode                 | auction trigger         | target stake | supplied stake | open interest |
+      | TRADING_MODE_OPENING_AUCTION | AUCTION_TRIGGER_OPENING | 550          | 0              | 0             |
+
+    Then the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | tt_0   | ETH/DEC21 | 2000              | 0.001 | buy  | BID              | 1          | 10     | submission |
+      | lp1 | tt_0   | ETH/DEC21 | 2000              | 0.001 | sell | ASK              | 1          | 10     | amendment  |
+
+    # Add wash trades
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | tt_4  | ETH/DEC21 | sell | 40     | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_4_0    |
+      | tt_4  | ETH/DEC21 | buy  | 40     | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_4_1    |
+
+    # # Check that target stake is unchanged
+    Then the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+      | 110        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 550          | 2000           | 50            |
+
+    Then the opening auction period ends for market "ETH/DEC21"
+
+    Then the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
+      | 110        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 550          | 2000           | 50            |

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -451,7 +451,7 @@ func (b *OrderBook) GetIndicativeTrades() ([]*types.Trade, error) {
 	uncrossOrders = uncrossingSide.ExtractOrders(price, volume, false)
 	opSide := b.getOppositeSide(uncrossSide)
 	output := make([]*types.Trade, 0, len(uncrossOrders))
-	trades, err := opSide.fakeUncrossAuction(uncrossOrders, false)
+	trades, err := opSide.fakeUncrossAuction(uncrossOrders)
 	if err != nil {
 		return nil, err
 	}

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -451,17 +451,15 @@ func (b *OrderBook) GetIndicativeTrades() ([]*types.Trade, error) {
 	uncrossOrders = uncrossingSide.ExtractOrders(price, volume, false)
 	opSide := b.getOppositeSide(uncrossSide)
 	output := make([]*types.Trade, 0, len(uncrossOrders))
-	for _, o := range uncrossOrders {
-		trades, err := opSide.fakeUncross(o, false)
-		if err != nil {
-			return nil, err
-		}
-		// Update all the trades to have the correct uncrossing price
-		for index := 0; index < len(trades); index++ {
-			trades[index].Price = price.Clone()
-		}
-		output = append(output, trades...)
+	trades, err := opSide.fakeUncrossAuction(uncrossOrders, false)
+	if err != nil {
+		return nil, err
 	}
+	// Update all the trades to have the correct uncrossing price
+	for index := 0; index < len(trades); index++ {
+		trades[index].Price = price.Clone()
+	}
+	output = append(output, trades...)
 
 	return output, nil
 }

--- a/matching/orderbook.go
+++ b/matching/orderbook.go
@@ -456,8 +456,8 @@ func (b *OrderBook) GetIndicativeTrades() ([]*types.Trade, error) {
 		return nil, err
 	}
 	// Update all the trades to have the correct uncrossing price
-	for index := 0; index < len(trades); index++ {
-		trades[index].Price = price.Clone()
+	for _, t := range trades {
+		t.Price = price.Clone()
 	}
 	output = append(output, trades...)
 

--- a/matching/orderbook_test.go
+++ b/matching/orderbook_test.go
@@ -3055,7 +3055,7 @@ func TestOrderBook_IndicativePriceAndVolume9(t *testing.T) {
 	}
 }
 
-// check behaviour consistent in the presence of wash trades
+// check behaviour consistent in the presence of wash trades.
 func TestOrderBook_IndicativePriceAndVolume10(t *testing.T) {
 	market := "testOrderbook"
 	book := getTestOrderBook(t, market)

--- a/matching/pricelevel_test.go
+++ b/matching/pricelevel_test.go
@@ -94,11 +94,20 @@ func TestUncross(t *testing.T) {
 		TimeInForce:   types.OrderTimeInForceGTC,
 		CreatedAt:     0,
 	}
+
+	order, fakeTrades, err := l.fakeUncross(aggresiveOrder, true)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), order.Remaining)
+
 	filled, trades, impactedOrders, err := l.uncross(aggresiveOrder, true)
 	assert.Equal(t, true, filled)
 	assert.Equal(t, 1, len(trades))
 	assert.Equal(t, 1, len(impactedOrders))
 	assert.NoError(t, err)
+
+	for i, tr := range trades {
+		assert.Equal(t, tr, fakeTrades[i])
+	}
 }
 
 func TestUncrossDecimals(t *testing.T) {
@@ -131,6 +140,11 @@ func TestUncrossDecimals(t *testing.T) {
 		TimeInForce:   types.OrderTimeInForceGTC,
 		CreatedAt:     0,
 	}
+
+	order, fakeTrades, err := l.fakeUncross(aggresiveOrder, true)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), order.Remaining)
+
 	filled, trades, impactedOrders, err := l.uncross(aggresiveOrder, true)
 	assert.Equal(t, true, filled)
 	assert.Equal(t, 1, len(trades))
@@ -139,4 +153,8 @@ func TestUncrossDecimals(t *testing.T) {
 	// ensure the price fields are set correctly
 	assert.Equal(t, passiveOrder.OriginalPrice.String(), trades[0].MarketPrice.String())
 	assert.Equal(t, passiveOrder.Price.String(), trades[0].Price.String())
+
+	for i, tr := range trades {
+		assert.Equal(t, tr, fakeTrades[i])
+	}
 }

--- a/matching/side.go
+++ b/matching/side.go
@@ -413,6 +413,71 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order, checkWashTrades bool) ([]*
 	return trades, err
 }
 
+// fakeUncrossAuction returns hypotehetical trades if the order book side were to be uncrossed with the agg orders supplied,
+// checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades).
+func (s *OrderBookSide) fakeUncrossAuction(orders []*types.Order, checkWashTrades bool) ([]*types.Trade, error) {
+	// in here we iterate from the end, as it's easier to remove the
+	// price levels from the back of the slice instead of from the front
+	// also it will allow us to reduce allocations
+	nOrders := len(orders)
+	if nOrders == 0 {
+		return []*types.Trade{}, nil
+	}
+
+	checkPrice := func(levelPrice *num.Uint, order *types.Order) bool {
+		if order.Side == types.SideBuy {
+			return levelPrice.GT(order.Price)
+		}
+		return levelPrice.LT(order.Price)
+	}
+
+	var (
+		ntrades []*types.Trade
+		iOrder  = 0
+		trades  []*types.Trade
+		lvl     *PriceLevel
+		err     error
+	)
+
+	fake := orders[iOrder].Clone()
+	for idx := len(s.levels) - 1; idx >= 0; idx-- {
+		// clone price level
+		lvl = clonePriceLevel(s.levels[idx])
+		for lvl.volume > 0 {
+			// not a market order && buy side price is too low => continue
+			if fake.Type != types.OrderTypeMarket && checkPrice(lvl.price, fake) {
+				continue
+			}
+
+			_, ntrades, _, err = lvl.uncross(fake, checkWashTrades)
+			washTrade := err != nil && err == ErrWashTrade
+			trades = append(trades, ntrades...)
+			// move to the next order if a wash trade is detected
+			if fake.Remaining == 0 || washTrade {
+				iOrder++
+				if iOrder >= nOrders {
+					return trades, err
+				}
+				fake = orders[iOrder].Clone()
+			}
+		}
+	}
+	return trades, err
+}
+
+func clonePriceLevel(lvl *PriceLevel) *PriceLevel {
+
+	orders := make([]*types.Order, 0, len(lvl.orders))
+	for _, o := range lvl.orders {
+		orders = append(orders, o.Clone())
+	}
+	return &PriceLevel{
+		price:  lvl.price.Clone(),
+		orders: orders,
+		volume: lvl.volume,
+	}
+}
+
 // uncross returns trades after order book side gets uncrossed with the agg order supplied,
 // checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades).
 func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool) ([]*types.Trade, []*types.Order, *num.Uint, error) {

--- a/matching/side.go
+++ b/matching/side.go
@@ -457,13 +457,13 @@ func (s *OrderBookSide) fakeUncrossAuction(orders []*types.Order) ([]*types.Trad
 			if fake.Remaining == 0 {
 				iOrder++
 				if iOrder >= nOrders {
-					return trades, err
+					return trades, nil
 				}
 				fake = orders[iOrder].Clone()
 			}
 		}
 	}
-	return trades, err
+	return trades, nil
 }
 
 func clonePriceLevel(lvl *PriceLevel) *PriceLevel {

--- a/matching/side.go
+++ b/matching/side.go
@@ -413,8 +413,7 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order, checkWashTrades bool) ([]*
 	return trades, err
 }
 
-// fakeUncrossAuction returns hypotehetical trades if the order book side were to be uncrossed with the agg orders supplied,
-// wash trades are allowed
+// fakeUncrossAuction returns hypotehetical trades if the order book side were to be uncrossed with the agg orders supplied, wash trades are allowed.
 func (s *OrderBookSide) fakeUncrossAuction(orders []*types.Order) ([]*types.Trade, error) {
 	// in here we iterate from the end, as it's easier to remove the
 	// price levels from the back of the slice instead of from the front
@@ -467,7 +466,6 @@ func (s *OrderBookSide) fakeUncrossAuction(orders []*types.Order) ([]*types.Trad
 }
 
 func clonePriceLevel(lvl *PriceLevel) *PriceLevel {
-
 	orders := make([]*types.Order, 0, len(lvl.orders))
 	for _, o := range lvl.orders {
 		orders = append(orders, o.Clone())

--- a/matching/side_test.go
+++ b/matching/side_test.go
@@ -555,3 +555,50 @@ func TestFakeUncrossNotEnoughVolume(t *testing.T) {
 	assert.Len(t, trades, 0)
 	assert.NoError(t, err)
 }
+
+func TestFakeUncrossAuction(t *testing.T) {
+	buySide := getPopulatedTestSide(types.SideBuy)
+
+	order1 := &types.Order{
+		ID:            "Id",
+		Party:         "A",
+		Price:         num.NewUint(99),
+		OriginalPrice: num.NewUint(99),
+		Side:          types.SideSell,
+		Size:          3,
+		Remaining:     3,
+		TimeInForce:   types.OrderTimeInForceGTC,
+		Type:          types.OrderTypeLimit,
+	}
+
+	order2 := &types.Order{
+		ID:            "Id",
+		Party:         "B",
+		Price:         num.NewUint(99),
+		OriginalPrice: num.NewUint(99),
+		Side:          types.SideSell,
+		Size:          3,
+		Remaining:     3,
+		TimeInForce:   types.OrderTimeInForceGTC,
+		Type:          types.OrderTypeLimit,
+	}
+
+	orders := []*types.Order{order1, order2}
+
+	fakeTrades, err := buySide.fakeUncrossAuction(orders)
+	assert.Len(t, fakeTrades, 6)
+	assert.NoError(t, err)
+
+	trades := []*types.Trade{}
+	for _, order := range orders {
+		trds, _, _, err := buySide.uncross(order, false)
+		assert.NoError(t, err)
+		trades = append(trades, trds...)
+	}
+	assert.Len(t, trades, 6)
+	assert.NoError(t, err)
+
+	for i, tr := range trades {
+		assert.Equal(t, tr, fakeTrades[i])
+	}
+}

--- a/positions/engine.go
+++ b/positions/engine.go
@@ -330,6 +330,10 @@ func (e *Engine) GetOpenInterestGivenTrades(trades []*types.Trade) uint64 {
 	posLocal := make(map[string]int64)
 	var ok bool
 	for _, t := range trades {
+		if t.Seller == t.Buyer {
+			// ignore wash trade
+			continue
+		}
 		bPos, sPos := int64(0), int64(0)
 		if bPos, ok = posLocal[t.Buyer]; !ok {
 			if p, ok := e.positions[t.Buyer]; ok {

--- a/positions/engine_test.go
+++ b/positions/engine_test.go
@@ -365,6 +365,16 @@ func TestGetOpenInterestGivenTrades(t *testing.T) {
 			},
 			ExpectedOI: 110,
 		},
+		{
+			// Same as above + wash trade -> should leave OI unchanged
+			ExistingPositions: []*types.Trade{},
+			Trades: []*types.Trade{
+				{Seller: "A", Buyer: "B", Size: 20, Price: num.Zero()},
+				{Seller: "A", Buyer: "C", Size: 30, Price: num.Zero()},
+				{Seller: "D", Buyer: "D", Size: 40, Price: num.Zero()},
+			},
+			ExpectedOI: 50,
+		},
 		// There at least 1 new party
 		{
 			// A: + 100 + 10, B: -100, C: -10 => OI: 110


### PR DESCRIPTION
Assure we get theoretical trades in line with those obtained when uncrossing order book in when leaving auction. Remove wash trades from theoretical open interest calculation. 

Closes #5480 #5478 