### PR TITLE
feat: Validate batch market instructions submitted to the wallet

### DIFF
--- a/wallet/commands/commands.go
+++ b/wallet/commands/commands.go
@@ -175,6 +175,10 @@ func wrapRequestCommandIntoInputData(data *commandspb.InputData, req *walletpb.S
 		data.Command = &commandspb.InputData_IssueSignatures{
 			IssueSignatures: req.GetIssueSignatures(),
 		}
+	case *walletpb.SubmitTransactionRequest_BatchMarketInstructions:
+		data.Command = &commandspb.InputData_BatchMarketInstructions{
+			BatchMarketInstructions: req.GetBatchMarketInstructions(),
+		}
 	default:
 		panic(fmt.Sprintf("command %v is not supported", cmd))
 	}

--- a/wallet/commands/commands.go
+++ b/wallet/commands/commands.go
@@ -66,6 +66,8 @@ func CheckSubmitTransactionRequest(req *walletpb.SubmitTransactionRequest) comma
 		cmdErr = commands.CheckProtocolUpgradeProposal(cmd.ProtocolUpgradeProposal)
 	case *walletpb.SubmitTransactionRequest_IssueSignatures:
 		cmdErr = commands.CheckIssueSignatures(cmd.IssueSignatures)
+	case *walletpb.SubmitTransactionRequest_BatchMarketInstructions:
+		cmdErr = commands.CheckBatchMarketInstructions(cmd.BatchMarketInstructions)
 	default:
 		errs.AddForProperty("input_data.command", commands.ErrIsNotSupported)
 	}


### PR DESCRIPTION
Adding validation of Batch Market Instructions to the Vegawallet layer to allow these transactions to be submitted through the wallet.