### PR TITLE
feat: dehistory allow initialise to segment to be explicitly specified

### DIFF
--- a/datanode/dehistory/initialise/config.go
+++ b/datanode/dehistory/initialise/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Config struct {
+	ToSegment         string            `long:"to-segment" description:"the segment to initialise up to, if omitted the datanode will attempt to fetch the latest segment from the network"`
 	MinimumBlockCount int64             `long:"block-count" description:"the minimum number of blocks to fetch"`
 	TimeOut           encoding.Duration `long:"timeout" description:"maximum time allowed to auto-initialise the node"`
 	GrpcAPIPorts      []int             `long:"grpc-api-ports" description:"list of additional ports to check to for api connection when getting latest segment"`
@@ -17,5 +18,6 @@ func NewDefaultConfig() Config {
 		MinimumBlockCount: 1,
 		TimeOut:           encoding.Duration{Duration: 1 * time.Minute},
 		GrpcAPIPorts:      []int{},
+		ToSegment:         "",
 	}
 }


### PR DESCRIPTION
closes #6737 

Segment to initialise from can now be explicitly specified at startup, e.g:

data-node node --dehistory.initialise.to-segment=QmXe48TYzE2kSRGu9bxZG5dYNe76vQ7TbYMqDwj4AETYw2