### PR TITLE
Improve test coverage for 0042-LIQF-setting_fees_and_rewarding_lps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [6427](https://github.com/vegaprotocol/vega/issues/6427) - Improve interactions documentation
 - [6431](https://github.com/vegaprotocol/vega/issues/6431) - Pass a human-readable input data in Transaction Succeeded and Failed notifications
 - [6448](https://github.com/vegaprotocol/vega/issues/6448) - Improve wallet interaction JSON conversion
+- [6454](https://github.com/vegaprotocol/vega/issues/6454) - Improve test coverage for setting fees and rewarding LPs
 
 ### 🐛 Fixes
 - [6444](https://github.com/vegaprotocol/vega/issues/6444) - Send a transaction error if the same node announces itself twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [6387](https://github.com/vegaprotocol/vega/issues/6387) - Fix max open interest calculation
 - [6416](https://github.com/vegaprotocol/vega/issues/6416) - Prevent submission of `erc20` address already used by another asset
 - [6375](https://github.com/vegaprotocol/vega/issues/6375) - If there is one unit left over at the end of final market settlement - transfer it to the network treasury. if there is more than one, log all transfers and panic. 
+- [6456](https://github.com/vegaprotocol/vega/issues/6456) - Assure liquidity fee gets update when target stake drops (even in the absence of trades) 
 
 ## 0.57.0
 

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -721,6 +721,7 @@ func (m *Market) OnTick(ctx context.Context, t time.Time) bool {
 	timer.EngineTimeCounterAdd()
 
 	m.updateMarketValueProxy()
+	m.updateLiquidityFee(ctx)
 	m.broker.Send(events.NewMarketTick(ctx, m.mkt.ID, t))
 	return m.closed
 }

--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -12,9 +12,15 @@ Feature: Test liquidity provider reward distribution
     And the price monitoring named "price-monitoring":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 3                 |
+    And the oracle spec for settlement data filtering data from "0xCAFECAFE" named "ethDec21Oracle":
+      | property         | type         | binding         |
+      | prices.ETH.value | TYPE_INTEGER | settlement data |
+    And the oracle spec for trading termination filtering data from "0xCAFECAFE" named "ethDec21Oracle":
+      | property           | type         | binding             |
+      | trading.terminated | TYPE_BOOLEAN | trading termination |
     And the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | oracle config          |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | ethDec21Oracle |
 
     And the following network parameters are set:
       | name                                                | value |
@@ -287,7 +293,6 @@ Feature: Test liquidity provider reward distribution
       | party2 | 1000  | 5    | party1  |
 
     And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
-
     # opening auction + time window
     Then time is updated to "2019-11-30T00:10:05Z"
 
@@ -296,7 +301,6 @@ Feature: Test liquidity provider reward distribution
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 4      | ETH   |
-
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
@@ -439,5 +443,201 @@ Feature: Test liquidity provider reward distribution
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 12     | ETH   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 3      | ETH   |
       | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 15     | ETH   |
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+ Scenario: 2 LPs joining at start, unequal commitments, market settles (0042-LIQF-014)
+
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | ETH   | 1000000000 |
+      | lp2    | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
+
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | buy  | BID              | 1          | 2      | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | buy  | MID              | 2          | 1      | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | sell | ASK              | 1          | 2      | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | sell | MID              | 2          | 1      | submission |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | buy  | BID              | 1          | 2      | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | buy  | MID              | 2          | 1      | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | sell | ASK              | 1          | 2      | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | sell | MID              | 2          | 1      | submission |
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the opening auction period ends for market "ETH/DEC21"
+
+    # no fees in auction
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 3                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller  |
+      | party2 | 951   | 12   | lp1     |
+      | party2 | 951   | 3    | lp2     |
+      | party2 | 1000  | 5    | party1  |
+
+    And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
+
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:10:05Z"
+
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 4      | ETH   |
+
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | buy  | 40     | 1000  | 2                | TYPE_LIMIT | TIF_GTC | party1-buy  |
+      | party2 | ETH/DEC21 | sell | 40     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell |
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 951   | 12   | lp1    |
+      | party1 | 951   | 3    | lp2    |
+
+    And the accumulated liquidity fees should be "15" for the market "ETH/DEC21"
+
+    When the oracles broadcast data signed with "0xCAFECAFE":
+      | name               | value |
+      | trading.terminated | true  |
+    Then the market state should be "STATE_TRADING_TERMINATED" for the market "ETH/DEC21"
+    
+    When the oracles broadcast data signed with "0xCAFECAFE":
+      | name             | value |
+      | prices.ETH.value | 42    |   
+    Then the market state should be "STATE_SETTLED" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+    And the following transfers should happen:
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 12     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 3      | ETH   |
+
+Scenario: 2 LPs joining at start, unequal commitments, 1 leaves later (0042-LIQF-012)
+
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | ETH   | 1000000000 |
+      | lp2    | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
+
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | buy  | BID              | 1          | 2      | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | buy  | MID              | 2          | 1      | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | sell | ASK              | 1          | 2      | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | sell | MID              | 2          | 1      | submission |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | buy  | BID              | 1          | 2      | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | buy  | MID              | 2          | 1      | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | sell | ASK              | 1          | 2      | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | sell | MID              | 2          | 1      | submission |
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the opening auction period ends for market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller  |
+      | party1 | 1000  | 60   | party2 |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the open interest should be "60" for the market "ETH/DEC21"
+    And the target stake should be "6000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+
+    And the liquidity provider fee shares for the market "ETH/DEC21" should be:
+      | party | equity like share | average entry valuation |
+      | lp1   | 0.8               | 8000                    |
+      | lp2   | 0.2               | 10000                   |
+
+    And the price monitoring bounds for the market "ETH/DEC21" should be:
+      | min bound | max bound |
+      | 500       | 1500      |
+
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
+
+    # no fees in auction
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 3                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller  |
+      | party2 | 951   | 12   | lp1     |
+      | party2 | 951   | 3    | lp2     |
+      | party2 | 1000  | 5    | party1  |
+
+    And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:10:05Z"
+
+    # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 16     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 4      | ETH   |
+
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | buy  | 40     | 1000  | 2                | TYPE_LIMIT | TIF_GTC | party1-buy  |
+      | party2 | ETH/DEC21 | sell | 40     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell |
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 951   | 12   | lp1    |
+      | party1 | 951   | 3    | lp2    |
+
+    And the accumulated liquidity fees should be "15" for the market "ETH/DEC21"
+
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type      |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | buy  | BID              | 1          | 2      | cancellation |
+    Then the liquidity provisions should have the following states:
+      | id  | party | market    | commitment amount | status           |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | STATUS_CANCELLED |
+
+    Then time is updated to "2019-11-30T00:20:06Z"
+
+    # now all the accumulated fees go to the remaining lp (as the other one cancelled their provision)
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account           | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 15     | ETH   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"

--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -70,7 +70,7 @@ Feature: Test liquidity provider reward distribution
       | min bound | max bound |
       | 500       | 1500      | 
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference    |
@@ -169,7 +169,7 @@ Feature: Test liquidity provider reward distribution
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.002" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
@@ -268,7 +268,7 @@ Feature: Test liquidity provider reward distribution
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
@@ -374,7 +374,7 @@ Feature: Test liquidity provider reward distribution
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"

--- a/core/integration/features/fees/trading-fees-pdp.feature
+++ b/core/integration/features/fees/trading-fees-pdp.feature
@@ -257,7 +257,7 @@ Feature: Fees calculations
       | trader3a | ETH   | ETH/DEC21 | 480    | 9531    |
       | trader3b | ETH   | ETH/DEC21 | 240    | 9766    |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "5" for the market "ETH/DEC21"
 
     Then the market data for the market "ETH/DEC21" should be:
@@ -710,7 +710,7 @@ Feature: Fees calculations
       | trader3 | ETH   | ETH/DEC21 | 240    | 9999766 |
       | trader4 | ETH   | ETH/DEC21 | 0      | 0       |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "4" for the market "ETH/DEC21"
 
     When the network moves ahead "11" blocks
@@ -1660,7 +1660,7 @@ Feature: Fees calculations
       | trader3a | ETH   | ETH/DEC21 | 3216   | 96834   |
       | trader4  | ETH   | ETH/DEC21 | 5506   | 94934   |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "30" for the market "ETH/DEC21"
 
     Then the following trades should be executed:

--- a/core/integration/features/rewards/asset_fees_rewards.feature
+++ b/core/integration/features/rewards/asset_fees_rewards.feature
@@ -348,7 +348,7 @@ Feature: Fees reward calculations for a single asset, single market
       | trader3a | ETH   | ETH/DEC21 | 480    | 9531    |
       | trader3b | ETH   | ETH/DEC21 | 240    | 9766    |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "5" for the market "ETH/DEC21"
 
     Then the market data for the market "ETH/DEC21" should be:

--- a/core/integration/features/verified/0029-FEES-trading_fees.feature
+++ b/core/integration/features/verified/0029-FEES-trading_fees.feature
@@ -259,7 +259,7 @@ Feature: Fees calculations
       | trader3a | ETH   | ETH/DEC21 | 480    | 9531    |
       | trader3b | ETH   | ETH/DEC21 | 240    | 9766    |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "5" for the market "ETH/DEC21"
 
     Then the market data for the market "ETH/DEC21" should be:
@@ -711,7 +711,7 @@ Feature: Fees calculations
       | trader3 | ETH   | ETH/DEC21 | 240    | 9999766 |
       | trader4 | ETH   | ETH/DEC21 | 0      | 0       |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "4" for the market "ETH/DEC21"
 
     When the network moves ahead "11" blocks
@@ -1681,7 +1681,7 @@ Feature: Fees calculations
       | trader4  | ETH   | ETH/DEC21 | 5580   | 94875   |
 
 
-    And the liquidity fee factor should "0.001" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "31" for the market "ETH/DEC21"
 
     Then the following trades should be executed:

--- a/core/integration/features/verified/0041-TSK-target_stake.feature
+++ b/core/integration/features/verified/0041-TSK-target_stake.feature
@@ -25,13 +25,20 @@ Feature: Target stake
     # setup accounts
     Given the parties deposit on asset's general account the following amount:
       | party | asset | amount    |
-      | tt_0  | BTC   | 100000000 |
+      | lp_1  | BTC   | 100000000 |
+      | lp_2  | BTC   | 100000000 |
+      | lp_3  | BTC   | 100000000 |
+      | lp_4  | BTC   | 100000000 |
+      | lp_5  | BTC   | 100000000 |
+      | lp_6  | BTC   | 100000000 |
+      | lp_7  | BTC   | 100000000 |
+      | lp_8  | BTC   | 100000000 |
       | tt_1  | BTC   | 100000000 |
       | tt_2  | BTC   | 100000000 |
       | tt_3  | BTC   | 100000000 |
       | tt_4  | BTC   | 100000000 |
 
-  Scenario: Max open interest changes over time (0041-TSTK-002, 0041-TSTK-003)
+  Scenario: Max open interest changes over time (0041-TSTK-002, 0041-TSTK-003, 0042-LIQF-007)
     Given the following network parameters are set:
       | name                              | value |
       | market.stake.target.timeWindow    | 10s   |
@@ -41,8 +48,8 @@ Feature: Target stake
     # positions and close out if needed too
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | tt_0  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | tt_0_0    |
-      | tt_0  | ETH/DEC21 | sell | 1000   | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_0_1    |
+      | lp_1  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | lp_1_0    |
+      | lp_1  | ETH/DEC21 | sell | 1000   | 110   | 0                | TYPE_LIMIT | TIF_GTC | lp_1_1    |
 
     # nothing should have traded yet
     Then the mark price should be "0" for the market "ETH/DEC21"
@@ -56,8 +63,22 @@ Feature: Target stake
 
     Then the parties submit the following liquidity provision:
       | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
-      | lp1 | tt_0  | ETH/DEC21 | 2000              | 0.001 | buy  | BID              | 1          | 10     | submission |
-      | lp1 | tt_0  | ETH/DEC21 | 2000              | 0.001 | sell | ASK              | 1          | 10     | amendment  |
+      | lp1 | lp_1  | ETH/DEC21 |  135              | 0.001 | buy  | BID              | 1          | 10     | submission |
+      | lp1 | lp_1  | ETH/DEC21 |  135              | 0.001 | sell | ASK              | 1          | 10     | amendment  |
+      | lp2 | lp_2  | ETH/DEC21 |  165              | 0.002 | buy  | BID              | 1          | 10     | submission |
+      | lp2 | lp_2  | ETH/DEC21 |  165              | 0.002 | sell | ASK              | 1          | 10     | amendment  |
+      | lp3 | lp_3  | ETH/DEC21 |  300              | 0.003 | buy  | BID              | 1          | 10     | submission |
+      | lp3 | lp_3  | ETH/DEC21 |  300              | 0.003 | sell | ASK              | 1          | 10     | amendment  |
+      | lp4 | lp_4  | ETH/DEC21 |  300              | 0.004 | buy  | BID              | 1          | 10     | submission |
+      | lp4 | lp_4  | ETH/DEC21 |  300              | 0.004 | sell | ASK              | 1          | 10     | amendment  |
+      | lp5 | lp_5  | ETH/DEC21 |  500              | 0.005 | buy  | BID              | 1          | 10     | submission |
+      | lp5 | lp_5  | ETH/DEC21 |  500              | 0.005 | sell | ASK              | 1          | 10     | amendment  |
+      | lp6 | lp_6  | ETH/DEC21 |  300              | 0.006 | buy  | BID              | 1          | 10     | submission |
+      | lp6 | lp_6  | ETH/DEC21 |  300              | 0.006 | sell | ASK              | 1          | 10     | amendment  |
+      | lp7 | lp_7  | ETH/DEC21 |  200              | 0.007 | buy  | BID              | 1          | 10     | submission |
+      | lp7 | lp_7  | ETH/DEC21 |  200              | 0.007 | sell | ASK              | 1          | 10     | amendment  |
+      | lp8 | lp_8  | ETH/DEC21 |  100              | 0.008 | buy  | BID              | 1          | 10     | submission |
+      | lp8 | lp_8  | ETH/DEC21 |  100              | 0.008 | sell | ASK              | 1          | 10     | amendment  |
 
     Then the opening auction period ends for market "ETH/DEC21"
 
@@ -68,7 +89,7 @@ Feature: Target stake
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 110        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 990          | 2000           | 60            |
-
+    And the liquidity fee factor should be "0.005" for the market "ETH/DEC21"
     # T0 + 1s
     Then the network moves ahead "1" blocks
 
@@ -82,6 +103,7 @@ Feature: Target stake
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 90         | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 810          | 2000           | 40            |
+    And the liquidity fee factor should be "0.004" for the market "ETH/DEC21"
 
     # T0 + 10s
     Then the network moves ahead "10" blocks
@@ -97,17 +119,21 @@ Feature: Target stake
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 90         | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 540          | 2000           | 30            |
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
 
     # target stake should be: 90 x 40 x 1.5 x 0.1 = 540
     And the target stake should be "540" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
 
     Then the network moves ahead "1" blocks
     # target stake should be: 90 x 30 x 1.5 x 0.1 = 405
     And the target stake should be "405" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
 
     # Move time 4x the window, the target stake remain unchanged as we rely on last value even if it drops outside the window (that's still what OI is)
     Then the network moves ahead "40" blocks
     And the target stake should be "405" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     |
@@ -116,6 +142,7 @@ Feature: Target stake
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 90         | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 270          | 2000           | 20            |
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
     
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     |
@@ -124,10 +151,12 @@ Feature: Target stake
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 90         | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 270          | 2000           | 0             |
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
 
     # target stake remain unchanged as open interest of 20 and 0 where both recorded with the same timestamp
     Then the network moves ahead "10" blocks
     And the target stake should be "270" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type        | tif     |
@@ -138,6 +167,7 @@ Feature: Target stake
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 90         | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 135          | 2000           | 10            |
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type        | tif     |
@@ -146,12 +176,14 @@ Feature: Target stake
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 110        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 165          | 2000           | 0             |
-
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+    
     # O is now the last recorded open interest so target stake should drop to 0
     Then the network moves ahead "10" blocks
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
       | 110        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 0            | 2000           | 0             |
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
   Scenario: Max open interest changes over time, testing change of timewindow (0041-TSTK-001; 0041-TSTK-004; 0041-TSTK-005)
     Given the following network parameters are set:
@@ -163,13 +195,13 @@ Feature: Target stake
     # positions and close out if needed too
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | tt_0  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | tt_0_0    |
-      | tt_0  | ETH/DEC21 | sell | 1000   | 110   | 0                | TYPE_LIMIT | TIF_GTC | tt_0_1    |
+      | lp_1  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | lp_1_0    |
+      | lp_1  | ETH/DEC21 | sell | 1000   | 110   | 0                | TYPE_LIMIT | TIF_GTC | lp_1_1    |
 
     And the parties submit the following liquidity provision:
       | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
-      | lp1 | tt_0  | ETH/DEC21 | 2000              | 0.001 | sell | ASK              | 1          | 20     | submission |
-      | lp1 | tt_0  | ETH/DEC21 | 2000              | 0.001 | buy  | BID              | 1          | -20    | submission |
+      | lp1 | lp_1  | ETH/DEC21 | 2000              | 0.001 | sell | ASK              | 1          | 20     | submission |
+      | lp1 | lp_1  | ETH/DEC21 | 2000              | 0.001 | buy  | BID              | 1          | -20    | submission |
 
     # nothing should have traded, we have mark price set apriori or
     # due to auction closing.
@@ -218,7 +250,7 @@ Feature: Target stake
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | tt_1  | ETH/DEC21 | buy  | 100    | 110   | 1                | TYPE_LIMIT | TIF_GTC | tt_0_0    |
+      | tt_1  | ETH/DEC21 | buy  | 100    | 110   | 1                | TYPE_LIMIT | TIF_GTC | lp_1_0    |
     Then the mark price should be "110" for the market "ETH/DEC21"
 
     # max_io=10+20+30-20+100=140
@@ -248,8 +280,8 @@ Feature: Target stake
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | tt_0  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | tt_0_0    |
-      | tt_0  | ETH/DEC21 | sell | 1000   | 200   | 0                | TYPE_LIMIT | TIF_GTC | tt_0_1    |
+      | lp_1  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | lp_1_0    |
+      | lp_1  | ETH/DEC21 | sell | 1000   | 200   | 0                | TYPE_LIMIT | TIF_GTC | lp_1_1    |
 
     Then the mark price should be "0" for the market "ETH/DEC21"
 
@@ -265,8 +297,8 @@ Feature: Target stake
 
     Then the parties submit the following liquidity provision:
       | id  | party | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
-      | lp1 | tt_0  | ETH/DEC21 | 2000              | 0.001 | buy  | BID              | 1          | 10     | submission |
-      | lp1 | tt_0  | ETH/DEC21 | 2000              | 0.001 | sell | ASK              | 1          | 10     | amendment  |
+      | lp1 | lp_1  | ETH/DEC21 | 2000              | 0.001 | buy  | BID              | 1          | 10     | submission |
+      | lp1 | lp_1  | ETH/DEC21 | 2000              | 0.001 | sell | ASK              | 1          | 10     | amendment  |
 
     # Add wash trades
     When the parties place the following orders:

--- a/core/integration/features/verified/0042-LIQF-fees_rewards.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards.feature
@@ -96,7 +96,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
@@ -210,7 +210,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.002" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.002" for the market "ETH/MAR22"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
@@ -308,7 +308,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
@@ -408,7 +408,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
@@ -474,7 +474,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | lp1   | 0.8               | 8000                    |
       | lp2   | 0.2               | 10000                   |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     #no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
@@ -594,7 +594,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
@@ -96,7 +96,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
@@ -217,7 +217,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.002" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.002" for the market "ETH/MAR22"
 
     # no fees in auction
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
@@ -92,7 +92,7 @@ Feature: Test liquidity provider reward distribution; Check what happens when di
       | min bound | max bound |
       | 500       | 1500      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -464,4 +464,4 @@ Scenario: 001: 0070-MKTD-007, 0042-LIQF-001, 0018-RSKM-005, 0018-RSKM-008
       | min bound | max bound |
       | 864       | 1154      |
 
-    And the liquidity fee factor should "0.001" for the market "ETH/MAR22"
+    And the liquidity fee factor should be "0.001" for the market "ETH/MAR22"

--- a/core/integration/main_test.go
+++ b/core/integration/main_test.go
@@ -351,7 +351,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^the accumulated infrastructure fees should be "([^"]*)" for the asset "([^"]*)"$`, func(amount, asset string) error {
 		return steps.TheAccumulatedInfrastructureFeesShouldBeForTheMarket(execsetup.broker, amount, asset)
 	})
-	s.Step(`^the liquidity fee factor should "([^"]*)" for the market "([^"]*)"$`, func(fee, marketID string) error {
+	s.Step(`^the liquidity fee factor should be "([^"]*)" for the market "([^"]*)"$`, func(fee, marketID string) error {
 		return steps.TheLiquidityFeeFactorShouldForTheMarket(execsetup.broker, fee, marketID)
 	})
 	s.Step(`^the market data for the market "([^"]+)" should be:$`, func(marketID string, table *godog.Table) error {


### PR DESCRIPTION
Covers a fee ACs from 0042 and fixes issue with liquidity fee not always being update when target stake drops.

...and a few superficial changes to some .feature files as I corrected the grammar of a cucumber step ("the liquidity fee factor should **be**"

Closes https://github.com/vegaprotocol/vega/issues/6454
Closes https://github.com/vegaprotocol/vega/issues/6456 