### PR TITLE
fix: add inputData validation in nullblockchain

### DIFF
--- a/commands/transaction.go
+++ b/commands/transaction.go
@@ -87,7 +87,7 @@ func CheckTransaction(tx *commandspb.Transaction, chainID string) (*commandspb.I
 		return nil, errs.ErrorOrNil()
 	}
 
-	inputData, inputErrs := checkInputData(tx.InputData)
+	inputData, inputErrs := CheckInputData(tx.InputData)
 	if !inputErrs.Empty() {
 		errs.Merge(inputErrs)
 		return nil, errs.ErrorOrNil()
@@ -155,7 +155,7 @@ func checkSignature(signature *commandspb.Signature, pubKey string, rawInputData
 	return nil
 }
 
-func checkInputData(rawInputData []byte) (*commandspb.InputData, Errors) {
+func CheckInputData(rawInputData []byte) (*commandspb.InputData, Errors) {
 	errs := NewErrors()
 
 	if len(rawInputData) == 0 {

--- a/core/processor/tx.go
+++ b/core/processor/tx.go
@@ -38,9 +38,9 @@ func DecodeTxNoValidation(payload []byte) (*Tx, error) {
 		return nil, fmt.Errorf("unable to unmarshal transaction: %w", err)
 	}
 
-	inputData := &commandspb.InputData{}
-	if err := proto.Unmarshal(tx.InputData, inputData); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal input data: %w", err)
+	inputData, err := commands.CheckInputData(tx.InputData)
+	if err := err.ErrorOrNil(); err != nil {
+		return nil, err
 	}
 
 	return &Tx{


### PR DESCRIPTION
Until now the nullblockchain didn't run verification of transaction in order to increase processing speed. However while this is useful for signature verification and POW, that could lead to introduce quite some issue in the transaction themselves which would not run validation of the input data anymore.

That's what happened here, the LiquidityProvisionAmendment would subnit negative offset, which would be catch through the validation, but didn't without, which means as well that the proto type get unmarshalled in a Uint which underflow straight away and create massive offsets.

close #6797  