### PR TITLE
feat: bug in feature test, initial order from trader3 should be rejected but got accepted in the feature test

### DIFF
--- a/core/integration/features/verified/Test_order_cancel_bug.feature
+++ b/core/integration/features/verified/Test_order_cancel_bug.feature
@@ -1,10 +1,6 @@
-Feature: Closeout-cascades
-# This is a test case to demonstrate that closeout cascade does NOT happen. In this test case, trader3 gets closed
-# out first after buying volume 50 at price 100, and then trader3's position is sold (via the network counterparty) to trader2 whose order is first in the order book
-# (volume 50 price 50)
-# At this moment, trader2 is under margin but the fuse breaks (if the mark price is actually updated from 100 to 50)
-# however, the design of the system is like a fuse and circuit breaker, the mark price will NOT update, so trader2 will not be closed out
-# till a new trade happens, and new mark price is set.
+Feature: Closeout-cascades-1
+# This is a test case to demonstrate an order can be rejected when the trader (who places an initial order) does not have enouge collateral to cover the initial margin level
+
   Background:
 
     Given the log normal risk model named "log-normal-risk-model-1":
@@ -81,18 +77,16 @@ Feature: Closeout-cascades
     When the parties place the following orders:
       | party      | market id | side | volume| price | resulting trades | type       | tif     | reference      |
       | trader3    | ETH/DEC19 | buy  | 10    | 100   | 0                | TYPE_LIMIT | TIF_GTC | buy-position-31 |
-      | auxiliary1 | ETH/DEC19 | sell | 10    | 100   | 1                | TYPE_LIMIT | TIF_GTC | sell-provider-1|
+      #| auxiliary1 | ETH/DEC19 | sell | 10    | 100   | 1                | TYPE_LIMIT | TIF_GTC | sell-provider-1|
 
     And the parties should have the following margin levels:
       | party     | market id  | maintenance | search | initial | release |
-      | trader2   | ETH/DEC19  | 0           | 0      | 0       | 0       |
-      | trader3   | ETH/DEC19  | 0           | 0      | 0       | 0       |
+      | trader3   | ETH/DEC19  | 81          | 121    | 162     | 243     |
 
-    # how come trader2's order is canceled?
+    # how come trader3's order is not rejected? they only have 90 in the collateral and the initial margin level is 162
     Then the parties should have the following account balances:
       | party   | asset | market id | margin   | general |
-      | trader2 | USD   | ETH/DEC19 | 0        | 2000    |
-      | trader3 | USD   | ETH/DEC19 | 0        | 0       |
+      | trader3 | USD   | ETH/DEC19 | 90       | 0       |
   
     Then the order book should have the following volumes for market "ETH/DEC19":
       | side | price  | volume   |

--- a/core/integration/features/verified/Test_order_cancel_bug.feature
+++ b/core/integration/features/verified/Test_order_cancel_bug.feature
@@ -1,0 +1,104 @@
+Feature: Closeout-cascades
+# This is a test case to demonstrate that closeout cascade does NOT happen. In this test case, trader3 gets closed
+# out first after buying volume 50 at price 100, and then trader3's position is sold (via the network counterparty) to trader2 whose order is first in the order book
+# (volume 50 price 50)
+# At this moment, trader2 is under margin but the fuse breaks (if the mark price is actually updated from 100 to 50)
+# however, the design of the system is like a fuse and circuit breaker, the mark price will NOT update, so trader2 will not be closed out
+# till a new trade happens, and new mark price is set.
+  Background:
+
+    Given the log normal risk model named "log-normal-risk-model-1":
+      | risk aversion | tau | mu | r | sigma |
+      | 0.000001      | 0.1 | 0  | 0 | 1.0   |
+      #risk factor short = 3.55690359157934000
+      #risk factor long = 0.801225765
+      And the margin calculator named "margin-calculator-1":
+      | search factor | initial factor | release factor |
+      | 1.5           | 2              | 3              |
+    And the markets:
+      | id        | quote name | asset | risk model              | margin calculator   | auction duration | fees         | price monitoring | oracle config          |
+      | ETH/DEC19 | BTC        | USD   | log-normal-risk-model-1 | margin-calculator-1 | 1                | default-none | default-none     | default-eth-for-future |
+    And the following network parameters are set:
+      | name                           | value |
+      | market.auction.minimumDuration | 1     |
+
+  Scenario: Distressed position gets taken over by another party whose margin level is insufficient to support it (however mark price doesn't get updated on closeout trade and hence no further closeouts are carried out) (0005-COLL-002)
+   # setup accounts, we are trying to closeout trader3 first and then trader2
+
+    Given the insurance pool balance should be "0" for the market "ETH/DEC19"
+
+    Given the parties deposit on asset's general account the following amount:
+      | party        | asset | amount        |
+      | auxiliary1   | USD   | 1000000000000 |
+      | auxiliary2   | USD   | 1000000000000 |
+      | trader2      | USD   | 2000          |
+      | trader3      | USD   | 90            |
+      | lprov        | USD   | 1000000000000 |
+
+    When the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | lprov  | ETH/DEC19 | 100000            | 0.001 | sell | ASK              | 100        | 55     | submission |
+      | lp1 | lprov  | ETH/DEC19 | 100000            | 0.001 | buy  | BID              | 100        | 55     | amendmend |
+  # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+  # trading happens at the end of the open auction period
+    Then the parties place the following orders:
+      | party     | market id | side | volume | price  | resulting trades| type       | tif     | reference |
+      | auxiliary2| ETH/DEC19 | buy  | 5      | 5      | 0               | TYPE_LIMIT | TIF_GTC | aux-b-5   |
+      | auxiliary1| ETH/DEC19 | sell | 10     | 1000   | 0               | TYPE_LIMIT | TIF_GTC | aux-s-1000|
+      | auxiliary2| ETH/DEC19 | buy  | 10     | 10     | 0               | TYPE_LIMIT | TIF_GTC | aux-b-1   |
+      | auxiliary1| ETH/DEC19 | sell | 10     | 10     | 0               | TYPE_LIMIT | TIF_GTC | aux-s-1   |
+    When the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    Then the auction ends with a traded volume of "10" at a price of "10"
+    And the mark price should be "10" for the market "ETH/DEC19"
+
+    # setup trader2 position to be ready to takeover trader3's position once trader3 is closed out
+    When the parties place the following orders:
+      | party     | market id | side | volume| price | resulting trades | type       | tif     | reference   |
+      | trader2   | ETH/DEC19 | buy  | 40    | 50    | 0                | TYPE_LIMIT | TIF_GTC | buy-order-3 |
+    Then the order book should have the following volumes for market "ETH/DEC19":
+      | side | price  | volume   |
+      | buy  | 5      | 5        |
+      | buy  | 50     | 4040     | 
+      | sell | 1000   | 10       | 
+      | sell | 1055   | 223      | 
+
+    And the parties should have the following margin levels:
+      | party     | market id  | maintenance | search | initial | release |
+      | trader2   | ETH/DEC19  | 321         | 481    | 642     | 963     |
+      # margin level = OrderSize*MarkPrice*RF = 40*10*0.801225765=321
+
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin   | general |
+      | trader2 | USD   | ETH/DEC19 | 642      | 1358    |
+
+    Then the parties should have the following profit and loss:
+      | party      | volume | unrealised pnl | realised pnl |
+      | auxiliary1 | -10    | 0              | 0            |
+      | auxiliary2 | 10     | 0              | 0            |
+
+    # setup trader3 position and close it out
+    When the parties place the following orders:
+      | party      | market id | side | volume| price | resulting trades | type       | tif     | reference      |
+      | trader3    | ETH/DEC19 | buy  | 10    | 100   | 0                | TYPE_LIMIT | TIF_GTC | buy-position-31 |
+      | auxiliary1 | ETH/DEC19 | sell | 10    | 100   | 1                | TYPE_LIMIT | TIF_GTC | sell-provider-1|
+
+    And the parties should have the following margin levels:
+      | party     | market id  | maintenance | search | initial | release |
+      | trader2   | ETH/DEC19  | 0           | 0      | 0       | 0       |
+      | trader3   | ETH/DEC19  | 0           | 0      | 0       | 0       |
+
+    # how come trader2's order is canceled?
+    Then the parties should have the following account balances:
+      | party   | asset | market id | margin   | general |
+      | trader2 | USD   | ETH/DEC19 | 0        | 2000    |
+      | trader3 | USD   | ETH/DEC19 | 0        | 0       |
+  
+    Then the order book should have the following volumes for market "ETH/DEC19":
+      | side | price  | volume   |
+      | buy  | 5      | 40005    |
+      | buy  | 50     | 0        | 
+      | sell | 1000   | 10       | 
+      | sell | 1055   | 223      | 
+
+    


### PR DESCRIPTION
- In line 79, the initial order from trader3 should be rejected since they do not have enough collateral to cover the initial margin level.

- I think its a bug existing in feature test.

- I did the same test in market-sim (with the same risk parameter/net work parameter and same orders on the market), and the order from trader3 does get rejected.