### PR TITLE
fix: reward.staking.delegation.competitionLevel can be 1.0

### DIFF
--- a/netparams/defaults.go
+++ b/netparams/defaults.go
@@ -110,7 +110,7 @@ func defaultNetParams() map[string]value {
 		StakingAndDelegationRewardPayoutDelay:             NewDuration(DurationGTE(0 * time.Second)).Mutable(true).MustUpdate("24h0m0s"),
 		StakingAndDelegationRewardDelegatorShare:          NewDecimal(DecimalGTE(num.DecimalZero()), DecimalLTE(num.MustDecimalFromString("1"))).Mutable(true).MustUpdate("0.883"),
 		StakingAndDelegationRewardMinimumValidatorStake:   NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("0"),
-		StakingAndDelegationRewardCompetitionLevel:        NewDecimal(DecimalGT(num.MustDecimalFromString("1")), DecimalLTE(num.MustDecimalFromString("1000"))).Mutable(true).MustUpdate("1.1"),
+		StakingAndDelegationRewardCompetitionLevel:        NewDecimal(DecimalGTE(num.MustDecimalFromString("1")), DecimalLTE(num.MustDecimalFromString("1000"))).Mutable(true).MustUpdate("1.1"),
 		StakingAndDelegationRewardMaxPayoutPerEpoch:       NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("7000000000000000000000"),
 		StakingAndDelegationRewardsMinValidators:          NewInt(IntGTE(1)).Mutable(true).MustUpdate("5"),
 		StakingAndDelegationRewardOptimalStakeMultiplier:  NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("3.0"),


### PR DESCRIPTION
[Spec](https://github.com/vegaprotocol/specs-internal/blob/master/protocol/0061-REWP-pos_rewards.md) says:
compLevel - This is a Network parameter that can be changed through a governance vote. Valid values are in the range 1 to infinity i.e. (including 1 but excluding infinity) i.e. 1 <= compLevel < infinity. Full name: reward.staking.delegation.competitionLevel. Default 1.1.

But we are currently rejecting a value of `1.0`.
