### PR TITLE
fix: do not hash before signing with clef, and fiddle recovery bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐛 Fixes
 - [6183](https://github.com/vegaprotocol/vega/issues/6183) - Shutdown blockchain before protocol services
 - [6148](https://github.com/vegaprotocol/vega/issues/6148) - Fix API descriptions for typos
+- [6187](https://github.com/vegaprotocol/vega/issues/6187) - Not not hash message before signing if using clef for validator heartbeats
 - [6138](https://github.com/vegaprotocol/vega/issues/6138) - Return more useful information when a transaction submitted to a node contains validation errors
 - [6156](https://github.com/vegaprotocol/vega/issues/6156) - Return only delegations for the specific node in `graphql` node delegation query
 - [6175](https://github.com/vegaprotocol/vega/issues/6175) - Fix `datanode` updating node public key on key rotation

--- a/core/validators/announce_node.go
+++ b/core/validators/announce_node.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"code.vegaprotocol.io/vega/core/nodewallets/eth/clef"
 	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
 	signatures "code.vegaprotocol.io/vega/libs/crypto/signature"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
@@ -104,7 +105,10 @@ func SignAnnounceNode(
 		return err
 	}
 
-	ethereumSignature, err := ethSigner.Sign(crypto.Keccak256(buf))
+	if ethSigner.Algo() != clef.ClefAlgoType {
+		buf = crypto.Keccak256(buf)
+	}
+	ethereumSignature, err := ethSigner.Sign(buf)
 	if err != nil {
 		return err
 	}

--- a/libs/crypto/signature/signature.go
+++ b/libs/crypto/signature/signature.go
@@ -31,6 +31,11 @@ func VerifyEthereumSignature(message, signature []byte, hexAddress string) error
 	address := common.HexToAddress(hexAddress)
 	hash := ecrypto.Keccak256(message)
 
+	// see reference in multisig control signature verification for more details
+	if signature[ecrypto.RecoveryIDOffset] == 27 || signature[ecrypto.RecoveryIDOffset] == 28 {
+		signature[ecrypto.RecoveryIDOffset] -= 27
+	}
+
 	// get the pubkey from the signature
 	pubkey, err := ecrypto.SigToPub(hash, signature)
 	if err != nil {


### PR DESCRIPTION
closes #6187

No transcation errors for heartbeats anymore: https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/7751/artifact/test_logs/workspace.tests.rewards.test_rewards/test_rewards_five_validator_no_multisig_for_ersatz/