### PR TITLE
feat: default snapshot behaviour is now to load if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [5989](https://github.com/vegaprotocol/vega/issues/5989) - Remove liquidity commitment from market proposal 
 - [6031](https://github.com/vegaprotocol/vega/issues/6031) - Remove market name from `graphql` market type
 - [6095](https://github.com/vegaprotocol/vega/issues/6095) - Rename taker fees to maker paid fees
+- [5442](https://github.com/vegaprotocol/vega/issues/5442) - Default behaviour when starting to node is to use the latest local snapshot if it exists
 
 ### 🗑️ Deprecation
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -575,14 +575,6 @@ func (app *App) OnInitChain(req tmtypes.RequestInitChain) tmtypes.ResponseInitCh
 	ctx = vgcontext.WithTraceID(ctx, hash)
 	app.blockCtx = ctx
 
-	// Start the snapshot engine letting it clear any pre-existing state so that if we are
-	// replaying a chain from block 0 we won't recreate snapshots for blocks as we revisit
-	// them
-	if err := app.snapshot.ClearAndInitialise(); err != nil {
-		app.cancel()
-		app.log.Fatal("couldn't start snapshot engine", logging.Error(err))
-	}
-
 	if err := app.ghandler.OnGenesis(ctx, req.Time, req.AppStateBytes); err != nil {
 		app.cancel()
 		app.log.Fatal("couldn't initialise vega with the genesis block", logging.Error(err))

--- a/core/snapshot/config.go
+++ b/core/snapshot/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	RetryLimit  int               `long:"max-retries" description:"Maximum number of times to try and apply snapshot chunk"`
 	Storage     string            `long:"storage" choice:"GOLevelDB" choice:"memory" description:"Storage type to use"`
 	DBPath      string            `long:"db-path" description:"Path to database"`
-	StartHeight int64             `long:"load-from-block-height" description:"Start the node by loading the snapshot taken at the given block-height. -1 for last snapshot, 0 for no reload (default: 0)"` // -1 for last snapshot, 0 for no reload
+	StartHeight int64             `long:"load-from-block-height" description:"Load from a local snapshot taken at the given block-height. Setting to -1 will load from the latest snapshot if it exists, 0 will force the chain to replay (default: -1)"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
@@ -45,7 +45,7 @@ func NewDefaultConfig() Config {
 		KeepRecent:  10,
 		RetryLimit:  5,
 		Storage:     goLevelDB,
-		StartHeight: 0,
+		StartHeight: -1,
 	}
 }
 


### PR DESCRIPTION
closes #5442 

I've kicked off a full run, which is its usual shade of red, but none of the snapshot tests or snapshot heavy network-infra-validator tests are failing, so we're good: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/9222/pipeline/33/