### PR TITLE
fix: node signature connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [6061](https://github.com/vegaprotocol/vega/issues/6061) - Attempt at stabilizing the tests on the broker in the core
 - [6178](https://github.com/vegaprotocol/vega/issues/6178) - Historical balances fails with `scany` error
 - [6193](https://github.com/vegaprotocol/vega/issues/6193) - Use Data field from transaction successfully sent but that were rejected
+- [6230](https://github.com/vegaprotocol/vega/issues/6230) - Node Signature Connection should return a list or an appropriate error message
 
 ## 0.55.0
 

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -2218,7 +2218,7 @@ func (t *tradingDataServiceV2) ListNodeSignatures(ctx context.Context, req *v2.L
 
 	sigs, pageInfo, err := t.notaryService.GetByResourceID(ctx, req.Id, pagination)
 	if err != nil {
-		return nil, apiError(codes.NotFound, err)
+		return nil, fmt.Errorf("could not retrieve resource: %w", err)
 	}
 
 	edges, err := makeEdges[*v2.NodeSignatureEdge](sigs)

--- a/datanode/gateway/graphql/generated.go
+++ b/datanode/gateway/graphql/generated.go
@@ -13638,7 +13638,7 @@ type NodeSignatureEdge {
 "Connection type for retrieving cursor-based paginated node signature information"
 type NodeSignaturesConnection {
   "List of node signatures available for the connection"
-  edges: [NodeSignatureEdge]
+  edges: [NodeSignatureEdge]!
   "Page information for the connection"
   pageInfo: PageInfo!
 }
@@ -30665,11 +30665,14 @@ func (ec *executionContext) _NodeSignaturesConnection_edges(ctx context.Context,
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]*v2.NodeSignatureEdge)
 	fc.Result = res
-	return ec.marshalONodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, field.Selections, res)
+	return ec.marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _NodeSignaturesConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *v2.NodeSignaturesConnection) (ret graphql.Marshaler) {
@@ -57715,6 +57718,9 @@ func (ec *executionContext) _NodeSignaturesConnection(ctx context.Context, sel a
 
 			out.Values[i] = innerFunc(ctx)
 
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "pageInfo":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._NodeSignaturesConnection_pageInfo(ctx, field, obj)
@@ -68552,6 +68558,44 @@ func (ec *executionContext) marshalNNodeSignature2ᚖcodeᚗvegaprotocolᚗioᚋ
 	return ec._NodeSignature(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx context.Context, sel ast.SelectionSet, v []*v2.NodeSignatureEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalONodeSignatureEdge2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNNodeStatus2codeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋvegaᚐNodeStatus(ctx context.Context, v interface{}) (vega.NodeStatus, error) {
 	res, err := marshallers.UnmarshalNodeStatus(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -72148,47 +72192,6 @@ func (ec *executionContext) marshalONodeSignature2ᚕᚖcodeᚗvegaprotocolᚗio
 			return graphql.Null
 		}
 	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalONodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx context.Context, sel ast.SelectionSet, v []*v2.NodeSignatureEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalONodeSignatureEdge2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
 
 	return ret
 }

--- a/datanode/gateway/graphql/generated.go
+++ b/datanode/gateway/graphql/generated.go
@@ -13638,7 +13638,7 @@ type NodeSignatureEdge {
 "Connection type for retrieving cursor-based paginated node signature information"
 type NodeSignaturesConnection {
   "List of node signatures available for the connection"
-  edges: [NodeSignatureEdge]!
+  edges: [NodeSignatureEdge!]!
   "Page information for the connection"
   pageInfo: PageInfo!
 }
@@ -30672,7 +30672,7 @@ func (ec *executionContext) _NodeSignaturesConnection_edges(ctx context.Context,
 	}
 	res := resTmp.([]*v2.NodeSignatureEdge)
 	fc.Result = res
-	return ec.marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, field.Selections, res)
+	return ec.marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdgeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _NodeSignaturesConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *v2.NodeSignaturesConnection) (ret graphql.Marshaler) {
@@ -68558,7 +68558,7 @@ func (ec *executionContext) marshalNNodeSignature2ᚖcodeᚗvegaprotocolᚗioᚋ
 	return ec._NodeSignature(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx context.Context, sel ast.SelectionSet, v []*v2.NodeSignatureEdge) graphql.Marshaler {
+func (ec *executionContext) marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*v2.NodeSignatureEdge) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -68582,7 +68582,7 @@ func (ec *executionContext) marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocol�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalONodeSignatureEdge2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, sel, v[i])
+			ret[i] = ec.marshalNNodeSignatureEdge2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -68593,7 +68593,23 @@ func (ec *executionContext) marshalNNodeSignatureEdge2ᚕᚖcodeᚗvegaprotocol�
 	}
 	wg.Wait()
 
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
 	return ret
+}
+
+func (ec *executionContext) marshalNNodeSignatureEdge2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx context.Context, sel ast.SelectionSet, v *v2.NodeSignatureEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._NodeSignatureEdge(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNNodeStatus2codeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋvegaᚐNodeStatus(ctx context.Context, v interface{}) (vega.NodeStatus, error) {
@@ -72194,13 +72210,6 @@ func (ec *executionContext) marshalONodeSignature2ᚕᚖcodeᚗvegaprotocolᚗio
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalONodeSignatureEdge2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐNodeSignatureEdge(ctx context.Context, sel ast.SelectionSet, v *v2.NodeSignatureEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._NodeSignatureEdge(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalONodeSignatureKind2codeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋvegaᚋcommandsᚋv1ᚐNodeSignatureKind(ctx context.Context, v interface{}) (v11.NodeSignatureKind, error) {

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -4333,7 +4333,7 @@ type NodeSignatureEdge {
 "Connection type for retrieving cursor-based paginated node signature information"
 type NodeSignaturesConnection {
   "List of node signatures available for the connection"
-  edges: [NodeSignatureEdge]!
+  edges: [NodeSignatureEdge!]!
   "Page information for the connection"
   pageInfo: PageInfo!
 }

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -4333,7 +4333,7 @@ type NodeSignatureEdge {
 "Connection type for retrieving cursor-based paginated node signature information"
 type NodeSignaturesConnection {
   "List of node signatures available for the connection"
-  edges: [NodeSignatureEdge]
+  edges: [NodeSignatureEdge]!
   "Page information for the connection"
   pageInfo: PageInfo!
 }

--- a/datanode/sqlstore/notary.go
+++ b/datanode/sqlstore/notary.go
@@ -66,8 +66,15 @@ func (n *Notary) GetByResourceID(ctx context.Context, id string, pagination enti
 		ns       []entities.NodeSignature
 	)
 
+	resourceID := entities.NodeSignatureID(id)
+	// make sure the resourceID is valid HexID
+	err = resourceID.Error()
+	if err != nil {
+		return nil, pageInfo, err
+	}
+
 	query := fmt.Sprintf(`SELECT resource_id, sig, kind, tx_hash, vega_time FROM node_signatures where resource_id=%s`,
-		nextBindVar(&args, entities.NodeID(id)))
+		nextBindVar(&args, entities.NodeSignatureID(id)))
 	query, args, err = PaginateQuery[entities.NodeSignatureCursor](query, args, notaryOrdering, pagination)
 	if err != nil {
 		return ns, pageInfo, err


### PR DESCRIPTION
Closes #6230 

This fix includes:
 - nodeSignatureConnection should return an empty list instead of null
 - nodeSignatureConnection should return an appropriate message when an invalid resource ID in given.