### PR TITLE
Candles transient failure fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [6119](https://github.com/vegaprotocol/vega/issues/6119) - Correct order in which market event is emitted
 - [5890](https://github.com/vegaprotocol/vega/issues/5890) - Margin breach during amend doesn't cancel order
 - [6144](https://github.com/vegaprotocol/vega/issues/6144) - Price and Pegged Offset in orders are Decimals
+- [6111](https://github.com/vegaprotocol/vega/issues/5890) - Handle candles transient failure and prevent subscription blocking 
 
 ## 0.54.0
 

--- a/datanode/candlesv2/candle_updates.go
+++ b/datanode/candlesv2/candle_updates.go
@@ -36,9 +36,9 @@ type subscriptionMsg struct {
 func (m subscriptionMsg) String() string {
 	if m.subscribe {
 		return fmt.Sprintf("unsubscribe, subscription id:%s", m.id)
-	} else {
-		return fmt.Sprintf("subscribe")
 	}
+
+	return "subscribe"
 }
 
 type CandleUpdates struct {

--- a/datanode/candlesv2/candle_updates.go
+++ b/datanode/candlesv2/candle_updates.go
@@ -27,36 +27,43 @@ type candleSource interface {
 		p entities.CursorPagination) ([]entities.Candle, entities.PageInfo, error)
 }
 
-type subscribeRequest struct {
-	id  string
-	out chan entities.Candle
+type subscriptionMsg struct {
+	subscribe bool
+	id        string
+	out       chan entities.Candle
+}
+
+func (m subscriptionMsg) String() string {
+	if m.subscribe {
+		return fmt.Sprintf("unsubscribe, subscription id:%s", m.id)
+	} else {
+		return fmt.Sprintf("subscribe")
+	}
 }
 
 type CandleUpdates struct {
-	log                *logging.Logger
-	candleSource       candleSource
-	candleID           string
-	subscribeChan      chan subscribeRequest
-	unsubscribeChan    chan string
-	nextSubscriptionID uint64
-	config             CandleUpdatesConfig
+	log                 *logging.Logger
+	candleSource        candleSource
+	candleID            string
+	subscriptionMsgChan chan subscriptionMsg
+	nextSubscriptionID  uint64
+	config              CandleUpdatesConfig
 }
 
 func NewCandleUpdates(ctx context.Context, log *logging.Logger, candleID string, candleSource candleSource,
-	config CandleUpdatesConfig) (*CandleUpdates, error,
-) {
+	config CandleUpdatesConfig,
+) *CandleUpdates {
 	ces := &CandleUpdates{
-		log:             log,
-		candleSource:    candleSource,
-		candleID:        candleID,
-		config:          config,
-		subscribeChan:   make(chan subscribeRequest),
-		unsubscribeChan: make(chan string),
+		log:                 log,
+		candleSource:        candleSource,
+		candleID:            candleID,
+		config:              config,
+		subscriptionMsgChan: make(chan subscriptionMsg, config.CandleUpdatesStreamSubscriptionMsgBufferSize),
 	}
 
 	go ces.run(ctx)
 
-	return ces, nil
+	return ces
 }
 
 func (s *CandleUpdates) run(ctx context.Context) {
@@ -66,34 +73,60 @@ func (s *CandleUpdates) run(ctx context.Context) {
 	ticker := time.NewTicker(s.config.CandleUpdatesStreamInterval.Duration)
 	var lastCandle *entities.Candle
 
+	errorGettingCandleUpdates := false
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			if len(subscriptions) > 0 {
-				candles, err := s.getCandleUpdates(ctx, lastCandle)
-				if err != nil {
-					s.log.Errorf("failed to get candles, closing stream for candle id %s: %w", s.candleID, err)
-					return
-				}
+		case subscriptionMsg := <-s.subscriptionMsgChan:
+			s.handleSubscription(subscriptions, subscriptionMsg, lastCandle)
+		default:
+			select {
+			case <-ctx.Done():
+				return
+			case subscription := <-s.subscriptionMsgChan:
+				s.handleSubscription(subscriptions, subscription, lastCandle)
+			case <-ticker.C:
+				if len(subscriptions) > 0 {
+					candles, err := s.getCandleUpdates(ctx, lastCandle)
+					if err != nil {
+						if !errorGettingCandleUpdates {
+							s.log.Errorf("failed to get candles for candle id %s: %w", s.candleID, err)
+						}
 
-				if len(candles) > 0 {
-					lastCandle = &candles[len(candles)-1]
-				}
+						errorGettingCandleUpdates = true
+					} else {
+						if errorGettingCandleUpdates {
+							s.log.Infof("successfully got candles for candle id %s", s.candleID)
+						}
+						errorGettingCandleUpdates = false
 
-				s.sendCandles(candles, subscriptions)
-			} else {
-				lastCandle = nil
+						if len(candles) > 0 {
+							lastCandle = &candles[len(candles)-1]
+						}
+
+						s.sendCandlesToSubscribers(candles, subscriptions)
+					}
+				} else {
+					lastCandle = nil
+				}
 			}
-		case subscription := <-s.subscribeChan:
-			subscriptions[subscription.id] = subscription.out
-			if lastCandle != nil {
-				s.sendCandles([]entities.Candle{*lastCandle}, map[string]chan entities.Candle{subscription.id: subscription.out})
-			}
-		case id := <-s.unsubscribeChan:
-			removeSubscription(subscriptions, id)
 		}
+	}
+}
+
+func (s *CandleUpdates) handleSubscription(subscriptions map[string]chan entities.Candle, subscription subscriptionMsg, lastCandle *entities.Candle) {
+	if subscription.subscribe {
+		s.addSubscription(subscriptions, subscription, lastCandle)
+	} else {
+		removeSubscription(subscriptions, subscription.id)
+	}
+}
+
+func (s *CandleUpdates) addSubscription(subscriptions map[string]chan entities.Candle, subscription subscriptionMsg, lastCandle *entities.Candle) {
+	subscriptions[subscription.id] = subscription.out
+	if lastCandle != nil {
+		s.sendCandlesToSubscribers([]entities.Candle{*lastCandle}, map[string]chan entities.Candle{subscription.id: subscription.out})
 	}
 }
 
@@ -111,21 +144,46 @@ func closeAllSubscriptions(subscribers map[string]chan entities.Candle) {
 }
 
 // Subscribe returns a unique subscription id and channel on which updates will be sent.
-func (s *CandleUpdates) Subscribe() (string, <-chan entities.Candle) {
+func (s *CandleUpdates) Subscribe() (string, <-chan entities.Candle, error) {
 	out := make(chan entities.Candle, s.config.CandleUpdatesStreamBufferSize)
 
 	nextID := atomic.AddUint64(&s.nextSubscriptionID, 1)
 	subscriptionID := fmt.Sprintf("%s-%d", s.candleID, nextID)
-	s.subscribeChan <- subscribeRequest{
-		id:  subscriptionID,
-		out: out,
+
+	msg := subscriptionMsg{
+		subscribe: true,
+		id:        subscriptionID,
+		out:       out,
 	}
 
-	return subscriptionID, out
+	err := s.sendSubscriptionMessage(msg)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return subscriptionID, out, nil
 }
 
-func (s *CandleUpdates) Unsubscribe(subscriptionID string) {
-	s.unsubscribeChan <- subscriptionID
+func (s *CandleUpdates) Unsubscribe(subscriptionID string) error {
+	msg := subscriptionMsg{
+		subscribe: false,
+		id:        subscriptionID,
+	}
+
+	return s.sendSubscriptionMessage(msg)
+}
+
+func (s *CandleUpdates) sendSubscriptionMessage(msg subscriptionMsg) error {
+	if s.config.CandleUpdatesStreamSubscriptionMsgBufferSize == 0 {
+		s.subscriptionMsgChan <- msg
+	} else {
+		select {
+		case s.subscriptionMsgChan <- msg:
+		default:
+			return fmt.Errorf("failed to send subscription message \"%s\", subscription message buffer is full, try again later", msg)
+		}
+	}
+	return nil
 }
 
 func (s *CandleUpdates) getCandleUpdates(ctx context.Context, lastCandle *entities.Candle) ([]entities.Candle, error) {
@@ -164,7 +222,7 @@ func (s *CandleUpdates) getCandleUpdates(ctx context.Context, lastCandle *entiti
 	return updates, nil
 }
 
-func (s *CandleUpdates) sendCandles(candles []entities.Candle, subscriptions map[string]chan entities.Candle) {
+func (s *CandleUpdates) sendCandlesToSubscribers(candles []entities.Candle, subscriptions map[string]chan entities.Candle) {
 	for subscriptionID, outCh := range subscriptions {
 		for _, candle := range candles {
 			select {

--- a/datanode/candlesv2/candle_updates_test.go
+++ b/datanode/candlesv2/candle_updates_test.go
@@ -19,14 +19,12 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/datanode/candlesv2"
+	"code.vegaprotocol.io/vega/datanode/config/encoding"
 	"code.vegaprotocol.io/vega/datanode/entities"
+	"code.vegaprotocol.io/vega/logging"
 
 	"github.com/shopspring/decimal"
-
 	"github.com/stretchr/testify/assert"
-
-	"code.vegaprotocol.io/vega/datanode/config/encoding"
-	"code.vegaprotocol.io/vega/logging"
 )
 
 type nonReturningCandleSource struct{}
@@ -37,8 +35,6 @@ func (t *nonReturningCandleSource) GetCandleDataForTimeSpan(ctx context.Context,
 	for {
 		time.Sleep(1 * time.Second)
 	}
-
-	return nil, entities.PageInfo{}, nil
 }
 
 type errorsAlwaysCandleSource struct{}
@@ -271,11 +267,11 @@ func TestSubscribeAndUnSubscribeWithNonReturningSource(t *testing.T) {
 	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
 		testCandleSource, newTestCandleConfig(1, 100).CandleUpdates)
 
-	subId1, _, _ := updates.Subscribe()
-	subId2, _, _ := updates.Subscribe()
+	subID1, _, _ := updates.Subscribe()
+	subID2, _, _ := updates.Subscribe()
 
-	updates.Unsubscribe(subId1)
-	updates.Unsubscribe(subId2)
+	updates.Unsubscribe(subID1)
+	updates.Unsubscribe(subID2)
 }
 
 func newTestCandleConfig(bufferSize int, subscribeBufferSize int) candlesv2.Config {

--- a/datanode/candlesv2/candle_updates_test.go
+++ b/datanode/candlesv2/candle_updates_test.go
@@ -14,6 +14,7 @@ package candlesv2_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -28,8 +29,29 @@ import (
 	"code.vegaprotocol.io/vega/logging"
 )
 
+type nonReturningCandleSource struct{}
+
+func (t *nonReturningCandleSource) GetCandleDataForTimeSpan(ctx context.Context, candleID string, from *time.Time, to *time.Time,
+	p entities.CursorPagination,
+) ([]entities.Candle, entities.PageInfo, error) {
+	for {
+		time.Sleep(1 * time.Second)
+	}
+
+	return nil, entities.PageInfo{}, nil
+}
+
+type errorsAlwaysCandleSource struct{}
+
+func (t *errorsAlwaysCandleSource) GetCandleDataForTimeSpan(ctx context.Context, candleID string, from *time.Time, to *time.Time,
+	p entities.CursorPagination,
+) ([]entities.Candle, entities.PageInfo, error) {
+	return nil, entities.PageInfo{}, fmt.Errorf("always errors")
+}
+
 type testCandleSource struct {
 	candles chan []entities.Candle
+	errorCh chan error
 }
 
 func (t *testCandleSource) GetCandleDataForTimeSpan(ctx context.Context, candleID string, from *time.Time, to *time.Time,
@@ -39,20 +61,99 @@ func (t *testCandleSource) GetCandleDataForTimeSpan(ctx context.Context, candleI
 	select {
 	case c := <-t.candles:
 		return c, pageInfo, nil
+	case err := <-t.errorCh:
+		return nil, entities.PageInfo{}, err
 	default:
 		return nil, pageInfo, nil
 	}
 }
 
+func TestSubscribeAndUnsubscribeWhenCandleSourceErrorsAlways(t *testing.T) {
+	errorsAlwaysCandleSource := &errorsAlwaysCandleSource{}
+
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		errorsAlwaysCandleSource, newTestCandleConfig(1, 0).CandleUpdates)
+
+	sub1Id, _, _ := updates.Subscribe()
+	sub2Id, _, _ := updates.Subscribe()
+
+	updates.Unsubscribe(sub1Id)
+	updates.Unsubscribe(sub2Id)
+}
+
+func TestUnsubscribeAfterTransientFailure(t *testing.T) {
+	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle), errorCh: make(chan error)}
+
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 0).CandleUpdates)
+	startTime := time.Now()
+
+	sub1Id, out1, _ := updates.Subscribe()
+	sub2Id, out2, _ := updates.Subscribe()
+
+	firstCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
+	testCandleSource.candles <- []entities.Candle{firstCandle}
+
+	candle1 := <-out1
+	assert.Equal(t, firstCandle, candle1)
+
+	candle2 := <-out2
+	assert.Equal(t, firstCandle, candle2)
+
+	testCandleSource.errorCh <- fmt.Errorf("transient error")
+
+	updates.Unsubscribe(sub1Id)
+	updates.Unsubscribe(sub2Id)
+}
+
+func TestSubscribeAfterTransientFailure(t *testing.T) {
+	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle), errorCh: make(chan error)}
+
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 0).CandleUpdates)
+	startTime := time.Now()
+
+	_, out1, _ := updates.Subscribe()
+	_, out2, _ := updates.Subscribe()
+
+	firstCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
+	testCandleSource.candles <- []entities.Candle{firstCandle}
+
+	candle1 := <-out1
+	assert.Equal(t, firstCandle, candle1)
+
+	candle2 := <-out2
+	assert.Equal(t, firstCandle, candle2)
+
+	testCandleSource.errorCh <- fmt.Errorf("transient error")
+
+	_, out3, _ := updates.Subscribe()
+
+	candle3 := <-out3
+	assert.Equal(t, firstCandle, candle3)
+
+	secondCandle := createCandle(startTime.Add(1*time.Minute), startTime.Add(1*time.Minute), 2, 2, 2, 2, 20)
+	testCandleSource.candles <- []entities.Candle{secondCandle}
+
+	candle1 = <-out1
+	assert.Equal(t, secondCandle, candle1)
+
+	candle2 = <-out2
+	assert.Equal(t, secondCandle, candle2)
+
+	candle3 = <-out3
+	assert.Equal(t, secondCandle, candle3)
+}
+
 func TestSubscribe(t *testing.T) {
 	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle)}
 
-	updates, _ := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
-		testCandleSource, newTestCandleConfig(1).CandleUpdates)
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 0).CandleUpdates)
 	startTime := time.Now()
 
-	_, out1 := updates.Subscribe()
-	_, out2 := updates.Subscribe()
+	_, out1, _ := updates.Subscribe()
+	_, out2, _ := updates.Subscribe()
 
 	expectedCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
 	testCandleSource.candles <- []entities.Candle{expectedCandle}
@@ -76,11 +177,11 @@ func TestSubscribe(t *testing.T) {
 func TestUnsubscribe(t *testing.T) {
 	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle)}
 
-	updates, _ := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
-		testCandleSource, newTestCandleConfig(1).CandleUpdates)
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 0).CandleUpdates)
 	startTime := time.Now()
 
-	id, out1 := updates.Subscribe()
+	id, out1, _ := updates.Subscribe()
 
 	expectedCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
 	testCandleSource.candles <- []entities.Candle{expectedCandle}
@@ -97,11 +198,11 @@ func TestUnsubscribe(t *testing.T) {
 func TestNewSubscriberAlwaysGetsLastCandle(t *testing.T) {
 	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle)}
 
-	updates, _ := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
-		testCandleSource, newTestCandleConfig(1).CandleUpdates)
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 0).CandleUpdates)
 	startTime := time.Now()
 
-	_, out1 := updates.Subscribe()
+	_, out1, _ := updates.Subscribe()
 
 	expectedCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
 	testCandleSource.candles <- []entities.Candle{expectedCandle}
@@ -109,17 +210,81 @@ func TestNewSubscriberAlwaysGetsLastCandle(t *testing.T) {
 	candle1 := <-out1
 	assert.Equal(t, expectedCandle, candle1)
 
-	_, out2 := updates.Subscribe()
+	_, out2, _ := updates.Subscribe()
 	candle2 := <-out2
 	assert.Equal(t, expectedCandle, candle2)
 }
 
-func newTestCandleConfig(bufferSize int) candlesv2.Config {
+func TestSubscribeWithNonZeroSubscribeBuffer(t *testing.T) {
+	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle)}
+
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 100).CandleUpdates)
+	startTime := time.Now()
+
+	_, out1, _ := updates.Subscribe()
+	_, out2, _ := updates.Subscribe()
+
+	expectedCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
+	testCandleSource.candles <- []entities.Candle{expectedCandle}
+
+	candle1 := <-out1
+	assert.Equal(t, expectedCandle, candle1)
+
+	candle2 := <-out2
+	assert.Equal(t, expectedCandle, candle2)
+
+	expectedCandle = createCandle(startTime.Add(1*time.Minute), startTime.Add(1*time.Minute), 2, 2, 2, 2, 20)
+	testCandleSource.candles <- []entities.Candle{expectedCandle}
+
+	candle1 = <-out1
+	assert.Equal(t, expectedCandle, candle1)
+
+	candle2 = <-out2
+	assert.Equal(t, expectedCandle, candle2)
+}
+
+func TestUnsubscribeWithNonZeroSubscribeBuffer(t *testing.T) {
+	testCandleSource := &testCandleSource{candles: make(chan []entities.Candle)}
+
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 100).CandleUpdates)
+	startTime := time.Now()
+
+	id, out1, _ := updates.Subscribe()
+
+	expectedCandle := createCandle(startTime, startTime, 1, 1, 1, 1, 10)
+	testCandleSource.candles <- []entities.Candle{expectedCandle}
+
+	candle1 := <-out1
+	assert.Equal(t, expectedCandle, candle1)
+
+	updates.Unsubscribe(id)
+
+	_, ok := <-out1
+	assert.False(t, ok, "candle should be closed")
+}
+
+func TestSubscribeAndUnSubscribeWithNonReturningSource(t *testing.T) {
+	testCandleSource := &nonReturningCandleSource{}
+
+	updates := candlesv2.NewCandleUpdates(context.Background(), logging.NewTestLogger(), "testCandles",
+		testCandleSource, newTestCandleConfig(1, 100).CandleUpdates)
+
+	subId1, _, _ := updates.Subscribe()
+	subId2, _, _ := updates.Subscribe()
+
+	updates.Unsubscribe(subId1)
+	updates.Unsubscribe(subId2)
+}
+
+func newTestCandleConfig(bufferSize int, subscribeBufferSize int) candlesv2.Config {
 	conf := candlesv2.NewDefaultConfig()
 	conf.CandleUpdates = candlesv2.CandleUpdatesConfig{
-		CandleUpdatesStreamBufferSize: bufferSize,
-		CandleUpdatesStreamInterval:   encoding.Duration{Duration: 1 * time.Microsecond},
-		CandlesFetchTimeout:           encoding.Duration{Duration: 2 * time.Minute},
+		CandleUpdatesStreamBufferSize:                bufferSize,
+		CandleUpdatesStreamInterval:                  encoding.Duration{Duration: 1 * time.Microsecond},
+		CandlesFetchTimeout:                          encoding.Duration{Duration: 2 * time.Minute},
+		CandleUpdatesStreamSubscriptionMsgBufferSize: subscribeBufferSize,
 	}
 
 	return conf

--- a/datanode/candlesv2/config.go
+++ b/datanode/candlesv2/config.go
@@ -35,9 +35,10 @@ type CandleStoreConfig struct {
 }
 
 type CandleUpdatesConfig struct {
-	CandleUpdatesStreamBufferSize int               `long:"candle-updates-stream-buffer-size" description:"buffer size used by the candle events stream for the per client per candle channel"`
-	CandleUpdatesStreamInterval   encoding.Duration `long:"candle-updates-stream-interval" description:"The time between sending updated candles"`
-	CandlesFetchTimeout           encoding.Duration `long:"candles-fetch-timeout" description:"Maximum time permissible to fetch candles"`
+	CandleUpdatesStreamBufferSize                int               `long:"candle-updates-stream-buffer-size" description:"buffer size used by the candle events stream for the per client per candle channel"`
+	CandleUpdatesStreamInterval                  encoding.Duration `long:"candle-updates-stream-interval" description:"The time between sending updated candles"`
+	CandlesFetchTimeout                          encoding.Duration `long:"candles-fetch-timeout" description:"Maximum time permissible to fetch candles"`
+	CandleUpdatesStreamSubscriptionMsgBufferSize int               `long:"candle-updates-stream-subscription-buffer-size" description:"size of the buffer used to hold pending subcribe/unsubscribe requests"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
@@ -46,9 +47,10 @@ func NewDefaultConfig() Config {
 	return Config{
 		Level: encoding.LogLevel{Level: logging.InfoLevel},
 		CandleUpdates: CandleUpdatesConfig{
-			CandleUpdatesStreamBufferSize: 100,
-			CandleUpdatesStreamInterval:   encoding.Duration{Duration: time.Second},
-			CandlesFetchTimeout:           encoding.Duration{Duration: 10 * time.Second},
+			CandleUpdatesStreamBufferSize:                100,
+			CandleUpdatesStreamInterval:                  encoding.Duration{Duration: time.Second},
+			CandlesFetchTimeout:                          encoding.Duration{Duration: 10 * time.Second},
+			CandleUpdatesStreamSubscriptionMsgBufferSize: 100,
 		},
 	}
 }


### PR DESCRIPTION
closes #6111

Fixes the issue with transient db failure killing the sending thread and ensures liveness of subscription handling regardless of success/failure of getting candle data from db.