### PR TITLE
fix: announce_node/rotate_eth_key/protocol_upgrade_proposal now retur…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Fixes
 - [6661](https://github.com/vegaprotocol/vega/issues/6661) - Scale price to asset decimal in estimate orders
+- [6685](https://github.com/vegaprotocol/vega/issues/6685) - `vega announce_node` now returns a `txHash` when successful or errors from `CheckTx`
 - [6687](https://github.com/vegaprotocol/vega/issues/6687) - Expose `admin.update_passphrase` in admin wallet API
 - [6686](https://github.com/vegaprotocol/vega/issues/6686) - Expose `admin.rename_wallet` in admin wallet API
 - [6496](https://github.com/vegaprotocol/vega/issues/6496) - Fix margin calculation for pegged and liquidity orders

--- a/core/evtforward/forwarder.go
+++ b/core/evtforward/forwarder.go
@@ -49,8 +49,8 @@ type TimeService interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/core/evtforward Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff)
-	CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff)
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff)
+	CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff)
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/validator_topology_mock.go -package mocks code.vegaprotocol.io/vega/core/evtforward ValidatorTopology
@@ -286,7 +286,7 @@ func (f *Forwarder) send(ctx context.Context, evt *commandspb.ChainEvent) {
 	}
 
 	// error doesn't matter here
-	f.cmd.Command(ctx, txn.ChainEventCommand, evt, func(err error) {
+	f.cmd.Command(ctx, txn.ChainEventCommand, evt, func(_ string, err error) {
 		if err != nil {
 			f.log.Error("could not send command", logging.String("tx-id", evt.TxId), logging.Error(err))
 		}

--- a/core/evtforward/mocks/commander_mock.go
+++ b/core/evtforward/mocks/commander_mock.go
@@ -38,7 +38,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method.
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3, arg4)
 }
@@ -50,7 +50,7 @@ func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2, arg3, arg4 interf
 }
 
 // CommandSync mocks base method.
-func (m *MockCommander) CommandSync(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) CommandSync(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CommandSync", arg0, arg1, arg2, arg3, arg4)
 }

--- a/core/integration/stubs/commander_stub.go
+++ b/core/integration/stubs/commander_stub.go
@@ -26,8 +26,8 @@ func NewCommanderStub() *CommanderStub {
 	return &CommanderStub{}
 }
 
-func (*CommanderStub) Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff) {
+func (*CommanderStub) Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff) {
 }
 
-func (*CommanderStub) CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff) {
+func (*CommanderStub) CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff) {
 }

--- a/core/nodewallets/commander_test.go
+++ b/core/nodewallets/commander_test.go
@@ -91,7 +91,7 @@ func testSignedCommandSuccess(t *testing.T) {
 	commander.chain.EXPECT().SubmitTransactionSync(gomock.Any(), gomock.Any()).Times(1).Return(&tmctypes.ResultBroadcastTx{}, nil)
 
 	ok := make(chan error)
-	commander.Command(context.Background(), cmd, payload, func(err error) {
+	commander.Command(context.Background(), cmd, payload, func(_ string, err error) {
 		ok <- err
 	}, nil)
 	assert.NoError(t, <-ok)
@@ -110,7 +110,7 @@ func testSignedCommandFailure(t *testing.T) {
 	commander.chain.EXPECT().SubmitTransactionSync(gomock.Any(), gomock.Any()).Times(1).Return(&tmctypes.ResultBroadcastTx{}, assert.AnError)
 
 	ok := make(chan error)
-	commander.Command(context.Background(), cmd, payload, func(err error) {
+	commander.Command(context.Background(), cmd, payload, func(_ string, err error) {
 		ok <- err
 	}, nil)
 	assert.Error(t, <-ok)

--- a/core/notary/mocks/commander_mock.go
+++ b/core/notary/mocks/commander_mock.go
@@ -38,7 +38,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method.
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3, arg4)
 }
@@ -50,7 +50,7 @@ func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2, arg3, arg4 interf
 }
 
 // CommandSync mocks base method.
-func (m *MockCommander) CommandSync(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) CommandSync(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CommandSync", arg0, arg1, arg2, arg3, arg4)
 }

--- a/core/notary/notary.go
+++ b/core/notary/notary.go
@@ -60,8 +60,8 @@ type Broker interface {
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/core/notary Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff)
-	CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff)
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff)
+	CommandSync(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff)
 }
 
 // Notary will aggregate all signatures of a node for
@@ -245,7 +245,7 @@ func (n *Notary) send(id string, kind commandspb.NodeSignatureKind, signature []
 	nsig := &commandspb.NodeSignature{Id: id, Sig: signature, Kind: kind}
 	// we send a background context here because the actual context is ignore by the commander
 	// which use a timeout of 5 seconds, this API may need to be addressed another day
-	n.cmd.Command(context.Background(), txn.NodeSignatureCommand, nsig, func(err error) {
+	n.cmd.Command(context.Background(), txn.NodeSignatureCommand, nsig, func(_ string, err error) {
 		// just a log is enough here, the transaction will be retried
 		// later
 		n.log.Error("could not send the transaction to tendermint", logging.Error(err))

--- a/core/statevar/engine.go
+++ b/core/statevar/engine.go
@@ -41,7 +41,7 @@ var (
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/commander_mock.go -package mocks code.vegaprotocol.io/vega/core/statevar Commander
 type Commander interface {
-	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(error), bo *backoff.ExponentialBackOff)
+	Command(ctx context.Context, cmd txn.Command, payload proto.Message, f func(string, error), bo *backoff.ExponentialBackOff)
 }
 
 // Broker send events.

--- a/core/statevar/mocks/commander_mock.go
+++ b/core/statevar/mocks/commander_mock.go
@@ -38,7 +38,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method.
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3, arg4)
 }

--- a/core/statevar/state_variable.go
+++ b/core/statevar/state_variable.go
@@ -239,7 +239,7 @@ func (sv *StateVariable) CalculationFinished(eventID string, result statevar.Sta
 
 	// need to release the lock before we send the transaction command
 	sv.lock.Unlock()
-	sv.cmd.Command(context.Background(), txn.StateVariableProposalCommand, svp, func(err error) { sv.logAndRetry(err, svp) }, nil)
+	sv.cmd.Command(context.Background(), txn.StateVariableProposalCommand, svp, func(_ string, err error) { sv.logAndRetry(err, svp) }, nil)
 	if sv.log.GetLevel() <= logging.DebugLevel {
 		sv.log.Debug("result calculated and sent to vega", logging.String("validator", sv.top.SelfNodeID()), logging.String("state-var", sv.ID), logging.String("event-id", eventID))
 	}
@@ -257,7 +257,7 @@ func (sv *StateVariable) logAndRetry(err error, svp *commandspb.StateVariablePro
 		if sv.log.IsDebug() {
 			sv.log.Debug("retrying to send state variable proposal command", logging.String("id", sv.ID), logging.String("event-id", sv.eventID))
 		}
-		sv.cmd.Command(context.Background(), txn.StateVariableProposalCommand, svp, func(err error) { sv.logAndRetry(err, svp) }, nil)
+		sv.cmd.Command(context.Background(), txn.StateVariableProposalCommand, svp, func(_ string, err error) { sv.logAndRetry(err, svp) }, nil)
 		return
 	}
 	sv.lock.Unlock()

--- a/core/validators/heartbeat.go
+++ b/core/validators/heartbeat.go
@@ -212,7 +212,7 @@ func (t *Topology) sendHeartbeat(ctx context.Context, hb *commandspb.ValidatorHe
 	bo.InitialInterval = 1 * time.Second
 
 	t.log.Debug("sending heartbeat", logging.String("nodeID", hb.NodeId))
-	t.cmd.CommandSync(ctx, txn.ValidatorHeartbeatCommand, hb, func(err error) {
+	t.cmd.CommandSync(ctx, txn.ValidatorHeartbeatCommand, hb, func(_ string, err error) {
 		if err != nil {
 			t.log.Error("couldn't send validator heartbeat", logging.Error(err))
 			return

--- a/core/validators/mocks/mocks.go
+++ b/core/validators/mocks/mocks.go
@@ -160,7 +160,7 @@ func (m *MockCommander) EXPECT() *MockCommanderMockRecorder {
 }
 
 // Command mocks base method.
-func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) Command(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Command", arg0, arg1, arg2, arg3, arg4)
 }
@@ -172,7 +172,7 @@ func (mr *MockCommanderMockRecorder) Command(arg0, arg1, arg2, arg3, arg4 interf
 }
 
 // CommandSync mocks base method.
-func (m *MockCommander) CommandSync(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(error), arg4 *backoff.ExponentialBackOff) {
+func (m *MockCommander) CommandSync(arg0 context.Context, arg1 txn.Command, arg2 protoiface.MessageV1, arg3 func(string, error), arg4 *backoff.ExponentialBackOff) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CommandSync", arg0, arg1, arg2, arg3, arg4)
 }


### PR DESCRIPTION
closes #6685 

The following CLI commands now return a txHash when sucessful:
- `vega announce_node`
- `vega rotate_eth_key`
- `vega protocol_upgrade_proposal`

Essentially the callback from the commander has changed from `func(error) -> func(string, error)` so it can return the txHash when successful, which we can then pass out from the CLI.

The commander now also checks the `resp.Code` in the returned `ResultBroadcastTx` for non-zero, which means transactions that make it to the network successfully, but fail `CheckTx` are now picked up as failures instead of silently being ignored (for example, failing spam requirements when announcing a node).

System test tweaks have been made [on this branch to](https://github.com/vegaprotocol/system-tests/compare/announce-cli?expand=1) test these changes and are passing:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/22100/pipeline/411


