### PR TITLE
fix: return error code and error string when validation happens in th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Fixes
 - [6148](https://github.com/vegaprotocol/vega/issues/6148) - Fix API descriptions for typos
+- [6138](https://github.com/vegaprotocol/vega/issues/6138) - Return more useful information when a transaction submitted to a node contains validation errors
 - [6156](https://github.com/vegaprotocol/vega/issues/6156) - Return only delegations for the specific node in `graphql` node delegation query
 - [6175](https://github.com/vegaprotocol/vega/issues/6175) - Fix `datanode` updating node public key on key rotation
 ## 0.55.0

--- a/core/blockchain/abci/abci_test.go
+++ b/core/blockchain/abci/abci_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	"code.vegaprotocol.io/vega/core/blockchain"
 	"code.vegaprotocol.io/vega/core/blockchain/abci"
 	"code.vegaprotocol.io/vega/core/txn"
 	"github.com/stretchr/testify/require"
@@ -119,7 +120,7 @@ func TestABCICheckTx(t *testing.T) {
 		req := types.RequestCheckTx{Tx: tx}
 		resp := app.CheckTx(req)
 		require.True(t, resp.IsErr())
-		require.Equal(t, abci.AbciTxnInternalError, resp.Code)
+		require.Equal(t, blockchain.AbciTxnInternalError, resp.Code)
 	})
 
 	t.Run("TxDecodingError", func(t *testing.T) {
@@ -128,6 +129,6 @@ func TestABCICheckTx(t *testing.T) {
 		req := types.RequestCheckTx{Tx: tx}
 		resp := app.CheckTx(req)
 		require.True(t, resp.IsErr())
-		require.Equal(t, abci.AbciTxnDecodingFailure, resp.Code)
+		require.Equal(t, blockchain.AbciTxnDecodingFailure, resp.Code)
 	})
 }

--- a/core/blockchain/abci/app.go
+++ b/core/blockchain/abci/app.go
@@ -15,6 +15,7 @@ package abci
 import (
 	"context"
 
+	"code.vegaprotocol.io/vega/core/blockchain"
 	"code.vegaprotocol.io/vega/core/txn"
 	"code.vegaprotocol.io/vega/core/types"
 
@@ -101,7 +102,7 @@ func (app *App) HandleDeliverTx(cmd txn.Command, fn TxHandler) *App {
 func (app *App) decodeTx(bytes []byte) (Tx, uint32, error) {
 	tx, err := app.codec.Decode(bytes, app.chainID)
 	if err != nil {
-		return nil, AbciTxnDecodingFailure, err
+		return nil, blockchain.AbciTxnDecodingFailure, err
 	}
 	return tx, 0, nil
 }

--- a/core/blockchain/client.go
+++ b/core/blockchain/client.go
@@ -22,6 +22,7 @@ import (
 	"code.vegaprotocol.io/vega/libs/proto"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 
+	"github.com/tendermint/tendermint/libs/bytes"
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
@@ -99,7 +100,9 @@ func (c *Client) CheckTransaction(ctx context.Context, tx *commandspb.Transactio
 	}
 
 	if _, err := commands.CheckTransaction(tx, chainID); err != nil {
-		return nil, err
+		return &tmctypes.ResultCheckTx{
+			ResponseCheckTx: NewResponseCheckTxError(AbciTxnDecodingFailure, err),
+		}, nil
 	}
 
 	marshalledTx, err := proto.Marshal(tx)
@@ -124,7 +127,10 @@ func (c *Client) SubmitTransactionSync(ctx context.Context, tx *commandspb.Trans
 	}
 
 	if _, err := commands.CheckTransaction(tx, chainID); err != nil {
-		return nil, err
+		return &tmctypes.ResultBroadcastTx{ //nolint:nilerr
+			Code: AbciTxnDecodingFailure,
+			Data: []byte(err.Error()),
+		}, nil
 	}
 
 	marshalledTx, err := proto.Marshal(tx)
@@ -151,7 +157,9 @@ func (c *Client) SubmitTransactionCommit(ctx context.Context, tx *commandspb.Tra
 	}
 
 	if _, err := commands.CheckTransaction(tx, chainID); err != nil {
-		return nil, err
+		return &tmctypes.ResultBroadcastTxCommit{
+			CheckTx: NewResponseCheckTxError(AbciTxnDecodingFailure, err),
+		}, nil
 	}
 
 	marshalledTx, err := proto.Marshal(tx)
@@ -178,7 +186,10 @@ func (c *Client) SubmitTransactionAsync(ctx context.Context, tx *commandspb.Tran
 	}
 
 	if _, err := commands.CheckTransaction(tx, chainID); err != nil {
-		return nil, err
+		return &tmctypes.ResultBroadcastTx{ //nolint:nilerr
+			Code: AbciTxnDecodingFailure,
+			Data: bytes.HexBytes(err.Error()),
+		}, nil
 	}
 
 	marshalledTx, err := proto.Marshal(tx)

--- a/core/blockchain/response.go
+++ b/core/blockchain/response.go
@@ -10,9 +10,26 @@
 // of this software will be governed by version 3 or later of the GNU General
 // Public License.
 
-package abci
+package blockchain
 
 import "github.com/tendermint/tendermint/abci/types"
+
+const (
+	// AbciTxnValidationFailure ...
+	AbciTxnValidationFailure uint32 = 51
+
+	// AbciTxnDecodingFailure code is returned when CheckTx or DeliverTx fail to decode the Txn.
+	AbciTxnDecodingFailure uint32 = 60
+
+	// AbciTxnInternalError code is returned when CheckTx or DeliverTx fail to process the Txn.
+	AbciTxnInternalError uint32 = 70
+
+	// AbciUnknownCommandError code is returned when the app doesn't know how to handle a given command.
+	AbciUnknownCommandError uint32 = 80
+
+	// AbciSpamError code is returned when CheckTx or DeliverTx fail spam protection tests.
+	AbciSpamError uint32 = 89
+)
 
 func NewResponseCheckTx(code uint32, info string) types.ResponseCheckTx {
 	return types.ResponseCheckTx{

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -26,6 +26,7 @@ import (
 
 	"code.vegaprotocol.io/vega/commands"
 	"code.vegaprotocol.io/vega/core/api"
+	"code.vegaprotocol.io/vega/core/blockchain"
 	"code.vegaprotocol.io/vega/core/blockchain/abci"
 	"code.vegaprotocol.io/vega/core/events"
 	"code.vegaprotocol.io/vega/core/genesis"
@@ -787,7 +788,7 @@ func (app *App) OnCheckTxSpam(tx abci.Tx) tmtypes.ResponseCheckTx {
 			if app.log.IsDebug() {
 				app.log.Debug(err.Error())
 			}
-			resp.Code = abci.AbciSpamError
+			resp.Code = blockchain.AbciSpamError
 			resp.Data = []byte(err.Error())
 			return resp
 		}
@@ -796,7 +797,7 @@ func (app *App) OnCheckTxSpam(tx abci.Tx) tmtypes.ResponseCheckTx {
 	if !app.nilSpam {
 		if _, err := app.spam.PreBlockAccept(tx); err != nil {
 			app.log.Error(err.Error())
-			resp.Code = abci.AbciSpamError
+			resp.Code = blockchain.AbciSpamError
 			resp.Data = []byte(err.Error())
 			return resp
 		}
@@ -813,7 +814,7 @@ func (app *App) OnCheckTx(ctx context.Context, _ tmtypes.RequestCheckTx, tx abci
 	}
 
 	if err := app.canSubmitTx(tx); err != nil {
-		resp.Code = abci.AbciTxnValidationFailure
+		resp.Code = blockchain.AbciTxnValidationFailure
 		resp.Data = []byte(err.Error())
 		return ctx, resp
 	}
@@ -897,7 +898,7 @@ func (app *App) OnDeliverTXSpam(ctx context.Context, tx abci.Tx) tmtypes.Respons
 	if !app.nilPow {
 		if err := app.pow.DeliverTx(tx); err != nil {
 			app.log.Error(err.Error())
-			resp.Code = abci.AbciSpamError
+			resp.Code = blockchain.AbciSpamError
 			resp.Data = []byte(err.Error())
 			app.broker.Send(events.NewTxErrEvent(ctxWithHash, err, tx.Party(), tx.GetCmd(), tx.Command().String()))
 			return resp
@@ -906,7 +907,7 @@ func (app *App) OnDeliverTXSpam(ctx context.Context, tx abci.Tx) tmtypes.Respons
 	if !app.nilSpam {
 		if _, err := app.spam.PostBlockAccept(tx); err != nil {
 			app.log.Error(err.Error())
-			resp.Code = abci.AbciSpamError
+			resp.Code = blockchain.AbciSpamError
 			resp.Data = []byte(err.Error())
 			evt := events.NewTxErrEvent(ctxWithHash, err, tx.Party(), tx.GetCmd(), tx.Command().String())
 			app.broker.Send(evt)
@@ -921,7 +922,7 @@ func (app *App) OnDeliverTx(ctx context.Context, req tmtypes.RequestDeliverTx, t
 	app.setTxStats(len(req.Tx))
 	var resp tmtypes.ResponseDeliverTx
 	if err := app.canSubmitTx(tx); err != nil {
-		resp.Code = abci.AbciTxnValidationFailure
+		resp.Code = blockchain.AbciTxnValidationFailure
 		resp.Data = []byte(err.Error())
 	}
 


### PR DESCRIPTION
closes #6138 

In the blockchain client layer when we validate the transaction proto before sending it through tendermint, we now convert those validation errors into tmtype response struct, instead of returning an `error` which always ends up as an internal error.

Test no longer bombs out and return a nice reason for failure: 
`vote_submission.proposal_id (should be a valid vega ID)`
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/7095/pipeline/269




