### PR TITLE
fix: omit undecodable transactions in block explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [6832](https://github.com/vegaprotocol/vega/issues/6832) - Add signature to transaction information returned by block explorer API
 - [6642](https://github.com/vegaprotocol/vega/issues/6642) - Add methods to manage the wallet service and its connections on wallet API version 2
 - [6853](https://github.com/vegaprotocol/vega/issues/6853) - Max gas and priority improvements
+- [6880](https://github.com/vegaprotocol/vega/issues/6880) - Omit transactions we can't decode in block explorer transaction list
 - [6640](https://github.com/vegaprotocol/vega/issues/6640) - Mark to market to happen every N seconds.
 
 ### 🐛 Fixes

--- a/blockexplorer/store/transactions.go
+++ b/blockexplorer/store/transactions.go
@@ -106,7 +106,8 @@ func (s *Store) ListTransactions(ctx context.Context,
 	for _, row := range rows {
 		tx, err := row.ToProto()
 		if err != nil {
-			return nil, err
+			s.log.Warn(fmt.Sprintf("unable to decode transaction %s: %v", row.TxHash, err))
+			continue
 		}
 		txs = append(txs, tx)
 	}


### PR DESCRIPTION
Closes #6880 
