### PR TITLE
fix: shutdown blockchain before protocol so we dont try to save a sna…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [6153](https://github.com/vegaprotocol/vega/issues/6153) - Display UI friendly logs when calling `session.send_transaction`
 
 ### 🐛 Fixes
+- [6183](https://github.com/vegaprotocol/vega/issues/6183) - Shutdown blockchain before protocol services
 - [6148](https://github.com/vegaprotocol/vega/issues/6148) - Fix API descriptions for typos
 - [6156](https://github.com/vegaprotocol/vega/issues/6156) - Return only delegations for the specific node in `graphql` node delegation query
 - [6175](https://github.com/vegaprotocol/vega/issues/6175) - Fix `datanode` updating node public key on key rotation

--- a/cmd/vega/node/node.go
+++ b/cmd/vega/node/node.go
@@ -205,14 +205,14 @@ func (n *Command) startProtocolUpgrade(version string) {
 }
 
 func (n *Command) Stop() error {
+	if n.blockchainServer != nil {
+		n.blockchainServer.Stop()
+	}
 	if n.protocol != nil {
 		n.protocol.Stop()
 	}
 	if n.grpcServer != nil {
 		n.grpcServer.Stop()
-	}
-	if n.blockchainServer != nil {
-		n.blockchainServer.Stop()
 	}
 	if n.proxyServer != nil {
 		n.proxyServer.Stop()
@@ -316,7 +316,7 @@ func (n *Command) startBlockchain(tmHome, network, networkURL string) error {
 		if err != nil {
 			return err
 		}
-		n.blockchainServer = blockchain.NewServer(n.tmNode)
+		n.blockchainServer = blockchain.NewServer(n.Log, n.tmNode)
 		// initialise the client
 		client, err := n.tmNode.GetClient()
 		if err != nil {
@@ -328,7 +328,7 @@ func (n *Command) startBlockchain(tmHome, network, networkURL string) error {
 		// nullchain acts as both the client and the server because its does everything
 		n.nullBlockchain = nullchain.NewClient(n.Log, n.conf.Blockchain.Null)
 		n.nullBlockchain.SetABCIApp(n.abciApp)
-		n.blockchainServer = blockchain.NewServer(n.nullBlockchain)
+		n.blockchainServer = blockchain.NewServer(n.Log, n.nullBlockchain)
 		// n.blockchainClient = blockchain.NewClient(n.nullBlockchain)
 		n.blockchainClient.Set(n.nullBlockchain)
 

--- a/core/blockchain/server.go
+++ b/core/blockchain/server.go
@@ -12,6 +12,8 @@
 
 package blockchain
 
+import "code.vegaprotocol.io/vega/logging"
+
 type ChainServerImpl interface {
 	ReloadConf(cfg Config)
 	Stop() error
@@ -21,12 +23,14 @@ type ChainServerImpl interface {
 // Server abstraction for the abci server.
 type Server struct {
 	*Config
+	log *logging.Logger
 	srv ChainServerImpl
 }
 
 // NewServer instantiate a new blockchain server.
-func NewServer(srv ChainServerImpl) *Server {
+func NewServer(log *logging.Logger, srv ChainServerImpl) *Server {
 	return &Server{
+		log: log,
 		srv: srv,
 	}
 }
@@ -37,6 +41,7 @@ func (s *Server) Start() error {
 
 // Stop gracefully shutdowns down the blockchain provider's server.
 func (s *Server) Stop() error {
+	s.log.Info("Stopping blockchain server")
 	return s.srv.Stop()
 }
 

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -140,9 +140,9 @@ func (n *Protocol) Start() error {
 // Stop will stop all services of the protocol.
 func (n *Protocol) Stop() error {
 	// unregister conf listeners
+	n.log.Info("Stopping protocol services")
 	n.confWatcher.Unregister(n.confListenerIDs)
 	n.services.Stop()
-
 	return nil
 }
 


### PR DESCRIPTION
closes #6183

The issue was that we were stopping the vega protocol before stopping tendermint. 

What that means is that the snapshot engine would close its connection to the snapshot database, but tendermint would still be calling in through the abci and would try to commit a block and save a new snapshot after we'd already closed down.