### PR TITLE
fix: send validator updates to TM during init chain so that checkpoin…

### DIFF
--- a/processor/abci.go
+++ b/processor/abci.go
@@ -560,7 +560,9 @@ func (app *App) OnInitChain(req tmtypes.RequestInitChain) tmtypes.ResponseInitCh
 		app.log.Fatal("couldn't initialise vega with the genesis block", logging.Error(err))
 	}
 
-	return tmtypes.ResponseInitChain{}
+	return tmtypes.ResponseInitChain{
+		Validators: app.top.GetValidatorPowerUpdates(),
+	}
 }
 
 func (app *App) OnEndBlock(req tmtypes.RequestEndBlock) (ctx context.Context, resp tmtypes.ResponseEndBlock) {

--- a/validators/topology_checkpoint.go
+++ b/validators/topology_checkpoint.go
@@ -114,7 +114,7 @@ func (t *Topology) Load(ctx context.Context, data []byte) error {
 		vUpdates = append(vUpdates, update)
 	}
 
-	// setting this to true so that at the end of the block
+	// setting this to true so we can pass the powers back to tendermint after initChain
 	t.validatorPowerUpdates = vUpdates
 	t.newEpochStarted = true
 	return nil


### PR DESCRIPTION
This is to make [0069-VCBS-048](https://github.com/vegaprotocol/specs-internal/blob/master/protocol/0069-VCBS-validators_chosen_by_stake.md#0069-VCBS-048) work.

When we load from a checkpoint we need to send the restored validator-powers to tendermint during `initChain`. Previously we were updating the powers at the first `OnEndBlock` call, which is too late.

Tests are green: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/3724/tests