### PR TITLE
6898 reject too new snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🛠 Improvements
+- [6898](https://github.com/vegaprotocol/vega/issues/6795) - allow `-snapshot.load-from-block-height=` to apply to `statesync` snapshots
 - [6795](https://github.com/vegaprotocol/vega/issues/6795) - max gas implementation
 - [6641](https://github.com/vegaprotocol/vega/issues/6641) - network wide limits
 - [6731](https://github.com/vegaprotocol/vega/issues/6731) - standardize on 'network' and '' for network party and no market identifiers

--- a/core/snapshot/config.go
+++ b/core/snapshot/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	RetryLimit  int               `long:"max-retries" description:"Maximum number of times to try and apply snapshot chunk"`
 	Storage     string            `long:"storage" choice:"GOLevelDB" choice:"memory" description:"Storage type to use"`
 	DBPath      string            `long:"db-path" description:"Path to database"`
-	StartHeight int64             `long:"load-from-block-height" description:"Load from a local snapshot taken at the given block-height. Setting to -1 will load from the latest snapshot if it exists, 0 will force the chain to replay (default: -1)"`
+	StartHeight int64             `long:"load-from-block-height" description:"Load from a snapshot at the given block-height. Setting to -1 will load from the latest snapshot available, 0 will force the chain to replay if not using statesync"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a

--- a/core/snapshot/engine.go
+++ b/core/snapshot/engine.go
@@ -439,6 +439,10 @@ func (e *Engine) applySnapshotFromLocalStore(ctx context.Context) error {
 }
 
 func (e *Engine) ReceiveSnapshot(snap *types.Snapshot) error {
+	if e.Config.StartHeight > 0 && snap.Height != uint64(e.Config.StartHeight) {
+		return fmt.Errorf("received snapshot height does not equal config height: %d != %d", snap.Height, e.Config.StartHeight)
+	}
+
 	if e.snapshot != nil {
 		// in case other peers provide snapshots, check if their hashes match what we want
 		if !bytes.Equal(e.snapshot.Hash, snap.Hash) {
@@ -446,7 +450,6 @@ func (e *Engine) ReceiveSnapshot(snap *types.Snapshot) error {
 		}
 		return e.snapshot.ValidateMeta(snap)
 	}
-	// @TODO here's where we check the hash or height we want
 	e.snapshot = snap
 	return nil
 }


### PR DESCRIPTION
closes #6898 

The option `snapshot.load-from-height=` now applies to snapshots discovered by state-sync, allowing a node operator to sync core with the block-height of a datanode that they have restored via IPFS.

Testing against devnet with `--snapshot.load-from-block-height=61200` we reject the offered snapshots at the higher height, and accept the one that matches the block we specified:
```
2022-11-22T14:31:37.415Z	INFO	tendermint	statesync/syncer.go:323	Offering snapshot to ABCI app	{"height": 61800, "format": 0, "hash": "zlLYfQJd5OqjLYgtVHe+J8M76ynGqZjjBXZMn8wWB+4="}
2022-11-22T14:31:37.415Z	ERROR	processor	processor/abci.go:605	snapshot rejected	{"error": "received snapshot height does not equal config height: 61800 != 61200"}
2022-11-22T14:31:37.415Z	INFO	tendermint	statesync/syncer.go:206	Snapshot rejected	{"height": 61800, "format": 0, "hash": "zlLYfQJd5OqjLYgtVHe+J8M76ynGqZjjBXZMn8wWB+4="}
2022-11-22T14:31:37.503Z	INFO	tendermint	light/client.go:559	VerifyHeader	{"height": 61501, "hash": "F8893477DB34E69C65793654EC33D3CC82C4977D13957245195B4E187C883DFD"}
2022-11-22T14:31:37.677Z	INFO	tendermint	light/client.go:559	VerifyHeader	{"height": 61502, "hash": "0FCCE1B166AB4B3A2D8E6E71146AFA38CFE572A43A7E68314E5EEF165AE6B058"}
2022-11-22T14:31:37.764Z	INFO	tendermint	statesync/syncer.go:323	Offering snapshot to ABCI app	{"height": 61500, "format": 0, "hash": "uoDi51v0NY5XgMzNiHpU3MB3sTy65BlZAtbUZCFEfrQ="}
2022-11-22T14:31:37.765Z	ERROR	processor	processor/abci.go:605	snapshot rejected	{"error": "received snapshot height does not equal config height: 61500 != 61200"}
2022-11-22T14:31:37.765Z	INFO	tendermint	statesync/syncer.go:206	Snapshot rejected	{"height": 61500, "format": 0, "hash": "uoDi51v0NY5XgMzNiHpU3MB3sTy65BlZAtbUZCFEfrQ="}
2022-11-22T14:31:37.853Z	INFO	tendermint	light/client.go:559	VerifyHeader	{"height": 61201, "hash": "91325BED93B66EA0755EBCBC05D96A5A2B71CE5B6D5C6B4D90A0A5FB1BE7754C"}
2022-11-22T14:31:38.030Z	INFO	tendermint	light/client.go:559	VerifyHeader	{"height": 61202, "hash": "F88A2A3B7D7E7CC76EA6F68A9823BFC0B7FE39AC7451177BBDF6C8592EA8DD16"}
2022-11-22T14:31:38.116Z	INFO	tendermint	statesync/syncer.go:323	Offering snapshot to ABCI app	{"height": 61200, "format": 0, "hash": "2oE1qbU4kyh9/YGgDoa4ORNKgo4uuEj5DvksGjf7CbE="}
2022-11-22T14:31:38.117Z	INFO	tendermint	statesync/syncer.go:340	Snapshot accepted, restoring	{"height": 61200, "format": 0, "hash": "2oE1qbU4kyh9/YGgDoa4ORNKgo4uuEj5DvksGjf7CbE="}
```