### PR TITLE
Fix/idgeneration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [5432](https://github.com/vegaprotocol/vega/issues/5431) - Do not accept transaction with unexpected public keys
 - [5478](https://github.com/vegaprotocol/vega/issues/5478) - Assure uncross and fake uncross are in line with each other
 - [5480](https://github.com/vegaprotocol/vega/issues/5480) - Assure indicative trades are in line with actual uncrossing trades
+- [5556](https://github.com/vegaprotocol/vega/issues/5556) - Fix id generation seed
 
 ## 0.52.0
 

--- a/libs/crypto/hash.go
+++ b/libs/crypto/hash.go
@@ -15,6 +15,7 @@ package crypto
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 
 	"golang.org/x/crypto/sha3"
 )
@@ -23,6 +24,26 @@ func Hash(key []byte) []byte {
 	hasher := sha3.New256()
 	hasher.Write(key)
 	return hasher.Sum(nil)
+}
+
+// HashHexStr hash a hex encoded string with sha3 256
+// returns an hex encoded string of the result.
+func HashHexStr(s string) string {
+	x, err := hex.DecodeString(s)
+	if err != nil {
+		panic(fmt.Sprintf("hex string required: %v", err))
+	}
+	hasher := sha3.New256()
+	hasher.Write(x)
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// HashStr hash a string (converts to bytes first)
+// returns an hex encoded string of the result.
+func HashStr(s string) string {
+	hasher := sha3.New256()
+	hasher.Write([]byte(s))
+	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func RandomHash() string {


### PR DESCRIPTION
While going through the code just now I realised that we could have an issue with ID generation when:
- calling on tick on market
- then calling removeExpiredOrders
- over all market

Basically it uses the same block hash to seed the derivation of IDs in:
- all markets onTick
- all markets removedExpiredOrders
Meaning that we would be regenerating the same IDs for expired orders accross markets etc.

. In order to fix it we:
- stop calling removeExpired from execution engine but call it from onTick in markets.
- use the a concatenation of the market ID + the block hash to seed the id generator.

close #5556  