### PR TITLE
Minor race in chain

### DIFF
--- a/core/api/core.go
+++ b/core/api/core.go
@@ -102,7 +102,7 @@ func (s *coreService) LastBlockHeight(
 
 	if atomic.LoadUint32(&s.hasGenesisTimeAndChainID) == 0 {
 		if err := s.getGenesisTimeAndChainID(ctx); err != nil {
-			return nil, fmt.Errorf("failed to intialilse chainID: %w", err)
+			return nil, fmt.Errorf("failed to intialise chainID: %w", err)
 		}
 	}
 

--- a/core/api/core.go
+++ b/core/api/core.go
@@ -100,9 +100,15 @@ func (s *coreService) LastBlockHeight(
 ) (*protoapi.LastBlockHeightResponse, error) {
 	defer metrics.StartAPIRequestAndTimeGRPC("LastBlockHeight")()
 
+	if atomic.LoadUint32(&s.hasGenesisTimeAndChainID) == 0 {
+		if err := s.getGenesisTimeAndChainID(ctx); err != nil {
+			return nil, fmt.Errorf("failed to intialilse chainID: %w", err)
+		}
+	}
+
 	blockHeight, blockHash := s.powParams.BlockData()
 	if s.log.IsDebug() {
-		s.log.Debug("block height requested, returning", logging.Uint64("block-height", blockHeight), logging.String("block hash", blockHash))
+		s.log.Debug("block height requested, returning", logging.Uint64("block-height", blockHeight), logging.String("block hash", blockHash), logging.String("chaindID", s.chainID))
 	}
 
 	if !s.powParams.IsReady() {

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -436,6 +436,7 @@ func (app *App) Info(_ tmtypes.RequestInfo) tmtypes.ResponseInfo {
 		resp.LastBlockHeight = height
 		resp.LastBlockAppHash = hash
 		app.abci.SetChainID(chainID)
+		app.chainCtx = vgcontext.WithChainID(context.Background(), chainID)
 	}
 
 	app.log.Info("ABCI service INFO requested",
@@ -644,9 +645,6 @@ func (app *App) OnBeginBlock(req tmtypes.RequestBeginBlock) (ctx context.Context
 
 	app.stats.SetHash(hash)
 	app.stats.SetHeight(uint64(req.Header.Height))
-
-	app.chainCtx = vgcontext.WithChainID(context.Background(), app.abci.GetChainID())
-
 	ctx = vgcontext.WithBlockHeight(vgcontext.WithTraceID(app.chainCtx, hash), req.Header.Height)
 	app.blockCtx = ctx
 


### PR DESCRIPTION
Found while playing around with vegacapsule/vegatools-perftest. If `Statistics` isn't called before `LastBlockHeight` then core returns an empty string for the chainID and just reads `s.chainID` unprotected.

Also the tiniest tidy up for setting the chainCtx after snapshot restore so that we don't do it every block.