### PR TITLE
fix: returning too many delegations in node delegations graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [6156](https://github.com/vegaprotocol/vega/issues/6156) - Return only delegations for the specific node in `graphql` node delegation query
 
 ## 0.55.0
 

--- a/datanode/gateway/graphql/node_resolver.go
+++ b/datanode/gateway/graphql/node_resolver.go
@@ -56,7 +56,7 @@ func (r *nodeResolver) RewardScore(ctx context.Context, obj *proto.Node) (proto.
 
 func (r *nodeResolver) DelegationsConnection(ctx context.Context, node *proto.Node, partyID *string, pagination *v2.Pagination) (*v2.DelegationsConnection, error) {
 	var nodeID *string
-	if node == nil {
+	if node != nil {
 		nodeID = &node.Id
 	}
 	return handleDelegationConnectionRequest(ctx, r.tradingDataClientV2, partyID, nodeID, nil, pagination)


### PR DESCRIPTION
Closes #6156  