### PR TITLE
fix: exclude tainted keys from session.key_list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - [6099](https://github.com/vegaprotocol/vega/issues/6099) - Allow recurring transfers with the same to and from but with different asset
 - [6119](https://github.com/vegaprotocol/vega/issues/6119) - Correct order in which market event is emitted
 - [5890](https://github.com/vegaprotocol/vega/issues/5890) - Margin breach during amend doesn't cancel order
+- [5988](https://github.com/vegaprotocol/vega/issues/5988) - Exclude tainted keys from `session.list_keys` endpoint
 
 ## 0.54.0
 

--- a/wallet/api/session_list_keys.go
+++ b/wallet/api/session_list_keys.go
@@ -38,8 +38,10 @@ func (h *ListKeys) Handle(_ context.Context, rawParams jsonrpc.Params) (jsonrpc.
 	}
 
 	keys := make([]string, 0, len(connectedWallet.RestrictedKeys))
-	for pubKey := range connectedWallet.RestrictedKeys {
-		keys = append(keys, pubKey)
+	for pubKey, kp := range connectedWallet.RestrictedKeys {
+		if !kp.IsTainted() {
+			keys = append(keys, pubKey)
+		}
 	}
 
 	return ListKeysResult{


### PR DESCRIPTION
close #5988  