### PR TITLE
fix: return 400 when error from send transaction is due to spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [5439](https://github.com/vegaprotocol/vega/issues/5439) - `vegawallet` returns 400 when transaction is blocked by spam
 
 ## 0.53.0
 


### PR DESCRIPTION
closes #5439 

Running the sample-api script for a market proposal against vegacapsule we now return 400 if we error due to spam protection etc:
```
AssertionError: http://127.0.0.1:1790/api/v1/command/sync returned HTTP 400 {"error":"InvalidArgument - party has insufficient tokens to submit proposal request in this epoch"}
```