### PR TITLE
feat: add release note formatting

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+---
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - renovate
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: New Features 🌱
+      labels:
+        - enhancement
+        - feature
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This allows the [release notes](https://github.com/vegaprotocol/vega/releases) to be formatted based on the labels given to a PR

The labels `breaking-change`, `bug` and `feature` / `enhancement` will add the PRs into the relevant sections as per this PoC example:

<img width="1108" alt="Screenshot 2022-10-31 at 16 25 43" src="https://user-images.githubusercontent.com/83510148/199058754-713ed1ec-20ac-47a9-8388-b667bc6b6a03.png">

**PR Authors must:**

- add one of the four labels to the PR when applicable
- add a reasonable description of the change (especially for breaking changes) so the community can easily understand the impact it may cause them 


**NOTE:**
Successive pre-release release notes will be collated, this is so that when you make a 'latest' release (or change a pre- release to a latest release) the notes have everything since the last 'latest' released version.
