### PR TITLE
fix: data-node starts slowly with non-empty database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [6519](https://github.com/vegaprotocol/vega/issues/6519) - Fix errors in the ledger entries `GraphQL` query.
 - [6515](https://github.com/vegaprotocol/vega/issues/6515) - Required properties in OpenRPC documentation are marked as such
 - [6234](https://github.com/vegaprotocol/vega/issues/6234) - Fix response in query for oracle data spec by id
+- [6508](https://github.com/vegaprotocol/vega/issues/6508) - Fix data node starts slowly when the database is not empty
 
 ## 0.58.0
 

--- a/datanode/sqlstore/orders.go
+++ b/datanode/sqlstore/orders.go
@@ -141,7 +141,7 @@ func (os *Orders) GetAllVersionsByOrderID(ctx context.Context, id string, p enti
 // from the orders data in the database.
 func (os *Orders) GetLiveOrders(ctx context.Context) ([]entities.Order, error) {
 	defer metrics.StartSQLQuery("Orders", "GetLiveOrders")()
-	query := fmt.Sprintf(`select %s from orders_current
+	query := fmt.Sprintf(`select %s from orders_live
 where type = 1
 and time_in_force not in (3, 4)
 and status in (1, 7)


### PR DESCRIPTION
Close #6508 

This was caused because the GetLiveOrders function was querying orders_current which use to be a view with just the latest versions of each order. Behind the scenes, the tables and views had changed. Current live orders can now be queried directly from the orders_live table. The orders_current view returns the most full history of each order including the current state.

Using the test db with approximately 95GB of data, the start time from the updated query can be seen from the following log excerpts:

### Before

```
2022-10-20T14:46:04.865+0100	INFO	root	start/node_pre.go:70	Attempting to connect to SQL stores...
2022-10-20T14:46:04.894+0100	INFO	db migration	v3@v3.6.1/up.go:210	goose: no migrations to run. current version: 1
2022-10-20T14:46:14.617+0100	DEBUG	connection_source	sqlstore/market_data.go:109	Retrieving markets data from Postgres
```

### After

```
2022-10-20T14:47:52.796+0100	INFO	root	start/node_pre.go:70	Attempting to connect to SQL stores...
2022-10-20T14:47:52.826+0100	INFO	db migration	v3@v3.6.1/up.go:210	goose: no migrations to run. current version: 1
2022-10-20T14:47:52.976+0100	DEBUG	connection_source	sqlstore/market_data.go:109	Retrieving markets data from Postgres
```