### PR TITLE
fix: cursor row filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The init command now also generate the configuration for tendermint, the flags `
 - [5279](https://github.com/vegaprotocol/vega/issues/5279) - Fix loading of proposals from checkpoint
 - [5598](https://github.com/vegaprotocol/vega/issues/5598) - Remove `currentTime` from topology engine to ease snapshot restoration
 - [5609](https://github.com/vegaprotocol/vega/issues/5609) - Set event forwarder last seen height after snapshot restore
+- [5782](https://github.com/vegaprotocol/vega/issues/5782) - `Pagination` with a cursor was returning incorrect results
 - [5629](https://github.com/vegaprotocol/vega/issues/5629) - Fixes for loading voting power from checkpoint with non genesis validators
 - [5626](https://github.com/vegaprotocol/vega/issues/5626) - Update `protos`, remove optional types
 - [5665](https://github.com/vegaprotocol/vega/issues/5665) - Binary version hash always contain `-modified` suffix

--- a/datanode/sqlstore/cursor.go
+++ b/datanode/sqlstore/cursor.go
@@ -15,6 +15,8 @@ package sqlstore
 import (
 	"fmt"
 	"strings"
+
+	"code.vegaprotocol.io/vega/datanode/entities"
 )
 
 type (
@@ -33,6 +35,192 @@ const (
 	GE Compare = ">="
 	LE Compare = "<="
 )
+
+type ColumnOrdering struct {
+	Name    string
+	Sorting Sorting
+}
+
+func NewColumnOrdering(name string, sorting Sorting) ColumnOrdering {
+	return ColumnOrdering{Name: name, Sorting: sorting}
+}
+
+type TableOrdering []ColumnOrdering
+
+func (t *TableOrdering) OrderByClause() string {
+	if len(*t) == 0 {
+		return ""
+	}
+
+	fragments := make([]string, len(*t))
+	for i, column := range *t {
+		fragments[i] = fmt.Sprintf("%s %s", column.Name, column.Sorting)
+	}
+	return fmt.Sprintf("ORDER BY %s", strings.Join(fragments, ","))
+}
+
+func (t *TableOrdering) Reversed() TableOrdering {
+	reversed := make([]ColumnOrdering, len(*t))
+	for i, column := range *t {
+		if column.Sorting == DESC {
+			reversed[i] = ColumnOrdering{Name: column.Name, Sorting: ASC}
+		}
+		if column.Sorting == ASC {
+			reversed[i] = ColumnOrdering{Name: column.Name, Sorting: DESC}
+		}
+	}
+	return reversed
+}
+
+// CursorPredicate generates an SQL predicate which excludes all rows before the supplied cursor,
+// with regards to the supplied table ordering. The values used for comparison are added to
+// the args list and bind variables used in the query fragment.
+//
+// For example, with if you had a query with columns sorted foo ASCENDING, bar DESCENDING and a
+// cursor with {foo=1, bar=2}, it would yield a string predicate like this:
+//
+// (foo > $1) OR (foo = $1 AND bar <= $2)
+//
+// And 'args' would have 1 and 2 appended to it.
+//
+// Notes:
+//  - The predicate *includes* the value at the cursor
+//  - Only fields that are present in both the cursor and the ordering are considered
+//  - The union of those fields must have enough information to uniquely identify a row
+//  - The table ordering must be sufficient to ensure that a row identified by a cursor cannot
+//    change position in relation to the other rows
+func CursorPredicate(args []interface{}, cursor interface{}, ordering TableOrdering) (string, []interface{}, error) {
+	cursorPredicates := []string{}
+	equalPredicates := []string{}
+
+	for i, column := range ordering {
+		// For the non-last columns, use LT/GT, so we don't include stuff before the cursor
+		var operator string
+		if column.Sorting == ASC {
+			operator = ">"
+		} else if column.Sorting == DESC {
+			operator = "<"
+		} else {
+			return "", nil, fmt.Errorf("unknown sort direction %s", column.Sorting)
+		}
+
+		// For the last column, we want to use GTE/LTE so we include the value at the cursor
+		isLast := i == (len(ordering) - 1)
+		if isLast {
+			operator = operator + "="
+		}
+
+		value, err := StructValueForColumn(cursor, column.Name)
+		if err != nil {
+			return "", nil, err
+		}
+
+		bindVar := nextBindVar(&args, value)
+		inequlityPredicate := fmt.Sprintf("%s %s %s", column.Name, operator, bindVar)
+
+		colPredicates := append(equalPredicates, inequlityPredicate)
+		colPredicateString := strings.Join(colPredicates, " AND ")
+		colPredicateString = fmt.Sprintf("(%s)", colPredicateString)
+		cursorPredicates = append(cursorPredicates, colPredicateString)
+
+		equlityPredicate := fmt.Sprintf("%s = %s", column.Name, bindVar)
+		equalPredicates = append(equalPredicates, equlityPredicate)
+	}
+
+	predicateString := strings.Join(cursorPredicates, " OR ")
+
+	return predicateString, args, nil
+}
+
+type parser interface {
+	Parse(string) error
+}
+
+// This is a bit magical, it allows us to use the real cursor type for instantiation and the pointer
+// type for calling methods with pointer receivers (e.g. Parse) for details see
+// https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#pointer-method-example
+type parserPtr[T any] interface {
+	parser
+	*T
+}
+
+// PaginateQuery takes a query string & bind arg list and returns the same with additional SQL to
+// - exclude rows before the cursor (or after it if the cusor is a backwards looking one)
+// - limit the number of rows to the pagination limit +1 (no cursor) or +2 (cursor)
+//   [for purposes of later figuring out whether there are next or previous pages]
+// - order the query according to the TableOrdering supplied
+//   the order is reversed if pagination request is backwards
+//
+// For example with cursor to a row where foo=42, and a pagination saying get the next 3 then:
+// PaginateQuery[MyCursor]("SELECT foo FROM my_table", args, ordering, pagination)
+//
+// Would append `42` to the arg list and return
+// SELECT foo FROM my_table WHERE foo>=$1 ORDER BY foo ASC LIMIT 5
+//
+// See CursorPredicate() for more details about how the cursor filtering is done.
+func PaginateQuery[T comparable, PT parserPtr[T]](
+	query string,
+	args []interface{},
+	ordering TableOrdering,
+	pagination entities.CursorPagination,
+) (string, []interface{}, error) {
+	// Extract a cusor struct from the pagination struct
+	cursor, err := parseCursor[T, PT](pagination)
+	if err != nil {
+		return "", nil, fmt.Errorf("parsing cursor: %w", err)
+	}
+
+	// If we're fetching rows before the cursor, reverse the ordering
+	if pagination.HasBackward() {
+		ordering = ordering.Reversed()
+	}
+
+	// If the cursor wasn't empty, exclude rows preceding the cursor's row
+	var emptyCursor T
+	if cursor != emptyCursor {
+		whereOrAnd := "WHERE"
+		if strings.Contains(strings.ToUpper(query), "WHERE") {
+			whereOrAnd = "AND"
+		}
+
+		var predicate string
+		predicate, args, err = CursorPredicate(args, cursor, ordering)
+		if err != nil {
+			return "", nil, fmt.Errorf("building cursor predicate: %w", err)
+		}
+		query = fmt.Sprintf("%s %s %s", query, whereOrAnd, predicate)
+	}
+
+	// Add an ORDER BY clause
+	query = fmt.Sprintf("%s %s", query, ordering.OrderByClause())
+
+	// And a LIMIT clause
+	limit := calculateLimit(pagination)
+	if limit != 0 {
+		query = fmt.Sprintf("%s LIMIT %d", query, limit)
+	}
+
+	return query, args, nil
+}
+
+func parseCursor[T any, PT parserPtr[T]](pagination entities.CursorPagination) (T, error) {
+	cursor := PT(new(T))
+
+	cursorStr := ""
+	if pagination.HasForward() && pagination.Forward.HasCursor() {
+		cursorStr = pagination.Forward.Cursor.Value()
+	} else if pagination.HasBackward() && pagination.Backward.HasCursor() {
+		cursorStr = pagination.Backward.Cursor.Value()
+	}
+
+	if cursorStr != "" {
+		err := cursor.Parse(cursorStr)
+		if err != nil {
+			return *cursor, fmt.Errorf("parsing cursor: %w", err)
+		}
+	}
+	return *cursor, nil
+}
 
 type CursorQueryParameter struct {
 	ColumnName string


### PR DESCRIPTION
Closes #5782 

Adds a new way of generating the SQL needed to filter out rows before a cursor which is more correct, and with some generic magic, also reduces a bunch of boilerplate.

I've left the existing method in for now so as to not pollute the PR (or waste time if this isn't accepted); once this is in I'll switch them all over.