### PR TITLE
Remove redundant TickSize() method

### DIFF
--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -357,7 +357,7 @@ func NewMarket(
 
 	now := timeService.GetTimeNow()
 	liqEngine := liquidity.NewSnapshotEngine(
-		liquidityConfig, log, timeService, broker, tradableInstrument.RiskModel, pMonitor, book, asset, mkt.ID, stateVarEngine, mkt.TickSize(), priceFactor.Clone(), positionFactor)
+		liquidityConfig, log, timeService, broker, tradableInstrument.RiskModel, pMonitor, book, asset, mkt.ID, stateVarEngine, priceFactor.Clone(), positionFactor)
 
 	// The market is initially created in a proposed state
 	mkt.State = types.MarketStateProposed

--- a/core/execution/market_snapshot.go
+++ b/core/execution/market_snapshot.go
@@ -117,7 +117,7 @@ func NewMarketFromSnapshot(
 	priceFactor := num.UintZero().Exp(num.NewUint(10), num.NewUint(exp))
 	lMonitor := lmon.NewMonitor(tsCalc, mkt.LiquidityMonitoringParameters)
 
-	liqEngine := liquidity.NewSnapshotEngine(liquidityConfig, log, timeService, broker, tradableInstrument.RiskModel, pMonitor, book, asset, mkt.ID, stateVarEngine, mkt.TickSize(), priceFactor.Clone(), positionFactor)
+	liqEngine := liquidity.NewSnapshotEngine(liquidityConfig, log, timeService, broker, tradableInstrument.RiskModel, pMonitor, book, asset, mkt.ID, stateVarEngine, priceFactor.Clone(), positionFactor)
 
 	now := timeService.GetTimeNow()
 	market := &Market{

--- a/core/liquidity/engine.go
+++ b/core/liquidity/engine.go
@@ -123,7 +123,6 @@ func NewEngine(config Config,
 	asset string,
 	marketID string,
 	stateVarEngine StateVarEngine,
-	tickSize *num.Uint,
 	priceFactor *num.Uint,
 	positionFactor num.Decimal,
 ) *Engine {

--- a/core/liquidity/engine_test.go
+++ b/core/liquidity/engine_test.go
@@ -88,7 +88,7 @@ func newTestEngine(t *testing.T, now time.Time) *testEngine {
 	risk.EXPECT().GetProjectionHorizon().AnyTimes()
 
 	engine := liquidity.NewSnapshotEngine(liquidityConfig,
-		log, tsvc, broker, risk, monitor, orderbook, asset, market, stateVarEngine, num.NewUint(100000), num.NewUint(100000), num.DecimalFromInt64(1),
+		log, tsvc, broker, risk, monitor, orderbook, asset, market, stateVarEngine, num.NewUint(100000), num.DecimalFromInt64(1),
 	)
 
 	return &testEngine{

--- a/core/liquidity/snapshot.go
+++ b/core/liquidity/snapshot.go
@@ -65,7 +65,6 @@ func NewSnapshotEngine(config Config,
 	asset string,
 	market string,
 	stateVarEngine StateVarEngine,
-	tickSize *num.Uint,
 	priceFactor *num.Uint,
 	positionFactor num.Decimal,
 ) *SnapshotEngine {
@@ -73,7 +72,7 @@ func NewSnapshotEngine(config Config,
 		// tickSize = 10^{market_dp} - used for calculating probabilities at offsets from the best bid/ask
 		// priceFactor = 10^{asset_dp} / 10^{market_dp} - used for scaling a price to the market
 		// positionFactor = 10^{position_dp} - used to scale sizes to the market position decimals
-		Engine:  NewEngine(config, log, timeService, broker, riskModel, priceMonitor, orderBook, asset, market, stateVarEngine, tickSize, priceFactor, positionFactor),
+		Engine:  NewEngine(config, log, timeService, broker, riskModel, priceMonitor, orderBook, asset, market, stateVarEngine, priceFactor, positionFactor),
 		pl:      types.Payload{},
 		market:  market,
 		stopped: false,

--- a/core/types/market.go
+++ b/core/types/market.go
@@ -656,11 +656,6 @@ func MarketFromProto(mkt *proto.Market) *Market {
 	return m
 }
 
-// tick size as implied by the decimal places for the market.
-func (m Market) TickSize() *num.Uint {
-	return num.UintZero().Exp(num.NewUint(10), num.NewUint(m.DecimalPlaces))
-}
-
 func (m Market) IntoProto() *proto.Market {
 	var (
 		openAuct *proto.AuctionDuration


### PR DESCRIPTION
This method is not correct. Since it's also not used for anything let's remove it.