### PR TITLE
5706 block buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🛠 Improvements
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [6613](https://github.com/vegaprotocol/vega/issues/6613) - Add file buffering to datanode
 
 ### 🐛 Fixes
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -197,6 +197,19 @@ func (l *NodeCommand) preRun([]string) (err error) {
 		return err
 	}
 
+	if l.conf.Broker.UseBufferedEventSource {
+		bufferFilePath, err := l.vegaPaths.CreateStatePathFor(paths.DataNodeEventBufferHome)
+		if err != nil {
+			l.Log.Error("failed to create path for buffered event source", logging.Error(err))
+			return err
+		}
+		eventSource, err = broker.NewBufferedEventSource(l.Log, l.conf.Broker.BufferedEventSourceConfig, eventSource, bufferFilePath)
+		if err != nil {
+			l.Log.Error("unable to initialise file buffered event source", logging.Error(err))
+			return err
+		}
+	}
+
 	eventSource = broker.NewFanOutEventSource(eventSource, l.conf.SQLStore.FanOutBufferSize, 2)
 
 	var onBlockCommittedFn func(ctx context.Context, chainId string, lastCommittedBlockHeight int64)

--- a/datanode/broker/buffered_event_source.go
+++ b/datanode/broker/buffered_event_source.go
@@ -1,0 +1,341 @@
+package broker
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+
+	"code.vegaprotocol.io/vega/core/events"
+	"code.vegaprotocol.io/vega/datanode/metrics"
+	"code.vegaprotocol.io/vega/logging"
+	eventspb "code.vegaprotocol.io/vega/protos/vega/events/v1"
+
+	"github.com/golang/protobuf/proto"
+)
+
+type FileBufferedEventSource struct {
+	log                   *logging.Logger
+	lastBufferedSeqNum    chan uint64
+	sendChannelBufferSize int
+	source                eventSource
+	bufferFilePath        string
+	config                BufferedEventSourceConfig
+}
+
+const (
+	numberOfSeqNumBytes = 8
+	numberOfSizeBytes   = 4
+)
+
+func NewBufferedEventSource(log *logging.Logger, config BufferedEventSourceConfig, source eventSource, bufferFilePath string) (*FileBufferedEventSource, error) {
+	err := os.RemoveAll(bufferFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove old buffer files:%w", err)
+	}
+
+	err = os.Mkdir(bufferFilePath, os.ModePerm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create buffer file directory:%w", err)
+	}
+
+	files, _ := ioutil.ReadDir(bufferFilePath)
+	for _, file := range files {
+		os.Remove(filepath.Join(bufferFilePath, file.Name()))
+	}
+
+	fb := &FileBufferedEventSource{
+		log:                log.Named("buffered-event-source"),
+		source:             source,
+		config:             config,
+		lastBufferedSeqNum: make(chan uint64, config.MaxBufferedEvents),
+		bufferFilePath:     bufferFilePath,
+	}
+
+	p := message.NewPrinter(language.English)
+	formattedMaxBufferedEvents := p.Sprintf("%f", config.MaxBufferedEvents)
+
+	fb.log.Infof("Starting buffered event source with a max buffered event count of %s, and events per buffer file size %d",
+		formattedMaxBufferedEvents, config.EventsPerFile)
+
+	return fb, nil
+}
+
+func (m *FileBufferedEventSource) Listen() error {
+	return m.source.Listen()
+}
+
+func (m *FileBufferedEventSource) Receive(ctx context.Context) (<-chan events.Event, <-chan error) {
+	sourceEventCh, sourceErrCh := m.source.Receive(ctx)
+
+	if m.config.EventsPerFile == 0 {
+		m.log.Info("events per file is set to 0, disabling event buffer")
+		return sourceEventCh, sourceErrCh
+	}
+
+	sinkEventCh := make(chan events.Event, m.sendChannelBufferSize)
+	sinkErrorCh := make(chan error, 1)
+
+	go func() {
+		m.writeEventsToBuffer(ctx, sourceEventCh, sourceErrCh, sinkErrorCh)
+	}()
+
+	go func() {
+		m.readEventsFromBuffer(ctx, sinkEventCh, sinkErrorCh)
+	}()
+
+	return sinkEventCh, sinkErrorCh
+}
+
+func (m *FileBufferedEventSource) writeEventsToBuffer(ctx context.Context, sourceEventCh <-chan events.Event,
+	sourceErrCh <-chan error, sinkErrorCh chan error,
+) {
+	bufferSeqNum := uint64(0)
+
+	var bufferFile *os.File
+	defer func() {
+		if bufferFile != nil {
+			err := bufferFile.Close()
+			if err != nil {
+				m.log.Errorf("failed to close event buffer file:%w", err)
+			}
+		}
+	}()
+
+	var err error
+	for {
+		select {
+		case event := <-sourceEventCh:
+			if bufferSeqNum%uint64(m.config.EventsPerFile) == 0 {
+				bufferFile, err = m.rollBufferFile(bufferFile, bufferSeqNum)
+				if err != nil {
+					sinkErrorCh <- fmt.Errorf("failed to roll buffer file:%w", err)
+				}
+			}
+
+			bufferSeqNum++
+			err = writeToBuffer(bufferFile, bufferSeqNum, event)
+			metrics.EventBufferWrittenCountInc()
+
+			if err != nil {
+				sinkErrorCh <- fmt.Errorf("failed to write events to buffer:%w", err)
+			}
+
+			select {
+			case m.lastBufferedSeqNum <- bufferSeqNum:
+			default:
+			loop:
+				for {
+					select {
+					case <-m.lastBufferedSeqNum:
+					case <-ctx.Done():
+						return
+					default:
+						break loop
+					}
+				}
+				m.lastBufferedSeqNum <- bufferSeqNum
+			}
+
+		case err = <-sourceErrCh:
+			sinkErrorCh <- err
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *FileBufferedEventSource) readEventsFromBuffer(ctx context.Context, sinkEventCh chan events.Event, sinkErrorCh chan error) {
+	var offset int64
+	var lastBufferSeqNum uint64
+	var lastSentBufferSeqNum uint64
+	var err error
+
+	var bufferFile *os.File
+
+	defer func() {
+		if bufferFile != nil {
+			err = bufferFile.Close()
+			if err != nil {
+				m.log.Errorf("failed to close event buffer file:%w", err)
+			}
+		}
+	}()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if lastBufferSeqNum > lastSentBufferSeqNum {
+			if bufferFile == nil {
+				offset = 0
+				bufferFile, err = m.openBufferFile(lastSentBufferSeqNum+1, lastSentBufferSeqNum+uint64(m.config.EventsPerFile))
+				if err != nil {
+					sinkErrorCh <- fmt.Errorf("failed to open buffer file:%w", err)
+					return
+				}
+			}
+
+			event, bufferSeqNum, read, err := readEvent(bufferFile, offset)
+			if err != nil {
+				sinkErrorCh <- fmt.Errorf("error when reading event from buffer file:%w", err)
+				return
+			}
+
+			offset += int64(read)
+
+			if event != nil {
+				evt := toEvent(ctx, event)
+				sinkEventCh <- evt
+				metrics.EventBufferReadCountInc()
+				lastSentBufferSeqNum = bufferSeqNum
+
+				if lastSentBufferSeqNum%uint64(m.config.EventsPerFile) == 0 {
+					if err = m.removeBufferFile(bufferFile); err != nil {
+						sinkErrorCh <- fmt.Errorf("failed to remove buffer file:%w", err)
+					}
+					bufferFile = nil
+				}
+			} else {
+				// Time for the buffer write to complete if we were unable to read a complete event for a given seq num
+				time.Sleep(10 * time.Millisecond)
+			}
+		} else {
+			// Wait until told there is new data written to the buffer
+			select {
+			case <-ctx.Done():
+				return
+			case bufferSeqNum := <-m.lastBufferedSeqNum:
+				lastBufferSeqNum = bufferSeqNum
+			}
+		}
+	}
+}
+
+func (m *FileBufferedEventSource) rollBufferFile(currentBufferFile *os.File, seqNum uint64) (*os.File, error) {
+	if currentBufferFile != nil {
+		err := currentBufferFile.Close()
+		if err != nil {
+			return nil, fmt.Errorf("unable to create new buffer file, failed to close current events buffer file:%w", err)
+		}
+	}
+
+	newBufferFile, err := m.createFile(seqNum+1, seqNum+uint64(m.config.EventsPerFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create events buffer file:%w", err)
+	}
+	return newBufferFile, nil
+}
+
+func writeToBuffer(bufferFile *os.File, bufferSeqNum uint64, event events.Event) error {
+	e := event.StreamMessage()
+
+	seqNumBytes := make([]byte, numberOfSeqNumBytes)
+	sizeBytes := make([]byte, numberOfSizeBytes)
+
+	size := numberOfSeqNumBytes + uint32(proto.Size(e))
+	protoBytes, err := proto.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("failed to marshal bus event:%w", err)
+	}
+
+	binary.BigEndian.PutUint64(seqNumBytes, bufferSeqNum)
+	binary.BigEndian.PutUint32(sizeBytes, size)
+	allBytes := append([]byte{}, sizeBytes...)
+	allBytes = append(allBytes, seqNumBytes...)
+	allBytes = append(allBytes, protoBytes...)
+	_, err = bufferFile.Write(allBytes)
+	if err != nil {
+		return fmt.Errorf("failed to write to buffer file:%w", err)
+	}
+
+	return nil
+}
+
+func (m *FileBufferedEventSource) removeBufferFile(bufferFile *os.File) error {
+	err := bufferFile.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close last event buffer file:%w", err)
+	}
+
+	err = os.Remove(bufferFile.Name())
+	if err != nil {
+		return fmt.Errorf("failed to remove event buffer file:%w", err)
+	}
+	return nil
+}
+
+func readEvent(eventFile *os.File, offset int64) (event *eventspb.BusEvent, seqNum uint64,
+	totalBytesRead uint32, err error,
+) {
+	sizeBytes := make([]byte, numberOfSizeBytes)
+	read, err := eventFile.ReadAt(sizeBytes, offset)
+
+	if err == io.EOF {
+		return nil, 0, 0, nil
+	} else if err != nil {
+		return nil, 0, 0, fmt.Errorf("error reading message size from events file:%w", err)
+	}
+
+	if read < numberOfSizeBytes {
+		return nil, 0, 0, nil
+	}
+
+	messageOffset := offset + numberOfSizeBytes
+
+	msgSize := binary.BigEndian.Uint32(sizeBytes)
+	seqNumAndMsgBytes := make([]byte, msgSize)
+	read, err = eventFile.ReadAt(seqNumAndMsgBytes, messageOffset)
+	if err == io.EOF {
+		return nil, 0, 0, nil
+	} else if err != nil {
+		return nil, 0, 0, fmt.Errorf("error reading message bytes from events file:%w", err)
+	}
+
+	if read < int(msgSize) {
+		return nil, 0, 0, nil
+	}
+
+	seqNumBytes := seqNumAndMsgBytes[:numberOfSeqNumBytes]
+	seqNum = binary.BigEndian.Uint64(seqNumBytes)
+
+	event = &eventspb.BusEvent{}
+	msgBytes := seqNumAndMsgBytes[numberOfSeqNumBytes:]
+	err = proto.Unmarshal(msgBytes, event)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to unmarshal bus event: %w", err)
+	}
+	totalBytesRead = numberOfSizeBytes + msgSize
+
+	return event, seqNum, totalBytesRead, nil
+}
+
+func (m *FileBufferedEventSource) getBufferFileName(fromSeqNum uint64, toSeqNum uint64) string {
+	return fmt.Sprintf("%s/datanode-buffer-%d-%d", m.bufferFilePath, fromSeqNum, toSeqNum)
+}
+
+func (m *FileBufferedEventSource) createFile(fromSeqNum uint64, toSeqNum uint64) (*os.File, error) {
+	bufferFileName := m.getBufferFileName(fromSeqNum, toSeqNum)
+	bufferFile, err := os.Create(bufferFileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create buffer file: %s :%w", bufferFileName, err)
+	}
+	return bufferFile, err
+}
+
+func (m *FileBufferedEventSource) openBufferFile(fromSeqNum uint64, toSeqNum uint64) (*os.File, error) {
+	bufferFileName := m.getBufferFileName(fromSeqNum, toSeqNum)
+	bufferFile, err := os.Open(bufferFileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open buffer file: %s :%w", bufferFileName, err)
+	}
+	return bufferFile, nil
+}

--- a/datanode/broker/buffered_event_source_test.go
+++ b/datanode/broker/buffered_event_source_test.go
@@ -1,0 +1,203 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/core/events"
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FileBufferedEventSource_BufferingDisabledWhenEventsPerFileIsZero(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	path := t.TempDir()
+
+	eventSource := &testEventSource{
+		eventsCh: make(chan events.Event, 1000),
+		errCh:    make(chan error),
+	}
+
+	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+		EventsPerFile:         0,
+		SendChannelBufferSize: 1000,
+		MaxBufferedEvents:     10000,
+	}, eventSource, path)
+
+	assert.NoError(t, err)
+
+	evtCh, _ := fb.Receive(ctx)
+
+	numberOfEventsToSend := 100
+	for i := 0; i < numberOfEventsToSend; i++ {
+		a := events.NewAssetEvent(context.Background(), types.Asset{ID: fmt.Sprintf("%03d", i)})
+		eventSource.eventsCh <- a
+	}
+
+	// This check consumes all events, and after each event buffer file is read it checks that it is removed
+	for i := 0; i < numberOfEventsToSend; i++ {
+		files, _ := ioutil.ReadDir(path)
+		assert.Equal(t, 0, len(files))
+		e := <-evtCh
+		r := e.(*events.Asset)
+		assert.Equal(t, fmt.Sprintf("%03d", i), r.Asset().Id)
+	}
+}
+
+func Test_FileBufferedEventSource_ErrorSentOnPathError(t *testing.T) {
+	eventSource := &testEventSource{
+		eventsCh: make(chan events.Event),
+		errCh:    make(chan error),
+	}
+
+	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+		EventsPerFile:         10,
+		SendChannelBufferSize: 0,
+		MaxBufferedEvents:     10000,
+	}, eventSource, "thepaththatdoesntexist")
+
+	assert.NoError(t, err)
+
+	_, errCh := fb.Receive(context.Background())
+
+	eventSource.errCh <- fmt.Errorf("test error")
+
+	assert.NotNil(t, <-errCh)
+}
+
+func Test_FileBufferedEventSource_ErrorsArePassedThrough(t *testing.T) {
+	path := t.TempDir()
+
+	eventSource := &testEventSource{
+		eventsCh: make(chan events.Event),
+		errCh:    make(chan error),
+	}
+
+	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+		EventsPerFile:         10,
+		SendChannelBufferSize: 0,
+		MaxBufferedEvents:     10000,
+	}, eventSource, path)
+
+	assert.NoError(t, err)
+
+	_, errCh := fb.Receive(context.Background())
+
+	eventSource.errCh <- fmt.Errorf("test error")
+
+	assert.NotNil(t, <-errCh)
+}
+
+func Test_FileBufferedEventSource_EventsAreBufferedAndPassedThrough(t *testing.T) {
+	path := t.TempDir()
+
+	eventSource := &testEventSource{
+		eventsCh: make(chan events.Event),
+		errCh:    make(chan error),
+	}
+
+	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+		EventsPerFile:         10,
+		SendChannelBufferSize: 0,
+		MaxBufferedEvents:     10000,
+	}, eventSource, path)
+
+	assert.NoError(t, err)
+
+	evtCh, _ := fb.Receive(context.Background())
+
+	a1 := events.NewAssetEvent(context.Background(), types.Asset{ID: "1"})
+	a2 := events.NewAssetEvent(context.Background(), types.Asset{ID: "2"})
+	a3 := events.NewAssetEvent(context.Background(), types.Asset{ID: "3"})
+
+	eventSource.eventsCh <- a1
+	eventSource.eventsCh <- a2
+	eventSource.eventsCh <- a3
+
+	e1 := <-evtCh
+	r1 := e1.(*events.Asset)
+	e2 := <-evtCh
+	r2 := e2.(*events.Asset)
+	e3 := <-evtCh
+	r3 := e3.(*events.Asset)
+
+	assert.Equal(t, "1", r1.Asset().Id)
+	assert.Equal(t, "2", r2.Asset().Id)
+	assert.Equal(t, "3", r3.Asset().Id)
+}
+
+func Test_FileBufferedEventSource_RollsBufferFiles(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	path := t.TempDir()
+
+	eventSource := &testEventSource{
+		eventsCh: make(chan events.Event),
+		errCh:    make(chan error),
+	}
+
+	eventsPerFile := 10
+	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+		EventsPerFile:         eventsPerFile,
+		SendChannelBufferSize: 0,
+		MaxBufferedEvents:     10000,
+	}, eventSource, path)
+
+	assert.NoError(t, err)
+
+	evtCh, _ := fb.Receive(ctx)
+
+	numberOfEventsToSend := 100
+	for i := 0; i < numberOfEventsToSend; i++ {
+		a := events.NewAssetEvent(context.Background(), types.Asset{ID: fmt.Sprintf("%03d", i)})
+		eventSource.eventsCh <- a
+	}
+
+	// This check consumes all events, and after each event buffer file is read it checks that it is removed
+	for i := 0; i < numberOfEventsToSend; i++ {
+		if i%eventsPerFile == 0 {
+			files, _ := ioutil.ReadDir(path)
+			expectedNumFiles := (numberOfEventsToSend - i) / eventsPerFile
+
+			// As it interacts with disk, there is a bit of asynchronicity, this loop is to ensure that the directory
+			// has chance to update. It will timeout if this test fails
+			for expectedNumFiles != len(files) {
+				files, _ = ioutil.ReadDir(path)
+				time.Sleep(5 * time.Millisecond)
+			}
+
+			sort.Slice(files, func(i int, j int) bool {
+				return files[i].ModTime().Before(files[j].ModTime())
+			})
+			for j, f := range files {
+				expectedFilename := fmt.Sprintf("datanode-buffer-%d-%d", (j+i/eventsPerFile)*eventsPerFile+1, (j+1+i/eventsPerFile)*eventsPerFile)
+				assert.Equal(t, expectedFilename, f.Name())
+			}
+		}
+
+		e := <-evtCh
+		r := e.(*events.Asset)
+		assert.Equal(t, fmt.Sprintf("%03d", i), r.Asset().Id)
+	}
+}
+
+type testEventSource struct {
+	eventsCh chan events.Event
+	errCh    chan error
+}
+
+func (t *testEventSource) Listen() error {
+	return nil
+}
+
+func (t *testEventSource) Receive(ctx context.Context) (<-chan events.Event, <-chan error) {
+	return t.eventsCh, t.errCh
+}

--- a/datanode/broker/config.go
+++ b/datanode/broker/config.go
@@ -23,13 +23,15 @@ const namedLogger = "broker"
 
 // Config represents the configuration of the broker.
 type Config struct {
-	Level                          encoding.LogLevel     `long:"log-level"`
-	SocketConfig                   SocketConfig          `group:"Socket" namespace:"socket"`
-	SocketServerInboundBufferSize  int                   `long:"socket-server-inbound-buffer-size"`
-	SocketServerOutboundBufferSize int                   `long:"socket-server-outbound-buffer-size"`
-	FileEventSourceConfig          FileEventSourceConfig `group:"FileEventSourceConfig" namespace:"fileeventsource"`
-	UseEventFile                   encoding.Bool         `long:"use-event-file" description:"set to true to source events from a file"`
-	PanicOnError                   encoding.Bool         `long:"panic-on-error" description:"if an error occurs on event push the broker will panic, else log the error"`
+	Level                          encoding.LogLevel         `long:"log-level"`
+	SocketConfig                   SocketConfig              `group:"Socket" namespace:"socket"`
+	SocketServerInboundBufferSize  int                       `long:"socket-server-inbound-buffer-size"`
+	SocketServerOutboundBufferSize int                       `long:"socket-server-outbound-buffer-size"`
+	FileEventSourceConfig          FileEventSourceConfig     `group:"FileEventSourceConfig" namespace:"fileeventsource"`
+	UseEventFile                   encoding.Bool             `long:"use-event-file" description:"set to true to source events from a file"`
+	PanicOnError                   encoding.Bool             `long:"panic-on-error" description:"if an error occurs on event push the broker will panic, else log the error"`
+	UseBufferedEventSource         encoding.Bool             `long:"use-buffered-event-source" description:"if true datanode will buffer events"`
+	BufferedEventSourceConfig      BufferedEventSourceConfig `group:"BufferedEventSource" namespace:"bufferedeventsource"`
 }
 
 // NewDefaultConfig creates an instance of config with default values.
@@ -49,8 +51,14 @@ func NewDefaultConfig() Config {
 			TimeBetweenBlocks:     encoding.Duration{Duration: 1 * time.Second},
 			SendChannelBufferSize: 1000,
 		},
-		UseEventFile: false,
-		PanicOnError: false,
+		UseEventFile:           false,
+		PanicOnError:           false,
+		UseBufferedEventSource: true,
+		BufferedEventSourceConfig: BufferedEventSourceConfig{
+			EventsPerFile:         10_000_000,
+			SendChannelBufferSize: 10_000,
+			MaxBufferedEvents:     100_000_000,
+		},
 	}
 }
 
@@ -65,4 +73,10 @@ type SocketConfig struct {
 	Port               int    `long:"port" description:" "`
 	MaxReceiveTimeouts int    `long:"max-receive-timeouts"`
 	TransportType      string `long:"transport-type"`
+}
+
+type BufferedEventSourceConfig struct {
+	EventsPerFile         int `long:"events-per-file" description:"the number of events to store in a file buffer, set to 0 to disable the buffer"`
+	SendChannelBufferSize int `long:"send-buffer-size" description:"sink event channel buffer size"`
+	MaxBufferedEvents     int `long:"max-buffered-events" description:"max number of events that can be buffered, after this point events will no longer be buffered"`
 }

--- a/datanode/metrics/prometheus.go
+++ b/datanode/metrics/prometheus.go
@@ -70,6 +70,9 @@ var (
 	lastSnapshotCurrentStateBytes prometheus.Gauge
 	lastSnapshotHistoryBytes      prometheus.Gauge
 	lastSnapshotSeconds           prometheus.Gauge
+
+	eventBufferWrittenCount prometheus.Counter
+	eventBufferReadCount    prometheus.Counter
 )
 
 // abstract prometheus types.
@@ -508,6 +511,38 @@ func setupMetrics() error {
 	blockCounter = bt
 
 	h, err = addInstrument(
+		Counter,
+		"event_buffer_written_count",
+		Namespace("datanode"),
+		Vectors(),
+		Help("Total number of event written to the event buffer"),
+	)
+	if err != nil {
+		return err
+	}
+	ebwc, err := h.Counter()
+	if err != nil {
+		return err
+	}
+	eventBufferWrittenCount = ebwc
+
+	h, err = addInstrument(
+		Counter,
+		"event_buffer_read_count",
+		Namespace("datanode"),
+		Vectors(),
+		Help("Total number of events read from the event buffer"),
+	)
+	if err != nil {
+		return err
+	}
+	ebrc, err := h.Counter()
+	if err != nil {
+		return err
+	}
+	eventBufferReadCount = ebrc
+
+	h, err = addInstrument(
 		Gauge,
 		"block_height",
 		Namespace("datanode"),
@@ -674,6 +709,20 @@ func AddBlockHandlingTime(duration time.Duration) {
 	if blockHandlingTime != nil {
 		blockHandlingTime.Add(duration.Seconds())
 	}
+}
+
+func EventBufferWrittenCountInc() {
+	if eventBufferWrittenCount == nil {
+		return
+	}
+	eventBufferWrittenCount.Inc()
+}
+
+func EventBufferReadCountInc() {
+	if eventBufferReadCount == nil {
+		return
+	}
+	eventBufferReadCount.Inc()
 }
 
 func BlockCounterInc(labelValues ...string) {

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -275,6 +275,9 @@ var (
 	// DataNodeDeHistoryHome is the folder containing the decentralised history data.
 	DataNodeDeHistoryHome = StatePath(filepath.Join(DataNodeStateHome.String(), "dehistory"))
 
+	// DataNodeEventBufferHome is the folder containing event buffer files.
+	DataNodeEventBufferHome = StatePath(filepath.Join(DataNodeStateHome.String(), "eventsbuffer"))
+
 	// NodeStateHome is the folder containing the state of the node.
 	NodeStateHome = StatePath("node")
 


### PR DESCRIPTION
closes #6613

Originally written when we were going to restore data node from full snapshot rather than deltas.  Parked when moved to deltas.  Do we want to use this to better handle recovery scenarios (its original intention really)

Written with the following 2 constraints in mind:

1) It is the standard event path, i.e. not something that is only used when data-node starts to get behind.  Reasoning being that this is not something we only want to rely on when things start to go 'wrong' it should be used day in day out so we confidence in it and don't start finding issues at just the wrong time.

2) Given the above, and the need to not add meaningful latency to events, and to avoid thrash polling the disk, it uses a queue internally to notify the reader when data has been written and is ready to consume, the `lastBufferedSeqNum` queue.  Note, to keep the impl simple (that rhymes) I assumed that we do not need to worry about this queue backing up (from a mem pov) as its just uint64s.  

For clarity:  be aware the bufferSeqNum is NOT the same as the seq number on events.

