### PR TITLE
fix: candle connection not returning candle data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [6202](https://github.com/vegaprotocol/vega/issues/6202) - Always update margins for parties on amend
 - [6228](https://github.com/vegaprotocol/vega/issues/6228) - Reject protocol upgrade downgrades
 - [6245](https://github.com/vegaprotocol/vega/issues/6245) - Recalculate equity values when virtual stake changes
+- [6248](https://github.com/vegaprotocol/vega/issues/6245) - Candles connection is not returning any candle data
 
 ## 0.55.0
 

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -543,8 +543,16 @@ func (t *tradingDataServiceV2) ListCandleData(ctx context.Context, req *v2.ListC
 		return nil, errors.New("sql candle service not available")
 	}
 
-	from := vegatime.UnixNano(req.FromTimestamp)
-	to := vegatime.UnixNano(req.ToTimestamp)
+	var from, to *time.Time
+	if req.FromTimestamp != 0 {
+		fromTimestamp := vegatime.UnixNano(req.FromTimestamp)
+		from = &fromTimestamp
+	}
+
+	if req.ToTimestamp != 0 {
+		toTimestamp := vegatime.UnixNano(req.ToTimestamp)
+		to = &toTimestamp
+	}
 
 	pagination := entities.CursorPagination{}
 	if req.Pagination != nil {
@@ -554,7 +562,7 @@ func (t *tradingDataServiceV2) ListCandleData(ctx context.Context, req *v2.ListC
 		}
 	}
 
-	candles, pageInfo, err := t.candleService.GetCandleDataForTimeSpan(ctx, req.CandleId, &from, &to, pagination)
+	candles, pageInfo, err := t.candleService.GetCandleDataForTimeSpan(ctx, req.CandleId, from, to, pagination)
 	if err != nil {
 		return nil, apiError(codes.Internal, ErrCandleServiceGetCandleData, err)
 	}

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -28,6 +28,7 @@ import (
 	"code.vegaprotocol.io/vega/datanode/sqlstore"
 	"code.vegaprotocol.io/vega/datanode/vegatime"
 	"code.vegaprotocol.io/vega/libs/num"
+	"code.vegaprotocol.io/vega/libs/ptr"
 	"code.vegaprotocol.io/vega/logging"
 	v2 "code.vegaprotocol.io/vega/protos/data-node/api/v2"
 	"code.vegaprotocol.io/vega/protos/vega"
@@ -545,13 +546,11 @@ func (t *tradingDataServiceV2) ListCandleData(ctx context.Context, req *v2.ListC
 
 	var from, to *time.Time
 	if req.FromTimestamp != 0 {
-		fromTimestamp := vegatime.UnixNano(req.FromTimestamp)
-		from = &fromTimestamp
+		from = ptr.From(vegatime.UnixNano(req.FromTimestamp))
 	}
 
 	if req.ToTimestamp != 0 {
-		toTimestamp := vegatime.UnixNano(req.ToTimestamp)
-		to = &toTimestamp
+		to = ptr.From(vegatime.UnixNano(req.ToTimestamp))
 	}
 
 	pagination := entities.CursorPagination{}

--- a/datanode/gateway/graphql/connection_handlers.go
+++ b/datanode/gateway/graphql/connection_handlers.go
@@ -58,8 +58,8 @@ func handleCandleConnectionRequest(ctx context.Context, client TradingDataServic
 
 	req := v2.ListCandleDataRequest{
 		CandleId:      candleID,
-		FromTimestamp: since.Unix(),
-		ToTimestamp:   to.Unix(),
+		FromTimestamp: since.UnixNano(),
+		ToTimestamp:   to.UnixNano(),
 		Interval:      interval,
 		Pagination:    pagination,
 	}


### PR DESCRIPTION
Closes #6248 

This was caused by a mishandling of the from and to dates being passed to the postgres query builder for the candles. The bad dates caused the query to always return no data.