### PR TITLE
dehistory command errors need to unwrap the grpc error

### DIFF
--- a/cmd/data-node/commands/dehistory/dump-segment.go
+++ b/cmd/data-node/commands/dehistory/dump-segment.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"google.golang.org/grpc/status"
+
 	"code.vegaprotocol.io/vega/datanode/config"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/paths"
@@ -69,10 +71,19 @@ func (cmd *dumpSegment) Execute(args []string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to copy segment to target file:%w", err)
+		return errorFromGrpcError("failed to copy segment to target file", err)
 	}
 
 	fmt.Printf("segment %s dumped to target file %s\n", segmentID, targetFilePath)
 
 	return nil
+}
+
+func errorFromGrpcError(msg string, err error) error {
+	s, ok := status.FromError(err)
+	if !ok {
+		return fmt.Errorf("%s:%s", msg, err)
+	}
+
+	return fmt.Errorf("%s:%s", msg, s.Details())
 }

--- a/cmd/data-node/commands/dehistory/fetch.go
+++ b/cmd/data-node/commands/dehistory/fetch.go
@@ -77,7 +77,8 @@ func (cmd *fetchCmd) Execute(args []string) error {
 				HistorySegmentId: historySegmentId,
 			})
 			if err != nil {
-				return initialise.FetchResult{}, fmt.Errorf("failed to fetch decentralized history segments:%w", err)
+				return initialise.FetchResult{},
+					errorFromGrpcError("failed to fetch decentralized history segments", err)
 			}
 
 			return initialise.FetchResult{

--- a/cmd/data-node/commands/dehistory/latest_history_segment.go
+++ b/cmd/data-node/commands/dehistory/latest_history_segment.go
@@ -51,7 +51,7 @@ func (cmd *latestHistorySegment) Execute(_ []string) error {
 
 	resp, err := client.GetActiveDeHistoryPeerAddresses(context.Background(), &v2.GetActiveDeHistoryPeerAddressesRequest{})
 	if err != nil {
-		return fmt.Errorf("failed to active peer addresses:%w", err)
+		return errorFromGrpcError("failed to get active peer addresses", err)
 	}
 	peerAddresses := resp.IpAddresses
 

--- a/cmd/data-node/commands/dehistory/list_active_peers.go
+++ b/cmd/data-node/commands/dehistory/list_active_peers.go
@@ -50,7 +50,7 @@ func (cmd *listActivePeers) Execute(_ []string) error {
 
 	resp, err := client.GetActiveDeHistoryPeerAddresses(context.Background(), &v2.GetActiveDeHistoryPeerAddressesRequest{})
 	if err != nil {
-		return fmt.Errorf("failed to active peer addresses:%w", err)
+		return errorFromGrpcError("failed to active peer addresses", err)
 	}
 	peerAddresses := resp.IpAddresses
 


### PR DESCRIPTION
closes #6729   The error from the client used in dehistory commands needs to be unwrapped otherwise the error logged is totally useless.