### PR TITLE
fix: propagate an error in command specific checkTx back to the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Fixes
 - [5476](https://github.com/vegaprotocol/vega/issues/5476) - Include settlement price in snapshot
 - [5476](https://github.com/vegaprotocol/vega/issues/5314) - Fix validation of checkpoint file
+- [5499](https://github.com/vegaprotocol/vega/issues/5499) - Add error from app specific validation to check transaction response
 
 ## 0.52.0
 

--- a/blockchain/abci/abci.go
+++ b/blockchain/abci/abci.go
@@ -110,8 +110,8 @@ func (app *App) CheckTx(req types.RequestCheckTx) (resp types.ResponseCheckTx) {
 	// Lookup for check tx, skip if not found
 	if fn, ok := app.checkTxs[tx.Command()]; ok {
 		if err := fn(ctx, tx); err != nil {
-			resp.Code = AbciTxnInternalError
 			println("transaction failed command validation", tx.Command().String(), "tid", tx.GetPoWTID(), err.Error())
+			return AddCommonCheckTxEvents(NewResponseCheckTxError(AbciTxnInternalError, err), tx)
 		}
 	}
 


### PR DESCRIPTION
Closes #5499 