### PR TITLE
chore: run sql store tests in temporary transactions

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -116,7 +116,7 @@ linters = ["exhaustruct", "noctx"]
 
 # Don't complain about context not being first argument in tests (convention is to use *testing.T)
 [[issues.exclude-rules]]
-path = "_test.go"
+paths = ["_test.go", "helpers.go"]
 linters = ["revive"]
 text = "context-as-argument"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🛠 Improvements
 - [7052](https://github.com/vegaprotocol/vega/issues/7052) - Add a specific error message when trying to access administrative endpoints on wallet API
+- [7064](https://github.com/vegaprotocol/vega/issues/7064) - Make `SQL` store tests run in temporary transactions instead of truncating all tables for each test
 
 ### 🐛 Fixes
 - [7037](https://github.com/vegaprotocol/vega/issues/7037) - Reinstate permissions endpoints on the wallet API

--- a/cmd/data-node/commands/start/sqlsubscribers.go
+++ b/cmd/data-node/commands/start/sqlsubscribers.go
@@ -171,7 +171,7 @@ func (s *SQLSubscribers) CreateAllStores(ctx context.Context, Log *logging.Logge
 	s.assetStore = sqlstore.NewAssets(transactionalConnectionSource)
 	s.blockStore = sqlstore.NewBlocks(transactionalConnectionSource)
 	s.partyStore = sqlstore.NewParties(transactionalConnectionSource)
-	s.partyStore.Initialise()
+	s.partyStore.Initialise(ctx)
 	s.accountStore = sqlstore.NewAccounts(transactionalConnectionSource)
 	s.balanceStore = sqlstore.NewBalances(transactionalConnectionSource)
 	s.ledger = sqlstore.NewLedger(transactionalConnectionSource)

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -224,7 +224,7 @@ func (t *tradingDataServiceV2) ListLedgerEntries(ctx context.Context, req *v2.Li
 		return nil, apiError(codes.InvalidArgument, fmt.Errorf("invalid cursor: %w", err))
 	}
 
-	entries, pageInfo, err := t.ledgerService.Query(leFilter, dateRange, pagination)
+	entries, pageInfo, err := t.ledgerService.Query(ctx, leFilter, dateRange, pagination)
 	if err != nil {
 		return nil, apiError(codes.InvalidArgument, fmt.Errorf("could not query ledger entries: %w", err))
 	}
@@ -259,7 +259,7 @@ func (t *tradingDataServiceV2) ListBalanceChanges(ctx context.Context, req *v2.L
 		return nil, apiError(codes.InvalidArgument, fmt.Errorf("invalid cursor: %w", err))
 	}
 
-	balances, pageInfo, err := t.accountService.QueryAggregatedBalances(filter, dateRange, pagination)
+	balances, pageInfo, err := t.accountService.QueryAggregatedBalances(ctx, filter, dateRange, pagination)
 	if err != nil {
 		return nil, fmt.Errorf("querying balances: %w", err)
 	}
@@ -1303,7 +1303,7 @@ func (t *tradingDataServiceV2) ListMarginLevels(ctx context.Context, in *v2.List
 		return nil, apiError(codes.Internal, err)
 	}
 
-	edges, err := makeEdges[*v2.MarginEdge](marginLevels, t.accountService)
+	edges, err := makeEdges[*v2.MarginEdge](marginLevels, ctx, t.accountService)
 	if err != nil {
 		return nil, apiError(codes.Internal, err)
 	}
@@ -1338,7 +1338,7 @@ func (t *tradingDataServiceV2) ObserveMarginLevels(req *v2.ObserveMarginLevelsRe
 	}
 
 	return observe(ctx, t.log, "MarginLevel", marginLevelsChan, ref, func(ml entities.MarginLevels) error {
-		protoMl, err := ml.ToProto(t.accountService)
+		protoMl, err := ml.ToProto(ctx, t.accountService)
 		if err != nil {
 			return apiError(codes.Internal, err)
 		}
@@ -1908,7 +1908,7 @@ func (t *tradingDataServiceV2) ListTransfers(ctx context.Context, req *v2.ListTr
 		return nil, apiError(codes.Internal, err)
 	}
 
-	edges, err := makeEdges[*v2.TransferEdge](transfers, t.accountService)
+	edges, err := makeEdges[*v2.TransferEdge](transfers, ctx, t.accountService)
 	if err != nil {
 		return nil, apiError(codes.Internal, err)
 	}

--- a/datanode/dehistory/service_test.go
+++ b/datanode/dehistory/service_test.go
@@ -768,8 +768,8 @@ type sqlStoreBroker interface {
 }
 
 func emptyDatabase() {
-	// NOTE: do not use databasetest.DeleteEverything(), for these we need a totally fresh database everytime to ensure
-	// we model as closely as possible what happens in practice
+	// For these we need a totally fresh database every time to ensure we model as closely as
+	// possible what happens in practice
 	var err error
 	var poolConfig *pgxpool.Config
 

--- a/datanode/entities/transfer.go
+++ b/datanode/entities/transfer.go
@@ -26,7 +26,7 @@ import (
 
 type AccountSource interface {
 	Obtain(ctx context.Context, a *Account) error
-	GetByID(id AccountID) (Account, error)
+	GetByID(ctx context.Context, id AccountID) (Account, error)
 }
 
 type _Transfer struct{}
@@ -54,13 +54,13 @@ type Transfer struct {
 	Reason              *string
 }
 
-func (t *Transfer) ToProto(accountSource AccountSource) (*eventspb.Transfer, error) {
-	fromAcc, err := accountSource.GetByID(t.FromAccountID)
+func (t *Transfer) ToProto(ctx context.Context, accountSource AccountSource) (*eventspb.Transfer, error) {
+	fromAcc, err := accountSource.GetByID(ctx, t.FromAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("getting from account for transfer proto:%w", err)
 	}
 
-	toAcc, err := accountSource.GetByID(t.ToAccountID)
+	toAcc, err := accountSource.GetByID(ctx, t.ToAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("getting to account for transfer proto:%w", err)
 	}
@@ -206,23 +206,28 @@ func (t Transfer) Cursor() *Cursor {
 }
 
 func (t Transfer) ToProtoEdge(input ...any) (*v2.TransferEdge, error) {
-	if len(input) == 0 {
-		return nil, fmt.Errorf("expected account source argument")
+	if len(input) != 2 {
+		return nil, fmt.Errorf("expected account source and context argument")
 	}
 
-	switch as := input[0].(type) {
-	case AccountSource:
-		transferProto, err := t.ToProto(as)
-		if err != nil {
-			return nil, err
-		}
-		return &v2.TransferEdge{
-			Node:   transferProto,
-			Cursor: t.Cursor().Encode(),
-		}, nil
-	default:
-		return nil, fmt.Errorf("expected account source argument, got:%v", as)
+	ctx, ok := input[0].(context.Context)
+	if !ok {
+		return nil, fmt.Errorf("first argument must be a context.Context, got: %v", input[0])
 	}
+
+	as, ok := input[1].(AccountSource)
+	if !ok {
+		return nil, fmt.Errorf("second argument must be an AccountSource, got: %v", input[1])
+	}
+
+	transferProto, err := t.ToProto(ctx, as)
+	if err != nil {
+		return nil, err
+	}
+	return &v2.TransferEdge{
+		Node:   transferProto,
+		Cursor: t.Cursor().Encode(),
+	}, nil
 }
 
 type TransferCursor struct {

--- a/datanode/service/accounts.go
+++ b/datanode/service/accounts.go
@@ -22,10 +22,10 @@ import (
 )
 
 type AccountStore interface {
-	GetByID(id entities.AccountID) (entities.Account, error)
-	GetAll() ([]entities.Account, error)
+	GetByID(ctx context.Context, id entities.AccountID) (entities.Account, error)
+	GetAll(ctx context.Context) ([]entities.Account, error)
 	Obtain(ctx context.Context, a *entities.Account) error
-	Query(filter entities.AccountFilter) ([]entities.Account, error)
+	Query(ctx context.Context, filter entities.AccountFilter) ([]entities.Account, error)
 	QueryBalancesV1(ctx context.Context, filter entities.AccountFilter, pagination entities.OffsetPagination) ([]entities.AccountBalance, error)
 	QueryBalances(ctx context.Context, filter entities.AccountFilter, pagination entities.CursorPagination) ([]entities.AccountBalance, entities.PageInfo, error)
 }
@@ -33,7 +33,7 @@ type AccountStore interface {
 type BalanceStore interface {
 	Flush(ctx context.Context) ([]entities.AccountBalance, error)
 	Add(b entities.AccountBalance) error
-	Query(filter entities.AccountFilter, dateRange entities.DateRange, pagination entities.CursorPagination) (*[]entities.AggregatedBalance, entities.PageInfo, error)
+	Query(ctx context.Context, filter entities.AccountFilter, dateRange entities.DateRange, pagination entities.CursorPagination) (*[]entities.AggregatedBalance, entities.PageInfo, error)
 }
 
 type Account struct {
@@ -52,20 +52,20 @@ func NewAccount(aStore AccountStore, bStore BalanceStore, log *logging.Logger) *
 	}
 }
 
-func (a *Account) GetByID(id entities.AccountID) (entities.Account, error) {
-	return a.aStore.GetByID(id)
+func (a *Account) GetByID(ctx context.Context, id entities.AccountID) (entities.Account, error) {
+	return a.aStore.GetByID(ctx, id)
 }
 
-func (a *Account) GetAll() ([]entities.Account, error) {
-	return a.aStore.GetAll()
+func (a *Account) GetAll(ctx context.Context) ([]entities.Account, error) {
+	return a.aStore.GetAll(ctx)
 }
 
 func (a *Account) Obtain(ctx context.Context, acc *entities.Account) error {
 	return a.aStore.Obtain(ctx, acc)
 }
 
-func (a *Account) Query(filter entities.AccountFilter) ([]entities.Account, error) {
-	return a.aStore.Query(filter)
+func (a *Account) Query(ctx context.Context, filter entities.AccountFilter) ([]entities.Account, error) {
+	return a.aStore.Query(ctx, filter)
 }
 
 func (a *Account) QueryBalancesV1(ctx context.Context, filter entities.AccountFilter, pagination entities.OffsetPagination) ([]entities.AccountBalance, error) {
@@ -89,8 +89,8 @@ func (a *Account) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (a *Account) QueryAggregatedBalances(filter entities.AccountFilter, dateRange entities.DateRange, pagination entities.CursorPagination) (*[]entities.AggregatedBalance, entities.PageInfo, error) {
-	return a.bStore.Query(filter, dateRange, pagination)
+func (a *Account) QueryAggregatedBalances(ctx context.Context, filter entities.AccountFilter, dateRange entities.DateRange, pagination entities.CursorPagination) (*[]entities.AggregatedBalance, entities.PageInfo, error) {
+	return a.bStore.Query(ctx, filter, dateRange, pagination)
 }
 
 func (a *Account) ObserveAccountBalances(ctx context.Context, retries int, marketID string,

--- a/datanode/service/ledger.go
+++ b/datanode/service/ledger.go
@@ -24,7 +24,7 @@ import (
 type ledgerStore interface {
 	Flush(ctx context.Context) ([]entities.LedgerEntry, error)
 	Add(le entities.LedgerEntry) error
-	Query(filter *entities.LedgerEntryFilter, dateRange entities.DateRange, pagination entities.CursorPagination) (*[]entities.AggregatedLedgerEntry, entities.PageInfo, error)
+	Query(ctx context.Context, filter *entities.LedgerEntryFilter, dateRange entities.DateRange, pagination entities.CursorPagination) (*[]entities.AggregatedLedgerEntry, entities.PageInfo, error)
 }
 
 type LedgerEntriesStore interface {
@@ -78,11 +78,13 @@ func (l *Ledger) GetSubscribersCount() int32 {
 }
 
 func (l *Ledger) Query(
+	ctx context.Context,
 	filter *entities.LedgerEntryFilter,
 	dateRange entities.DateRange,
 	pagination entities.CursorPagination,
 ) (*[]entities.AggregatedLedgerEntry, entities.PageInfo, error) {
 	return l.store.Query(
+		ctx,
 		filter,
 		dateRange,
 		pagination)

--- a/datanode/service/risk.go
+++ b/datanode/service/risk.go
@@ -28,7 +28,7 @@ type MarginLevelsStore interface {
 }
 
 type AccountSource interface {
-	GetByID(id entities.AccountID) (entities.Account, error)
+	GetByID(ctx context.Context, id entities.AccountID) (entities.Account, error)
 }
 
 type Risk struct {
@@ -73,7 +73,7 @@ func (r *Risk) ObserveMarginLevels(
 ) (accountCh <-chan []entities.MarginLevels, ref uint64) {
 	ch, ref := r.observer.Observe(ctx, retries,
 		func(ml entities.MarginLevels) bool {
-			acc, err := r.accountSource.GetByID(ml.AccountID)
+			acc, err := r.accountSource.GetByID(ctx, ml.AccountID)
 			if err != nil {
 				return false
 			}

--- a/datanode/sqlstore/accounts.go
+++ b/datanode/sqlstore/accounts.go
@@ -86,9 +86,8 @@ func (as *Accounts) Add(ctx context.Context, a *entities.Account) error {
 	return err
 }
 
-func (as *Accounts) GetByID(id entities.AccountID) (entities.Account, error) {
+func (as *Accounts) GetByID(ctx context.Context, id entities.AccountID) (entities.Account, error) {
 	a := entities.Account{}
-	ctx := context.Background()
 	defer metrics.StartSQLQuery("Accounts", "GetByID")()
 	return a, as.wrapE(
 		pgxscan.Get(ctx, as.Connection, &a,
@@ -99,8 +98,7 @@ func (as *Accounts) GetByID(id entities.AccountID) (entities.Account, error) {
 	)
 }
 
-func (as *Accounts) GetAll() ([]entities.Account, error) {
-	ctx := context.Background()
+func (as *Accounts) GetAll(ctx context.Context) ([]entities.Account, error) {
 	accounts := []entities.Account{}
 	defer metrics.StartSQLQuery("Accounts", "GetAll")()
 	err := pgxscan.Select(ctx, as.Connection, &accounts, `
@@ -160,7 +158,7 @@ func deterministicAccountID(a *entities.Account) entities.AccountID {
 	return entities.AccountID(accountID)
 }
 
-func (as *Accounts) Query(filter entities.AccountFilter) ([]entities.Account, error) {
+func (as *Accounts) Query(ctx context.Context, filter entities.AccountFilter) ([]entities.Account, error) {
 	query, args, err := filterAccountsQuery(filter, true)
 	if err != nil {
 		return nil, err
@@ -168,7 +166,7 @@ func (as *Accounts) Query(filter entities.AccountFilter) ([]entities.Account, er
 	accs := []entities.Account{}
 
 	defer metrics.StartSQLQuery("Accounts", "Query")()
-	rows, err := as.Connection.Query(context.Background(), query, args...)
+	rows, err := as.Connection.Query(ctx, query, args...)
 	if err != nil {
 		return accs, fmt.Errorf("querying accounts: %w", err)
 	}

--- a/datanode/sqlstore/assets.go
+++ b/datanode/sqlstore/assets.go
@@ -97,7 +97,7 @@ func (as *Assets) GetByID(ctx context.Context, id string) (entities.Asset, error
 
 	defer metrics.StartSQLQuery("Assets", "GetByID")()
 	err := pgxscan.Get(ctx, as.Connection, &a,
-		getAssetQuery()+` WHERE id=$1`,
+		getAssetQuery(ctx)+` WHERE id=$1`,
 		entities.AssetID(id))
 
 	if err == nil {
@@ -109,7 +109,7 @@ func (as *Assets) GetByID(ctx context.Context, id string) (entities.Asset, error
 func (as *Assets) GetAll(ctx context.Context) ([]entities.Asset, error) {
 	assets := []entities.Asset{}
 	defer metrics.StartSQLQuery("Assets", "GetAll")()
-	err := pgxscan.Select(ctx, as.Connection, &assets, getAssetQuery())
+	err := pgxscan.Select(ctx, as.Connection, &assets, getAssetQuery(ctx))
 	return assets, err
 }
 
@@ -121,7 +121,7 @@ func (as *Assets) GetAllWithCursorPagination(ctx context.Context, pagination ent
 	var args []interface{}
 	var err error
 
-	query := getAssetQuery()
+	query := getAssetQuery(ctx)
 	query, args, err = PaginateQuery[entities.AssetCursor](query, args, assetOrdering, pagination)
 	if err != nil {
 		return nil, pageInfo, err
@@ -137,6 +137,6 @@ func (as *Assets) GetAllWithCursorPagination(ctx context.Context, pagination ent
 	return assets, pageInfo, nil
 }
 
-func getAssetQuery() string {
+func getAssetQuery(ctx context.Context) string {
 	return `SELECT * FROM assets_current`
 }

--- a/datanode/sqlstore/balances.go
+++ b/datanode/sqlstore/balances.go
@@ -49,7 +49,7 @@ func (bs *Balances) Add(b entities.AccountBalance) error {
 	return nil
 }
 
-func (bs *Balances) Query(filter entities.AccountFilter, dateRange entities.DateRange,
+func (bs *Balances) Query(ctx context.Context, filter entities.AccountFilter, dateRange entities.DateRange,
 	pagination entities.CursorPagination,
 ) (*[]entities.AggregatedBalance, entities.PageInfo, error) {
 	var pageInfo entities.PageInfo
@@ -96,7 +96,7 @@ func (bs *Balances) Query(filter entities.AccountFilter, dateRange entities.Date
 	}
 
 	defer metrics.StartSQLQuery("Balances", "Query")()
-	rows, err := bs.Connection.Query(context.Background(), query, args...)
+	rows, err := bs.Connection.Query(ctx, query, args...)
 	if err != nil {
 		return nil, pageInfo, fmt.Errorf("querying balances: %w", err)
 	}

--- a/datanode/sqlstore/blocks.go
+++ b/datanode/sqlstore/blocks.go
@@ -56,9 +56,8 @@ func (bs *Blocks) Add(ctx context.Context, b entities.Block) error {
 	return nil
 }
 
-func (bs *Blocks) GetAll() ([]entities.Block, error) {
+func (bs *Blocks) GetAll(ctx context.Context) ([]entities.Block, error) {
 	defer metrics.StartSQLQuery("Blocks", "GetAll")()
-	ctx := context.Background()
 	blocks := []entities.Block{}
 	err := pgxscan.Select(ctx, bs.Connection, &blocks,
 		`SELECT vega_time, height, hash
@@ -76,7 +75,7 @@ func (bs *Blocks) GetAtHeight(ctx context.Context, height int64) (entities.Block
 		return block, nil
 	}
 
-	return block, bs.wrapE(pgxscan.Get(context.Background(), bs.Connection, &block,
+	return block, bs.wrapE(pgxscan.Get(ctx, bs.Connection, &block,
 		`SELECT vega_time, height, hash
 		FROM blocks
 		WHERE height=$1`, height))

--- a/datanode/sqlstore/blocks_test.go
+++ b/datanode/sqlstore/blocks_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func addTestBlock(t *testing.T, bs *sqlstore.Blocks) entities.Block {
+func addTestBlock(t *testing.T, ctx context.Context, bs *sqlstore.Blocks) entities.Block {
 	t.Helper()
-	return addTestBlockForTime(t, bs, time.Now())
+	return addTestBlockForTime(t, ctx, bs, time.Now())
 }
 
-func addTestBlockForTime(t *testing.T, bs *sqlstore.Blocks, vegaTime time.Time) entities.Block {
+func addTestBlockForTime(t *testing.T, ctx context.Context, bs *sqlstore.Blocks, vegaTime time.Time) entities.Block {
 	t.Helper()
 	// Make a block
 	hash, err := hex.DecodeString("deadbeef")
@@ -42,95 +42,107 @@ func addTestBlockForTime(t *testing.T, bs *sqlstore.Blocks, vegaTime time.Time) 
 	}
 
 	// Add it to the database
-	err = bs.Add(context.Background(), block1)
+	err = bs.Add(ctx, block1)
 	assert.NoError(t, err)
 
 	return block1
 }
 
 func TestBlock(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 
 	// See how many we have right now (it's possible that other tests added some)
-	blocks, err := bs.GetAll()
+	blocks, err := bs.GetAll(ctx)
 	assert.NoError(t, err)
 	blocksLen := len(blocks)
 
-	block1 := addTestBlock(t, bs)
-
-	// Add it again, we should get a primary key violation
-	err = bs.Add(context.Background(), block1)
-	assert.Error(t, err)
+	block1 := addTestBlock(t, ctx, bs)
 
 	// Query and check we've got back a block the same as the one we put in
-	blocks, err = bs.GetAll()
+	blocks, err = bs.GetAll(ctx)
 	assert.NoError(t, err)
 	assert.Len(t, blocks, blocksLen+1)
 	assert.Equal(t, blocks[0], block1)
+
+	// Add it again, we should get a primary key violation [do this last as it invalidates tx]
+	err = bs.Add(ctx, block1)
+	assert.Error(t, err)
 }
 
 func TestGetLastBlock(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 
 	now := time.Now()
 
-	addTestBlockForTime(t, bs, now)
-	block2 := addTestBlockForTime(t, bs, now.Add(1*time.Second))
+	addTestBlockForTime(t, ctx, bs, now)
+	block2 := addTestBlockForTime(t, ctx, bs, now.Add(1*time.Second))
 
 	// Query the last block
-	block, err := bs.GetLastBlock(context.Background())
+	block, err := bs.GetLastBlock(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, block2, block)
 }
 
 func TestGetOldestHistoryBlock(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 
 	now := time.Now()
 
-	block1 := addTestBlockForTime(t, bs, now)
-	addTestBlockForTime(t, bs, now.Add(1*time.Second))
+	block1 := addTestBlockForTime(t, ctx, bs, now)
+	addTestBlockForTime(t, ctx, bs, now.Add(1*time.Second))
 
 	// Query the first block
-	block, err := bs.GetOldestHistoryBlock(context.Background())
+	block, err := bs.GetOldestHistoryBlock(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, block1, block)
 }
 
 func TestGetOldestHistoryBlockWhenNoHistoryBlocks(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 	// Query the first block
-	_, err := bs.GetOldestHistoryBlock(context.Background())
+	_, err := bs.GetOldestHistoryBlock(ctx)
 	assert.Equal(t, entities.ErrNotFound, err)
 }
 
 func TestGetLastBlockAfterRecovery(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 
 	now := time.Now()
 
-	addTestBlockForTime(t, bs, now)
-	block2 := addTestBlockForTime(t, bs, now.Add(1*time.Second))
+	addTestBlockForTime(t, ctx, bs, now)
+	block2 := addTestBlockForTime(t, ctx, bs, now.Add(1*time.Second))
 
 	// Recreate the store
 	bs = sqlstore.NewBlocks(connectionSource)
 
 	// Query the last block
-	block, err := bs.GetLastBlock(context.Background())
+	block, err := bs.GetLastBlock(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, block2, block)
 }
 
 func TestGetLastBlockWhenNoBlocks(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 
 	// Query the last block
-	_, err := bs.GetLastBlock(context.Background())
+	_, err := bs.GetLastBlock(ctx)
 	assert.Equal(t, entities.ErrNotFound, err)
 }

--- a/datanode/sqlstore/chain_test.go
+++ b/datanode/sqlstore/chain_test.go
@@ -13,7 +13,6 @@
 package sqlstore_test
 
 import (
-	"context"
 	"testing"
 
 	"code.vegaprotocol.io/vega/datanode/entities"
@@ -22,7 +21,9 @@ import (
 )
 
 func TestChain(t *testing.T) {
-	ctx := context.Background()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	cs := sqlstore.NewChain(connectionSource)
 
 	chain1 := entities.Chain{ID: "my-test-chain"}

--- a/datanode/sqlstore/helpers/accounts.go
+++ b/datanode/sqlstore/helpers/accounts.go
@@ -11,6 +11,7 @@ import (
 )
 
 func AddTestAccount(t *testing.T,
+	ctx context.Context,
 	accountStore *sqlstore.Accounts,
 	party entities.Party,
 	asset entities.Asset,
@@ -26,12 +27,13 @@ func AddTestAccount(t *testing.T,
 		VegaTime: block.VegaTime,
 	}
 
-	err := accountStore.Add(context.Background(), &account)
+	err := accountStore.Add(ctx, &account)
 	require.NoError(t, err)
 	return account
 }
 
 func AddTestAccountWithMarketAndType(t *testing.T,
+	ctx context.Context,
 	accountStore *sqlstore.Accounts,
 	party entities.Party,
 	asset entities.Asset,
@@ -48,7 +50,7 @@ func AddTestAccountWithMarketAndType(t *testing.T,
 		VegaTime: block.VegaTime,
 	}
 
-	err := accountStore.Add(context.Background(), &account)
+	err := accountStore.Add(ctx, &account)
 	require.NoError(t, err)
 	return account
 }

--- a/datanode/sqlstore/helpers/markets.go
+++ b/datanode/sqlstore/helpers/markets.go
@@ -9,23 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func AddTestMarket(t *testing.T, ms *sqlstore.Markets, block entities.Block) entities.Market {
+func AddTestMarket(t *testing.T, ctx context.Context, ms *sqlstore.Markets, block entities.Block) entities.Market {
 	t.Helper()
 	market := entities.Market{
 		ID:       entities.MarketID(GenerateID()),
 		VegaTime: block.VegaTime,
 	}
 
-	err := ms.Upsert(context.Background(), &market)
+	err := ms.Upsert(ctx, &market)
 	require.NoError(t, err)
 	return market
 }
 
-func GenerateMarkets(t *testing.T, numMarkets int, block entities.Block, ms *sqlstore.Markets) []entities.Market {
+func GenerateMarkets(t *testing.T, ctx context.Context, numMarkets int, block entities.Block, ms *sqlstore.Markets) []entities.Market {
 	t.Helper()
 	markets := make([]entities.Market, numMarkets)
 	for i := 0; i < numMarkets; i++ {
-		markets[i] = AddTestMarket(t, ms, block)
+		markets[i] = AddTestMarket(t, ctx, ms, block)
 	}
 	return markets
 }

--- a/datanode/sqlstore/key_rotations_test.go
+++ b/datanode/sqlstore/key_rotations_test.go
@@ -39,9 +39,8 @@ func TestKeyRotationsCursorPagination(t *testing.T) {
 }
 
 func testKeyRotationPaginationNoPagination(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, false)
@@ -61,9 +60,8 @@ func testKeyRotationPaginationNoPagination(t *testing.T) {
 }
 
 func testKeyRotationPaginationFirstPage(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -84,9 +82,8 @@ func testKeyRotationPaginationFirstPage(t *testing.T) {
 }
 
 func testKeyRotationPaginationLastPage(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -107,9 +104,8 @@ func testKeyRotationPaginationLastPage(t *testing.T) {
 }
 
 func testKeyRotationPaginationFirstAndAfter(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -131,9 +127,8 @@ func testKeyRotationPaginationFirstAndAfter(t *testing.T) {
 }
 
 func testKeyRotationPaginationLastAndBefore(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -156,9 +151,8 @@ func testKeyRotationPaginationLastAndBefore(t *testing.T) {
 }
 
 func testKeyRotationPaginationNoPaginationNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, true)
@@ -178,9 +172,8 @@ func testKeyRotationPaginationNoPaginationNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationFirstPageNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -201,9 +194,8 @@ func testKeyRotationPaginationFirstPageNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationLastPageNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -224,9 +216,8 @@ func testKeyRotationPaginationLastPageNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationFirstAndAfterNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -248,9 +239,8 @@ func testKeyRotationPaginationFirstAndAfterNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationLastAndBeforeNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -272,9 +262,8 @@ func testKeyRotationPaginationLastAndBeforeNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeNoPagination(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, false)
@@ -294,9 +283,8 @@ func testKeyRotationPaginationForNodeNoPagination(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeFirstPage(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -317,9 +305,8 @@ func testKeyRotationPaginationForNodeFirstPage(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeLastPage(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -340,9 +327,8 @@ func testKeyRotationPaginationForNodeLastPage(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeFirstAndAfter(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -364,9 +350,8 @@ func testKeyRotationPaginationForNodeFirstAndAfter(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeLastAndBefore(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -388,9 +373,8 @@ func testKeyRotationPaginationForNodeLastAndBefore(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeNoPaginationNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, true)
@@ -410,9 +394,8 @@ func testKeyRotationPaginationForNodeNoPaginationNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeFirstPageNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -433,9 +416,8 @@ func testKeyRotationPaginationForNodeFirstPageNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeLastPageNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -456,9 +438,8 @@ func testKeyRotationPaginationForNodeLastPageNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeFirstAndAfterNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	first := int32(3)
@@ -480,9 +461,8 @@ func testKeyRotationPaginationForNodeFirstAndAfterNewestFirst(t *testing.T) {
 }
 
 func testKeyRotationPaginationForNodeLastAndBeforeNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
 	ks, keys := setKeyRotationStoreTest(t, ctx)
 	last := int32(3)
@@ -511,15 +491,15 @@ func setKeyRotationStoreTest(t *testing.T, ctx context.Context) (*sqlstore.KeyRo
 
 	keyRotations := make([]entities.KeyRotation, 20)
 	blockTime := time.Date(2022, 8, 2, 9, 0, 0, 0, time.Local)
-	block := addTestBlockForTime(t, bs, blockTime)
+	block := addTestBlockForTime(t, ctx, bs, blockTime)
 
-	addTestNode(t, ns, block, "deadbeef01")
-	addTestNode(t, ns, block, "deadbeef02")
+	addTestNode(t, ctx, ns, block, "deadbeef01")
+	addTestNode(t, ctx, ns, block, "deadbeef02")
 
 	for i := 0; i < 2; i++ {
 		for j := 0; j < 10; j++ {
 			blockTime = blockTime.Add(time.Minute)
-			block := addTestBlockForTime(t, bs, blockTime)
+			block := addTestBlockForTime(t, ctx, bs, blockTime)
 
 			kr := entities.KeyRotation{
 				NodeID:      entities.NodeID(fmt.Sprintf("deadbeef%02d", i+1)),

--- a/datanode/sqlstore/market_data_test.go
+++ b/datanode/sqlstore/market_data_test.go
@@ -28,7 +28,6 @@ import (
 
 	"code.vegaprotocol.io/vega/datanode/entities"
 	"code.vegaprotocol.io/vega/datanode/sqlstore"
-	"github.com/jackc/pgx/v4"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,27 +73,19 @@ func Test_MarketData(t *testing.T) {
 }
 
 func shouldInsertAValidMarketDataRecord(t *testing.T) {
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
 	md := sqlstore.NewMarketData(connectionSource)
 
-	DeleteEverything()
-
-	config := NewTestConfig()
-	connStr := config.ConnectionConfig.GetConnectionString()
-
-	testTimeout := time.Second * 10
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
-
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
 	var rowCount int
 
-	err = conn.QueryRow(ctx, `select count(*) from market_data`).Scan(&rowCount)
+	err := connectionSource.Connection.QueryRow(ctx, `select count(*) from market_data`).Scan(&rowCount)
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, bs)
+	block := addTestBlock(t, ctx, bs)
 
 	err = md.Add(&entities.MarketData{
 		Market:            entities.MarketID("deadbeef"),
@@ -106,22 +97,22 @@ func shouldInsertAValidMarketDataRecord(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = md.Flush(context.Background())
+	_, err = md.Flush(ctx)
 	require.NoError(t, err)
 
-	err = conn.QueryRow(ctx, `select count(*) from market_data`).Scan(&rowCount)
+	err = connectionSource.Connection.QueryRow(ctx, `select count(*) from market_data`).Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, rowCount)
 }
 
 func getLatestMarketData(t *testing.T) {
-	store, err := setupMarketData(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	store, err := setupMarketData(t, ctx)
 	if err != nil {
 		t.Fatalf("could not set up test: %s", err)
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
 
 	marketID := entities.MarketID("8cc0e020c0bc2f9eba77749d81ecec8283283b85941722c2cb88318aaf8b8cd8")
 
@@ -167,13 +158,13 @@ func getLatestMarketData(t *testing.T) {
 }
 
 func getAllForMarketBetweenDates(t *testing.T) {
-	store, err := setupMarketData(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	store, err := setupMarketData(t, ctx)
 	if err != nil {
 		t.Fatalf("could not set up test: %s", err)
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
 
 	market := "8cc0e020c0bc2f9eba77749d81ecec8283283b85941722c2cb88318aaf8b8cd8"
 
@@ -417,11 +408,11 @@ func getAllForMarketBetweenDates(t *testing.T) {
 }
 
 func getForMarketFromDate(t *testing.T) {
-	store, err := setupMarketData(t)
-	require.NoError(t, err)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	store, err := setupMarketData(t, ctx)
+	require.NoError(t, err)
 
 	startDate := time.Date(2022, 2, 11, 10, 5, 0, 0, time.UTC)
 
@@ -641,11 +632,11 @@ func getForMarketFromDate(t *testing.T) {
 }
 
 func getForMarketToDate(t *testing.T) {
-	store, err := setupMarketData(t)
-	require.NoError(t, err)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	store, err := setupMarketData(t, ctx)
+	require.NoError(t, err)
 
 	startDate := time.Date(2022, 2, 11, 10, 2, 0, 0, time.UTC)
 
@@ -868,13 +859,11 @@ func getForMarketToDate(t *testing.T) {
 	})
 }
 
-func setupMarketData(t *testing.T) (*sqlstore.MarketData, error) {
+func setupMarketData(t *testing.T, ctx context.Context) (*sqlstore.MarketData, error) {
 	t.Helper()
 
 	bs := sqlstore.NewBlocks(connectionSource)
 	md := sqlstore.NewMarketData(connectionSource)
-
-	DeleteEverything()
 
 	f, err := os.Open(filepath.Join("testdata", "marketdata.csv"))
 	if err != nil {
@@ -889,6 +878,7 @@ func setupMarketData(t *testing.T) (*sqlstore.MarketData, error) {
 	hash, err = hex.DecodeString("deadbeef")
 	assert.NoError(t, err)
 
+	addedBlocksAt := make(map[time.Time]struct{})
 	seqNum := 0
 	for {
 		line, err := reader.Read()
@@ -902,20 +892,24 @@ func setupMarketData(t *testing.T) (*sqlstore.MarketData, error) {
 		marketData := csvToMarketData(t, line, seqNum)
 		seqNum++
 
-		// Postgres only stores timestamps in microsecond resolution
-		block := entities.Block{
-			VegaTime: marketData.VegaTime,
-			Height:   2,
-			Hash:     hash,
-		}
+		if _, alreadyAdded := addedBlocksAt[marketData.VegaTime]; !alreadyAdded {
+			// Postgres only stores timestamps in microsecond resolution
+			block := entities.Block{
+				VegaTime: marketData.VegaTime,
+				Height:   2,
+				Hash:     hash,
+			}
 
-		// Add it to the database
-		_ = bs.Add(context.Background(), block)
+			// Add it to the database
+			err = bs.Add(ctx, block)
+			require.NoError(t, err)
+			addedBlocksAt[marketData.VegaTime] = struct{}{}
+		}
 
 		err = md.Add(marketData)
 		require.NoError(t, err)
 	}
-	_, err = md.Flush(context.Background())
+	_, err = md.Flush(ctx)
 	require.NoError(t, err)
 
 	return md, nil

--- a/datanode/sqlstore/markets_test.go
+++ b/datanode/sqlstore/markets_test.go
@@ -21,7 +21,6 @@ import (
 	"code.vegaprotocol.io/vega/datanode/sqlstore"
 	"code.vegaprotocol.io/vega/protos/vega"
 	"github.com/georgysavva/scany/pgxscan"
-	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,13 +38,11 @@ func TestMarkets_Get(t *testing.T) {
 }
 
 func getByIDShouldReturnTheRequestedMarketIfItExists(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
+	bs, md := setupMarketsTest(t)
 
-	testTimeout := time.Second * 10
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
-
-	block := addTestBlock(t, bs)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+	block := addTestBlock(t, ctx, bs)
 
 	market := entities.Market{
 		ID:       "deadbeef",
@@ -65,13 +62,11 @@ func getByIDShouldReturnTheRequestedMarketIfItExists(t *testing.T) {
 }
 
 func getByIDShouldReturnErrorIfTheMarketDoesNotExist(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
+	bs, md := setupMarketsTest(t)
 
-	testTimeout := time.Second * 10
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
-
-	block := addTestBlock(t, bs)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+	block := addTestBlock(t, ctx, bs)
 
 	market := entities.Market{
 		ID:       "deadbeef",
@@ -87,13 +82,11 @@ func getByIDShouldReturnErrorIfTheMarketDoesNotExist(t *testing.T) {
 }
 
 func getAllShouldNotIncludeRejectedMarkets(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
+	bs, md := setupMarketsTest(t)
 
-	testTimeout := time.Second * 10
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
-
-	block := addTestBlock(t, bs)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+	block := addTestBlock(t, ctx, bs)
 
 	market := entities.Market{
 		ID:       "deadbeef",
@@ -123,13 +116,11 @@ func getAllShouldNotIncludeRejectedMarkets(t *testing.T) {
 }
 
 func getAllPagedShouldNotIncludeRejectedMarkets(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
+	bs, md := setupMarketsTest(t)
 
-	testTimeout := time.Second * 10
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
-
-	block := addTestBlock(t, bs)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+	block := addTestBlock(t, ctx, bs)
 
 	market := entities.Market{
 		ID:       "deadbeef",
@@ -165,61 +156,49 @@ func getAllPagedShouldNotIncludeRejectedMarkets(t *testing.T) {
 }
 
 func shouldInsertAValidMarketRecord(t *testing.T) {
-	bs, md, config := setupMarketsTest(t)
-	connStr := config.ConnectionConfig.GetConnectionString()
+	bs, md := setupMarketsTest(t)
 
-	testTimeout := time.Second * 1000000
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
+	conn := connectionSource.Connection
 	var rowCount int
 
-	err = conn.QueryRow(ctx, `select count(*) from markets`).Scan(&rowCount)
+	err := conn.QueryRow(ctx, `select count(*) from markets`).Scan(&rowCount)
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, bs)
+	block := addTestBlock(t, ctx, bs)
 
 	marketProto := getTestMarket()
 
 	market, err := entities.NewMarketFromProto(marketProto, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting market proto to database entity")
 
-	err = md.Upsert(context.Background(), market)
+	err = md.Upsert(ctx, market)
 	require.NoError(t, err, "Saving market entity to database")
 	err = conn.QueryRow(ctx, `select count(*) from markets`).Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, rowCount)
 }
 
-func setupMarketsTest(t *testing.T) (*sqlstore.Blocks, *sqlstore.Markets, sqlstore.Config) {
+func setupMarketsTest(t *testing.T) (*sqlstore.Blocks, *sqlstore.Markets) {
 	t.Helper()
 	bs := sqlstore.NewBlocks(connectionSource)
 	md := sqlstore.NewMarkets(connectionSource)
-
-	DeleteEverything()
-
-	config := NewTestConfig()
-
-	return bs, md, config
+	return bs, md
 }
 
 func shouldUpdateAValidMarketRecord(t *testing.T) {
-	bs, md, config := setupMarketsTest(t)
-	connStr := config.ConnectionConfig.GetConnectionString()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 
-	testTimeout := time.Second * 10
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	defer cancel()
-
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
+	conn := connectionSource.Connection
 	var rowCount int
 
 	t.Run("should have no markets in the database", func(t *testing.T) {
-		err = conn.QueryRow(ctx, `select count(*) from markets`).Scan(&rowCount)
+		err := conn.QueryRow(ctx, `select count(*) from markets`).Scan(&rowCount)
 		require.NoError(t, err)
 		assert.Equal(t, 0, rowCount)
 	})
@@ -228,13 +207,13 @@ func shouldUpdateAValidMarketRecord(t *testing.T) {
 	var marketProto *vega.Market
 
 	t.Run("should insert a valid market record to the database", func(t *testing.T) {
-		block = addTestBlock(t, bs)
+		block = addTestBlock(t, ctx, bs)
 		marketProto = getTestMarket()
 
 		market, err := entities.NewMarketFromProto(marketProto, generateTxHash(), block.VegaTime)
 		require.NoError(t, err, "Converting market proto to database entity")
 
-		err = md.Upsert(context.Background(), market)
+		err = md.Upsert(ctx, market)
 		require.NoError(t, err, "Saving market entity to database")
 
 		var got entities.Market
@@ -253,7 +232,7 @@ func shouldUpdateAValidMarketRecord(t *testing.T) {
 
 		require.NoError(t, err, "Converting market proto to database entity")
 
-		err = md.Upsert(context.Background(), market)
+		err = md.Upsert(ctx, market)
 		require.NoError(t, err, "Saving market entity to database")
 
 		var got entities.Market
@@ -268,12 +247,12 @@ func shouldUpdateAValidMarketRecord(t *testing.T) {
 		newMarketProto := marketProto.DeepClone()
 		newMarketProto.TradableInstrument.Instrument.Metadata.Tags = append(newMarketProto.TradableInstrument.Instrument.Metadata.Tags, "DDD")
 		time.Sleep(time.Second)
-		newBlock := addTestBlock(t, bs)
+		newBlock := addTestBlock(t, ctx, bs)
 
 		market, err := entities.NewMarketFromProto(newMarketProto, generateTxHash(), newBlock.VegaTime)
 		require.NoError(t, err, "Converting market proto to database entity")
 
-		err = md.Upsert(context.Background(), market)
+		err = md.Upsert(ctx, market)
 		require.NoError(t, err, "Saving market entity to database")
 
 		err = conn.QueryRow(ctx, `select count(*) from markets`).Scan(&rowCount)
@@ -455,7 +434,7 @@ func populateTestMarkets(ctx context.Context, t *testing.T, bs *sqlstore.Blocks,
 	}
 
 	for _, market := range markets {
-		block := addTestBlock(t, bs)
+		block := addTestBlock(t, ctx, bs)
 		market.VegaTime = block.VegaTime
 		blockTimes[market.ID.String()] = block.VegaTime
 		err := md.Upsert(ctx, &market)
@@ -481,9 +460,11 @@ func TestMarketsCursorPagination(t *testing.T) {
 }
 
 func testCursorPaginationReturnsTheSpecifiedMarket(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	bs, md := setupMarketsTest(t)
+
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, false)
@@ -512,9 +493,9 @@ func testCursorPaginationReturnsTheSpecifiedMarket(t *testing.T) {
 }
 
 func testCursorPaginationReturnsAllMarkets(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 
@@ -550,9 +531,9 @@ func testCursorPaginationReturnsAllMarkets(t *testing.T) {
 }
 
 func testCursorPaginationReturnsFirstPage(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	first := int32(3)
@@ -589,9 +570,9 @@ func testCursorPaginationReturnsFirstPage(t *testing.T) {
 }
 
 func testCursorPaginationReturnsLastPage(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	last := int32(3)
@@ -628,9 +609,9 @@ func testCursorPaginationReturnsLastPage(t *testing.T) {
 }
 
 func testCursorPaginationReturnsPageTraversingForward(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	first := int32(3)
@@ -673,9 +654,9 @@ func testCursorPaginationReturnsPageTraversingForward(t *testing.T) {
 }
 
 func testCursorPaginationReturnsPageTraversingBackward(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	last := int32(3)
@@ -718,9 +699,9 @@ func testCursorPaginationReturnsPageTraversingBackward(t *testing.T) {
 }
 
 func testCursorPaginationReturnsTheSpecifiedMarketNewestFirst(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, true)
@@ -754,9 +735,9 @@ func testCursorPaginationReturnsTheSpecifiedMarketNewestFirst(t *testing.T) {
 }
 
 func testCursorPaginationReturnsAllMarketsNewestFirst(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 
@@ -792,9 +773,9 @@ func testCursorPaginationReturnsAllMarketsNewestFirst(t *testing.T) {
 }
 
 func testCursorPaginationReturnsFirstPageNewestFirst(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	first := int32(3)
@@ -831,9 +812,9 @@ func testCursorPaginationReturnsFirstPageNewestFirst(t *testing.T) {
 }
 
 func testCursorPaginationReturnsLastPageNewestFirst(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	last := int32(3)
@@ -870,9 +851,9 @@ func testCursorPaginationReturnsLastPageNewestFirst(t *testing.T) {
 }
 
 func testCursorPaginationReturnsPageTraversingForwardNewestFirst(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	first := int32(3)
@@ -915,9 +896,9 @@ func testCursorPaginationReturnsPageTraversingForwardNewestFirst(t *testing.T) {
 }
 
 func testCursorPaginationReturnsPageTraversingBackwardNewestFirst(t *testing.T) {
-	bs, md, _ := setupMarketsTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
+	bs, md := setupMarketsTest(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
 	blockTimes := make(map[string]time.Time)
 	populateTestMarkets(ctx, t, bs, md, blockTimes)
 	last := int32(3)

--- a/datanode/sqlstore/network_limits_test.go
+++ b/datanode/sqlstore/network_limits_test.go
@@ -13,7 +13,6 @@
 package sqlstore_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -24,11 +23,12 @@ import (
 )
 
 func TestNetworkLimits(t *testing.T) {
-	defer DeleteEverything()
-	ctx := context.Background()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	bs := sqlstore.NewBlocks(connectionSource)
-	block := addTestBlock(t, bs)
-	block2 := addTestBlock(t, bs)
+	block := addTestBlock(t, ctx, bs)
+	block2 := addTestBlock(t, ctx, bs)
 	nls := sqlstore.NewNetworkLimits(connectionSource)
 
 	nl := entities.NetworkLimits{

--- a/datanode/sqlstore/parties.go
+++ b/datanode/sqlstore/parties.go
@@ -41,9 +41,9 @@ func NewParties(connectionSource *ConnectionSource) *Parties {
 
 // Initialise adds the built-in 'network' party which is never explicitly sent on the event
 // bus, but nonetheless is necessary.
-func (ps *Parties) Initialise() {
+func (ps *Parties) Initialise(ctx context.Context) {
 	defer metrics.StartSQLQuery("Parties", "Initialise")()
-	_, err := ps.Connection.Exec(context.Background(),
+	_, err := ps.Connection.Exec(ctx,
 		`INSERT INTO parties(id, tx_hash) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
 		entities.PartyID("network"), entities.TxHash("01"))
 	if err != nil {

--- a/datanode/sqlstore/votes_test.go
+++ b/datanode/sqlstore/votes_test.go
@@ -31,7 +31,9 @@ import (
 	"code.vegaprotocol.io/vega/protos/vega"
 )
 
-func addTestVote(t *testing.T, vs *sqlstore.Votes,
+func addTestVote(t *testing.T,
+	ctx context.Context,
+	vs *sqlstore.Votes,
 	party entities.Party,
 	proposal entities.Proposal,
 	value entities.VoteValue,
@@ -48,7 +50,7 @@ func addTestVote(t *testing.T, vs *sqlstore.Votes,
 		VegaTime:                    block.VegaTime,
 		InitialTime:                 block.VegaTime,
 	}
-	err := vs.Add(context.Background(), r)
+	err := vs.Add(ctx, r)
 	require.NoError(t, err)
 	return r
 }
@@ -66,51 +68,53 @@ func assertVotesMatch(t *testing.T, expected, actual []entities.Vote) {
 }
 
 func TestVotes(t *testing.T) {
-	defer DeleteEverything()
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
 	partyStore := sqlstore.NewParties(connectionSource)
 	propStore := sqlstore.NewProposals(connectionSource)
 	voteStore := sqlstore.NewVotes(connectionSource)
 	blockStore := sqlstore.NewBlocks(connectionSource)
-	block1 := addTestBlock(t, blockStore)
-	block2 := addTestBlock(t, blockStore)
+	block1 := addTestBlock(t, ctx, blockStore)
+	block2 := addTestBlock(t, ctx, blockStore)
 
-	party1 := addTestParty(t, partyStore, block1)
-	party2 := addTestParty(t, partyStore, block1)
-	prop1 := addTestProposal(t, propStore, helpers.GenerateID(), party1, helpers.GenerateID(), block1, entities.ProposalStateEnacted, entities.ProposalRationale{ProposalRationale: &vega.ProposalRationale{Title: "myurl1.com", Description: "desc"}}, entities.ProposalTerms{ProposalTerms: &vega.ProposalTerms{Change: &vega.ProposalTerms_NewMarket{}}})
-	prop2 := addTestProposal(t, propStore, helpers.GenerateID(), party1, helpers.GenerateID(), block1, entities.ProposalStateEnacted, entities.ProposalRationale{ProposalRationale: &vega.ProposalRationale{Title: "myurl2.com", Description: "desc"}}, entities.ProposalTerms{ProposalTerms: &vega.ProposalTerms{Change: &vega.ProposalTerms_NewMarket{}}})
+	party1 := addTestParty(t, ctx, partyStore, block1)
+	party2 := addTestParty(t, ctx, partyStore, block1)
+	prop1 := addTestProposal(t, ctx, propStore, helpers.GenerateID(), party1, helpers.GenerateID(), block1, entities.ProposalStateEnacted, entities.ProposalRationale{ProposalRationale: &vega.ProposalRationale{Title: "myurl1.com", Description: "desc"}}, entities.ProposalTerms{ProposalTerms: &vega.ProposalTerms{Change: &vega.ProposalTerms_NewMarket{}}})
+	prop2 := addTestProposal(t, ctx, propStore, helpers.GenerateID(), party1, helpers.GenerateID(), block1, entities.ProposalStateEnacted, entities.ProposalRationale{ProposalRationale: &vega.ProposalRationale{Title: "myurl2.com", Description: "desc"}}, entities.ProposalTerms{ProposalTerms: &vega.ProposalTerms{Change: &vega.ProposalTerms_NewMarket{}}})
 
 	party1ID := party1.ID.String()
 	prop1ID := prop1.ID.String()
 
-	vote1 := addTestVote(t, voteStore, party1, prop1, entities.VoteValueYes, block1)
-	vote2 := addTestVote(t, voteStore, party1, prop2, entities.VoteValueYes, block1)
+	vote1 := addTestVote(t, ctx, voteStore, party1, prop1, entities.VoteValueYes, block1)
+	vote2 := addTestVote(t, ctx, voteStore, party1, prop2, entities.VoteValueYes, block1)
 	// Change vote in same block
-	vote3 := addTestVote(t, voteStore, party2, prop1, entities.VoteValueYes, block1)
-	vote3b := addTestVote(t, voteStore, party2, prop1, entities.VoteValueNo, block1)
+	vote3 := addTestVote(t, ctx, voteStore, party2, prop1, entities.VoteValueYes, block1)
+	vote3b := addTestVote(t, ctx, voteStore, party2, prop1, entities.VoteValueNo, block1)
 	// Change vote in next block
-	vote4 := addTestVote(t, voteStore, party2, prop2, entities.VoteValueYes, block1)
-	vote4b := addTestVote(t, voteStore, party2, prop2, entities.VoteValueNo, block2)
+	vote4 := addTestVote(t, ctx, voteStore, party2, prop2, entities.VoteValueYes, block1)
+	vote4b := addTestVote(t, ctx, voteStore, party2, prop2, entities.VoteValueNo, block2)
 
 	_ = vote3
 	_ = vote4
 
 	t.Run("GetAll", func(t *testing.T) {
 		expected := []entities.Vote{vote1, vote2, vote3b, vote4b}
-		actual, err := voteStore.Get(context.Background(), nil, nil, nil)
+		actual, err := voteStore.Get(ctx, nil, nil, nil)
 		require.NoError(t, err)
 		assertVotesMatch(t, expected, actual)
 	})
 
 	t.Run("GetByProposal", func(t *testing.T) {
 		expected := []entities.Vote{vote1, vote3b}
-		actual, err := voteStore.Get(context.Background(), &prop1ID, nil, nil)
+		actual, err := voteStore.Get(ctx, &prop1ID, nil, nil)
 		require.NoError(t, err)
 		assertVotesMatch(t, expected, actual)
 	})
 
 	t.Run("GetByParty", func(t *testing.T) {
 		expected := []entities.Vote{vote1, vote2}
-		actual, err := voteStore.Get(context.Background(), nil, &party1ID, nil)
+		actual, err := voteStore.Get(ctx, nil, &party1ID, nil)
 		require.NoError(t, err)
 		assertVotesMatch(t, expected, actual)
 	})
@@ -118,7 +122,7 @@ func TestVotes(t *testing.T) {
 	t.Run("GetByValue", func(t *testing.T) {
 		expected := []entities.Vote{vote3b, vote4b}
 		no := entities.VoteValueNo
-		actual, err := voteStore.Get(context.Background(), nil, nil, &no)
+		actual, err := voteStore.Get(ctx, nil, nil, &no)
 		require.NoError(t, err)
 		assertVotesMatch(t, expected, actual)
 	})
@@ -126,20 +130,20 @@ func TestVotes(t *testing.T) {
 	t.Run("GetByEverything", func(t *testing.T) {
 		expected := []entities.Vote{vote1}
 		yes := entities.VoteValueYes
-		actual, err := voteStore.Get(context.Background(), &prop1ID, &party1ID, &yes)
+		actual, err := voteStore.Get(ctx, &prop1ID, &party1ID, &yes)
 		require.NoError(t, err)
 		assertVotesMatch(t, expected, actual)
 	})
 
 	t.Run("GetConnectionByEverything", func(t *testing.T) {
 		expected := []entities.Vote{vote1}
-		actual, _, err := voteStore.GetConnection(context.Background(), &prop1ID, &party1ID, entities.DefaultCursorPagination(true))
+		actual, _, err := voteStore.GetConnection(ctx, &prop1ID, &party1ID, entities.DefaultCursorPagination(true))
 		require.NoError(t, err)
 		assertVotesMatch(t, expected, actual)
 	})
 }
 
-func setupPaginationTestVotes(t *testing.T) (*sqlstore.Votes, entities.Party, []entities.Vote) {
+func setupPaginationTestVotes(t *testing.T, ctx context.Context) (*sqlstore.Votes, entities.Party, []entities.Vote) {
 	t.Helper()
 	votes := make([]entities.Vote, 0, 10)
 
@@ -149,15 +153,16 @@ func setupPaginationTestVotes(t *testing.T) (*sqlstore.Votes, entities.Party, []
 	blockStore := sqlstore.NewBlocks(connectionSource)
 
 	blockTime := time.Now()
-	block := addTestBlockForTime(t, blockStore, blockTime)
-	party := addTestParty(t, partyStore, block)
+	block := addTestBlockForTime(t, ctx, blockStore, blockTime)
+	party := addTestParty(t, ctx, partyStore, block)
 
 	rand.Seed(time.Now().UnixNano())
 
 	for i := 0; i < 10; i++ {
 		blockTime = blockTime.Add(time.Second)
-		block = addTestBlockForTime(t, blockStore, blockTime)
+		block = addTestBlockForTime(t, ctx, blockStore, blockTime)
 		prop := addTestProposal(t,
+			ctx,
 			propStore,
 			helpers.GenerateID(),
 			party,
@@ -173,7 +178,7 @@ func setupPaginationTestVotes(t *testing.T) (*sqlstore.Votes, entities.Party, []
 			voteValue = entities.VoteValueNo
 		}
 
-		vote := addTestVote(t, voteStore, party, prop, voteValue, block)
+		vote := addTestVote(t, ctx, voteStore, party, prop, voteValue, block)
 		votes = append(votes, vote)
 	}
 
@@ -195,12 +200,12 @@ func TestVotesCursorPagination(t *testing.T) {
 }
 
 func testVotesCursorPaginationNoPagination(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, false)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes, got)
@@ -213,13 +218,13 @@ func testVotesCursorPaginationNoPagination(t *testing.T) {
 }
 
 func testVotesCursorPaginationFirstNoAfter(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	first := int32(3)
 	pagination, err := entities.NewCursorPagination(&first, nil, nil, nil, false)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[:3], got)
@@ -232,14 +237,14 @@ func testVotesCursorPaginationFirstNoAfter(t *testing.T) {
 }
 
 func testVotesCursorPaginationFirstWithAfter(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	first := int32(3)
 	after := votes[2].Cursor().Encode()
 	pagination, err := entities.NewCursorPagination(&first, &after, nil, nil, false)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[3:6], got)
@@ -252,13 +257,13 @@ func testVotesCursorPaginationFirstWithAfter(t *testing.T) {
 }
 
 func testVotesCursorPaginationLastNoBefore(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	last := int32(3)
 	pagination, err := entities.NewCursorPagination(nil, nil, &last, nil, false)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[7:], got)
@@ -271,14 +276,14 @@ func testVotesCursorPaginationLastNoBefore(t *testing.T) {
 }
 
 func testVotesCursorPaginationLastWithBefore(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	last := int32(3)
 	before := votes[7].Cursor().Encode()
 	pagination, err := entities.NewCursorPagination(nil, nil, &last, &before, false)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[4:7], got)
@@ -291,13 +296,13 @@ func testVotesCursorPaginationLastWithBefore(t *testing.T) {
 }
 
 func testVotesCursorPaginationNoPaginationNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	votes = entities.ReverseSlice(votes)
 	pagination, err := entities.NewCursorPagination(nil, nil, nil, nil, true)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes, got)
@@ -310,14 +315,14 @@ func testVotesCursorPaginationNoPaginationNewestFirst(t *testing.T) {
 }
 
 func testVotesCursorPaginationFirstNoAfterNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	votes = entities.ReverseSlice(votes)
 	first := int32(3)
 	pagination, err := entities.NewCursorPagination(&first, nil, nil, nil, true)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[:3], got)
@@ -330,15 +335,15 @@ func testVotesCursorPaginationFirstNoAfterNewestFirst(t *testing.T) {
 }
 
 func testVotesCursorPaginationFirstWithAfterNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	votes = entities.ReverseSlice(votes)
 	first := int32(3)
 	after := votes[2].Cursor().Encode()
 	pagination, err := entities.NewCursorPagination(&first, &after, nil, nil, true)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[3:6], got)
@@ -351,14 +356,14 @@ func testVotesCursorPaginationFirstWithAfterNewestFirst(t *testing.T) {
 }
 
 func testVotesCursorPaginationLastNoBeforeNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	votes = entities.ReverseSlice(votes)
 	last := int32(3)
 	pagination, err := entities.NewCursorPagination(nil, nil, &last, nil, true)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[7:], got)
@@ -371,15 +376,15 @@ func testVotesCursorPaginationLastNoBeforeNewestFirst(t *testing.T) {
 }
 
 func testVotesCursorPaginationLastWithBeforeNewestFirst(t *testing.T) {
-	defer DeleteEverything()
-	vs, party, votes := setupPaginationTestVotes(t)
+	ctx, rollback := tempTransaction(t)
+	defer rollback()
+
+	vs, party, votes := setupPaginationTestVotes(t, ctx)
 	votes = entities.ReverseSlice(votes)
 	last := int32(3)
 	before := votes[7].Cursor().Encode()
 	pagination, err := entities.NewCursorPagination(nil, nil, &last, &before, true)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	got, pageInfo, err := vs.GetByPartyConnection(ctx, party.ID.String(), pagination)
 	require.NoError(t, err)
 	require.Equal(t, votes[4:7], got)

--- a/datanode/sqlsubscribers/margin_levels_test.go
+++ b/datanode/sqlsubscribers/margin_levels_test.go
@@ -70,6 +70,6 @@ func (TestNullAccountSource) Obtain(ctx context.Context, a *entities.Account) er
 	return nil
 }
 
-func (TestNullAccountSource) GetByID(id entities.AccountID) (entities.Account, error) {
+func (TestNullAccountSource) GetByID(ctx context.Context, id entities.AccountID) (entities.Account, error) {
 	panic("implement me")
 }

--- a/datanode/sqlsubscribers/transfers.go
+++ b/datanode/sqlsubscribers/transfers.go
@@ -33,7 +33,7 @@ type TransferStore interface {
 
 type AccountSource interface {
 	Obtain(ctx context.Context, a *entities.Account) error
-	GetByID(id entities.AccountID) (entities.Account, error)
+	GetByID(ctx context.Context, id entities.AccountID) (entities.Account, error)
 }
 
 type Transfer struct {


### PR DESCRIPTION
Closes #7064 

As a large bonus, the SQL store tests go from taking ~20 minutes to taking ~40 seconds.

Sorry it's a fairly large diff, but it's mostly trivial stuff. This turned out to be _much_ more of a mission than I anticipated. 

Currently for each test we iterate over all the tables in the database and truncate them to ensure a fresh database for each test.

There was a pretty big bug where we were sharing a global variable with e.g. the integration and dehistory tests, which meant we were trying to drop the wrong database. However even after fixing that truncating tables was problematic and kept running into locking issues with timescales's background worker processes.

Instead, here we start a transaction for each test and simply roll it back when done.

This exposed a few places where we weren't correctly making use of contexts in the SQL stores, so I've fixed that as well.