### PR TITLE
fix: use all bytes of ipfs identity seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [6801](https://github.com/vegaprotocol/vega/issues/6801) - Fix internal data source validations
 - [6766](https://github.com/vegaprotocol/vega/issues/6766) - Handle relative vega home path being passed in `postgres` snapshots
 - [6799](https://github.com/vegaprotocol/vega/issues/6799) - Move LP fees in transit to the network treasury
+- [6781](https://github.com/vegaprotocol/vega/issues/6781) - Fix bug where only first 32 characters of the `IPFS` identity seed were used.
 - [6824](https://github.com/vegaprotocol/vega/issues/6824) - Respect `VEGA_HOME` for embedded `postgres` log location
 - [6843](https://github.com/vegaprotocol/vega/issues/6843) - Fix Visor runner keys
 - [6826](https://github.com/vegaprotocol/vega/issues/6826) - Update `spam.pow.numberOfPastBlocks` range values

--- a/datanode/dehistory/store/store.go
+++ b/datanode/dehistory/store/store.go
@@ -3,7 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
-	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -955,17 +955,10 @@ func createIdentityFromSeed(seed []byte) (config.Identity, error) {
 	var sk crypto.PrivKey
 	var pk crypto.PubKey
 
-	for len(seed) < ed25519.SeedSize {
-		seed = append(seed, seed...)
-	}
+	// Everything > 32 bytes is ignored in GenerateEd25519Key so do a little pre hashing
+	seedHash := sha256.Sum256(seed)
 
-	if len(seed) < ed25519.SeedSize {
-		return config.Identity{},
-			fmt.Errorf("failed to create identity seed from node address, seed length %d is less than minimum seed size %d",
-				len(seed), ed25519.SeedSize)
-	}
-
-	priv, pub, err := crypto.GenerateEd25519Key(bytes.NewReader(seed))
+	priv, pub, err := crypto.GenerateEd25519Key(bytes.NewReader(seedHash[:]))
 	if err != nil {
 		return ident, err
 	}


### PR DESCRIPTION
This was causing nodes in the system test to have the same IPFS Identity + KeyPair

Hopefully closes #6781 