### PR TITLE
feat: upload binaries when release already exists in vega

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,9 @@ pipeline {
                                 withGHCLI('credentialsId': 'github-vega-ci-bot-artifacts') {
                                     sh label: 'Upload artifacts', script: '''#!/bin/bash -e
                                         [[ $TAG_NAME =~ '-pre' ]] && prerelease='--prerelease' || prerelease=''
-                                        gh release create $TAG_NAME $prerelease ./cmd/vega/vega-*
+
+                                        gh release view $TAG_NAME && gh release upload $TAG_NAME ./cmd/vega/vega-* \
+                                            || gh release create $TAG_NAME $prerelease ./cmd/vega/vega-*
                                     '''
                                 }
                             }


### PR DESCRIPTION
Tested:

```bash
✗ cd ../vega 
➜  vega git:(develop) ✗ export TAG_NAME=v0.53.0 
➜  vega git:(develop) ✗ gh release view $TAG_NAME && gh release upload $TAG_NAME ./cmd/vega/vega-* \ 
                                            || gh release create $TAG_NAME $prerelease ./cmd/vega/vega-*
v0.53.0
Pre-release • github-actions[bot] released this about 2 hours ago



Assets
vegawallet-darwin-amd64.zip   9.59 MiB
vegawallet-darwin-arm64.zip   9.06 MiB
vegawallet-linux-amd64.zip    9.52 MiB
vegawallet-linux-arm64.zip    8.93 MiB
vegawallet-windows-arm64.zip  8.86 MiB

View on GitHub: https://github.com/vegaprotocol/vega/releases/tag/v0.53.0
⣻ 
Successfully uploaded 3 assets to v0.53.0
```