### PR TITLE
fix: datanode socketDir CLI long option

### DIFF
--- a/datanode/sqlstore/config.go
+++ b/datanode/sqlstore/config.go
@@ -39,7 +39,7 @@ type ConnectionConfig struct {
 	Username              string            `long:"username"`
 	Password              string            `long:"password"`
 	Database              string            `long:"database"`
-	SocketDir             string            `long:"location of postgres UNIX socket directory (used if host is empty string)"`
+	SocketDir             string            `long:"socket-dir" description:"location of postgres UNIX socket directory (used if host is empty string)"`
 	MaxConnLifetime       encoding.Duration `long:"max-conn-lifetime"`
 	MaxConnLifetimeJitter encoding.Duration `long:"max-conn-lifetime-jitter"`
 }


### PR DESCRIPTION
It made me chuckle:
```
 --sqlstore.ConnectionConfig.location of postgres UNIX socket directory used if host is empty string=
```

but we're good now:
```
--sqlstore.ConnectionConfig.socket-dir=         location of postgres UNIX socket directory (used if host is empty string) (default: /tmp)
```