### PR TITLE
Tidy-up: remove `err` from `GetRiskFactors()` return signature

### DIFF
--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -3108,12 +3108,7 @@ func (m *Market) getOrderByID(orderID string) (*types.Order, bool, error) {
 }
 
 func (m *Market) getTheoreticalTargetStake() *num.Uint {
-	rf, err := m.risk.GetRiskFactors()
-	if err != nil {
-		logging.Error(err)
-		m.log.Debug("unable to get risk factors, can't calculate target")
-		return num.UintZero()
-	}
+	rf := m.risk.GetRiskFactors()
 
 	// Ignoring the error as GetTheoreticalTargetStake handles trades==nil and len(trades)==0
 	trades, _ := m.matching.GetIndicativeTrades()
@@ -3123,13 +3118,7 @@ func (m *Market) getTheoreticalTargetStake() *num.Uint {
 }
 
 func (m *Market) getTargetStake() *num.Uint {
-	rf, err := m.risk.GetRiskFactors()
-	if err != nil {
-		logging.Error(err)
-		m.log.Debug("unable to get risk factors, can't calculate target")
-		return num.UintZero()
-	}
-	return m.tsCalc.GetTargetStake(*rf, m.timeService.GetTimeNow(), m.getCurrentMarkPrice())
+	return m.tsCalc.GetTargetStake(*m.risk.GetRiskFactors(), m.timeService.GetTimeNow(), m.getCurrentMarkPrice())
 }
 
 func (m *Market) getSuppliedStake() *num.Uint {
@@ -3147,18 +3136,11 @@ func (m *Market) checkLiquidity(ctx context.Context, trades []*types.Trade, pers
 		_, vAsk, _ = m.getBestStaticAskPriceAndVolume()
 	}
 
-	rf, err := m.risk.GetRiskFactors()
-	if err != nil {
-		m.log.Panic("unable to get risk factors, can't check liquidity",
-			logging.String("market-id", m.GetID()),
-			logging.Error(err))
-	}
-
 	return m.lMonitor.CheckLiquidity(
 		m.as, m.timeService.GetTimeNow(),
 		m.getSuppliedStake(),
 		trades,
-		*rf,
+		*m.risk.GetRiskFactors(),
 		m.getReferencePrice(),
 		vBid, vAsk,
 		persistentOrder)

--- a/core/execution/market_snapshot.go
+++ b/core/execution/market_snapshot.go
@@ -169,7 +169,7 @@ func NewMarketFromSnapshot(
 }
 
 func (m *Market) getState() *types.ExecMarket {
-	rf, _ := m.risk.GetRiskFactors()
+	rf := m.risk.GetRiskFactors()
 	var sp *num.Uint
 	if m.settlementPriceInMarket != nil {
 		sp = m.settlementPriceInMarket.Clone()

--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -172,9 +172,9 @@ func (e *Engine) ReloadConf(cfg Config) {
 	e.cfgMu.Unlock()
 }
 
-// GetRiskFactors returns risk factors per specified asset if available and an error otherwise.
-func (e *Engine) GetRiskFactors() (*types.RiskFactor, error) {
-	return e.factors, nil
+// GetRiskFactors returns risk factors per specified asset.
+func (e *Engine) GetRiskFactors() *types.RiskFactor {
+	return e.factors
 }
 
 func (e *Engine) UpdateMarginAuction(ctx context.Context, evts []events.Margin, price *num.Uint) ([]events.Risk, []events.Margin) {


### PR DESCRIPTION
Tidy-up: remove error from risk engine's GetRiskFactors() return signature as it's always `nil` + remove handling of that error in downstream code. 

Please note this is something I did while exploring other stuff, though it might be useful, but if it's in any way controversial than please feel free to close without merging. 