### PR TITLE
feat: add /api/v1/network/chainid endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [5519](https://github.com/vegaprotocol/vega/pull/5519) - Add `--genesis-file` option to the `load_checkpoint` command
 - [5525](https://github.com/vegaprotocol/vega/pull/5525) - Release `vegawallet` from the core
 - [5524](https://github.com/vegaprotocol/vega/pull/5524) - Align `vegawallet` and core versions
+- [5524](https://github.com/vegaprotocol/vega/pull/5549) - Add endpoint for getting the network's `chain-id`
 
 ### 🐛 Fixes
 - [5476](https://github.com/vegaprotocol/vega/issues/5476) - Include settlement price in snapshot

--- a/cmd/vegawallet/commands/service_endpoints.go
+++ b/cmd/vegawallet/commands/service_endpoints.go
@@ -22,6 +22,7 @@ const startupT = ` # Authentication
 
  # Network management
  - network:                 GET    {{.WalletServiceLocalAddress}}/api/v1/network
+ - network chainid:         GET    {{.WalletServiceLocalAddress}}/api/v1/network/chainid
 
  # Wallet management
  - create a wallet:         POST   {{.WalletServiceLocalAddress}}/api/v1/wallets

--- a/wallet/service/mocks/node_forward_mock.go
+++ b/wallet/service/mocks/node_forward_mock.go
@@ -51,6 +51,21 @@ func (mr *MockNodeForwardMockRecorder) CheckTx(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckTx", reflect.TypeOf((*MockNodeForward)(nil).CheckTx), arg0, arg1, arg2)
 }
 
+// GetNetworkChainID mocks base method.
+func (m *MockNodeForward) GetNetworkChainID(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkChainID", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworkChainID indicates an expected call of GetNetworkChainID.
+func (mr *MockNodeForwardMockRecorder) GetNetworkChainID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkChainID", reflect.TypeOf((*MockNodeForward)(nil).GetNetworkChainID), arg0)
+}
+
 // HealthCheck mocks base method.
 func (m *MockNodeForward) HealthCheck(arg0 context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
closes #5549 

Tested against fairground:
```
wwestgarth@wwestgarth-macbook ~ -  $ curl -s http://127.0.0.1:1789/api/v1/network/chainid | jq
{
  "chainID": "testnet-43f9ed"
}
```