### PR TITLE
Use (context aware) database connection in sql stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 
 ### 🐛 Fixes
 - [6296](https://github.com/vegaprotocol/vega/issues/6296) - Add `assetId` as a field to the `GraphQL UpdateAsset` type
+- [6324](https://github.com/vegaprotocol/vega/issues/6324) - Ensure all `datanode` insert points use dedicated connection
 - [6273](https://github.com/vegaprotocol/vega/issues/6273) - Deposits return an empty list when no party is provided
-
 
 ## 0.56.0
 

--- a/datanode/sqlstore/chain.go
+++ b/datanode/sqlstore/chain.go
@@ -38,7 +38,7 @@ func (c *Chain) Get(ctx context.Context) (entities.Chain, error) {
 	chain := entities.Chain{}
 
 	query := `SELECT id from chain`
-	err := pgxscan.Get(ctx, c.pool, &chain, query)
+	err := pgxscan.Get(ctx, c.Connection, &chain, query)
 
 	if errors.Is(err, pgx.ErrNoRows) {
 		return entities.Chain{}, entities.ErrChainNotFound

--- a/datanode/sqlstore/erc20_multisig_event.go
+++ b/datanode/sqlstore/erc20_multisig_event.go
@@ -96,7 +96,7 @@ func (m *ERC20MultiSigSignerEvent) GetAddedEvents(ctx context.Context, validator
 	}
 
 	defer metrics.StartSQLQuery("ERC20MultiSigSignerEvent", "GetAddedEvents")()
-	if err = pgxscan.Select(ctx, m.pool, &out, query, args...); err != nil {
+	if err = pgxscan.Select(ctx, m.Connection, &out, query, args...); err != nil {
 		return nil, pageInfo, fmt.Errorf("failed to retrieve multisig signer events: %w", err)
 	}
 
@@ -151,7 +151,7 @@ func (m *ERC20MultiSigSignerEvent) GetRemovedEvents(ctx context.Context, validat
 	}
 
 	defer metrics.StartSQLQuery("ERC20MultiSigSignerEvent", "GetRemovedEvents")()
-	if err = pgxscan.Select(ctx, m.pool, &out, query, args...); err != nil {
+	if err = pgxscan.Select(ctx, m.Connection, &out, query, args...); err != nil {
 		return nil, pageInfo, fmt.Errorf("failed to retrieve multisig signer events: %w", err)
 	}
 

--- a/datanode/sqlstore/ethereum_key_rotations.go
+++ b/datanode/sqlstore/ethereum_key_rotations.go
@@ -71,7 +71,7 @@ func (store *EthereumKeyRotations) List(ctx context.Context,
 
 	ethereumKeyRotations := []entities.EthereumKeyRotation{}
 
-	if err = pgxscan.Select(ctx, store.pool, &ethereumKeyRotations, query, args...); err != nil {
+	if err = pgxscan.Select(ctx, store.Connection, &ethereumKeyRotations, query, args...); err != nil {
 		return nil, entities.PageInfo{}, err
 	}
 

--- a/datanode/sqlstore/key_rotations.go
+++ b/datanode/sqlstore/key_rotations.go
@@ -69,7 +69,7 @@ func (store *KeyRotations) GetAllPubKeyRotations(ctx context.Context, pagination
 		return nil, pageInfo, err
 	}
 
-	if err = pgxscan.Select(ctx, store.pool, &keyRotations, query, args...); err != nil {
+	if err = pgxscan.Select(ctx, store.Connection, &keyRotations, query, args...); err != nil {
 		return nil, pageInfo, fmt.Errorf("failed to retrieve key rotations: %w", err)
 	}
 
@@ -99,7 +99,7 @@ func (store *KeyRotations) GetPubKeyRotationsPerNode(ctx context.Context, nodeID
 	query := fmt.Sprintf(`SELECT * FROM key_rotations WHERE node_id = %s`, nextBindVar(&args, id))
 	query, args = orderAndPaginateWithCursor(query, pagination, cursorParams, args...)
 
-	if err := pgxscan.Select(ctx, store.pool, &keyRotations, query, args...); err != nil {
+	if err := pgxscan.Select(ctx, store.Connection, &keyRotations, query, args...); err != nil {
 		return nil, pageInfo, fmt.Errorf("failed to retrieve key rotations: %w", err)
 	}
 

--- a/datanode/sqlstore/liquidity_provision.go
+++ b/datanode/sqlstore/liquidity_provision.go
@@ -50,7 +50,7 @@ func NewLiquidityProvision(connectionSource *ConnectionSource) *LiquidityProvisi
 
 func (lp *LiquidityProvision) Flush(ctx context.Context) error {
 	defer metrics.StartSQLQuery("LiquidityProvision", "Flush")()
-	flushed, err := lp.batcher.Flush(ctx, lp.pool)
+	flushed, err := lp.batcher.Flush(ctx, lp.Connection)
 	if err != nil {
 		return err
 	}

--- a/datanode/sqlstore/margin_levels.go
+++ b/datanode/sqlstore/margin_levels.go
@@ -56,7 +56,7 @@ func (ml *MarginLevels) Add(marginLevel entities.MarginLevels) error {
 
 func (ml *MarginLevels) Flush(ctx context.Context) ([]entities.MarginLevels, error) {
 	defer metrics.StartSQLQuery("MarginLevels", "Flush")()
-	return ml.batcher.Flush(ctx, ml.pool)
+	return ml.batcher.Flush(ctx, ml.Connection)
 }
 
 func (ml *MarginLevels) GetMarginLevelsByID(ctx context.Context, partyID, marketID string, pagination entities.OffsetPagination) ([]entities.MarginLevels, error) {

--- a/datanode/sqlstore/node.go
+++ b/datanode/sqlstore/node.go
@@ -268,7 +268,7 @@ func (store *Node) GetNodeData(ctx context.Context) (entities.NodeData, error) {
 
 	nodeData := entities.NodeData{}
 
-	err := pgxscan.Get(ctx, store.pool, &nodeData, query)
+	err := pgxscan.Get(ctx, store.Connection, &nodeData, query)
 	return nodeData, err
 }
 
@@ -361,7 +361,7 @@ func (store *Node) GetNodes(ctx context.Context, epochSeq uint64, pagination ent
 		return nil, pageInfo, err
 	}
 
-	if err = pgxscan.Select(ctx, store.pool, &nodes, query, args...); err != nil {
+	if err = pgxscan.Select(ctx, store.Connection, &nodes, query, args...); err != nil {
 		return nil, pageInfo, fmt.Errorf("could not get nodes: %w", err)
 	}
 
@@ -450,7 +450,7 @@ func (store *Node) GetNodeByID(ctx context.Context, nodeID string, epochSeq uint
 		AND nodes.id=$2
 	`
 
-	err := pgxscan.Get(ctx, store.pool, &node, query, epochSeq, id)
+	err := pgxscan.Get(ctx, store.Connection, &node, query, epochSeq, id)
 	if pgxscan.NotFound(err) {
 		return node, fmt.Errorf("'%v': %w", nodeID, ErrNodeNotFound)
 	}


### PR DESCRIPTION
Rather than using the connection pool directly, to ensure that inserts and updates happen in the dedicated connection (and transaction) provided by the event handling loop.

Closes #6324  
