### PR TITLE
fix: transfer one event serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [6759](https://github.com/vegaprotocol/vega/issues/6759) - Send events when liquidity provisions are `undeployed`
 - [6764](https://github.com/vegaprotocol/vega/issues/6764) - If a trading terminated oracle changes after trading already terminated do not subscribe to it
 - [6775](https://github.com/vegaprotocol/vega/issues/6775) - Fix oracle spec identifiers
+- [6762](https://github.com/vegaprotocol/vega/issues/6762) - Fix one off transfer events serialization
 
 ## 0.62.0
 

--- a/commands/transfer_funds.go
+++ b/commands/transfer_funds.go
@@ -17,7 +17,7 @@ func CheckTransfer(cmd *commandspb.Transfer) error {
 	return checkTransfer(cmd).ErrorOrNil()
 }
 
-func checkTransfer(cmd *commandspb.Transfer) Errors {
+func checkTransfer(cmd *commandspb.Transfer) (e Errors) {
 	errs := NewErrors()
 
 	if cmd == nil {
@@ -108,10 +108,10 @@ func checkTransfer(cmd *commandspb.Transfer) Errors {
 			// dispatch strategy only makes sense for reward pools
 			if k.Recurring.DispatchStrategy != nil {
 				// check account type is one of the relevant reward accounts
-				if !(cmd.ToAccountType == vega.AccountType_ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES ||
-					cmd.ToAccountType == vega.AccountType_ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES ||
-					cmd.ToAccountType == vega.AccountType_ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES ||
-					cmd.ToAccountType == vega.AccountType_ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS) {
+				if cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES &&
+					cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES &&
+					cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES &&
+					cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS {
 					errs.AddForProperty("transfer.kind.dispatch_strategy", ErrIsNotValid)
 				}
 				// check asset for metric is passed unless it's a market proposer reward

--- a/core/types/banking.go
+++ b/core/types/banking.go
@@ -168,6 +168,7 @@ func (o *OneOffTransfer) IntoEvent(reason *string) *eventspb.Transfer {
 		Reason:          reason,
 	}
 
+	out.Kind = &eventspb.Transfer_OneOff{}
 	if o.DeliverOn != nil {
 		out.Kind = &eventspb.Transfer_OneOff{
 			OneOff: &eventspb.OneOffTransfer{

--- a/datanode/entities/transfer.go
+++ b/datanode/entities/transfer.go
@@ -167,8 +167,10 @@ func TransferFromProto(ctx context.Context, t *eventspb.Transfer, txHash TxHash,
 	switch v := t.Kind.(type) {
 	case *eventspb.Transfer_OneOff:
 		transfer.TransferType = OneOff
-		deliverOn := time.Unix(v.OneOff.DeliverOn, 0)
-		transfer.DeliverOn = &deliverOn
+		if v.OneOff != nil {
+			deliverOn := time.Unix(v.OneOff.DeliverOn, 0)
+			transfer.DeliverOn = &deliverOn
+		}
 	case *eventspb.Transfer_Recurring:
 		transfer.TransferType = Recurring
 		transfer.StartEpoch = &v.Recurring.StartEpoch


### PR DESCRIPTION
This ensure the one off transfer are constructed properly (the datanode would always think hthe transfer is of Unknown type overwise)

close #6762  