### PR TITLE
fix: set gql complexity limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [5682](https://github.com/vegaprotocol/vega/issues/5682) - Expose equity share weight in the API
 - [5684](https://github.com/vegaprotocol/vega/issues/5684) - Added date range to a number of historic balances, deposits, withdrawals, orders and trades queries
 - [6071](https://github.com/vegaprotocol/vega/issues/6071) - Allow for empty settlement asset in recurring transfer metric definition for market proposer bonus
+- [6042](https://github.com/vegaprotocol/vega/issues/5270) - Set GraphQL query complexity limit
 
 ### 🐛 Fixes
 - [5934](https://github.com/vegaprotocol/vega/issues/5934) - Ensure wallet without permissions can be read

--- a/datanode/README.md
+++ b/datanode/README.md
@@ -215,6 +215,45 @@ Note that Linux systems generally require processes listening on ports under 102
   setcap cap_net_bind_service=ep data-node run
   ```
 
+#### GraphQL Complexity
+
+Currently the GraphQL complexity limit is globally set to 3750.
+This setting is theoretic at the moment and will be refined and have different levels for different queries/resolvers in the future.
+
+The intention behind this limit is to prevent the VEGA system from being anused by heavy queries (DOS).
+The complexity level is mostly affected by the number of objects a query contains. So the heaviest ones we currently have in the system (based on discussion with Matt) are:
+SimpleMarkets (embedded candles):
+1 candle: 151
+91 candles: 788
+
+MarketInfo (embedded candles):
+1 candle: 399
+91 candles: 1036
+
+Orders (embedded orders):
+Complexity for:
+1 order is: 163
+80 orders: 4003
+
+Trades (embedded trades):
+Complexity with
+1 trade is:
+118
+75 trades: 1393
+
+Positions (embedded positions):
+Complexity with 1 position is 129
+For 40 positions is:
+2500
+
+The approximate number of positions queries by customers is 40.
+
+At the moment we do not have a precise idea what limit would be appropriate to set for candles and orders. This would take some time and experience.
+So for 40 positions - complexity is 2500. A theoretical value of 3000 is set as a maximum + 25% -> 3750.
+The GraphQL will return error for queries that have complexity above the set limit: "GraphQL error: Query is too complex to execute" and will not proceed with execution.
+
+Further settings for GraphQL limits will be customized for specific evil queries and will be set for the specific GraphQL resolvers methods. That would also affect subscriptions and oneoff queries.
+
 ### REST
 
 REST provides a standard between computer systems on the web, making it easier for systems to communicate with each other. It is arguably simpler to work with than gRPC and GraphQL. In Vega the REST API is a reverse proxy to the gRPC API, however it does not support streaming.

--- a/datanode/gateway/graphql/server.go
+++ b/datanode/gateway/graphql/server.go
@@ -162,10 +162,13 @@ func (g *GraphServer) Start() error {
 			debug.PrintStack()
 			return errors.New("an internal error occurred")
 		}),
+
+		handler.ComplexityLimit(3750),
 	}
 	if g.GraphQL.ComplexityLimit > 0 {
 		options = append(options, handler.ComplexityLimit(g.GraphQL.ComplexityLimit))
 	}
+
 	// FIXME(jeremy): to be removed once everyone has move to the new endpoint
 	handlr.Handle("/query", gateway.RemoteAddrMiddleware(g.log, corz.Handler(
 		handler.GraphQL(NewExecutableSchema(config), options...),


### PR DESCRIPTION
close #5720 
This PR tries to define GraphQL complexity limit setting.
In order to calculate the complexity limit it is safe to use, we look at the most expensive queries we use as well as _the number of objects_ we allow in them;

_query Candles:_
Query complexity for 1 candle is 96.
For (example) 91 candles is 636

_SimpleMarkets complexity:_
1 candle: 151
91 candles: 788

_query MarketInfo:_ 
1 candle: 399
91 candles: 1036

_query Orders:_
Complexity for:
1 order is: 163
80 orders: 4003

_query Trades:_
Complexity with 
1 trade is:
118
75 trades: 1393

_query Positions:_
Complexity with 1 position is 129
For 40 positions is:
2500

As per my conversation with Matthew Russel yesterday - we can set the number of positions limit to approximately 50.
That would make the complexity limit for `Positions` query 3130.

For number of candles and orders allowed, the decision concerns what level of restrictions we would set for the customer to see.
@jeremyletang , we would like to advise with you about this, please advise if there is someone else we should mention here, maybe @barnabee as well?

_
[gql-candles-2.txt](https://github.com/vegaprotocol/vega/files/9475879/gql-candles-2.txt)
[gql-candles-3.txt](https://github.com/vegaprotocol/vega/files/9475880/gql-candles-3.txt)
[gql-orderfields-4.txt](https://github.com/vegaprotocol/vega/files/9475881/gql-orderfields-4.txt)
[gql-orderfields-5.txt](https://github.com/vegaprotocol/vega/files/9475882/gql-orderfields-5.txt)
[gql-positions-6.txt](https://github.com/vegaprotocol/vega/files/9475883/gql-positions-6.txt)
[gql-tradefields-4.txt](https://github.com/vegaprotocol/vega/files/9475884/gql-tradefields-4.txt)
[gql-candles-1.txt](https://github.com/vegaprotocol/vega/files/9475878/gql-candles-1.txt)_