### PR TITLE
fix: positions inserter not using dedicated postgres connection

### DIFF
--- a/datanode/sqlstore/positions.go
+++ b/datanode/sqlstore/positions.go
@@ -50,7 +50,7 @@ func NewPositions(connectionSource *ConnectionSource) *Positions {
 
 func (ps *Positions) Flush(ctx context.Context) ([]entities.Position, error) {
 	defer metrics.StartSQLQuery("Positions", "Flush")()
-	return ps.batcher.Flush(ctx, ps.pool)
+	return ps.batcher.Flush(ctx, ps.Connection)
 }
 
 func (ps *Positions) Add(ctx context.Context, p entities.Position) error {


### PR DESCRIPTION
but the pool instead (which is for queries); so positions weren't inside the single block level transaction