### PR TITLE
feat: label AC 0038-OLIQ-011

### DIFF
--- a/core/integration/features/position_tracking/verified-positions-resolution-5-lognormal.feature
+++ b/core/integration/features/position_tracking/verified-positions-resolution-5-lognormal.feature
@@ -24,7 +24,8 @@ Feature: Position resolution case 5 lognormal risk model
       | network.markPriceUpdateMaximumFrequency | 0s    |
 
   @MTMDelta
-  Scenario: using lognormal risk model, set "designatedLooser" closeout while the position of "designatedLooser" is not fully covered by orders on the order book (0007-POSN-013)
+  Scenario: using lognormal risk model, set "designatedLooser" closeout while the position of "designatedLooser" is not fully covered by orders on the order book (0007-POSN-013, 0038-OLIQ-011)
+
 
     # setup accounts
     Given the parties deposit on asset's general account the following amount:
@@ -60,6 +61,7 @@ Feature: Position resolution case 5 lognormal risk model
       | party  | asset | market id | margin | general      | bond |
       | lpprov | USD   | ETH/DEC19 | 682144 | 999999308856 | 9000 |
 
+    # If an LP order has offset set such that the resulting price falls outside [1,2001] then the system adjusts it automatically so that it's placed on the bound
     Then the order book should have the following volumes for market "ETH/DEC19":
       | side | price | volume |
       | sell | 2001  | 5      |


### PR DESCRIPTION
Label AC 0038-OLIQ-011: If an LP order has offset set such that the resulting price falls outside `[min_lp_vol_price, max_lp_vol_price]` then the system adjusts it automatically so that it's placed on the bound

close [issue #7056 ](https://github.com/vegaprotocol/vega/issues/7056)