### PR TITLE
feat: wallet V2 permissions are updated dynamically when an operation…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🚨 Breaking changes
 - [6716](https://github.com/vegaprotocol/vega/issues/6716) - Use timestamp on all times fields
+- [6887](https://github.com/vegaprotocol/vega/issues/6716) - `client.get_permissions` and `client.request_permissions` have been removed from Wallet service V2 with permissions now asked during `client.list_keys`
 - [6725](https://github.com/vegaprotocol/vega/issues/6725) - Fix inconsistent use of node field on `GraphQL` connection edges
 - [6746](https://github.com/vegaprotocol/vega/issues/6746) - The `validating_nodes` has been removed from `NodeData` and replaced with details of each node set
 

--- a/cmd/vegawallet/commands/service_run.go
+++ b/cmd/vegawallet/commands/service_run.go
@@ -458,12 +458,12 @@ func handleAPIv2Request(interaction interactor.Interaction, responseChan chan<- 
 			p.Print(p.String().CheckMark().SuccessText(data.Message).NextLine())
 		}
 	case interactor.RequestPermissionsReview:
-		str := p.String().BlueArrow().Text("The application \"").InfoText(data.Hostname).Text("\" want to update the permissions for the wallet \"").InfoText(data.Wallet).Text("\":").NextLine()
+		str := p.String().BlueArrow().Text("The application \"").InfoText(data.Hostname).Text("\" requires the following permissions for \"").InfoText(data.Wallet).Text("\":").NextLine()
 		for perm, access := range data.Permissions {
 			str.ListItem().Text("- ").InfoText(perm).Text(": ").InfoText(access).NextLine()
 		}
 		p.Print(str)
-		approved := yesOrNo(p.String().QuestionMark().Text("Do you approve this update?"), p)
+		approved := yesOrNo(p.String().QuestionMark().Text("Do you want to grant these permissions?"), p)
 		if approved {
 			p.Print(p.String().CheckMark().Text("Permissions update approved.").NextLine())
 		} else {

--- a/wallet/api/api.go
+++ b/wallet/api/api.go
@@ -194,9 +194,7 @@ func ClientAPI(log *zap.Logger, walletStore WalletStore, interactor Interactor, 
 	walletAPI.RegisterMethod("client.connect_wallet", NewConnectWallet(walletStore, interactor, sessions))
 	walletAPI.RegisterMethod("client.disconnect_wallet", NewDisconnectWallet(sessions))
 	walletAPI.RegisterMethod("client.get_chain_id", NewGetChainID(nodeSelector))
-	walletAPI.RegisterMethod("client.get_permissions", NewGetPermissions(sessions))
-	walletAPI.RegisterMethod("client.list_keys", NewListKeys(sessions))
-	walletAPI.RegisterMethod("client.request_permissions", NewRequestPermissions(walletStore, interactor, sessions))
+	walletAPI.RegisterMethod("client.list_keys", NewListKeys(walletStore, interactor, sessions))
 	walletAPI.RegisterMethod("client.sign_transaction", NewSignTransaction(interactor, nodeSelector, sessions))
 	walletAPI.RegisterMethod("client.send_transaction", NewSendTransaction(interactor, nodeSelector, sessions))
 

--- a/wallet/api/client_list_keys_test.go
+++ b/wallet/api/client_list_keys_test.go
@@ -2,25 +2,39 @@ package api_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
 	"code.vegaprotocol.io/vega/libs/jsonrpc"
 	vgrand "code.vegaprotocol.io/vega/libs/rand"
 	"code.vegaprotocol.io/vega/wallet/api"
+	"code.vegaprotocol.io/vega/wallet/api/mocks"
 	"code.vegaprotocol.io/vega/wallet/wallet"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestListKeys(t *testing.T) {
 	for i := 0; i < 100; i++ {
-		t.Run("Listing keys with invalid params fails", testListingKeysWithInvalidParamsFails)
 		t.Run("Listing keys with valid params succeeds", testListingKeysWithValidParamsSucceeds)
-		t.Run("Listing keys excludes tainted keys", testListingKeysExcludesTaintedKeys)
-		t.Run("Listing keys with invalid token fails", testListingKeysWithInvalidTokenFails)
-		t.Run("Listing keys with not enough permissions fails", testListingKeysWithNotEnoughPermissionsFails)
 	}
+	t.Run("Listing keys with invalid params fails", testListingKeysWithInvalidParamsFails)
+	t.Run("Listing keys excludes tainted keys", testListingKeysExcludesTaintedKeys)
+	t.Run("Listing keys with invalid token fails", testListingKeysWithInvalidTokenFails)
+	t.Run("Listing keys with not enough permissions fails", testListingKeysWithNotEnoughPermissionsFails)
+	t.Run("Cancelling the review does not update the permissions", testListingKeysCancellingTheReviewDoesNotUpdatePermissions)
+	t.Run("Interrupting the request does not update the permissions", testListingKeysInterruptingTheRequestDoesNotUpdatePermissions)
+	t.Run("Interrupting the request does not update the permissions", testListingKeysInterruptingTheRequestDoesNotUpdatePermissions)
+	t.Run("Getting internal error during the review does not update the permissions", testListingKeysGettingInternalErrorDuringReviewDoesNotUpdatePermissions)
+	t.Run("Cancelling the passphrase request does not update the permissions", testListingKeysCancellingThePassphraseRequestDoesNotUpdatePermissions)
+	t.Run("Interrupting the request during the passphrase request does not update the permissions", testListingKeysInterruptingTheRequestDuringPassphraseRequestDoesNotUpdatePermissions)
+	t.Run("Getting internal error during the passphrase request does not update the permissions", testListingKeysGettingInternalErrorDuringPassphraseRequestDoesNotUpdatePermissions)
+	t.Run("Using wrong passphrase does not update the permissions", testListingKeysUsingWrongPassphraseDoesNotUpdatePermissions)
+	t.Run("Getting internal error during the wallet retrieval does not update the permissions", testListingKeysGettingInternalErrorDuringWalletRetrievalDoesNotUpdatePermissions)
+	t.Run("Getting internal error during the wallet saving does not update the permissions", testListingKeysGettingInternalErrorDuringWalletSavingDoesNotUpdatePermissions)
+	t.Run("Updating the permissions does not overwrite untracked changes", testListingKeysUpdatingPermissionsDoesNotOverwriteUntrackedChanges)
 }
 
 func testListingKeysWithInvalidParamsFails(t *testing.T) {
@@ -158,7 +172,7 @@ func testListingKeysWithInvalidTokenFails(t *testing.T) {
 
 func testListingKeysWithNotEnoughPermissionsFails(t *testing.T) {
 	// given
-	ctx := context.Background()
+	ctx, traceID := contextWithTraceID()
 	expectedPermissions := wallet.Permissions{
 		PublicKeys: wallet.PublicKeysPermission{
 			Access:         wallet.NoAccess,
@@ -166,6 +180,10 @@ func testListingKeysWithNotEnoughPermissionsFails(t *testing.T) {
 		},
 	}
 	hostname := "vega.xyz"
+	originalPermissions := wallet.Permissions{}
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
 	w, _ := walletWithPerms(t, hostname, expectedPermissions)
 	_, err := w.GenerateKeyPair(nil)
 	if err != nil {
@@ -175,6 +193,10 @@ func testListingKeysWithNotEnoughPermissionsFails(t *testing.T) {
 	// setup
 	handler := newListKeysHandler(t)
 	token := connectWallet(t, handler.sessions, hostname, w)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, w.Name(), requestedPermissions).Times(1).Return(false, nil)
 
 	// when
 	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
@@ -182,13 +204,407 @@ func testListingKeysWithNotEnoughPermissionsFails(t *testing.T) {
 	})
 
 	// then
+	assertUserRejectionError(t, errorDetails)
 	assert.Empty(t, result)
-	assertRequestNotPermittedError(t, errorDetails, api.ErrReadAccessOnPublicKeysRequired)
+
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysCancellingTheReviewDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(false, api.ErrUserCloseTheConnection)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertConnectionClosedError(t, errorDetails)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysInterruptingTheRequestDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(false, api.ErrRequestInterrupted)
+	handler.interactor.EXPECT().NotifyError(ctx, traceID, api.ServerError, api.ErrRequestInterrupted).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertRequestInterruptionError(t, errorDetails)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysGettingInternalErrorDuringReviewDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(false, assert.AnError)
+	handler.interactor.EXPECT().NotifyError(ctx, traceID, api.InternalError, fmt.Errorf("requesting the permissions review failed: %w", assert.AnError)).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertInternalError(t, errorDetails, api.ErrCouldNotRequestPermissions)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysCancellingThePassphraseRequestDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return("", api.ErrUserCloseTheConnection)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertConnectionClosedError(t, errorDetails)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysInterruptingTheRequestDuringPassphraseRequestDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return("", api.ErrRequestInterrupted)
+	handler.interactor.EXPECT().NotifyError(ctx, traceID, api.ServerError, api.ErrRequestInterrupted).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertRequestInterruptionError(t, errorDetails)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysGettingInternalErrorDuringPassphraseRequestDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(ctx, traceID, wallet1.Name()).Times(1).Return("", assert.AnError)
+	handler.interactor.EXPECT().NotifyError(ctx, traceID, api.InternalError, fmt.Errorf("requesting the passphrase failed: %w", assert.AnError)).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertInternalError(t, errorDetails, api.ErrCouldNotRequestPermissions)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysUsingWrongPassphraseDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	cancelCtx, cancelFn := context.WithCancel(ctx)
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+	passphrase := vgrand.RandomStr(5)
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(cancelCtx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(cancelCtx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(cancelCtx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(cancelCtx, traceID, wallet1.Name()).Times(1).Return(passphrase, nil)
+	handler.walletStore.EXPECT().GetWallet(cancelCtx, wallet1.Name(), passphrase).Times(1).Return(nil, wallet.ErrWrongPassphrase)
+	handler.interactor.EXPECT().NotifyError(cancelCtx, traceID, api.UserError, wallet.ErrWrongPassphrase).Times(1).Do(func(_ context.Context, _ string, _ api.ErrorType, _ error) {
+		// Once everything has been called once, we cancel the handler to break the loop.
+		cancelFn()
+	})
+
+	// when
+	result, errorDetails := handler.handle(t, cancelCtx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertRequestInterruptionError(t, errorDetails)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysGettingInternalErrorDuringWalletRetrievalDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, _ := walletWithPerms(t, hostname, originalPermissions)
+	passphrase := vgrand.RandomStr(5)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(ctx, traceID, wallet1.Name()).Times(1).Return(passphrase, nil)
+	handler.walletStore.EXPECT().GetWallet(ctx, wallet1.Name(), passphrase).Times(1).Return(nil, assert.AnError)
+	handler.interactor.EXPECT().NotifyError(ctx, traceID, api.InternalError, fmt.Errorf("could not retrieve the wallet: %w", assert.AnError)).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertInternalError(t, errorDetails, api.ErrCouldNotRequestPermissions)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysGettingInternalErrorDuringWalletSavingDoesNotUpdatePermissions(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	walletName := vgrand.RandomStr(5)
+	originalPermissions := wallet.Permissions{}
+	wallet1, recoveryPhrase, err := wallet.NewHDWallet(walletName)
+	if err != nil {
+		t.Fatalf("could not create wallet for test: %v", err)
+	}
+	if _, err := wallet1.GenerateKeyPair(nil); err != nil {
+		t.Fatalf("could not generate key for test: %v", err)
+	}
+
+	// Clone the wallet1, so we can emulate a different instance returned by
+	// the wallet store.
+	loadedWallet, err := wallet.ImportHDWallet(walletName, recoveryPhrase, 2)
+	if err != nil {
+		t.Fatalf("could not import wallet for test: %v", err)
+	}
+	if _, err := loadedWallet.GenerateKeyPair(nil); err != nil {
+		t.Fatalf("could not generate key for test: %v", err)
+	}
+	passphrase := vgrand.RandomStr(5)
+	requestedPermissions := map[string]string{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), requestedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(ctx, traceID, wallet1.Name()).Times(1).Return(passphrase, nil)
+	handler.walletStore.EXPECT().GetWallet(ctx, wallet1.Name(), passphrase).Times(1).Return(loadedWallet, nil)
+	handler.walletStore.EXPECT().SaveWallet(ctx, loadedWallet, passphrase).Times(1).Return(assert.AnError)
+	handler.interactor.EXPECT().NotifyError(ctx, traceID, api.InternalError, fmt.Errorf("could not save the wallet: %w", assert.AnError)).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assertInternalError(t, errorDetails, api.ErrCouldNotRequestPermissions)
+	assert.Empty(t, result)
+	// Verifying the connected wallet is not updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, originalPermissions.Summary(), connectedWallet.Permissions().Summary())
+}
+
+func testListingKeysUpdatingPermissionsDoesNotOverwriteUntrackedChanges(t *testing.T) {
+	// given
+	ctx, traceID := contextWithTraceID()
+	hostname := vgrand.RandomStr(5)
+	walletName := vgrand.RandomStr(5)
+	wallet1, recoveryPhrase, err := wallet.NewHDWallet(walletName)
+	if err != nil {
+		t.Fatalf("could not create wallet for test: %v", err)
+	}
+
+	// Clone the wallet1, so we can modify the clone without tempering with wallet1.
+	modifiedWallet, err := wallet.ImportHDWallet(walletName, recoveryPhrase, 2)
+	if err != nil {
+		t.Fatalf("could not import wallet for test: %v", err)
+	}
+	kp, _ := modifiedWallet.GenerateKeyPair([]wallet.Metadata{{Key: "name", Value: "hello"}})
+
+	passphrase := vgrand.RandomStr(5)
+	askedPermissions := wallet.PermissionsSummary{
+		"public_keys": "read",
+	}
+
+	// setup
+	handler := newListKeysHandler(t)
+	token := connectWallet(t, handler.sessions, hostname, wallet1)
+	// -- expected calls
+	handler.interactor.EXPECT().NotifyInteractionSessionBegan(ctx, gomock.Any()).Times(1).Return(nil)
+	handler.interactor.EXPECT().NotifyInteractionSessionEnded(ctx, gomock.Any()).Times(1)
+	handler.interactor.EXPECT().RequestPermissionsReview(ctx, traceID, hostname, wallet1.Name(), askedPermissions).Times(1).Return(true, nil)
+	handler.interactor.EXPECT().RequestPassphrase(ctx, traceID, wallet1.Name()).Times(1).Return(passphrase, nil)
+	handler.walletStore.EXPECT().GetWallet(ctx, wallet1.Name(), passphrase).Times(1).Return(modifiedWallet, nil)
+	handler.walletStore.EXPECT().SaveWallet(ctx, gomock.Any(), passphrase).Times(1).DoAndReturn(func(_ context.Context, w wallet.Wallet, _ string) error {
+		// We verify that the saved wallet contains the modification from the modified wallet and the permissions update from wallet1.
+		assert.Equal(t, []wallet.KeyPair{kp}, w.ListKeyPairs())
+		assert.Equal(t, wallet.Permissions{
+			PublicKeys: wallet.PublicKeysPermission{
+				Access: wallet.ReadAccess,
+			},
+		}, w.Permissions(hostname))
+		return nil
+	})
+	handler.interactor.EXPECT().NotifySuccessfulRequest(ctx, traceID, api.PermissionsSuccessfullyUpdated).Times(1)
+
+	// when
+	result, errorDetails := handler.handle(t, ctx, api.ClientListKeysParams{
+		Token: token,
+	})
+
+	// then
+	assert.Nil(t, errorDetails)
+	require.NotEmpty(t, result)
+	// Verifying the connected wallet is updated.
+	connectedWallet, err := handler.sessions.GetConnectedWallet(token)
+	require.NoError(t, err)
+	assert.Equal(t, askedPermissions, connectedWallet.Permissions().Summary())
 }
 
 type listKeysHandler struct {
 	*api.ClientListKeys
-	sessions *api.Sessions
+	ctrl        *gomock.Controller
+	walletStore *mocks.MockWalletStore
+	interactor  *mocks.MockInteractor
+	sessions    *api.Sessions
 }
 
 func (h *listKeysHandler) handle(t *testing.T, ctx context.Context, params interface{}) (api.ClientListKeysResult, *jsonrpc.ErrorDetails) {
@@ -208,10 +624,17 @@ func (h *listKeysHandler) handle(t *testing.T, ctx context.Context, params inter
 func newListKeysHandler(t *testing.T) *listKeysHandler {
 	t.Helper()
 
+	ctrl := gomock.NewController(t)
+	walletStore := mocks.NewMockWalletStore(ctrl)
+	interactor := mocks.NewMockInteractor(ctrl)
+
 	sessions := api.NewSessions()
 
 	return &listKeysHandler{
-		ClientListKeys: api.NewListKeys(sessions),
+		ClientListKeys: api.NewListKeys(walletStore, interactor, sessions),
+		ctrl:           ctrl,
+		walletStore:    walletStore,
+		interactor:     interactor,
 		sessions:       sessions,
 	}
 }

--- a/wallet/api/client_request_permissions.go
+++ b/wallet/api/client_request_permissions.go
@@ -10,8 +10,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const PermissionsSuccessfullyUpdated = "The permissions have been successfully updated."
-
 type ClientRequestPermissionsParams struct {
 	Token                string                    `json:"token"`
 	RequestedPermissions wallet.PermissionsSummary `json:"requestedPermissions"`

--- a/wallet/api/interactor/interaction.go
+++ b/wallet/api/interactor/interaction.go
@@ -203,7 +203,7 @@ type RequestPassphrase struct {
 }
 
 // RequestPermissionsReview is a review request emitted when a third-party
-// application wants to update the permissions.
+// application performs an operation that requires an update to the permissions.
 type RequestPermissionsReview struct {
 	Hostname    string            `json:"hostname"`
 	Wallet      string            `json:"wallet"`


### PR DESCRIPTION
closes #6887 

The `client.get_permissions` and `client.request_permissions` methods have been removed from the V2 wallet service and replaced with dynamic permissions update. Now when a client asks to `client.list_keys` if they do not have permissions the wallet will prompt to update them.

The flow now looks like:
```
? Which wallet do you want to use? test2
➜ Enter the passphrase for the wallet "test2":
✓ The connection to the wallet has been successfully established.

[call to `client.list_keys` happens here]

➜ The application "wwestgarth-janky-script" requires the following permissions for "test2":
    - public_keys: read
? Do you want to grant these permissions? (yes/no) yes
✓ Permissions update approved.
➜ Enter the passphrase for the wallet "test2":
✓ The permissions have been successfully updated.
```

There is not much new code here. It was mostly copy-and-pasting the `interactor` flow from `client.request_permissions` to be under `client.list_keys`.