### PR TITLE
fix: better handling of panics in nullblock chain when replay/recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🛠 Improvements
 - [6795](https://github.com/vegaprotocol/vega/issues/6795 - max gas implementation
 - [6641](https://github.com/vegaprotocol/vega/issues/6641) - network wide limits
+- [6792](https://github.com/vegaprotocol/vega/issues/6792) - Better handling of panics when moving time with `nullchain`, add endpoint to query whether `nullchain` is replaying
 
 ### 🐛 Fixes
 - [6801](https://github.com/vegaprotocol/vega/issues/6801) - Fix internal data source validations


### PR DESCRIPTION
closes #6792 

The adds the following fixes and improvements:
- file replay is now stopped gracefully prevent scary panics if you `ctrl+c` during replay
- an endpoint has been added which return whether the nullchain is replaying or not, so that the vega-sim can tell whats going on
- if a panic happens during time-forwarding the node now stops instead of getting caught in the http-handler's recover and continuing like nothing happened
- I've been less clever with how/when we save a block to a file so that we now will *always* record *all* the transactions in a block that panics.

I've given all these changes a whirl under a basic vega-sim scenario forcing panics here and there, and it all looks good now.