### PR TITLE
fix: check if event forwarding engine is started before reloading config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [7037](https://github.com/vegaprotocol/vega/issues/7037) - Reinstate permissions endpoints on the wallet API
 - [7034](https://github.com/vegaprotocol/vega/issues/7034) - Rename `network` to `name` in `admin.remove_network`
 - [7031](https://github.com/vegaprotocol/vega/issues/7031) - `datanode` expects protocol upgrade event in the right sequence
+- [7072](https://github.com/vegaprotocol/vega/issues/7072) - Check if event forwarding engine is started before reloading
 - [7017](https://github.com/vegaprotocol/vega/issues/7017) - Fix issue with market update during opening auction
 
 

--- a/core/evtforward/engine.go
+++ b/core/evtforward/engine.go
@@ -56,8 +56,9 @@ func (e *Engine) ReloadConf(config Config) {
 		)
 		e.log.SetLevel(config.Level.Get())
 	}
-
-	e.ethEngine.ReloadConf(config.Ethereum)
+	if e.ethEngine != nil {
+		e.ethEngine.ReloadConf(config.Ethereum)
+	}
 }
 
 func (e *Engine) UpdateStakingStartingBlock(b uint64) {


### PR DESCRIPTION
closes #7072 

When loading from a snapshot the flow goes:
- setup config watchers
- set-time now from the vega time in the snapshot
- propagate network parameters

`ethEngine` is initialised during the propagation of the network parameters, and the config watches are kicked off during a time update. So if you set a node to load from snapshot, and make a change to the config file in the slim interval between the watcher being set up, and the snapshot-engine updating the time, we'll panic as we try to update the `ethEngine` that doesn't exist yet.