### PR TITLE
fix: close files after reading them in verifier

### DIFF
--- a/cmd/vega/verify/verifier.go
+++ b/cmd/vega/verify/verifier.go
@@ -80,6 +80,8 @@ func readFile(r *reporter, path string) []byte {
 		r.Err("%v, no such file or directory", path)
 		return nil
 	}
+	defer f.Close()
+
 	bytes, err := ioutil.ReadAll(f)
 	if err != nil {
 		r.Err("unable to read file: %v", err)


### PR DESCRIPTION
Not closing the genesis files after reading them was causing test cleanup to fail on windows