### PR TITLE
chore: remove go-proto-validators

### DIFF
--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -13,6 +13,8 @@
 package netparams
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"code.vegaprotocol.io/vega/core/types"
@@ -45,7 +47,7 @@ func defaultNetParams() map[string]value {
 		MarketTargetStakeTimeWindow:                     NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate("1h0m0s"),
 		MarketTargetStakeScalingFactor:                  NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("10"),
 		MarketValueWindowLength:                         NewDuration(DurationGT(0 * time.Second)).Mutable(true).MustUpdate(week),
-		MarketPriceMonitoringDefaultParameters:          NewJSON(&proto.PriceMonitoringParameters{}, JSONProtoValidator()).Mutable(true).MustUpdate(`{"triggers": []}`),
+		MarketPriceMonitoringDefaultParameters:          NewJSON(&proto.PriceMonitoringParameters{}).Mutable(true).MustUpdate(`{"triggers": []}`),
 		MarketLiquidityProvisionShapesMaxSize:           NewInt(IntGT(0)).Mutable(true).MustUpdate("100"),
 		MarketMinLpStakeQuantumMultiple:                 NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("1"),
 		RewardMarketCreationQuantumMultiple:             NewDecimal(DecimalGTE(num.DecimalZero())).Mutable(true).MustUpdate("1"),
@@ -191,4 +193,35 @@ func checkOptionalRFC3339Date(d string) error {
 	// now let's just try to parse and see
 	_, err := time.Parse(time.RFC3339, d)
 	return err
+}
+
+func PriceMonitoringParametersValidation(i interface{}) error {
+	pmp, ok := i.(*proto.PriceMonitoringParameters)
+	if !ok {
+		return errors.New("not a price monitoring parameters type")
+	}
+
+	for _, trigger := range pmp.Triggers {
+		if trigger.Horizon <= 0 {
+			return fmt.Errorf("triggers.horizon must be greater than `0`, got `%d`", trigger.Horizon)
+		}
+
+		probability, err := num.DecimalFromString(trigger.Probability)
+		if err != nil {
+			return fmt.Errorf("triggers.probability must be greater than `0`, got `%s`", trigger.Probability)
+		}
+
+		if probability.Cmp(num.DecimalZero()) <= 0 {
+			return fmt.Errorf("triggers.probability must be greater than `0`, got `%s`", trigger.Probability)
+		}
+		if probability.Cmp(num.DecimalFromInt64(1)) >= 0 {
+			return fmt.Errorf("triggers.probability must be lower than `1`, got `%s`", trigger.Probability)
+		}
+
+		if trigger.AuctionExtension <= 0 {
+			return fmt.Errorf("triggers.auction_extension must be greater than `0`, got `%d`", trigger.AuctionExtension)
+		}
+	}
+
+	return nil
 }

--- a/core/netparams/values.go
+++ b/core/netparams/values.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/libs/num"
-	validators "github.com/mwitkow/go-proto-validators"
 )
 
 type baseValue struct{}
@@ -795,12 +794,6 @@ func (j *JSON) MustUpdate(value string) *JSON {
 
 func (j *JSON) String() string {
 	return j.rawval
-}
-
-func JSONProtoValidator() func(interface{}) error {
-	return func(t interface{}) error {
-		return validators.CallValidatorIfExists(t)
-	}
 }
 
 type StringRule func(string) error

--- a/core/netparams/values_test.go
+++ b/core/netparams/values_test.go
@@ -17,7 +17,8 @@ import (
 	"testing"
 
 	"code.vegaprotocol.io/vega/core/netparams"
-	types "code.vegaprotocol.io/vega/protos/vega"
+	"code.vegaprotocol.io/vega/protos/vega"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,7 +90,7 @@ func TestJSONValues(t *testing.T) {
 func TestJSONVPriceMonitoringParameters(t *testing.T) {
 	// happy case, populated parameters array
 	validPmJSONString := `{"triggers": [{"horizon": 60, "probability": "0.95", "auction_extension": 90},{"horizon": 120, "probability": "0.99", "auction_extension": 180}]}`
-	j := netparams.NewJSON(&types.PriceMonitoringParameters{}, netparams.JSONProtoValidator()).Mutable(true).MustUpdate(validPmJSONString)
+	j := netparams.NewJSON(&vega.PriceMonitoringParameters{}, netparams.PriceMonitoringParametersValidation).Mutable(true).MustUpdate(validPmJSONString)
 	assert.NotNil(t, j)
 	err := j.Validate(validPmJSONString)
 	assert.NoError(t, err)
@@ -97,7 +98,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 	err = j.Update(validPmJSONString)
 	assert.NoError(t, err)
 
-	pm := &types.PriceMonitoringParameters{}
+	pm := &vega.PriceMonitoringParameters{}
 	err = j.ToJSONStruct(pm)
 	assert.NoError(t, err)
 
@@ -111,7 +112,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 
 	// happy case, empty parameters array
 	validPmJSONString = `{"triggers": []}`
-	j = netparams.NewJSON(&types.PriceMonitoringParameters{}, netparams.JSONProtoValidator()).Mutable(true).MustUpdate(validPmJSONString)
+	j = netparams.NewJSON(&vega.PriceMonitoringParameters{}, netparams.PriceMonitoringParametersValidation).Mutable(true).MustUpdate(validPmJSONString)
 	assert.NotNil(t, j)
 	err = j.Validate(validPmJSONString)
 	assert.NoError(t, err)
@@ -119,7 +120,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 	err = j.Update(validPmJSONString)
 	assert.NoError(t, err)
 
-	pm = &types.PriceMonitoringParameters{}
+	pm = &vega.PriceMonitoringParameters{}
 	err = j.ToJSONStruct(pm)
 	assert.NoError(t, err)
 
@@ -140,7 +141,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 
 	// horizon
 	invalidPmJSONString = `{"triggers": [{"horizon": 0, "probability": "0.95", "auction_extension": 90},{"horizon": 120, "probability": "0.99", "auction_extension": 180}]}`
-	expectedErrorMsg = "invalid field Triggers.Horizon: value '0' must be greater than '0'"
+	expectedErrorMsg = "triggers.horizon must be greater than `0`, got `0`"
 	err = j.Validate(invalidPmJSONString)
 	assert.EqualError(t, err, expectedErrorMsg)
 
@@ -149,7 +150,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 
 	// probability
 	invalidPmJSONString = `{"triggers": [{"horizon": 60, "probability": "0", "auction_extension": 90},{"horizon": 120, "probability": "0.99", "auction_extension": 180}]}`
-	expectedErrorMsg = "invalid field Triggers.Probability: value '0' must be strictly greater than '0'"
+	expectedErrorMsg = "triggers.probability must be greater than `0`, got `0`"
 	err = j.Validate(invalidPmJSONString)
 	assert.EqualError(t, err, expectedErrorMsg)
 
@@ -157,7 +158,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 	assert.EqualError(t, err, expectedErrorMsg)
 
 	invalidPmJSONString = `{"triggers": [{"horizon": 60, "probability": "1", "auction_extension": 90},{"horizon": 120, "probability": "0.99", "auction_extension": 180}]}`
-	expectedErrorMsg = "invalid field Triggers.Probability: value '1' must be strictly lower than '1'"
+	expectedErrorMsg = "triggers.probability must be lower than `1`, got `1`"
 	err = j.Validate(invalidPmJSONString)
 	assert.EqualError(t, err, expectedErrorMsg)
 
@@ -166,7 +167,7 @@ func TestJSONVPriceMonitoringParameters(t *testing.T) {
 
 	// auctionExtension
 	invalidPmJSONString = `{"triggers": [{"horizon": 60, "probability": "0.95", "auction_extension": 0},{"horizon": 120, "probability": "0.99", "auction_extension": 180}]}`
-	expectedErrorMsg = "invalid field Triggers.AuctionExtension: value '0' must be greater than '0'"
+	expectedErrorMsg = "triggers.auction_extension must be greater than `0`, got `0`"
 	err = j.Validate(invalidPmJSONString)
 	assert.EqualError(t, err, expectedErrorMsg)
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/jinzhu/copier v0.2.8
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/mattn/go-isatty v0.0.14
-	github.com/mwitkow/go-proto-validators v0.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/rs/cors v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -1010,8 +1010,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=
 github.com/mwitkow/go-proto-validators v0.2.0/go.mod h1:ZfA1hW+UH/2ZHOWvQ3HnQaU0DtnpXu850MZiy+YUgcc=
-github.com/mwitkow/go-proto-validators v0.3.2 h1:qRlmpTzm2pstMKKzTdvwPCF5QfBNURSlAgN/R+qbKos=
-github.com/mwitkow/go-proto-validators v0.3.2/go.mod h1:ej0Qp0qMgHN/KtDyUt+Q1/tA7a5VarXUOUxD+oeD30w=
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=


### PR DESCRIPTION
We used to use the go-proto-validator package to generate validation for the proto type. We do not anymore, so I removed the depdendency