### PR TITLE
fix: only check the checkpoint file name for 3 hypens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Fixes
 - [5476](https://github.com/vegaprotocol/vega/issues/5476) - Include settlement price in snapshot
+- [5476](https://github.com/vegaprotocol/vega/issues/5314) - Fix validation of checkpoint file
 
 ## 0.52.0
 

--- a/cmd/vega/genesis/load_checkpoint.go
+++ b/cmd/vega/genesis/load_checkpoint.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"code.vegaprotocol.io/vega/genesis"
@@ -62,7 +63,7 @@ func (opts *loadCheckpointCmd) Execute(_ []string) error {
 		return err
 	}
 
-	splits := strings.Split(f.Name(), "-")
+	splits := strings.Split(filepath.Base(f.Name()), "-")
 	if len(splits) != 3 {
 		return fmt.Errorf("invalid checkpoint file name: `%v`", f.Name())
 	}


### PR DESCRIPTION
closes #5314

Help unblock(-ish) the checkpoint capsule tests running on the CI. I've tested locally doing this:
```
vega genesis load_checkpoint --checkpoint-path=/Users/wwestgarth/Downloads/testnet/thing-thing/20220621153424-167-a2159168681166ad70bea2fd93abe17db2956c28ef07935ebca489baaa776986.cp
```