### PR TITLE
fix: dropping db intermittently hangs on snapshot test

### DIFF
--- a/datanode/snapshot/service_test.go
+++ b/datanode/snapshot/service_test.go
@@ -707,15 +707,7 @@ func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 }
 
 func emptyDatabase() {
-	err := sqlstore.RecreateVegaDatabase(context.Background(), logging.NewTestLogger(), sqlConfig.ConnectionConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	err = sqlstore.CreateVegaSchema(logging.NewTestLogger(), sqlConfig.ConnectionConfig)
-	if err != nil {
-		panic(err)
-	}
+	databasetest.DeleteEverything()
 }
 
 func TestRestoringFromDifferentHeightsWithFullHistory(t *testing.T) {


### PR DESCRIPTION
closes #6353  dropping db (with force) intermittently hangs on snapshot test, wipe  database instead of dropping database between tests to avoid the hang.