### PR TITLE
feat: multiple transactions submitted with the same proof of work  al…

### DIFF
--- a/core/pow/noop_engine.go
+++ b/core/pow/noop_engine.go
@@ -31,7 +31,7 @@ func (e *NoopEngine) BeginBlock(blockHeight uint64, blockHash string) {
 }
 
 func (e *NoopEngine) EndOfBlock() {}
-
+func (e *NoopEngine) Commit()     {}
 func (e *NoopEngine) CheckTx(tx abci.Tx) error {
 	return nil
 }

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -84,6 +84,7 @@ type PoWEngine interface {
 	EndOfBlock()
 	CheckTx(tx abci.Tx) error
 	DeliverTx(tx abci.Tx) error
+	Commit()
 }
 
 //nolint:interfacebloat
@@ -785,6 +786,10 @@ func (app *App) OnBeginBlock(
 func (app *App) OnCommit() (resp tmtypes.ResponseCommit) {
 	app.log.Debug("entering commit", logging.Time("at", time.Now()))
 	defer func() { app.log.Debug("leaving commit", logging.Time("at", time.Now())) }()
+
+	if !app.nilPow {
+		app.pow.Commit()
+	}
 
 	// call checkpoint _first_ so the snapshot contains the correct checkpoint state.
 	cpt, _ := app.checkpoint.Checkpoint(app.blockCtx, app.currentTimestamp)


### PR DESCRIPTION
…ready seen in previous blocks or in local mempool should be pre-rejected

[will add an issue once it's confirmed with @Vegaklaus]