### PR TITLE
fix: ensure updated asset remains as STATUS_ENABLED

### DIFF
--- a/core/assets/assets.go
+++ b/core/assets/assets.go
@@ -318,6 +318,7 @@ func (s *Service) ApplyAssetUpdate(ctx context.Context, assetID string) error {
 	if !ok {
 		return ErrAssetDoesNotExist
 	}
+	updatedAsset.SetEnabled()
 	if err := currentAsset.Update(updatedAsset); err != nil {
 		s.log.Panic("couldn't update the asset", logging.Error(err))
 	}


### PR DESCRIPTION
When we update an asset we merged the struct of the updated asset into the active asset by calling `currentAsset.Update(updatedAsset)`. Because the updatedAsset is still in a proposed state, it means the update sets the state of the active, enabled asset as `STATUS_PROPOSED`, which is shouldn't be.

This fixes it.

I've updated the update-asset system test to now check for and enabled-status:
https://github.com/vegaprotocol/system-tests/compare/more-checks-update-asset?expand=1

https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/7376/pipeline/269


Its related to [#6123](https://github.com/vegaprotocol/vega/issues/6123) because when we restore an active-asset from a snapshot we set it to enabled, and as a result the status mismatches with an unrestored node which will think the updated asset is still proposed.