### PR TITLE
fix: set the snapshot creation timeout log default greater than reasonable snapshot creation time

### DIFF
--- a/datanode/dehistory/snapshot/config.go
+++ b/datanode/dehistory/snapshot/config.go
@@ -7,15 +7,13 @@ import (
 )
 
 type Config struct {
-	PanicOnSnapshotCreationError encoding.Bool     `long:"panic-on-snapshot-creation-error" description:""`
-	WaitForCreationLockTimeout   encoding.Duration `long:"wait-for-creation-lock-timeout" description:"the maximum a caller to create snapshot should have to wait to acquire the creation lock"`
+	WaitForCreationLockTimeout encoding.Duration `long:"wait-for-creation-lock-timeout" description:"the maximum a caller to create snapshot should have to wait to acquire the creation lock"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
 // pointer to a logger instance to be used for logging within the package.
 func NewDefaultConfig() Config {
 	return Config{
-		WaitForCreationLockTimeout:   encoding.Duration{Duration: 5 * time.Second},
-		PanicOnSnapshotCreationError: true,
+		WaitForCreationLockTimeout: encoding.Duration{Duration: 5 * time.Minute},
 	}
 }


### PR DESCRIPTION
closes #6751 

also should always panic on snapshot creation failure as subsequent snapshots will be incorrect as they will be unable to link to the previous snapshot.