### PR TITLE
feat: simplify config and make it so only publishing nodes create segments

### DIFF
--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -237,7 +237,7 @@ func (l *NodeCommand) preRun([]string) (err error) {
 	var protocolUpgradeHandler broker.ProtocolUpgradeHandler
 
 	if l.conf.DeHistory.Enabled {
-		blockCommitHandler := snapshot.NewBlockCommitHandler(l.Log, l.snapshotService.SnapshotData, l.networkParameterService.GetByKey,
+		blockCommitHandler := dehistory.NewBlockCommitHandler(l.Log, l.conf.DeHistory, l.snapshotService.SnapshotData, l.networkParameterService.GetByKey,
 			bool(l.conf.Broker.UseEventFile), l.conf.Broker.FileEventSourceConfig.TimeBetweenBlocks.Duration)
 		onBlockCommittedHandler = blockCommitHandler.OnBlockCommitted
 		protocolUpgradeHandler = dehistory.NewProtocolUpgradeHandler(l.Log, l.protocolUpgradeService,

--- a/datanode/config/config.go
+++ b/datanode/config/config.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"os"
 
+	"code.vegaprotocol.io/vega/datanode/dehistory"
+
 	"code.vegaprotocol.io/vega/datanode/api"
 	"code.vegaprotocol.io/vega/datanode/broker"
 	"code.vegaprotocol.io/vega/datanode/candlesv2"
 	"code.vegaprotocol.io/vega/datanode/config/encoding"
-	"code.vegaprotocol.io/vega/datanode/dehistory"
 	"code.vegaprotocol.io/vega/datanode/gateway"
 	"code.vegaprotocol.io/vega/datanode/metrics"
 	"code.vegaprotocol.io/vega/datanode/service"

--- a/datanode/dehistory/block_commit_handler.go
+++ b/datanode/dehistory/block_commit_handler.go
@@ -1,4 +1,4 @@
-package snapshot
+package dehistory
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 type BlockCommitHandler struct {
 	log                       *logging.Logger
+	cfg                       Config
 	snapshotData              func(ctx context.Context, chainID string, toHeight int64) error
 	getNetworkParameter       func(ctx context.Context, key string) (entities.NetworkParameter, error)
 	blockInterval             int64
@@ -22,12 +23,14 @@ type BlockCommitHandler struct {
 
 func NewBlockCommitHandler(
 	log *logging.Logger,
+	cfg Config,
 	snapshotData func(ctx context.Context, chainID string, toHeight int64) error,
 	getNetworkParameter func(ctx context.Context, key string) (entities.NetworkParameter, error),
 	usingEventFile bool, eventFileTimeBetweenBlock time.Duration,
 ) *BlockCommitHandler {
 	return &BlockCommitHandler{
 		log:                       log.Named("block-commit-handler"),
+		cfg:                       cfg,
 		snapshotData:              snapshotData,
 		getNetworkParameter:       getNetworkParameter,
 		usingEventFile:            usingEventFile,
@@ -71,7 +74,7 @@ func (b *BlockCommitHandler) OnBlockCommitted(ctx context.Context, chainID strin
 }
 
 func (b *BlockCommitHandler) snapshotRequiredAtBlockHeight(lastCommittedBlockHeight int64) bool {
-	if b.blockInterval > 0 {
+	if b.cfg.Publish && b.blockInterval > 0 {
 		return lastCommittedBlockHeight > 0 && lastCommittedBlockHeight%b.blockInterval == 0
 	}
 

--- a/datanode/dehistory/config.go
+++ b/datanode/dehistory/config.go
@@ -1,8 +1,6 @@
 package dehistory
 
 import (
-	"time"
-
 	"code.vegaprotocol.io/vega/datanode/config/encoding"
 	"code.vegaprotocol.io/vega/datanode/dehistory/initialise"
 	"code.vegaprotocol.io/vega/datanode/dehistory/snapshot"
@@ -15,8 +13,7 @@ type Config struct {
 	Enabled       encoding.Bool     `long:"enabled" description:"set to false to disable decentralized history"`
 	WipeOnStartup encoding.Bool     `long:"wipe-on-startup" description:"remove all deHistory state on startup"`
 
-	AddSnapshotsToStore  encoding.Bool     `long:"add-snapshots-to-store" description:"if true snapshot data produced by this node will be added to the decentralise history store"`
-	AddSnapshotsInterval encoding.Duration `long:"add-snapshots-interval" description:"interval between checking for and adding snapshot data to the decentralised store"`
+	Publish encoding.Bool `long:"publish" description:"if true this node will create and publish decentralized history segments"`
 
 	Store    store.Config    `group:"Store" namespace:"store"`
 	Snapshot snapshot.Config `group:"Snapshot" namespace:"snapshot"`
@@ -28,13 +25,12 @@ type Config struct {
 // pointer to a logger instance to be used for logging within the package.
 func NewDefaultConfig() Config {
 	return Config{
-		Level:                encoding.LogLevel{Level: logging.InfoLevel},
-		Enabled:              true,
-		WipeOnStartup:        true,
-		AddSnapshotsToStore:  true,
-		AddSnapshotsInterval: encoding.Duration{Duration: 5 * time.Second},
-		Store:                store.NewDefaultConfig(),
-		Snapshot:             snapshot.NewDefaultConfig(),
-		Initialise:           initialise.NewDefaultConfig(),
+		Level:         encoding.LogLevel{Level: logging.InfoLevel},
+		Enabled:       true,
+		WipeOnStartup: true,
+		Publish:       true,
+		Store:         store.NewDefaultConfig(),
+		Snapshot:      snapshot.NewDefaultConfig(),
+		Initialise:    initialise.NewDefaultConfig(),
 	}
 }

--- a/datanode/dehistory/service.go
+++ b/datanode/dehistory/service.go
@@ -83,10 +83,10 @@ func NewWithStore(ctx context.Context, log *logging.Logger, chainID string, cfg 
 		}
 	}
 
-	if cfg.AddSnapshotsToStore {
+	if cfg.Publish {
 		var err error
 		go func() {
-			ticker := time.NewTicker(cfg.AddSnapshotsInterval.Duration)
+			ticker := time.NewTicker(5 * time.Second)
 			for {
 				select {
 				case <-ctx.Done():

--- a/datanode/dehistory/service_test.go
+++ b/datanode/dehistory/service_test.go
@@ -311,7 +311,6 @@ func TestMain(t *testing.M) {
 
 		datanodeConfig := config2.NewDefaultConfig()
 		cfg := dehistory.NewDefaultConfig()
-		cfg.AddSnapshotsInterval = encoding.Duration{Duration: 1 * time.Second}
 		cfg.WipeOnStartup = false
 		deHistoryService, err = dehistory.NewWithStore(outerCtx, log, chainID, cfg, sqlConfig.ConnectionConfig, snapshotService,
 			deHistoryStore, datanodeConfig.API.Port, snapshotCopyFromPath, snapshotCopyToPath)
@@ -753,7 +752,7 @@ func setupDeHistoryService(ctx context.Context, log *logging.Logger, inputSnapsh
 	snapshotCopyFromPath, snapshotCopyToPath string,
 ) *dehistory.Service {
 	cfg := dehistory.NewDefaultConfig()
-	cfg.AddSnapshotsToStore = false
+	cfg.Publish = false
 
 	datanodeConfig := config2.NewDefaultConfig()
 	deHistoryService, err := dehistory.NewWithStore(ctx, log, chainID, cfg, sqlConfig.ConnectionConfig,


### PR DESCRIPTION
closes #6911 

To allow accurate assessment of impact of decentralized history creation on node performance the 'AddToStore' flag should be changed to 'Publish' and should control not just whether segments get added to IPFS but also whether they get created at all. Also this change goes some towards supporting a 'lite' form of the datanode that will not publish decentralized history segments (to be done in a seperate PR).