### PR TITLE
fix: output from nodewallet reload is now more useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🚨 Breaking changes
 - [6505](https://github.com/vegaprotocol/vega/issues/6505) - Allow negative position decimal places for market
 - [6477](https://github.com/vegaprotocol/vega/issues/6477) - Allow the user to specify a different passphrase when isolating a key
+- [6549](https://github.com/vegaprotocol/vega/issues/6549) - Output from `nodewallet reload` is now more useful `json`
 - [6458](https://github.com/vegaprotocol/vega/issues/6458) - Rename `GetMultiSigSigner...Bundles API` functions to `ListMultiSigSigner...Bundles` to be consistent with `v2 APIs`
 
 ### 🗑️ Deprecation

--- a/cmd/vega/nodewallet/reload.go
+++ b/cmd/vega/nodewallet/reload.go
@@ -22,7 +22,6 @@ import (
 
 	"code.vegaprotocol.io/vega/core/admin"
 	"code.vegaprotocol.io/vega/core/config"
-	vgfmt "code.vegaprotocol.io/vega/libs/fmt"
 	"code.vegaprotocol.io/vega/logging"
 
 	"github.com/jessevdk/go-flags"
@@ -63,27 +62,22 @@ func (opts *reloadCmd) Execute(_ []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var data map[string]string
+	var resp *admin.NodeWalletReloadReply
 	switch opts.Chain {
 	case vegaChain, ethereumChain:
-		resp, err := sc.NodeWalletReload(ctx, opts.Chain)
+		resp, err = sc.NodeWalletReload(ctx, opts.Chain)
 		if err != nil {
 			return fmt.Errorf("failed to reload node wallet: %w", err)
-		}
-
-		data = map[string]string{
-			"OldWallet": resp.OldWallet.String(),
-			"NewWallet": resp.NewWallet.String(),
 		}
 	default:
 		return fmt.Errorf("chain %q is not supported", opts.Chain)
 	}
-
 	if output.IsHuman() {
 		fmt.Println(green("reload successful:"))
-		vgfmt.PrettyPrint(data)
+
+		vgjson.PrettyPrint(resp)
 	} else if output.IsJSON() {
-		if err := vgjson.Print(data); err != nil {
+		if err := vgjson.Print(resp); err != nil {
 			return err
 		}
 	}

--- a/core/admin/nodewallets.go
+++ b/core/admin/nodewallets.go
@@ -32,11 +32,7 @@ type wallet interface {
 
 type Wallet struct {
 	Name      string `json:"name"`
-	PublicKey string `json:"public_key"`
-}
-
-func (w *Wallet) String() string {
-	return fmt.Sprintf("Name: %s, PublicKey: %s", w.Name, w.PublicKey)
+	PublicKey string `json:"publicKey"`
 }
 
 func newWallet(w wallet) Wallet {
@@ -51,8 +47,8 @@ type NodeWalletArgs struct {
 }
 
 type NodeWalletReloadReply struct {
-	OldWallet Wallet
-	NewWallet Wallet
+	OldWallet Wallet `json:"oldWallet"`
+	NewWallet Wallet `json:"newWallet"`
 }
 
 type NodeWallet struct {


### PR DESCRIPTION
closes #6549 

Now looks like:
```
{
  "oldWallet": {
    "name": "some-wallet-name",
    "publicKey": "c3848cfce23861f44a3abe3dd96f5427edcab29f481928bcb120b1044469b9ab"
  },
  "newWallet": {
    "name": "some-wallet-name-2",
    "publicKey": "4bd6c22c72b7c5503d14ed513a2f9a705d9875449cc9144a372328825170b3f8"
  }
}
```

system test is happy: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/17908/pipeline/407