### PR TITLE
fix: do not trim 0x from the eth address since we now store it with t…

### DIFF
--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -683,7 +683,7 @@ func (t *tradingDataServiceV2) GetERC20MultiSigSignerRemovedBundles(ctx context.
 		p = entities.OffsetPaginationFromProto(req.Pagination)
 	}
 
-	res, err := t.multiSigService.GetRemovedEvents(ctx, nodeID, strings.TrimPrefix(submitter, "0x"), epochID, p)
+	res, err := t.multiSigService.GetRemovedEvents(ctx, nodeID, submitter, epochID, p)
 	if err != nil {
 		c := codes.Internal
 		if errors.Is(err, entities.ErrInvalidID) {


### PR DESCRIPTION
We store the eth addresses as bytes including the `0x` so when we query, we need the `x0`

A test flexing it: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/6441/tests