### PR TITLE
fix: ensure read is isolated before returning event processing thread

### DIFF
--- a/datanode/dehistory/snapshot/service_create_snapshot.go
+++ b/datanode/dehistory/snapshot/service_create_snapshot.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"code.vegaprotocol.io/vega/datanode/sqlstore"
+
 	"code.vegaprotocol.io/vega/datanode/dehistory/fsutil"
 
 	"code.vegaprotocol.io/vega/datanode/metrics"
@@ -77,6 +79,9 @@ func (b *Service) CreateSnapshot(ctx context.Context, chainID string, fromHeight
 		return CreateSnapshotResult{}, fmt.Errorf("failed to create write lock file:%w", err)
 	}
 	cleanUp = append(cleanUp, func() { _ = os.Remove(snapshotInProgressFile) })
+
+	// To ensure reads are isolated from this point forward execute a read on last block
+	sqlstore.GetLastBlockUsingConnection(ctx, copyDataTx)
 
 	go func() {
 		defer func() { runAllInReverseOrder(cleanUp) }()


### PR DESCRIPTION
closes #6673  

According to the postgres spec: 
SERIALIZABLE
All statements of the current transaction can only see rows committed before the first query or data-modification statement was executed in this transaction. If a pattern of reads and writes among concurrent serializable transactions would create a situation which could not have occurred for any serial (one-at-a-time) execution of those transactions, one of them will be rolled back with a serialization_failure error.

The important bit being **before the first query or data-modification statement was executed in this transaction**, prior to this change such a query was not being executed.   This change adds a read before returning the event processing thread to ensure the snapshot see's an effetively 'frozen' state at the given block height.

