### PR TITLE
fix: return better status codes when transaction is blocked by spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The init command now also generate the configuration for tendermint, the flags `
 ### 🛠 Improvements
 - [5589](https://github.com/vegaprotocol/vega/issues/5589) - Used custom version of Clef
 - [5541](https://github.com/vegaprotocol/vega/issues/5541) - Support permissions in wallets
+- [5439](https://github.com/vegaprotocol/vega/issues/5439) - `vegwallet` returns better responses when a transaction fails
 
 ### 🐛 Fixes
 - [5571](https://github.com/vegaprotocol/vega/issues/5571) - Restore pending assets status correctly after snapshot restore

--- a/api/core.go
+++ b/api/core.go
@@ -149,7 +149,7 @@ func (s *coreService) SubmitTransaction(ctx context.Context, req *protoapi.Submi
 	return &protoapi.SubmitTransactionResponse{
 		Success: txResult.Code == 0,
 		Code:    txResult.Code,
-		Data:    txResult.Data.String(),
+		Data:    string(txResult.Data.Bytes()),
 		Log:     txResult.Log,
 		Height:  0,
 		TxHash:  txResult.Hash.String(),

--- a/api/core.go
+++ b/api/core.go
@@ -143,33 +143,11 @@ func (s *coreService) SubmitTransaction(ctx context.Context, req *protoapi.Submi
 
 	txResult, err := s.blockchain.SubmitTransactionSync(ctx, req.Tx)
 	if err != nil {
-		// This is Tendermint's specific error signature
-		if _, ok := err.(interface {
-			Code() uint32
-			Details() string
-			Error() string
-		}); ok {
-			s.log.Debug("unable to submit transaction", logging.Error(err))
-			fullError := apiError(codes.InvalidArgument, err)
-			if txResult != nil {
-				return &protoapi.SubmitTransactionResponse{
-					Success: false,
-					Code:    txResult.Code,
-					Data:    txResult.Data.String(),
-					Log:     txResult.Log,
-					Height:  0,
-					TxHash:  txResult.Hash.String(),
-				}, fullError
-			}
-			return nil, fullError
-		}
-		s.log.Debug("unable to submit transaction", logging.Error(err))
-
 		return nil, apiError(codes.Internal, err)
 	}
 
 	return &protoapi.SubmitTransactionResponse{
-		Success: true,
+		Success: txResult.Code == 0,
 		Code:    txResult.Code,
 		Data:    txResult.Data.String(),
 		Log:     txResult.Log,
@@ -188,25 +166,6 @@ func (s *coreService) CheckTransaction(ctx context.Context, req *protoapi.CheckT
 
 	checkResult, err := s.blockchain.CheckTransaction(ctx, req.Tx)
 	if err != nil {
-		if _, ok := err.(interface {
-			Code() uint32
-			Details() string
-			Error() string
-		}); ok {
-			s.log.Debug("unable to check transaction", logging.Error(err))
-			fullError := apiError(codes.InvalidArgument, err)
-			if checkResult != nil {
-				return &protoapi.CheckTransactionResponse{
-					Code:      checkResult.Code,
-					Success:   false,
-					GasWanted: checkResult.GasWanted,
-					GasUsed:   checkResult.GasUsed,
-				}, fullError
-			}
-			return nil, fullError
-		}
-		s.log.Debug("unable to check transaction", logging.Error(err))
-
 		return nil, apiError(codes.Internal, err)
 	}
 
@@ -228,25 +187,6 @@ func (s *coreService) CheckRawTransaction(ctx context.Context, req *protoapi.Che
 
 	checkResult, err := s.blockchain.CheckRawTransaction(ctx, req.Tx)
 	if err != nil {
-		if _, ok := err.(interface {
-			Code() uint32
-			Details() string
-			Error() string
-		}); ok {
-			s.log.Debug("unable to check raw transaction", logging.Error(err))
-			fullError := apiError(codes.InvalidArgument, err)
-			if checkResult != nil {
-				return &protoapi.CheckRawTransactionResponse{
-					Code:      checkResult.Code,
-					Success:   false,
-					GasWanted: checkResult.GasWanted,
-					GasUsed:   checkResult.GasUsed,
-				}, fullError
-			}
-			return nil, fullError
-		}
-		s.log.Debug("unable to check raw transaction", logging.Error(err))
-
 		return nil, apiError(codes.Internal, err)
 	}
 

--- a/blockchain/abci/client.go
+++ b/blockchain/abci/client.go
@@ -55,45 +55,21 @@ func NewClient(addr string) (*Client, error) {
 
 func (c *Client) SendTransactionAsync(ctx context.Context, bytes []byte) (*tmctypes.ResultBroadcastTx, error) {
 	// Fire off the transaction for consensus
-	res, err := c.tmclt.BroadcastTxAsync(ctx, bytes)
-	if err != nil {
-		return res, err
-	}
-	return res, nil
+	return c.tmclt.BroadcastTxAsync(ctx, bytes)
 }
 
 func (c *Client) CheckTransaction(ctx context.Context, bytes []byte) (*tmctypes.ResultCheckTx, error) {
-	res, err := c.tmclt.CheckTx(ctx, bytes)
-	if err != nil {
-		return nil, err
-	} else if !res.IsOK() {
-		return res, newUserInputError(res.Code, string(res.Data))
-	}
-
-	return res, nil
+	return c.tmclt.CheckTx(ctx, bytes)
 }
 
 func (c *Client) SendTransactionSync(ctx context.Context, bytes []byte) (*tmctypes.ResultBroadcastTx, error) {
 	// Fire off the transaction for consensus
-	r, err := c.tmclt.BroadcastTxSync(ctx, bytes)
-	if err != nil {
-		return nil, err
-	} else if r.Code != 0 {
-		return r, newUserInputError(r.Code, string(r.Data))
-	}
-
-	return r, nil
+	return c.tmclt.BroadcastTxSync(ctx, bytes)
 }
 
 func (c *Client) SendTransactionCommit(ctx context.Context, bytes []byte) (*tmctypes.ResultBroadcastTxCommit, error) {
 	// Fire off the transaction for consensus
-	r, err := c.tmclt.BroadcastTxCommit(ctx, bytes)
-	if err != nil {
-		return nil, err
-	} else if r.CheckTx.Code != 0 {
-		return r, newUserInputError(r.CheckTx.Code, string(r.CheckTx.Data))
-	}
-	return r, nil
+	return c.tmclt.BroadcastTxCommit(ctx, bytes)
 }
 
 // GetGenesisTime retrieves the genesis time from the blockchain.
@@ -212,28 +188,4 @@ func (c *Client) Subscribe(ctx context.Context, fn func(tmctypes.ResultEvent) er
 
 func (c *Client) Start() error {
 	return nil // Nothing to do for this client type.
-}
-
-type userInputError struct {
-	code    uint32
-	details string
-}
-
-func newUserInputError(code uint32, details string) userInputError {
-	return userInputError{
-		code:    code,
-		details: details,
-	}
-}
-
-func (e userInputError) Code() uint32 {
-	return e.code
-}
-
-func (e userInputError) Details() string {
-	return e.details
-}
-
-func (e userInputError) Error() string {
-	return e.details
 }

--- a/blockchain/abci/local_client.go
+++ b/blockchain/abci/local_client.go
@@ -38,35 +38,16 @@ func (c *LocalClient) SendTransactionAsync(ctx context.Context, bytes []byte) (*
 
 func (c *LocalClient) SendTransactionSync(ctx context.Context, bytes []byte) (*tmctypes.ResultBroadcastTx, error) {
 	// Fire off the transaction for consensus
-	res, err := c.node.BroadcastTxSync(ctx, bytes)
-	if err != nil {
-		return nil, err
-	} else if res.Code != 0 {
-		return res, newUserInputError(res.Code, string(res.Data))
-	}
-	return res, nil
+	return c.node.BroadcastTxSync(ctx, bytes)
 }
 
 func (c *LocalClient) SendTransactionCommit(ctx context.Context, bytes []byte) (*tmctypes.ResultBroadcastTxCommit, error) {
 	// Fire off the transaction for consensus
-	res, err := c.node.BroadcastTxCommit(ctx, bytes)
-	if err != nil {
-		return nil, err
-	} else if res.CheckTx.Code != 0 {
-		return res, newUserInputError(res.CheckTx.Code, string(res.CheckTx.Data))
-	}
-	return res, nil
+	return c.node.BroadcastTxCommit(ctx, bytes)
 }
 
 func (c *LocalClient) CheckTransaction(ctx context.Context, bytes []byte) (*tmctypes.ResultCheckTx, error) {
-	res, err := c.node.CheckTx(ctx, bytes)
-	if err != nil {
-		return nil, err
-	} else if !res.IsOK() {
-		return res, newUserInputError(res.Code, string(res.Data))
-	}
-
-	return res, nil
+	return c.node.CheckTx(ctx, bytes)
 }
 
 // GetGenesisTime retrieves the genesis time from the blockchain.

--- a/cmd/vegawallet/commands/command_send.go
+++ b/cmd/vegawallet/commands/command_send.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -295,13 +296,22 @@ func SendCommand(w io.Writer, rf *RootFlags, req *SendCommandRequest) error {
 
 	log.Info("calculated proof of work for transaction", zap.String("signature", tx.Signature.Value))
 
-	txHash, err := forwarder.SendTx(ctx, tx, api.SubmitTransactionRequest_TYPE_ASYNC, cltIdx)
+	resp, err := forwarder.SendTx(ctx, tx, api.SubmitTransactionRequest_TYPE_ASYNC, cltIdx)
 	if err != nil {
 		log.Error("couldn't send transaction", zap.Error(err))
 		return fmt.Errorf("couldn't send transaction: %w", err)
 	}
 
-	log.Info("transaction successfully sent", zap.String("hash", txHash))
+	if !resp.Success {
+		d, err := hex.DecodeString(resp.Data)
+		if err != nil {
+			log.Error("unable to decode resp error string")
+		}
+		log.Error("transaction failed", zap.String("err", string(d)), zap.Uint32("code", resp.Code))
+		return fmt.Errorf("transaction failed: %s", string(d))
+	}
+
+	log.Info("transaction successfully sent", zap.String("hash", resp.TxHash))
 
 	return nil
 }

--- a/wallet/node/forwarder.go
+++ b/wallet/node/forwarder.go
@@ -161,7 +161,7 @@ func (n *Forwarder) CheckTx(ctx context.Context, tx *commandspb.Transaction, clt
 	return resp, err
 }
 
-func (n *Forwarder) SendTx(ctx context.Context, tx *commandspb.Transaction, ty api.SubmitTransactionRequest_Type, cltIdx int) (string, error) {
+func (n *Forwarder) SendTx(ctx context.Context, tx *commandspb.Transaction, ty api.SubmitTransactionRequest_Type, cltIdx int) (*api.SubmitTransactionResponse, error) {
 	req := api.SubmitTransactionRequest{
 		Tx:   tx,
 		Type: ty,
@@ -186,10 +186,10 @@ func (n *Forwarder) SendTx(ctx context.Context, tx *commandspb.Transaction, ty a
 		},
 		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), n.nodeCfgs.Retries),
 	); err != nil {
-		return "", err
+		return resp, err
 	}
 
-	return resp.TxHash, nil
+	return resp, nil
 }
 
 func (n *Forwarder) handleSubmissionError(err error) error {

--- a/wallet/service/mocks/node_forward_mock.go
+++ b/wallet/service/mocks/node_forward_mock.go
@@ -97,10 +97,10 @@ func (mr *MockNodeForwardMockRecorder) LastBlockHeightAndHash(arg0 interface{}) 
 }
 
 // SendTx mocks base method.
-func (m *MockNodeForward) SendTx(arg0 context.Context, arg1 *v10.Transaction, arg2 v1.SubmitTransactionRequest_Type, arg3 int) (string, error) {
+func (m *MockNodeForward) SendTx(arg0 context.Context, arg1 *v10.Transaction, arg2 v1.SubmitTransactionRequest_Type, arg3 int) (*v1.SubmitTransactionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendTx", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(*v1.SubmitTransactionResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/wallet/service/service.go
+++ b/wallet/service/service.go
@@ -1005,13 +1005,7 @@ func (s *Service) writeTxError(w http.ResponseWriter, r *api.SubmitTransactionRe
 		s.log.Error("unknown transaction code", zap.Uint32("code", r.Code))
 		code = http.StatusInternalServerError
 	}
-
-	errStr, err := hex.DecodeString(r.Data)
-	if err != nil {
-		s.log.Error("unable to decode transaction error string")
-	}
-
-	s.writeError(w, newErrorResponse(string(errStr)), code)
+	s.writeError(w, newErrorResponse(r.Data), code)
 }
 
 func (s *Service) writeError(w http.ResponseWriter, e error, status int) {

--- a/wallet/service/service.go
+++ b/wallet/service/service.go
@@ -28,6 +28,14 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	TxnValidationFailure   uint32 = 51
+	TxnDecodingFailure     uint32 = 60
+	TxnInternalError       uint32 = 70
+	TxnUnknownCommandError uint32 = 80
+	TxnSpamError           uint32 = 89
+)
+
 type Service struct {
 	*httprouter.Router
 
@@ -410,7 +418,7 @@ type Auth interface {
 // NodeForward ...
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/node_forward_mock.go -package mocks code.vegaprotocol.io/vega/wallet/service NodeForward
 type NodeForward interface {
-	SendTx(context.Context, *commandspb.Transaction, api.SubmitTransactionRequest_Type, int) (string, error)
+	SendTx(context.Context, *commandspb.Transaction, api.SubmitTransactionRequest_Type, int) (*api.SubmitTransactionResponse, error)
 	CheckTx(context.Context, *commandspb.Transaction, int) (*api.CheckTransactionResponse, error)
 	HealthCheck(context.Context) error
 	GetNetworkChainID(context.Context) (string, error)
@@ -856,7 +864,7 @@ func (s *Service) signTx(token string, w http.ResponseWriter, r *http.Request, _
 	}
 
 	sentAt := time.Now()
-	txHash, err := s.nodeForward.SendTx(r.Context(), tx, ty, cltIdx)
+	resp, err := s.nodeForward.SendTx(r.Context(), tx, ty, cltIdx)
 	if err != nil {
 		s.policy.Report(SentTransaction{
 			Tx:     tx,
@@ -868,8 +876,19 @@ func (s *Service) signTx(token string, w http.ResponseWriter, r *http.Request, _
 		return
 	}
 
+	if !resp.Success {
+		s.policy.Report(SentTransaction{
+			Tx:     tx,
+			TxID:   txID,
+			Error:  err,
+			SentAt: sentAt,
+		})
+		s.writeTxError(w, resp)
+		return
+	}
+
 	s.policy.Report(SentTransaction{
-		TxHash: txHash,
+		TxHash: resp.TxHash,
 		TxID:   txID,
 		Tx:     tx,
 		SentAt: sentAt,
@@ -882,7 +901,7 @@ func (s *Service) signTx(token string, w http.ResponseWriter, r *http.Request, _
 		TxID       string                  `json:"txId"`
 		Tx         *commandspb.Transaction `json:"tx"`
 	}{
-		TxHash:     txHash,
+		TxHash:     resp.TxHash,
 		ReceivedAt: receivedAt,
 		SentAt:     sentAt,
 		TxID:       txID,
@@ -971,6 +990,28 @@ func (s *Service) writeForbiddenError(w http.ResponseWriter, e error) {
 
 func (s *Service) writeInternalError(w http.ResponseWriter, e error) {
 	s.writeError(w, newErrorResponse(e.Error()), http.StatusInternalServerError)
+}
+
+func (s *Service) writeTxError(w http.ResponseWriter, r *api.SubmitTransactionResponse) {
+	var code int
+	switch r.Code {
+	case TxnSpamError:
+		code = http.StatusTooManyRequests
+	case TxnUnknownCommandError, TxnValidationFailure, TxnDecodingFailure:
+		code = http.StatusBadRequest
+	case TxnInternalError:
+		code = http.StatusInternalServerError
+	default:
+		s.log.Error("unknown transaction code", zap.Uint32("code", r.Code))
+		code = http.StatusInternalServerError
+	}
+
+	errStr, err := hex.DecodeString(r.Data)
+	if err != nil {
+		s.log.Error("unable to decode transaction error string")
+	}
+
+	s.writeError(w, newErrorResponse(string(errStr)), code)
 }
 
 func (s *Service) writeError(w http.ResponseWriter, e error, status int) {

--- a/wallet/service/service_test.go
+++ b/wallet/service/service_test.go
@@ -15,6 +15,7 @@ import (
 	api "code.vegaprotocol.io/protos/vega/api/v1"
 	commandspb "code.vegaprotocol.io/protos/vega/commands/v1"
 	vgrand "code.vegaprotocol.io/shared/libs/rand"
+	"code.vegaprotocol.io/vega/blockchain/abci"
 	"code.vegaprotocol.io/vega/wallet/crypto"
 	"code.vegaprotocol.io/vega/wallet/network"
 	"code.vegaprotocol.io/vega/wallet/service"
@@ -112,6 +113,7 @@ func TestService(t *testing.T) {
 	t.Run("Verifying anything with invalid request fails", testVerifyingAnyDataWithInvalidRequestFails)
 	t.Run("Requesting the chain id is successful", testGetNetworkChainIDSuccess)
 	t.Run("Requesting the chain id fails when node in available", testGetNetworkChainIDFailure)
+	t.Run("Signing transaction fails spam", testAcceptSigningTransactionFailsSpam)
 }
 
 func testServiceCreateWalletOK(t *testing.T) {
@@ -814,7 +816,8 @@ func testAcceptSigningTransactionSucceeds(t *testing.T) {
 	// setup
 	s.auth.EXPECT().VerifyToken(token).Times(1).Return(walletName, nil)
 	s.handler.EXPECT().SignTx(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&commandspb.Transaction{}, nil)
-	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1)
+	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1).
+		Return(&api.SubmitTransactionResponse{Success: true}, nil)
 	s.nodeForward.EXPECT().LastBlockHeightAndHash(gomock.Any()).Times(1).Return(&api.LastBlockHeightResponse{
 		Height:              42,
 		Hash:                "0292041e2f0cf741894503fb3ead4cb817bca2375e543aa70f7c4d938157b5a6",
@@ -862,7 +865,8 @@ func testSigningTransactionWithPropagationSucceeds(t *testing.T) {
 	// setup
 	s.auth.EXPECT().VerifyToken(token).Times(1).Return(walletName, nil)
 	s.handler.EXPECT().SignTx(walletName, gomock.Any(), gomock.Any()).Times(1).Return(&commandspb.Transaction{}, nil)
-	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1)
+	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1).
+		Return(&api.SubmitTransactionResponse{Success: true}, nil)
 	s.nodeForward.EXPECT().LastBlockHeightAndHash(gomock.Any()).Times(1).Return(&api.LastBlockHeightResponse{
 		Height:              42,
 		Hash:                "0292041e2f0cf741894503fb3ead4cb817bca2375e543aa70f7c4d938157b5a6",
@@ -890,7 +894,8 @@ func testSigningTransactionWithFailedPropagationFails(t *testing.T) {
 	// setup
 	s.auth.EXPECT().VerifyToken(token).Times(1).Return(walletName, nil)
 	s.handler.EXPECT().SignTx(walletName, gomock.Any(), gomock.Any()).Times(1).Return(&commandspb.Transaction{}, nil)
-	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1).Return("", assert.AnError)
+	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1).
+		Return(nil, assert.AnError)
 	s.nodeForward.EXPECT().LastBlockHeightAndHash(gomock.Any()).Times(1).Return(&api.LastBlockHeightResponse{
 		Height:              42,
 		Hash:                "0292041e2f0cf741894503fb3ead4cb817bca2375e543aa70f7c4d938157b5a6",
@@ -1269,4 +1274,33 @@ func serveHTTP(t *testing.T, s *testService, req *http.Request) (int, []byte) {
 	}
 
 	return resp.StatusCode, body
+}
+
+func testAcceptSigningTransactionFailsSpam(t *testing.T) {
+	s := getTestService(t, "manual")
+	defer s.ctrl.Finish()
+
+	// given
+	walletName := vgrand.RandomStr(5)
+	token := vgrand.RandomStr(5)
+	headers := authHeaders(t, token)
+	pubKey := vgrand.RandomStr(5)
+	payload := fmt.Sprintf(`{"pubKey": "%s", "orderCancellation": {}}`, pubKey)
+
+	// setup
+	s.auth.EXPECT().VerifyToken(token).AnyTimes().Return(walletName, nil)
+	s.handler.EXPECT().SignTx(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&commandspb.Transaction{}, nil)
+	s.nodeForward.EXPECT().LastBlockHeightAndHash(gomock.Any()).AnyTimes().Return(&api.LastBlockHeightResponse{
+		Height:              42,
+		Hash:                "0292041e2f0cf741894503fb3ead4cb817bca2375e543aa70f7c4d938157b5a6",
+		SpamPowDifficulty:   2,
+		SpamPowHashFunction: "sha3_24_rounds",
+	}, 0, nil)
+	// when
+
+	s.nodeForward.EXPECT().SendTx(gomock.Any(), gomock.Any(), api.SubmitTransactionRequest_TYPE_ASYNC, gomock.Any()).Times(1).
+		Return(&api.SubmitTransactionResponse{Success: false, Code: abci.AbciSpamError}, nil)
+
+	statusCode, _ := serveHTTP(t, s, signTxRequest(t, payload, headers))
+	assert.Equal(t, http.StatusTooManyRequests, statusCode)
 }


### PR DESCRIPTION
closes #5439

We now get reponses from the wallet that look like this:
```
AssertionError: http://127.0.0.1:1790/api/v1/command/sync returned HTTP 429 {"error":"party has insufficient tokens to submit proposal request in this epoch"}
```


Most of the refactor is because we were doing this silly thing in the blockchain client where we return an `err` _and_ the response if `resp.Code` was non-zero and where `err` actually was just `resp.Data`:
```
if err != nil {
    return resp, err
}
```

But in the generated protos code (both coming through tendermint, and also out from core to the wallet again) it always drops the response if there is an error:
```
if err != nil {
    nil, err
}
```

so all of our nice specific codes/details when things went wrong that we thought we were passing back were just getting lost. Which is a bit mad.

The bulk of the changes here and in the wallet is to treat `err != nil` as an _error in the rpc_ and to treat `err == nil && !resp.Success` as a _successfully failing transaction_ and by that I mean one that got sent correctly, but was for good reason rejected by core, so nothing really went "wrong". This means the wallet can now look at `resp.Code` if `resp.Success == false` to know what went on and to set a http-status that makes sense for the probably user-error.

Note: This is a breaking change because any callers (like the wallet) will now have to check `resp.Success` as well as just `err != nil` which they may not have been doing before.