### PR TITLE
chore: dns remove data merge from dehistory

### DIFF
--- a/cmd/data-node/commands/dehistory/load.go
+++ b/cmd/data-node/commands/dehistory/load.go
@@ -71,7 +71,7 @@ func (cmd *loadCmd) Execute(_ []string) error {
 		return fmt.Errorf("failed new dehistory service:%w", err)
 	}
 
-	from, to, err := getSpanOfAllAvailableHistory(context.Background(), deHistoryService)
+	from, to, err := getSpanOfAllAvailableHistory(deHistoryService)
 	if err != nil {
 		return fmt.Errorf("failed to get span of all available history:%w", err)
 	}
@@ -86,18 +86,8 @@ func (cmd *loadCmd) Execute(_ []string) error {
 		return nil
 	}
 
-	datanodeIsEmpty, err := initialise.DataNodeIsEmpty(ctx, cmd.SQLStore.ConnectionConfig)
-	if err != nil {
-		return fmt.Errorf("failed to check if datanode is empty:%w", err)
-	}
-
-	if datanodeIsEmpty {
-		fmt.Printf("Datanode has no data, history from block height %d to %d is available to load\n",
-			from, to)
-	} else {
-		fmt.Printf("History from block height %d to %d is available to load, current datanode block span is %d to %d\n",
-			from, to, datanodeFromHeight, datanodeToHeight)
-	}
+	fmt.Printf("Decentralized history from block height %d to %d is available to load, current datanode block span is %d to %d\n",
+		from, to, datanodeFromHeight, datanodeToHeight)
 
 	yes := flags.YesOrNo("Do you want to load this history?")
 
@@ -115,8 +105,8 @@ func (cmd *loadCmd) Execute(_ []string) error {
 	return nil
 }
 
-func getSpanOfAllAvailableHistory(ctx context.Context, dehistoryService *dehistory.Service) (from int64, to int64, err error) {
-	contiguousHistory, err := dehistoryService.GetContiguousHistory(ctx)
+func getSpanOfAllAvailableHistory(dehistoryService *dehistory.Service) (from int64, to int64, err error) {
+	contiguousHistory, err := dehistoryService.GetContiguousHistory()
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get contiguous history data")
 	}

--- a/datanode/dehistory/aggregation/aggregation.go
+++ b/datanode/dehistory/aggregation/aggregation.go
@@ -1,54 +1,37 @@
 package aggregation
 
 import (
-	"errors"
 	"sort"
 
 	"code.vegaprotocol.io/vega/datanode/dehistory/store"
-	"code.vegaprotocol.io/vega/datanode/entities"
 )
 
 type AggregatedHistorySegment struct {
-	HeightFrom              int64
-	HeightTo                int64
-	ChainID                 string
-	FromCurrentDatanodeData bool
+	HeightFrom int64
+	HeightTo   int64
+	ChainID    string
 }
 
-// GetContiguousHistoryIncludingDataNodeExistingData returns the contiguous history oldest segment first.
-func GetContiguousHistoryIncludingDataNodeExistingData(histories []store.SegmentIndexEntry, datanodeOldestHistoryBlock *entities.Block,
-	datanodeLastBlock *entities.Block,
-) ([]AggregatedHistorySegment, error) {
-	if datanodeOldestHistoryBlock == nil || datanodeLastBlock == nil {
-		if datanodeOldestHistoryBlock != nil || datanodeLastBlock != nil {
-			return nil, errors.New(" datanodeLastBlock and datanodeOldestHistoryBlock must both be either nil or not nil")
-		}
-	}
-
-	if len(histories) == 0 {
-		return nil, nil
-	}
-
-	chainID := histories[0].ChainID
-
+// GetHighestContiguousHistoryFromSegmentIndexEntry returns the contiguous history oldest segment first.
+func GetHighestContiguousHistoryFromSegmentIndexEntry(histories []store.SegmentIndexEntry) []AggregatedHistorySegment {
 	aggHistory := make([]AggregatedHistorySegment, 0, 10)
 	for _, indexEntry := range histories {
 		aggHistory = append(aggHistory, AggregatedHistorySegment{
-			HeightFrom:              indexEntry.HeightFrom,
-			HeightTo:                indexEntry.HeightTo,
-			ChainID:                 indexEntry.ChainID,
-			FromCurrentDatanodeData: false,
+			HeightFrom: indexEntry.HeightFrom,
+			HeightTo:   indexEntry.HeightTo,
+			ChainID:    indexEntry.ChainID,
 		})
 	}
 
-	dataNodeHistorySegment := getHistorySegmentForDataNodeExistingData(chainID, datanodeOldestHistoryBlock, datanodeLastBlock)
+	return GetHighestContiguousHistory(aggHistory)
+}
 
-	var startFromHistorySegment AggregatedHistorySegment
-	if dataNodeHistorySegment != nil {
-		startFromHistorySegment = *dataNodeHistorySegment
-	} else {
-		startFromHistorySegment = getMostRecentHistorySegment(aggHistory)
+func GetHighestContiguousHistory(aggHistory []AggregatedHistorySegment) []AggregatedHistorySegment {
+	if len(aggHistory) == 0 {
+		return nil
 	}
+
+	startFromHistorySegment := getMostRecentHistorySegment(aggHistory)
 
 	contiguousHistory := getContiguousHistoryFromFirstHistorySegment(startFromHistorySegment, aggHistory)
 
@@ -57,20 +40,7 @@ func GetContiguousHistoryIncludingDataNodeExistingData(histories []store.Segment
 		return contiguousHistory[i].HeightFrom < contiguousHistory[j].HeightFrom
 	})
 
-	return contiguousHistory, nil
-}
-
-func getHistorySegmentForDataNodeExistingData(chainID string, datanodeOldestHistoryBlock *entities.Block, datanodeLastBlock *entities.Block) *AggregatedHistorySegment {
-	if datanodeOldestHistoryBlock == nil || datanodeLastBlock == nil {
-		return nil
-	}
-
-	return &AggregatedHistorySegment{
-		ChainID:                 chainID,
-		HeightFrom:              datanodeOldestHistoryBlock.Height,
-		HeightTo:                datanodeLastBlock.Height,
-		FromCurrentDatanodeData: true,
-	}
+	return contiguousHistory
 }
 
 func getMostRecentHistorySegment(aggHistory []AggregatedHistorySegment) AggregatedHistorySegment {

--- a/datanode/dehistory/aggregation/aggregation_test.go
+++ b/datanode/dehistory/aggregation/aggregation_test.go
@@ -6,117 +6,13 @@ import (
 	"code.vegaprotocol.io/vega/datanode/dehistory/aggregation"
 	"code.vegaprotocol.io/vega/datanode/dehistory/store"
 
-	"code.vegaprotocol.io/vega/datanode/entities"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetHistoryIncludingDatanodeStateWhenDatanodeHasData(t *testing.T) {
-	var datanodeOldestHistoryBlock *entities.Block
-	var datanodeLastBlock *entities.Block
-
-	datanodeOldestHistoryBlock = &entities.Block{Height: 0}
-	datanodeLastBlock = &entities.Block{Height: 5000}
-
-	historySnapshots := []store.SegmentIndexEntry{
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 3001, HeightTo: 4000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 2001, HeightTo: 3000}},
-	}
-
-	histories, _ := aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
-	assert.Equal(t, len(histories), 1)
-	assert.Equal(t, int64(0), histories[0].HeightFrom)
-	assert.Equal(t, int64(5000), histories[0].HeightTo)
-
-	datanodeOldestHistoryBlock = &entities.Block{Height: 2001}
-	datanodeLastBlock = &entities.Block{Height: 5000}
-
-	historySnapshots = []store.SegmentIndexEntry{
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 1001, HeightTo: 2000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 2001, HeightTo: 3000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 3001, HeightTo: 4000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 4001, HeightTo: 5000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 5001, HeightTo: 6000}},
-	}
-
-	histories, _ = aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
-
-	assert.Equal(t, len(histories), 2)
-	assert.Equal(t, int64(1001), histories[0].HeightFrom)
-	assert.Equal(t, int64(2000), histories[0].HeightTo)
-	assert.Equal(t, int64(2001), histories[1].HeightFrom)
-	assert.Equal(t, int64(5000), histories[1].HeightTo)
-
-	datanodeOldestHistoryBlock = &entities.Block{Height: 4001}
-	datanodeLastBlock = &entities.Block{Height: 5000}
-
-	historySnapshots = []store.SegmentIndexEntry{
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 1001, HeightTo: 2000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 2001, HeightTo: 3000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 3001, HeightTo: 4000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 4001, HeightTo: 5000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 5001, HeightTo: 6000}},
-	}
-
-	histories, _ = aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
-
-	assert.Equal(t, len(histories), 4)
-	assert.Equal(t, int64(1001), histories[0].HeightFrom)
-	assert.Equal(t, int64(2000), histories[0].HeightTo)
-	assert.Equal(t, int64(2001), histories[1].HeightFrom)
-	assert.Equal(t, int64(3000), histories[1].HeightTo)
-	assert.Equal(t, int64(3001), histories[2].HeightFrom)
-	assert.Equal(t, int64(4000), histories[2].HeightTo)
-	assert.Equal(t, int64(4001), histories[3].HeightFrom)
-	assert.Equal(t, int64(5000), histories[3].HeightTo)
-
-	datanodeOldestHistoryBlock = &entities.Block{Height: 4001}
-	datanodeLastBlock = &entities.Block{Height: 5050}
-
-	historySnapshots = []store.SegmentIndexEntry{
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 1001, HeightTo: 2000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 2001, HeightTo: 3000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 3001, HeightTo: 4000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 4001, HeightTo: 5000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 5001, HeightTo: 6000}},
-	}
-
-	histories, _ = aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
-
-	assert.Equal(t, len(histories), 4)
-	assert.Equal(t, int64(1001), histories[0].HeightFrom)
-	assert.Equal(t, int64(2000), histories[0].HeightTo)
-	assert.Equal(t, int64(2001), histories[1].HeightFrom)
-	assert.Equal(t, int64(3000), histories[1].HeightTo)
-	assert.Equal(t, int64(3001), histories[2].HeightFrom)
-	assert.Equal(t, int64(4000), histories[2].HeightTo)
-	assert.Equal(t, int64(4001), histories[3].HeightFrom)
-	assert.Equal(t, int64(5050), histories[3].HeightTo)
-
-	datanodeOldestHistoryBlock = &entities.Block{Height: 0}
-	datanodeLastBlock = &entities.Block{Height: 5050}
-
-	historySnapshots = []store.SegmentIndexEntry{
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 1001, HeightTo: 2000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 2001, HeightTo: 3000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 3001, HeightTo: 4000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 4001, HeightTo: 5000}},
-		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 5001, HeightTo: 6000}},
-	}
-
-	histories, _ = aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
-
-	assert.Equal(t, len(histories), 1)
-	assert.Equal(t, int64(0), histories[0].HeightFrom)
-	assert.Equal(t, int64(5050), histories[0].HeightTo)
-}
-
-func TestGetHistoryIncludingDatanodeStatWhenDatanodeIsEmpty(t *testing.T) {
-	var datanodeOldestHistoryBlock *entities.Block
-	var datanodeLastBlock *entities.Block
-
+func TestGetContiguousHistory(t *testing.T) {
 	var historySnapshots []store.SegmentIndexEntry
 
-	histories, _ := aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
+	histories := aggregation.GetHighestContiguousHistoryFromSegmentIndexEntry(historySnapshots)
 	assert.Nil(t, histories)
 
 	historySnapshots = []store.SegmentIndexEntry{
@@ -125,7 +21,7 @@ func TestGetHistoryIncludingDatanodeStatWhenDatanodeIsEmpty(t *testing.T) {
 		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 2001, HeightTo: 3000}},
 	}
 
-	histories, _ = aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
+	histories = aggregation.GetHighestContiguousHistoryFromSegmentIndexEntry(historySnapshots)
 
 	assert.Equal(t, 3, len(histories))
 	assert.Equal(t, int64(3000), histories[2].HeightTo)
@@ -141,7 +37,7 @@ func TestGetHistoryIncludingDatanodeStatWhenDatanodeIsEmpty(t *testing.T) {
 		{SegmentMetaData: store.SegmentMetaData{HeightFrom: 3001, HeightTo: 4000}},
 	}
 
-	histories, _ = aggregation.GetContiguousHistoryIncludingDataNodeExistingData(historySnapshots, datanodeOldestHistoryBlock, datanodeLastBlock)
+	histories = aggregation.GetHighestContiguousHistoryFromSegmentIndexEntry(historySnapshots)
 
 	assert.Equal(t, 2, len(histories))
 	assert.Equal(t, int64(4000), histories[1].HeightTo)

--- a/datanode/dehistory/snapshot/service.go
+++ b/datanode/dehistory/snapshot/service.go
@@ -41,7 +41,7 @@ func NewSnapshotService(log *logging.Logger, config Config, connConfig sqlstore.
 }
 
 func (b *Service) SnapshotData(ctx context.Context, chainID string, toHeight int64, fromHeight int64) error {
-	_, err := b.CreateSnapshotAsync(ctx, chainID, fromHeight, toHeight)
+	_, err := b.CreateSnapshot(ctx, chainID, fromHeight, toHeight)
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot from height %d to %d: %w", fromHeight, toHeight, err)
 	}


### PR DESCRIPTION
closes #6577 

Original datanode snapshot behaviour had been to snapshot datanode data before restoring it from snapshots.  With the way decentralized history works this state is local anyway and so there is no need to snapshot the datanode data before restoring from decentralized history, this behaivour should be removed.