### PR TITLE
fix: Do not fail silently when wallet fails to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Vega specific entries
 build/
+vegawallet
 bin/
 cmd/*/*-dbg
 cmd/vega/vega*
+cmd/vegawallet/vegawallet*
 cmd/vegabenchmark/vegabenchmark*
 cmd/examples/nullchain/nullchain*
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [5499](https://github.com/vegaprotocol/vega/issues/5499) - Add error from app specific validation to check transaction response
 - [5508](https://github.com/vegaprotocol/vega/issues/5508) - Fix duplicated staking events
 - [5514](https://github.com/vegaprotocol/vega/issues/5514) - Emit `rewardScore` event correctly after loading from checkpoint
+- [5520](https://github.com/vegaprotocol/vega/issues/5520) - Do not fail silently when wallet fails to start
 
 ## 0.52.0
 

--- a/cmd/vegawallet/commands/cmd.go
+++ b/cmd/vegawallet/commands/cmd.go
@@ -57,7 +57,7 @@ func Execute(w *Writer) {
 func fprintErrorInteractive(w *Writer, execErr error) {
 	if vgterm.HasTTY() {
 		p := printer.NewInteractivePrinter(w.Out)
-		p.CrossMark().DangerText(execErr.Error()).NextLine()
+		p.Print(p.String().CrossMark().DangerText(execErr.Error()).NextLine())
 	} else {
 		_, _ = fmt.Fprintln(w.Err, execErr)
 	}

--- a/cmd/vegawallet/commands/command_send.go
+++ b/cmd/vegawallet/commands/command_send.go
@@ -258,7 +258,7 @@ func SendCommand(w io.Writer, rf *RootFlags, req *SendCommandRequest) error {
 
 	p := printer.NewInteractivePrinter(w)
 	if rf.Output == flags.InteractiveOutput {
-		p.BlueArrow().InfoText("Logs").NextLine()
+		p.Print(p.String().BlueArrow().InfoText("Logs").NextLine())
 	}
 
 	ctx, cancelFn := context.WithTimeout(context.Background(), ForwarderRequestTimeout)

--- a/cmd/vegawallet/commands/command_sign.go
+++ b/cmd/vegawallet/commands/command_sign.go
@@ -173,10 +173,12 @@ func (f *SignCommandFlags) Validate() (*wallet.SignCommandRequest, error) {
 func PrintSignCommandResponse(w io.Writer, req *wallet.SignCommandResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().SuccessText("Command signature successful").NextSection()
-	p.Text("Transaction (base64-encoded):").NextLine().WarningText(req.Base64Transaction).NextSection()
+	str := p.String()
+	defer p.Print(str)
+	str.CheckMark().SuccessText("Command signature successful").NextSection()
+	str.Text("Transaction (base64-encoded):").NextLine().WarningText(req.Base64Transaction).NextSection()
 
-	p.BlueArrow().InfoText("Send a transaction").NextLine()
-	p.Text("To send a raw transaction, see the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s tx send --help", os.Args[0])).NextSection()
+	str.BlueArrow().InfoText("Send a transaction").NextLine()
+	str.Text("To send a raw transaction, see the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s tx send --help", os.Args[0])).NextSection()
 }

--- a/cmd/vegawallet/commands/init.go
+++ b/cmd/vegawallet/commands/init.go
@@ -108,13 +108,16 @@ func Init(home string, f *InitFlags) (*InitResponse, error) {
 func PrintInitResponse(w io.Writer, resp *InitResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().Text("Service public RSA keys created at: ").SuccessText(resp.RSAKeys.PublicKeyFilePath).NextLine()
-	p.CheckMark().Text("Service private RSA keys created at: ").SuccessText(resp.RSAKeys.PrivateKeyFilePath).NextLine()
-	p.CheckMark().SuccessText("Initialisation succeeded").NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.BlueArrow().InfoText("Create a wallet").NextLine()
-	p.Text("To create a wallet, use the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s create --wallet \"YOUR_USERNAME\"", os.Args[0])).NextSection()
-	p.Text("The ").Bold("--wallet").Text(" flag sets the name of your wallet and will be used to login to Vega Console.").NextSection()
-	p.Text("For more information, use ").Bold("--help").Text(" flag.").NextLine()
+	str.CheckMark().Text("Service public RSA keys created at: ").SuccessText(resp.RSAKeys.PublicKeyFilePath).NextLine()
+	str.CheckMark().Text("Service private RSA keys created at: ").SuccessText(resp.RSAKeys.PrivateKeyFilePath).NextLine()
+	str.CheckMark().SuccessText("Initialisation succeeded").NextSection()
+
+	str.BlueArrow().InfoText("Create a wallet").NextLine()
+	str.Text("To create a wallet, use the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s create --wallet \"YOUR_USERNAME\"", os.Args[0])).NextSection()
+	str.Text("The ").Bold("--wallet").Text(" flag sets the name of your wallet and will be used to login to Vega Console.").NextSection()
+	str.Text("For more information, use ").Bold("--help").Text(" flag.").NextLine()
 }

--- a/cmd/vegawallet/commands/key.go
+++ b/cmd/vegawallet/commands/key.go
@@ -27,7 +27,7 @@ func NewCmdKey(w io.Writer, rf *RootFlags) *cobra.Command {
 	return cmd
 }
 
-func printMeta(p *printer.InteractivePrinter, meta []wallet.Meta) {
+func printMeta(str *printer.FormattedString, meta []wallet.Meta) {
 	padding := 0
 	for _, m := range meta {
 		keyLen := len(m.Key)
@@ -37,6 +37,6 @@ func printMeta(p *printer.InteractivePrinter, meta []wallet.Meta) {
 	}
 
 	for _, m := range meta {
-		p.WarningText(fmt.Sprintf("%-*s", padding, m.Key)).Text(" | ").WarningText(m.Value).NextLine()
+		str.WarningText(fmt.Sprintf("%-*s", padding, m.Key)).Text(" | ").WarningText(m.Value).NextLine()
 	}
 }

--- a/cmd/vegawallet/commands/key_annotate.go
+++ b/cmd/vegawallet/commands/key_annotate.go
@@ -160,11 +160,13 @@ func PrintAnnotateKeyResponse(w io.Writer, req *wallet.AnnotateKeyRequest) {
 	metadataHaveBeenCleared := len(req.Metadata) == 0
 
 	p := printer.NewInteractivePrinter(w)
+	str := p.String()
+	defer p.Print(str)
 	if metadataHaveBeenCleared {
-		p.CheckMark().SuccessText("Annotation cleared").NextLine()
+		str.CheckMark().SuccessText("Annotation cleared").NextLine()
 		return
 	}
-	p.CheckMark().SuccessText("Annotation succeeded").NextSection()
-	p.Text("New metadata:").NextLine()
-	printMeta(p, req.Metadata)
+	str.CheckMark().SuccessText("Annotation succeeded").NextSection()
+	str.Text("New metadata:").NextLine()
+	printMeta(str, req.Metadata)
 }

--- a/cmd/vegawallet/commands/key_describe.go
+++ b/cmd/vegawallet/commands/key_describe.go
@@ -119,23 +119,26 @@ func (f *DescribeKeyFlags) Validate() (*wallet.DescribeKeyRequest, error) {
 }
 
 func PrintDescribeKeyResponse(w io.Writer, resp *wallet.DescribeKeyResponse) {
-	p := printer.NewInteractivePrinter(w).NextLine()
+	p := printer.NewInteractivePrinter(w)
 
-	p.Text("Name:              ").WarningText(wallet.GetKeyName(resp.Meta)).NextLine()
-	p.Text("Public key:        ").WarningText(resp.PublicKey).NextLine()
-	p.Text("Algorithm Name:    ").WarningText(resp.Algorithm.Name).NextLine()
-	p.Text("Algorithm Version: ").WarningText(fmt.Sprint(resp.Algorithm.Version)).NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.Text("Key pair is: ")
+	str.Text("Name:              ").WarningText(wallet.GetKeyName(resp.Meta)).NextLine()
+	str.Text("Public key:        ").WarningText(resp.PublicKey).NextLine()
+	str.Text("Algorithm Name:    ").WarningText(resp.Algorithm.Name).NextLine()
+	str.Text("Algorithm Version: ").WarningText(fmt.Sprint(resp.Algorithm.Version)).NextSection()
+
+	str.Text("Key pair is: ")
 	switch resp.IsTainted {
 	case true:
-		p.DangerText("tainted").NextLine()
+		str.DangerText("tainted").NextLine()
 	case false:
-		p.SuccessText("not tainted").NextLine()
+		str.SuccessText("not tainted").NextLine()
 	}
-	p.Text("Tainting a key pair marks it as unsafe to use and ensures it will not be used to sign transactions.").NextLine()
-	p.Text("This mechanism is useful when the key pair has been compromised.").NextSection()
+	str.Text("Tainting a key pair marks it as unsafe to use and ensures it will not be used to sign transactions.").NextLine()
+	str.Text("This mechanism is useful when the key pair has been compromised.").NextSection()
 
-	p.Text("Metadata:").NextLine()
-	printMeta(p, resp.Meta)
+	str.Text("Metadata:").NextLine()
+	printMeta(str, resp.Meta)
 }

--- a/cmd/vegawallet/commands/key_generate.go
+++ b/cmd/vegawallet/commands/key_generate.go
@@ -129,16 +129,17 @@ func (f *GenerateKeyFlags) Validate() (*wallet.GenerateKeyRequest, error) {
 func PrintGenerateKeyResponse(w io.Writer, req *wallet.GenerateKeyRequest, resp *wallet.GenerateKeyResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().Text("Key pair has been generated in wallet ").Bold(req.Wallet).NextLine()
-	p.CheckMark().SuccessText("Generating a key pair succeeded").NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.Text("Public key:").NextLine()
-	p.WarningText(resp.PublicKey).NextLine()
-	p.Text("Metadata:").NextLine()
-	printMeta(p, resp.Meta)
-	p.NextSection()
-
-	p.BlueArrow().InfoText("Run the service").NextLine()
-	p.Text("Now, you can run the service. See the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s service run --help", os.Args[0])).NextLine()
+	str.CheckMark().Text("Key pair has been generated in wallet ").Bold(req.Wallet).NextLine()
+	str.CheckMark().SuccessText("Generating a key pair succeeded").NextSection()
+	str.Text("Public key:").NextLine()
+	str.WarningText(resp.PublicKey).NextLine()
+	str.Text("Metadata:").NextLine()
+	printMeta(str, resp.Meta)
+	str.NextSection()
+	str.BlueArrow().InfoText("Run the service").NextLine()
+	str.Text("Now, you can run the service. See the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s service run --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/key_isolate.go
+++ b/cmd/vegawallet/commands/key_isolate.go
@@ -132,6 +132,8 @@ func (f *IsolateKeyFlags) Validate() (*wallet.IsolateKeyRequest, error) {
 func PrintIsolateKeyResponse(w io.Writer, resp *wallet.IsolateKeyResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().Text("Key pair has been isolated in wallet ").Bold(resp.Wallet).Text(" at: ").SuccessText(resp.FilePath).NextLine()
-	p.CheckMark().SuccessText("Key isolation succeeded").NextLine()
+	str := p.String()
+	defer p.Print(str)
+	str.CheckMark().Text("Key pair has been isolated in wallet ").Bold(resp.Wallet).Text(" at: ").SuccessText(resp.FilePath).NextLine()
+	str.CheckMark().SuccessText("Key isolation succeeded").NextLine()
 }

--- a/cmd/vegawallet/commands/key_list.go
+++ b/cmd/vegawallet/commands/key_list.go
@@ -110,11 +110,14 @@ func (f *ListKeysFlags) Validate() (*wallet.ListKeysRequest, error) {
 func PrintListKeysResponse(w io.Writer, resp *wallet.ListKeysResponse) {
 	p := printer.NewInteractivePrinter(w)
 
+	str := p.String()
+	defer p.Print(str)
+
 	for i, key := range resp.Keys {
 		if i != 0 {
-			p.NextLine()
+			str.NextLine()
 		}
-		p.Text("Name:       ").WarningText(key.Name).NextLine()
-		p.Text("Public key: ").WarningText(key.PublicKey).NextLine()
+		str.Text("Name:       ").WarningText(key.Name).NextLine()
+		str.Text("Public key: ").WarningText(key.PublicKey).NextLine()
 	}
 }

--- a/cmd/vegawallet/commands/key_rotate.go
+++ b/cmd/vegawallet/commands/key_rotate.go
@@ -160,9 +160,13 @@ func (f *RotateKeyFlags) Validate() (*wallet.RotateKeyRequest, error) {
 
 func PrintRotateKeyResponse(w io.Writer, req *wallet.RotateKeyResponse) {
 	p := printer.NewInteractivePrinter(w)
-	p.CheckMark().SuccessText("Key rotation succeeded").NextSection()
-	p.Text("Transaction (base64-encoded):").NextLine()
-	p.Text(req.Base64Transaction).NextLine()
-	p.Text("Master public key used:").NextLine()
-	p.Text(req.MasterPublicKey).NextLine()
+
+	str := p.String()
+	defer p.Print(str)
+
+	str.CheckMark().SuccessText("Key rotation succeeded").NextSection()
+	str.Text("Transaction (base64-encoded):").NextLine()
+	str.Text(req.Base64Transaction).NextLine()
+	str.Text("Master public key used:").NextLine()
+	str.Text(req.MasterPublicKey).NextLine()
 }

--- a/cmd/vegawallet/commands/key_taint.go
+++ b/cmd/vegawallet/commands/key_taint.go
@@ -124,12 +124,15 @@ func (f *TaintKeyFlags) Validate() (*wallet.TaintKeyRequest, error) {
 func PrintTaintKeyResponse(w io.Writer) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().SuccessText("Tainting succeeded").NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.RedArrow().DangerText("Important").NextLine()
-	p.Text("If you tainted a key for security reasons, you should not untaint it.").NextSection()
+	str.CheckMark().SuccessText("Tainting succeeded").NextSection()
 
-	p.BlueArrow().InfoText("Untaint a key").NextLine()
-	p.Text("You may have tainted a key pair by mistake. If you want to untaint it, see the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s key untaint --help", os.Args[0])).NextLine()
+	str.RedArrow().DangerText("Important").NextLine()
+	str.Text("If you tainted a key for security reasons, you should not untaint it.").NextSection()
+
+	str.BlueArrow().InfoText("Untaint a key").NextLine()
+	str.Text("You may have tainted a key pair by mistake. If you want to untaint it, see the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s key untaint --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/key_untaint.go
+++ b/cmd/vegawallet/commands/key_untaint.go
@@ -123,12 +123,15 @@ func (f *UntaintKeyFlags) Validate() (*wallet.UntaintKeyRequest, error) {
 func PrintUntaintKeyResponse(w io.Writer) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().SuccessText("Untainting succeeded").NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.RedArrow().DangerText("Important").NextLine()
-	p.Text("If you tainted a key for security reasons, you should not use it.").NextLine()
+	str.CheckMark().SuccessText("Untainting succeeded").NextSection()
 
-	p.BlueArrow().InfoText("Taint a key").NextLine()
-	p.Text("To taint a key pair, see the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s key taint --help", os.Args[0])).NextLine()
+	str.RedArrow().DangerText("Important").NextLine()
+	str.Text("If you tainted a key for security reasons, you should not use it.").NextLine()
+
+	str.BlueArrow().InfoText("Taint a key").NextLine()
+	str.Text("To taint a key pair, see the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s key taint --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/message_sign.go
+++ b/cmd/vegawallet/commands/message_sign.go
@@ -141,10 +141,13 @@ func (f *SignMessageFlags) Validate() (*wallet.SignMessageRequest, error) {
 func PrintSignMessageResponse(w io.Writer, req *wallet.SignMessageResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().SuccessText("Message signature successful").NextSection()
-	p.Text("Signature (base64-encoded):").NextLine().WarningText(req.Base64).NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.BlueArrow().InfoText("Sign a message").NextLine()
-	p.Text("To verify a message, see the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s verify --help", os.Args[0])).NextSection()
+	str.CheckMark().SuccessText("Message signature successful").NextSection()
+	str.Text("Signature (base64-encoded):").NextLine().WarningText(req.Base64).NextSection()
+
+	str.BlueArrow().InfoText("Sign a message").NextLine()
+	str.Text("To verify a message, see the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s verify --help", os.Args[0])).NextSection()
 }

--- a/cmd/vegawallet/commands/message_verify.go
+++ b/cmd/vegawallet/commands/message_verify.go
@@ -124,13 +124,16 @@ func (f *VerifyMessageFlags) Validate() (*crypto.VerifyMessageRequest, error) {
 func PrintVerifyMessageResponse(w io.Writer, isValid bool) {
 	p := printer.NewInteractivePrinter(w)
 
+	str := p.String()
+	defer p.Print(str)
+
 	if isValid {
-		p.CheckMark().SuccessText("Valid signature").NextSection()
+		str.CheckMark().SuccessText("Valid signature").NextSection()
 	} else {
-		p.CrossMark().DangerText("Invalid signature").NextSection()
+		str.CrossMark().DangerText("Invalid signature").NextSection()
 	}
 
-	p.BlueArrow().InfoText("Sign a message").NextLine()
-	p.Text("To sign a message, see the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s sign --help", os.Args[0])).NextLine()
+	str.BlueArrow().InfoText("Sign a message").NextLine()
+	str.Text("To sign a message, see the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s sign --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/network_delete.go
+++ b/cmd/vegawallet/commands/network_delete.go
@@ -111,5 +111,9 @@ func (f *DeleteNetworkFlags) Validate() (*network.DeleteNetworkRequest, error) {
 
 func PrintDeleteNetworkResponse(w io.Writer, networkName string) {
 	p := printer.NewInteractivePrinter(w)
-	p.CheckMark().SuccessText("Network ").SuccessBold(networkName).SuccessText(" deleted").NextLine()
+
+	str := p.String()
+	defer p.Print(str)
+
+	str.CheckMark().SuccessText("Network ").SuccessBold(networkName).SuccessText(" deleted").NextLine()
 }

--- a/cmd/vegawallet/commands/network_describe.go
+++ b/cmd/vegawallet/commands/network_describe.go
@@ -98,36 +98,40 @@ func BuildCmdDescribeNetwork(w io.Writer, handler DescribeNetworkHandler, rf *Ro
 
 func PrintDescribeNetworkResponse(w io.Writer, resp *network.DescribeNetworkResponse) {
 	p := printer.NewInteractivePrinter(w)
-	p.NextLine().Text("Network").NextLine()
-	p.Text("  Name:         ").WarningText(resp.Name).NextLine()
-	p.Text("  Address:      ").WarningText(resp.Host).WarningText(":").WarningText(fmt.Sprint(resp.Port)).NextLine()
-	p.Text("  Token expiry: ").WarningText(resp.TokenExpiry).NextLine()
-	p.Text("  Level:        ").WarningText(resp.Level)
-	p.NextSection()
 
-	p.Text("API.GRPC").NextLine()
-	p.Text("  Retries: ").WarningText(fmt.Sprint(resp.API.GRPCConfig.Retries)).NextLine()
-	p.Text("  Hosts:").NextLine()
+	str := p.String()
+	defer p.Print(str)
+
+	str.NextLine().Text("Network").NextLine()
+	str.Text("  Name:         ").WarningText(resp.Name).NextLine()
+	str.Text("  Address:      ").WarningText(resp.Host).WarningText(":").WarningText(fmt.Sprint(resp.Port)).NextLine()
+	str.Text("  Token expiry: ").WarningText(resp.TokenExpiry).NextLine()
+	str.Text("  Level:        ").WarningText(resp.Level)
+	str.NextSection()
+
+	str.Text("API.GRPC").NextLine()
+	str.Text("  Retries: ").WarningText(fmt.Sprint(resp.API.GRPCConfig.Retries)).NextLine()
+	str.Text("  Hosts:").NextLine()
 	for _, h := range resp.API.GRPCConfig.Hosts {
-		p.Text("    - ").WarningText(h).NextLine()
+		str.Text("    - ").WarningText(h).NextLine()
 	}
-	p.NextLine()
+	str.NextLine()
 
-	p.Text("API.REST").NextLine()
-	p.Text("  Hosts:").NextLine()
+	str.Text("API.REST").NextLine()
+	str.Text("  Hosts:").NextLine()
 	for _, h := range resp.API.RESTConfig.Hosts {
-		p.Text("    - ").WarningText(h).NextLine()
+		str.Text("    - ").WarningText(h).NextLine()
 	}
 
-	p.NextLine()
-	p.Text("API.GraphQL").NextLine()
-	p.Text("  Hosts:").NextLine()
+	str.NextLine()
+	str.Text("API.GraphQL").NextLine()
+	str.Text("  Hosts:").NextLine()
 	for _, h := range resp.API.GraphQLConfig.Hosts {
-		p.Text("    - ").WarningText(h).NextLine()
+		str.Text("    - ").WarningText(h).NextLine()
 	}
-	p.NextLine()
+	str.NextLine()
 
-	p.Text("Console").NextLine()
-	p.Text("  Address: ").WarningText(resp.Console.URL).WarningText(":").WarningText(fmt.Sprint(resp.Console.LocalPort))
-	p.NextSection()
+	str.Text("Console").NextLine()
+	str.Text("  Address: ").WarningText(resp.Console.URL).WarningText(":").WarningText(fmt.Sprint(resp.Console.LocalPort))
+	str.NextSection()
 }

--- a/cmd/vegawallet/commands/network_import.go
+++ b/cmd/vegawallet/commands/network_import.go
@@ -132,7 +132,10 @@ func (f *ImportNetworkFlags) Validate() (*network.ImportNetworkFromSourceRequest
 func PrintImportNetworkResponse(w io.Writer, resp *network.ImportNetworkFromSourceResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().SuccessText("Importing the network succeeded").NextSection()
-	p.Text("Name:").NextLine().WarningText(resp.Name).NextLine()
-	p.Text("File path:").NextLine().WarningText(resp.FilePath).NextLine()
+	str := p.String()
+	defer p.Print(str)
+
+	str.CheckMark().SuccessText("Importing the network succeeded").NextSection()
+	str.Text("Name:").NextLine().WarningText(resp.Name).NextLine()
+	str.Text("File path:").NextLine().WarningText(resp.FilePath).NextLine()
 }

--- a/cmd/vegawallet/commands/network_list.go
+++ b/cmd/vegawallet/commands/network_list.go
@@ -71,12 +71,15 @@ func BuildCmdListNetworks(w io.Writer, handler ListNetworksHandler, rf *RootFlag
 func PrintListNetworksResponse(w io.Writer, resp *network.ListNetworksResponse) {
 	p := printer.NewInteractivePrinter(w)
 
+	str := p.String()
+	defer p.Print(str)
+
 	if len(resp.Networks) == 0 {
-		p.InfoText("No network registered").NextLine()
+		str.InfoText("No network registered").NextLine()
 		return
 	}
 
 	for _, net := range resp.Networks {
-		p.Text(fmt.Sprintf("- %s", net)).NextLine()
+		str.Text(fmt.Sprintf("- %s", net)).NextLine()
 	}
 }

--- a/cmd/vegawallet/commands/network_locate.go
+++ b/cmd/vegawallet/commands/network_locate.go
@@ -76,5 +76,8 @@ func BuildCmdLocateNetworks(w io.Writer, handler LocateNetworksHandler, rf *Root
 func PrintLocateNetworksResponse(w io.Writer, resp *LocateNetworksResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.Text("Network configuration files are located at: ").SuccessText(resp.Path).NextLine()
+	str := p.String()
+	defer p.Print(str)
+
+	str.Text("Network configuration files are located at: ").SuccessText(resp.Path).NextLine()
 }

--- a/cmd/vegawallet/commands/printer/interactive.go
+++ b/cmd/vegawallet/commands/printer/interactive.go
@@ -12,10 +12,10 @@ type InteractivePrinter struct {
 	writer       io.Writer
 	profile      termenv.Profile
 	checkMark    string
-	bangMark     string
 	crossMark    string
 	questionMark string
 	arrow        termenv.Style
+	bangMark     termenv.Style
 }
 
 func fancyPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
@@ -23,21 +23,22 @@ func fancyPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
 		writer:       w,
 		profile:      profile,
 		checkMark:    termenv.String("✓ ").Foreground(profile.Color("2")).String(),
-		bangMark:     termenv.String("! ").Foreground(profile.Color("1")).String(),
 		questionMark: termenv.String("? ").Foreground(profile.Color("2")).String(),
 		crossMark:    termenv.String("✗ ").Foreground(profile.Color("1")).String(),
-		arrow:        termenv.String("➜ ").Foreground(profile.Color("2")),
+		bangMark:     termenv.String("! "),
+		arrow:        termenv.String("➜ "),
 	}
 }
 
 func ansiPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
 	return &InteractivePrinter{
-		writer:    w,
-		profile:   profile,
-		checkMark: termenv.String("* ").Foreground(profile.Color("2")).String(),
-		bangMark:  termenv.String("! ").Foreground(profile.Color("1")).String(),
-		crossMark: termenv.String("x ").Foreground(profile.Color("1")).String(),
-		arrow:     termenv.String("> ").Foreground(profile.Color("2")),
+		writer:       w,
+		profile:      profile,
+		checkMark:    termenv.String("* ").Foreground(profile.Color("2")).String(),
+		questionMark: termenv.String("? ").Foreground(profile.Color("2")).String(),
+		crossMark:    termenv.String("x ").Foreground(profile.Color("1")).String(),
+		bangMark:     termenv.String("! "),
+		arrow:        termenv.String("> "),
 	}
 }
 
@@ -70,8 +71,13 @@ func (p *InteractivePrinter) CheckMark() *InteractivePrinter {
 	return p
 }
 
-func (p *InteractivePrinter) BangMark() *InteractivePrinter {
-	p.printOut(p.bangMark)
+func (p *InteractivePrinter) WarningBangMark() *InteractivePrinter {
+	p.printOut(p.bangMark.Foreground(p.profile.Color("3")).String())
+	return p
+}
+
+func (p *InteractivePrinter) DangerBangMark() *InteractivePrinter {
+	p.printOut(p.bangMark.Foreground(p.profile.Color("1")).String())
 	return p
 }
 

--- a/cmd/vegawallet/commands/printer/interactive.go
+++ b/cmd/vegawallet/commands/printer/interactive.go
@@ -3,14 +3,14 @@ package printer
 import (
 	"fmt"
 	"io"
-	"runtime"
 
 	"github.com/muesli/termenv"
 )
 
 type InteractivePrinter struct {
-	writer       io.Writer
-	profile      termenv.Profile
+	writer  io.Writer
+	profile termenv.Profile
+
 	checkMark    string
 	crossMark    string
 	questionMark string
@@ -18,141 +18,131 @@ type InteractivePrinter struct {
 	bangMark     termenv.Style
 }
 
-func fancyPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
-	return &InteractivePrinter{
-		writer:       w,
-		profile:      profile,
-		checkMark:    termenv.String("✓ ").Foreground(profile.Color("2")).String(),
-		questionMark: termenv.String("? ").Foreground(profile.Color("2")).String(),
-		crossMark:    termenv.String("✗ ").Foreground(profile.Color("1")).String(),
-		bangMark:     termenv.String("! "),
-		arrow:        termenv.String("➜ "),
+func (p *InteractivePrinter) String() *FormattedString {
+	return &FormattedString{
+		profile:      p.profile,
+		checkMark:    p.checkMark,
+		crossMark:    p.crossMark,
+		questionMark: p.questionMark,
+		arrow:        p.arrow,
+		bangMark:     p.bangMark,
 	}
 }
 
-func ansiPrinter(w io.Writer, profile termenv.Profile) *InteractivePrinter {
-	return &InteractivePrinter{
-		writer:       w,
-		profile:      profile,
-		checkMark:    termenv.String("* ").Foreground(profile.Color("2")).String(),
-		questionMark: termenv.String("? ").Foreground(profile.Color("2")).String(),
-		crossMark:    termenv.String("x ").Foreground(profile.Color("1")).String(),
-		bangMark:     termenv.String("! "),
-		arrow:        termenv.String("> "),
-	}
-}
-
-func NewInteractivePrinter(w io.Writer) *InteractivePrinter {
-	enableLegacyWindowsANSI()
-	profile := termenv.EnvColorProfile()
-	if runtime.GOOS == "windows" {
-		return ansiPrinter(w, profile)
-	}
-	return fancyPrinter(w, profile)
-}
-
-func (p *InteractivePrinter) GreenArrow() *InteractivePrinter {
-	p.printOut(p.arrow.Foreground(p.profile.Color("2")).String())
-	return p
-}
-
-func (p *InteractivePrinter) RedArrow() *InteractivePrinter {
-	p.printOut(p.arrow.Foreground(p.profile.Color("1")).String())
-	return p
-}
-
-func (p *InteractivePrinter) BlueArrow() *InteractivePrinter {
-	p.printOut(p.arrow.Foreground(p.profile.Color("6")).String())
-	return p
-}
-
-func (p *InteractivePrinter) CheckMark() *InteractivePrinter {
-	p.printOut(p.checkMark)
-	return p
-}
-
-func (p *InteractivePrinter) WarningBangMark() *InteractivePrinter {
-	p.printOut(p.bangMark.Foreground(p.profile.Color("3")).String())
-	return p
-}
-
-func (p *InteractivePrinter) DangerBangMark() *InteractivePrinter {
-	p.printOut(p.bangMark.Foreground(p.profile.Color("1")).String())
-	return p
-}
-
-func (p *InteractivePrinter) QuestionMark() *InteractivePrinter {
-	p.printOut(p.questionMark)
-	return p
-}
-
-func (p *InteractivePrinter) CrossMark() *InteractivePrinter {
-	p.printOut(p.crossMark)
-	return p
-}
-
-func (p *InteractivePrinter) SuccessText(t string) *InteractivePrinter {
-	p.printOut(termenv.String(t).Foreground(p.profile.Color("2")).String())
-	return p
-}
-
-func (p *InteractivePrinter) InfoText(t string) *InteractivePrinter {
-	p.printOut(termenv.String(t).Foreground(p.profile.Color("6")).String())
-	return p
-}
-
-func (p *InteractivePrinter) WarningText(t string) *InteractivePrinter {
-	p.printOut(termenv.String(t).Foreground(p.profile.Color("3")).String())
-	return p
-}
-
-func (p *InteractivePrinter) DangerText(t string) *InteractivePrinter {
-	p.printOut(termenv.String(t).Foreground(p.profile.Color("1")).String())
-	return p
-}
-
-func (p *InteractivePrinter) NextLine() *InteractivePrinter {
-	p.printOut("\n")
-	return p
-}
-
-func (p *InteractivePrinter) NextSection() *InteractivePrinter {
-	p.printOut("\n\n")
-	return p
-}
-
-func (p *InteractivePrinter) Text(s string) *InteractivePrinter {
-	p.printOut(s)
-	return p
-}
-
-func (p *InteractivePrinter) Code(s string) *InteractivePrinter {
-	p.printOut(fmt.Sprintf("    $ %s", s))
-	return p
-}
-
-func (p *InteractivePrinter) Bold(name string) *InteractivePrinter {
-	p.printOut(termenv.String(name).Bold().String())
-	return p
-}
-
-func (p *InteractivePrinter) DangerBold(name string) *InteractivePrinter {
-	p.printOut(termenv.String(name).Bold().Foreground(p.profile.Color("1")).String())
-	return p
-}
-
-func (p *InteractivePrinter) SuccessBold(name string) *InteractivePrinter {
-	p.printOut(termenv.String(name).Bold().Foreground(p.profile.Color("2")).String())
-	return p
-}
-
-func (p *InteractivePrinter) Underline(name string) *InteractivePrinter {
-	p.printOut(termenv.String(name).Underline().String())
-	return p
-}
-
-func (p *InteractivePrinter) printOut(s string) {
-	if _, err := fmt.Fprint(p.writer, s); err != nil {
+func (p *InteractivePrinter) Print(s *FormattedString) {
+	if _, err := fmt.Fprint(p.writer, s.str); err != nil {
 		panic(fmt.Sprintf("couldn't write to %v: %v", p.writer, err))
 	}
+}
+
+type FormattedString struct {
+	profile termenv.Profile
+
+	checkMark    string
+	crossMark    string
+	questionMark string
+	arrow        termenv.Style
+	bangMark     termenv.Style
+
+	str string
+}
+
+func (s *FormattedString) GreenArrow() *FormattedString {
+	s.str += s.arrow.Foreground(s.profile.Color("2")).String()
+	return s
+}
+
+func (s *FormattedString) RedArrow() *FormattedString {
+	s.str += s.arrow.Foreground(s.profile.Color("1")).String()
+	return s
+}
+
+func (s *FormattedString) BlueArrow() *FormattedString {
+	s.str += s.arrow.Foreground(s.profile.Color("6")).String()
+	return s
+}
+
+func (s *FormattedString) CheckMark() *FormattedString {
+	s.str += s.checkMark
+	return s
+}
+
+func (s *FormattedString) WarningBangMark() *FormattedString {
+	s.str += s.bangMark.Foreground(s.profile.Color("3")).String()
+	return s
+}
+
+func (s *FormattedString) DangerBangMark() *FormattedString {
+	s.str += s.bangMark.Foreground(s.profile.Color("1")).String()
+	return s
+}
+
+func (s *FormattedString) QuestionMark() *FormattedString {
+	s.str += s.questionMark
+	return s
+}
+
+func (s *FormattedString) CrossMark() *FormattedString {
+	s.str += s.crossMark
+	return s
+}
+
+func (s *FormattedString) SuccessText(t string) *FormattedString {
+	s.str += termenv.String(t).Foreground(s.profile.Color("2")).String()
+	return s
+}
+
+func (s *FormattedString) InfoText(t string) *FormattedString {
+	s.str += termenv.String(t).Foreground(s.profile.Color("6")).String()
+	return s
+}
+
+func (s *FormattedString) WarningText(t string) *FormattedString {
+	s.str += termenv.String(t).Foreground(s.profile.Color("3")).String()
+	return s
+}
+
+func (s *FormattedString) DangerText(t string) *FormattedString {
+	s.str += termenv.String(t).Foreground(s.profile.Color("1")).String()
+	return s
+}
+
+func (s *FormattedString) NextLine() *FormattedString {
+	s.str += "\n"
+	return s
+}
+
+func (s *FormattedString) NextSection() *FormattedString {
+	s.str += "\n\n"
+	return s
+}
+
+func (s *FormattedString) Text(str string) *FormattedString {
+	s.str += str
+	return s
+}
+
+func (s *FormattedString) Code(str string) *FormattedString {
+	s.str += fmt.Sprintf("    $ %s", str)
+	return s
+}
+
+func (s *FormattedString) Bold(str string) *FormattedString {
+	s.str += termenv.String(str).Bold().String()
+	return s
+}
+
+func (s *FormattedString) DangerBold(str string) *FormattedString {
+	s.str += termenv.String(str).Bold().Foreground(s.profile.Color("1")).String()
+	return s
+}
+
+func (s *FormattedString) SuccessBold(str string) *FormattedString {
+	s.str += termenv.String(str).Bold().Foreground(s.profile.Color("2")).String()
+	return s
+}
+
+func (s *FormattedString) Underline(str string) *FormattedString {
+	s.str += termenv.String(str).Underline().String()
+	return s
 }

--- a/cmd/vegawallet/commands/printer/interactive_unix.go
+++ b/cmd/vegawallet/commands/printer/interactive_unix.go
@@ -3,5 +3,21 @@
 
 package printer
 
-// enableLegacyWindowsANSI is only needed on Windows.
-func enableLegacyWindowsANSI() {}
+import (
+	"io"
+
+	"github.com/muesli/termenv"
+)
+
+func NewInteractivePrinter(w io.Writer) *InteractivePrinter {
+	profile := termenv.EnvColorProfile()
+	return &InteractivePrinter{
+		writer:       w,
+		profile:      profile,
+		checkMark:    termenv.String("✓ ").Foreground(profile.Color("2")).String(),
+		questionMark: termenv.String("? ").Foreground(profile.Color("2")).String(),
+		crossMark:    termenv.String("✗ ").Foreground(profile.Color("1")).String(),
+		bangMark:     termenv.String("! "),
+		arrow:        termenv.String("➜ "),
+	}
+}

--- a/cmd/vegawallet/commands/printer/interactive_windows.go
+++ b/cmd/vegawallet/commands/printer/interactive_windows.go
@@ -1,13 +1,29 @@
 package printer
 
 import (
+	"io"
 	"os"
 	"sync"
 
+	"github.com/muesli/termenv"
 	"golang.org/x/sys/windows"
 )
 
 var enableANSI sync.Once
+
+func NewInteractivePrinter(w io.Writer) *InteractivePrinter {
+	enableLegacyWindowsANSI()
+	profile := termenv.EnvColorProfile()
+	return &InteractivePrinter{
+		writer:       w,
+		profile:      profile,
+		checkMark:    termenv.String("* ").Foreground(profile.Color("2")).String(),
+		questionMark: termenv.String("? ").Foreground(profile.Color("2")).String(),
+		crossMark:    termenv.String("x ").Foreground(profile.Color("1")).String(),
+		bangMark:     termenv.String("! "),
+		arrow:        termenv.String("> "),
+	}
+}
 
 // enableANSIColors enables support for ANSI color sequences in the Windows
 // default console (cmd.exe and the PowerShell application). Note that this

--- a/cmd/vegawallet/commands/root.go
+++ b/cmd/vegawallet/commands/root.go
@@ -78,18 +78,20 @@ func BuildCmdRoot(w io.Writer, vh CheckVersionHandler) *cobra.Command {
 			if !f.NoVersionCheck && f.Output == flags.InteractiveOutput {
 				p := printer.NewInteractivePrinter(w)
 				if version.IsUnreleased() {
-					p.CrossMark().DangerText("You are running an unreleased version of the Vega wallet (").DangerText(version.Version).DangerText("). Use it at your own risk!").NextSection()
+					p.Print(p.String().CrossMark().DangerText("You are running an unreleased version of the Vega wallet (").DangerText(version.Version).DangerText("). Use it at your own risk!").NextSection())
 				}
 
 				v, err := vh()
 				if err != nil {
-					p.CrossMark().DangerText(err.Error()).NextSection()
+					p.Print(p.String().CrossMark().DangerText(err.Error()).NextSection())
 					return nil
 				}
 
 				if v != nil {
-					p.Text("Version ").SuccessText(v.String()).Text(" is available. Your current version is ").DangerText(version.Version).Text(".").NextLine()
-					p.Text("Download the latest version at: ").Underline(vgversion.GetGithubReleaseURL(version.ReleasesURL, v)).NextSection()
+					str := p.String()
+					str.Text("Version ").SuccessText(v.String()).Text(" is available. Your current version is ").DangerText(version.Version).Text(".").NextLine()
+					str.Text("Download the latest version at: ").Underline(vgversion.GetGithubReleaseURL(version.ReleasesURL, v)).NextSection()
+					p.Print(str)
 				}
 			}
 			return nil

--- a/cmd/vegawallet/commands/service_endpoints.go
+++ b/cmd/vegawallet/commands/service_endpoints.go
@@ -121,9 +121,12 @@ func ListEndpoints(w io.Writer, rf *RootFlags, f *ListEndpointsFlags) error {
 
 	serviceHost := fmt.Sprintf("http://%v:%v", cfg.Host, cfg.Port)
 
-	p.BlueArrow().InfoText("Available endpoints").NextLine()
+	str := p.String()
+	defer p.Print(str)
+
+	str.BlueArrow().InfoText("Available endpoints").NextLine()
 	printServiceEndpoints(serviceHost)
-	p.NextLine()
+	str.NextLine()
 
 	return nil
 }

--- a/cmd/vegawallet/commands/service_run.go
+++ b/cmd/vegawallet/commands/service_run.go
@@ -219,6 +219,9 @@ func RunService(w io.Writer, rf *RootFlags, f *RunServiceFlags) error {
 
 	cliLog = cliLog.Named("command")
 
+	p.CheckMark().Text("Service logs located at: ").SuccessText(svcLogPath).NextLine()
+	p.CheckMark().Text("CLI logs located at: ").SuccessText(cliLogPath).NextLine()
+
 	consentRequests := make(chan service.ConsentRequest, MaxConsentRequests)
 	defer close(consentRequests)
 	sentTransactions := make(chan service.SentTransaction)
@@ -229,9 +232,11 @@ func RunService(w io.Writer, rf *RootFlags, f *RunServiceFlags) error {
 		cliLog.Info("TTY detected")
 		if f.EnableAutomaticConsent {
 			cliLog.Info("Automatic consent enabled")
+			p.WarningBangMark().WarningText("Automatic consent enabled").NextLine()
 			policy = service.NewAutomaticConsentPolicy()
 		} else {
 			cliLog.Info("Explicit consent enabled")
+			p.CheckMark().Text("Explicit consent enabled").NextLine()
 			policy = service.NewExplicitConsentPolicy(ctx, consentRequests, sentTransactions)
 		}
 	} else {
@@ -251,22 +256,23 @@ func RunService(w io.Writer, rf *RootFlags, f *RunServiceFlags) error {
 
 	go func() {
 		defer cancel()
+		serviceHost := fmt.Sprintf("http://%v:%v", cfg.Host, cfg.Port)
+		p.CheckMark().Text("Starting HTTP service at: ").SuccessText(serviceHost).NextLine()
+		cliLog.Info("starting HTTP service", zap.String("url", serviceHost))
 		if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			cliLog.Error("Error while starting HTTP server", zap.Error(err))
+			cliLog.Error("failed to start HTTP server", zap.Error(err))
+			p.DangerBangMark().Text("Failed to start HTTP server: ").DangerText(err.Error()).NextLine()
 		}
 	}()
 
-	serviceHost := fmt.Sprintf("http://%v:%v", cfg.Host, cfg.Port)
-	if !f.EnableAutomaticConsent {
-		p.CheckMark().Text("HTTP service started at: ").SuccessText(serviceHost).NextLine()
-	}
-	cliLog.Info(fmt.Sprintf("HTTP service started at: %s", serviceHost))
-
 	defer func() {
 		if err = srv.Stop(); err != nil {
-			cliLog.Error("Error while stopping HTTP server", zap.Error(err))
-			cliLog.Info("HTTP server stopped with success")
+			cliLog.Error("Failed to stop HTTP server", zap.Error(err))
+			p.DangerBangMark().Text("HTTP service stopped with error: ").DangerText(err.Error()).NextLine()
+			return
 		}
+		cliLog.Info("HTTP server stopped with success")
+		p.CheckMark().Text("HTTP service stopped").NextLine()
 	}()
 
 	var cs *proxy.Proxy
@@ -274,10 +280,12 @@ func RunService(w io.Writer, rf *RootFlags, f *RunServiceFlags) error {
 		cs = startConsole(cliLog, f, cfg, cancel, p)
 		defer func() {
 			if err = cs.Stop(); err != nil {
-				cliLog.Error("Error while stopping console proxy", zap.Error(err))
-			} else {
-				cliLog.Info("Console proxy stopped with success")
+				cliLog.Error("failed to stop console proxy", zap.Error(err))
+				p.DangerBangMark().Text("Failed to stop console proxy: ").DangerText(err.Error()).NextLine()
+				return
 			}
+			cliLog.Info("Console proxy stopped with success")
+			p.CheckMark().Text("Console proxy stopped").NextLine()
 		}()
 	}
 
@@ -286,18 +294,13 @@ func RunService(w io.Writer, rf *RootFlags, f *RunServiceFlags) error {
 		tokenDApp = startTokenDApp(cliLog, f, cfg, cancel, p)
 		defer func() {
 			if err = tokenDApp.Stop(); err != nil {
-				cliLog.Error("Error while stopping token dApp proxy", zap.Error(err))
-			} else {
-				cliLog.Info("Token dApp proxy stopped with success")
+				cliLog.Error("failed to stop token dApp proxy", zap.Error(err))
+				p.DangerBangMark().Text("Failed to stop token dApp proxy: ").DangerText(err.Error()).NextLine()
+				return
 			}
+			cliLog.Info("Token dApp proxy stopped with success")
+			p.CheckMark().Text("Token dApp proxy stopped").NextLine()
 		}()
-	}
-
-	if !f.EnableAutomaticConsent {
-		p.CheckMark().Text("Service logs located at: ").SuccessText(svcLogPath).NextLine()
-		p.CheckMark().Text("CLI logs located at: ").SuccessText(cliLogPath).NextLine()
-		p.CheckMark().SuccessText("Starting successful").NextSection()
-		p.NextLine()
 	}
 
 	waitSig(ctx, cancel, cliLog, consentRequests, sentTransactions, p)
@@ -324,22 +327,23 @@ func verifyNetworkConfig(cfg *network.Network, f *RunServiceFlags) error {
 
 func startConsole(log *zap.Logger, f *RunServiceFlags, cfg *network.Network, cancel context.CancelFunc, p *printer.InteractivePrinter) *proxy.Proxy {
 	cs := proxy.NewProxy(cfg.Console.LocalPort, cfg.Console.URL, cfg.API.GRPC.Hosts[0])
+	consoleLocalProxyURL := cs.GetLocalProxyURL()
 	go func() {
 		defer cancel()
+		p.CheckMark().Text("Starting console proxy for ").Bold(cfg.Console.URL).Text(" at: ").SuccessText(consoleLocalProxyURL).NextLine()
+		log.Info("starting console proxy", zap.String("target-url", cfg.Console.URL), zap.String("proxy-url", consoleLocalProxyURL))
 		if err := cs.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Error("error while starting the console proxy", zap.Error(err))
+			log.Error("Failed to start the console proxy", zap.Error(err))
+			p.DangerBangMark().Text("Failed to start console proxy: ").DangerText(consoleLocalProxyURL).NextLine()
 		}
 	}()
 
-	consoleLocalHost := fmt.Sprintf("http://127.0.0.1:%v", cfg.Console.LocalPort)
-	if !f.EnableAutomaticConsent {
-		p.CheckMark().Text("Console proxy pointing to ").Bold(cfg.Console.URL).Text(" started at: ").SuccessText(consoleLocalHost).NextLine()
-	}
-	log.Info(fmt.Sprintf("console proxy pointing to %s started at: %s", cfg.Console.URL, consoleLocalHost))
-
 	if !f.NoBrowser {
-		if err := open.Run(cs.GetBrowserURL()); err != nil {
+		p.CheckMark().Text("Opening browser for console proxy at: ").SuccessText(consoleLocalProxyURL).NextLine()
+		log.Info("opening browser for console proxy", zap.String("url", consoleLocalProxyURL))
+		if err := open.Run(consoleLocalProxyURL); err != nil {
 			log.Error("unable to open the application in the default browser", zap.Error(err))
+			p.DangerBangMark().Text("Failed to open the browser for console proxy: ").DangerText(err.Error()).NextLine()
 		}
 	}
 
@@ -348,22 +352,24 @@ func startConsole(log *zap.Logger, f *RunServiceFlags, cfg *network.Network, can
 
 func startTokenDApp(log *zap.Logger, f *RunServiceFlags, cfg *network.Network, cancel context.CancelFunc, p *printer.InteractivePrinter) *proxy.Proxy {
 	tokenDApp := proxy.NewProxy(cfg.TokenDApp.LocalPort, cfg.TokenDApp.URL, cfg.API.GRPC.Hosts[0])
+	tokenDAppLocalProxyURL := tokenDApp.GetLocalProxyURL()
 	go func() {
 		defer cancel()
+		p.CheckMark().Text("Starting token dApp proxy for ").Bold(cfg.TokenDApp.URL).Text(" at: ").SuccessText(tokenDAppLocalProxyURL).NextLine()
+		log.Info("starting token dApp proxy", zap.String("target-url", cfg.TokenDApp.URL), zap.String("proxy-url", tokenDAppLocalProxyURL))
+
 		if err := tokenDApp.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Error("error while starting the token dApp proxy", zap.Error(err))
+			log.Error("failed to start the token dApp proxy", zap.Error(err))
+			p.DangerBangMark().Text("Failed to start token dApp proxy: ").DangerText(tokenDAppLocalProxyURL).NextLine()
 		}
 	}()
 
-	tokenDAppLocalHost := fmt.Sprintf("http://127.0.0.1:%v", cfg.TokenDApp.LocalPort)
-	if !f.EnableAutomaticConsent {
-		p.CheckMark().Text("token dApp proxy pointing to ").Bold(cfg.TokenDApp.URL).Text(" started at: ").SuccessText(tokenDAppLocalHost).NextLine()
-	}
-	log.Info(fmt.Sprintf("token dApp proxy pointing to %s started at: %s", cfg.TokenDApp.URL, tokenDAppLocalHost))
-
 	if !f.NoBrowser {
-		if err := open.Run(tokenDApp.GetBrowserURL()); err != nil {
+		p.CheckMark().Text("Opening browser for token dApp proxy at: ").SuccessText(tokenDAppLocalProxyURL).NextLine()
+		log.Info("opening browser for token dApp proxy", zap.String("url", tokenDAppLocalProxyURL))
+		if err := open.Run(tokenDAppLocalProxyURL); err != nil {
 			log.Error("unable to open the token dApp in the default browser", zap.Error(err))
+			p.DangerBangMark().Text("Failed to open the browser for token dApp proxy: ").DangerText(err.Error()).NextLine()
 		}
 	}
 	return tokenDApp
@@ -430,8 +436,8 @@ func handleConsentRequests(ctx context.Context, log *zap.Logger, consentRequests
 				log.Info("transaction sent", zap.Any("ID", sentTx.TxID), zap.Any("hash", sentTx.TxHash))
 				if sentTx.Error != nil {
 					log.Error("transaction failed", zap.Any("transaction", marshalledTx))
-					p.BangMark().DangerText("Transaction failed").NextLine()
-					p.BangMark().DangerText("Error: ").DangerText(sentTx.Error.Error()).NextSection()
+					p.DangerBangMark().DangerText("Transaction failed").NextLine()
+					p.DangerBangMark().DangerText("Error: ").DangerText(sentTx.Error.Error()).NextSection()
 				} else {
 					log.Info("transaction sent", zap.Any("hash", sentTx.TxHash))
 					p.CheckMark().Text("Transaction with hash ").SuccessText(sentTx.TxHash).Text(" sent!").NextSection()
@@ -439,7 +445,7 @@ func handleConsentRequests(ctx context.Context, log *zap.Logger, consentRequests
 			} else {
 				log.Info("user rejected the signing of the transaction", zap.Any("transaction", marshalledTx))
 				consentRequest.Confirmation <- service.ConsentConfirmation{Decision: false}
-				p.BangMark().DangerText("Transaction rejected").NextSection()
+				p.DangerBangMark().DangerText("Transaction rejected").NextSection()
 			}
 		}
 	}

--- a/cmd/vegawallet/commands/tx_send.go
+++ b/cmd/vegawallet/commands/tx_send.go
@@ -190,8 +190,12 @@ func SendTx(w io.Writer, rf *RootFlags, req *SendTxRequest) error {
 	}()
 
 	p := printer.NewInteractivePrinter(w)
+
+	str := p.String()
+	defer p.Print(str)
+
 	if rf.Output == flags.InteractiveOutput {
-		p.BlueArrow().InfoText("Logs").NextLine()
+		str.BlueArrow().InfoText("Logs").NextLine()
 	}
 
 	ctx, cancelFn := context.WithTimeout(context.Background(), ForwarderRequestTimeout)
@@ -205,7 +209,7 @@ func SendTx(w io.Writer, rf *RootFlags, req *SendTxRequest) error {
 
 	log.Info("transaction successfully sent", zap.String("hash", txHash))
 	if rf.Output == flags.InteractiveOutput {
-		p.NextLine().CheckMark().Text("Transaction sent: ").SuccessText(txHash).NextLine()
+		str.NextLine().CheckMark().Text("Transaction sent: ").SuccessText(txHash).NextLine()
 	}
 
 	return nil

--- a/cmd/vegawallet/commands/version.go
+++ b/cmd/vegawallet/commands/version.go
@@ -59,11 +59,14 @@ func BuildCmdGetVersion(w io.Writer, handler GetVersionHandler, rf *RootFlags) *
 func PrintGetVersionResponse(w io.Writer, resp *version.GetVersionResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.Text("Software version:").NextLine().WarningText(resp.Version).NextSection()
-	p.Text("Git hash:").NextLine().WarningText(resp.GitHash).NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.RedArrow().DangerText("Important").NextLine()
-	p.Text("This command does NOT give you your wallet version.").NextLine()
-	p.Text("To get this information, see the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s info --help", os.Args[0])).NextLine()
+	str.Text("Software version:").NextLine().WarningText(resp.Version).NextSection()
+	str.Text("Git hash:").NextLine().WarningText(resp.GitHash).NextSection()
+
+	str.RedArrow().DangerText("Important").NextLine()
+	str.Text("This command does NOT give you your wallet version.").NextLine()
+	str.Text("To get this information, see the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s info --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/wallet_create.go
+++ b/cmd/vegawallet/commands/wallet_create.go
@@ -113,23 +113,26 @@ func (f *CreateWalletFlags) Validate() (*wallet.CreateWalletRequest, error) {
 func PrintCreateWalletResponse(w io.Writer, resp *wallet.CreateWalletResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().Text("Wallet ").Bold(resp.Wallet.Name).Text(" has been created at: ").SuccessText(resp.Wallet.FilePath).NextLine()
-	p.CheckMark().Text("First key pair has been generated for wallet ").Bold(resp.Wallet.Name).Text(" at: ").SuccessText(resp.Wallet.FilePath).NextLine()
-	p.CheckMark().SuccessText("Creating wallet succeeded").NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.Text("Wallet recovery phrase:").NextLine()
-	p.WarningText(resp.Wallet.RecoveryPhrase).NextLine()
-	p.Text("Wallet version:").NextLine()
-	p.WarningText(fmt.Sprintf("%d", resp.Wallet.Version)).NextLine()
-	p.Text("First public key:").NextLine()
-	p.WarningText(resp.Key.PublicKey).NextLine()
-	p.NextSection()
+	str.CheckMark().Text("Wallet ").Bold(resp.Wallet.Name).Text(" has been created at: ").SuccessText(resp.Wallet.FilePath).NextLine()
+	str.CheckMark().Text("First key pair has been generated for wallet ").Bold(resp.Wallet.Name).Text(" at: ").SuccessText(resp.Wallet.FilePath).NextLine()
+	str.CheckMark().SuccessText("Creating wallet succeeded").NextSection()
 
-	p.RedArrow().DangerText("Important").NextLine()
-	p.Text("Write down the ").Bold("recovery phrase").Text(" and the ").Bold("wallet's version").Text(", and store it somewhere safe and secure, now.").NextLine()
-	p.DangerText("The recovery phrase will not be displayed ever again, nor will you be able to retrieve it!").NextSection()
+	str.Text("Wallet recovery phrase:").NextLine()
+	str.WarningText(resp.Wallet.RecoveryPhrase).NextLine()
+	str.Text("Wallet version:").NextLine()
+	str.WarningText(fmt.Sprintf("%d", resp.Wallet.Version)).NextLine()
+	str.Text("First public key:").NextLine()
+	str.WarningText(resp.Key.PublicKey).NextLine()
+	str.NextSection()
 
-	p.BlueArrow().InfoText("Run the service").NextLine()
-	p.Text("Now, you can run the service. See the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s service run --help", os.Args[0])).NextLine()
+	str.RedArrow().DangerText("Important").NextLine()
+	str.Text("Write down the ").Bold("recovery phrase").Text(" and the ").Bold("wallet's version").Text(", and store it somewhere safe and secure, now.").NextLine()
+	str.DangerText("The recovery phrase will not be displayed ever again, nor will you be able to retrieve it!").NextSection()
+
+	str.BlueArrow().InfoText("Run the service").NextLine()
+	str.Text("Now, you can run the service. See the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s service run --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/wallet_delete.go
+++ b/cmd/vegawallet/commands/wallet_delete.go
@@ -122,5 +122,8 @@ func (f *DeleteWalletFlags) Validate() error {
 func PrintDeleteWalletResponse(w io.Writer, walletName string) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().SuccessText("Wallet ").SuccessBold(walletName).SuccessText(" deleted").NextLine()
+	str := p.String()
+	defer p.Print(str)
+
+	str.CheckMark().SuccessText("Wallet ").SuccessBold(walletName).SuccessText(" deleted").NextLine()
 }

--- a/cmd/vegawallet/commands/wallet_import.go
+++ b/cmd/vegawallet/commands/wallet_import.go
@@ -150,15 +150,18 @@ func (f *ImportWalletFlags) Validate() (*wallet.ImportWalletRequest, error) {
 func PrintImportWalletResponse(w io.Writer, resp *wallet.ImportWalletResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.CheckMark().Text("Wallet ").Bold(resp.Wallet.Name).Text(" has been imported at: ").SuccessText(resp.Wallet.FilePath).NextLine()
-	p.CheckMark().Text("First key pair has been generated for wallet ").Bold(resp.Wallet.Name).Text(" at: ").SuccessText(resp.Wallet.FilePath).NextLine()
-	p.CheckMark().SuccessText("Importing the wallet succeeded").NextSection()
+	str := p.String()
+	defer p.Print(str)
 
-	p.Text("First public key:").NextLine()
-	p.WarningText(resp.Key.PublicKey).NextLine()
-	p.NextSection()
+	str.CheckMark().Text("Wallet ").Bold(resp.Wallet.Name).Text(" has been imported at: ").SuccessText(resp.Wallet.FilePath).NextLine()
+	str.CheckMark().Text("First key pair has been generated for wallet ").Bold(resp.Wallet.Name).Text(" at: ").SuccessText(resp.Wallet.FilePath).NextLine()
+	str.CheckMark().SuccessText("Importing the wallet succeeded").NextSection()
 
-	p.BlueArrow().InfoText("Run the service").NextLine()
-	p.Text("Now, you can run the service. See the following command:").NextSection()
-	p.Code(fmt.Sprintf("%s service run --help", os.Args[0])).NextLine()
+	str.Text("First public key:").NextLine()
+	str.WarningText(resp.Key.PublicKey).NextLine()
+	str.NextSection()
+
+	str.BlueArrow().InfoText("Run the service").NextLine()
+	str.Text("Now, you can run the service. See the following command:").NextSection()
+	str.Code(fmt.Sprintf("%s service run --help", os.Args[0])).NextLine()
 }

--- a/cmd/vegawallet/commands/wallet_info.go
+++ b/cmd/vegawallet/commands/wallet_info.go
@@ -110,7 +110,10 @@ func (f *GetWalletInfoFlags) Validate() (*wallet.GetWalletInfoRequest, error) {
 func PrintGetWalletInfoResponse(w io.Writer, resp *wallet.GetWalletInfoResponse) {
 	p := printer.NewInteractivePrinter(w)
 
-	p.Text("Type:").NextLine().WarningText(resp.Type).NextLine()
-	p.Text("Version:").NextLine().WarningText(fmt.Sprintf("%d", resp.Version)).NextLine()
-	p.Text("ID:").NextLine().WarningText(resp.ID).NextLine()
+	str := p.String()
+	defer p.Print(str)
+
+	str.Text("Type:").NextLine().WarningText(resp.Type).NextLine()
+	str.Text("Version:").NextLine().WarningText(fmt.Sprintf("%d", resp.Version)).NextLine()
+	str.Text("ID:").NextLine().WarningText(resp.ID).NextLine()
 }

--- a/cmd/vegawallet/commands/wallet_list.go
+++ b/cmd/vegawallet/commands/wallet_list.go
@@ -68,12 +68,15 @@ func BuildCmdListWallets(w io.Writer, handler ListWalletsHandler, rf *RootFlags)
 func PrintListWalletsResponse(w io.Writer, resp *wallet.ListWalletsResponse) {
 	p := printer.NewInteractivePrinter(w)
 
+	str := p.String()
+	defer p.Print(str)
+
 	if len(resp.Wallets) == 0 {
-		p.InfoText("No wallet registered").NextLine()
+		str.InfoText("No wallet registered").NextLine()
 		return
 	}
 
 	for _, w := range resp.Wallets {
-		p.Text(fmt.Sprintf("- %s", w)).NextLine()
+		str.Text(fmt.Sprintf("- %s", w)).NextLine()
 	}
 }

--- a/wallet/proxy/proxy.go
+++ b/wallet/proxy/proxy.go
@@ -50,6 +50,6 @@ func (c *Proxy) Stop() error {
 	return c.server.Shutdown(context.Background())
 }
 
-func (c *Proxy) GetBrowserURL() string {
+func (c *Proxy) GetLocalProxyURL() string {
 	return fmt.Sprintf("http://%s", c.server.Addr)
 }


### PR DESCRIPTION
Close #5520 

# Test

1. Run the following command:
```sh
vega wallet service run -n fairground --automatic-consent --with-console --with-token-dapp
```

2. And  next to it, retry to run:
```sh
vega wallet service run -n fairground
```

3. Acknoledge the error message

4. Cancel the command run in point 1, and acknowledge the text is not messed up.
