### PR TITLE
fix: set all order's original price from priceFactor after snapshot r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [7102](https://github.com/vegaprotocol/vega/issues/7102) - Ensure the `api-token init -f` wipes the tokens file
 - [7106](https://github.com/vegaprotocol/vega/issues/7106) - Properties of oracle data sent in non-deterministic order 
 - [7029](https://github.com/vegaprotocol/vega/issues/7029) - Remove unsafe `GRPC` endpoint in data node
+- [7112](https://github.com/vegaprotocol/vega/issues/7112) - Restore order's original price when restoring from a snapshot
 
 
 ## 0.64.0

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -667,6 +667,9 @@ func (m *Market) PostRestore(ctx context.Context) error {
 		parties[p] = struct{}{}
 	}
 	m.parties = parties
+
+	// tell the matching engine about the markets price factor so it can finish restoring orders
+	m.matching.RestoreWithMarketPriceFactor(m.priceFactor)
 	return nil
 }
 

--- a/core/execution/pegged_orders.go
+++ b/core/execution/pegged_orders.go
@@ -76,7 +76,7 @@ func (p *PeggedOrders) Park(o *types.Order) {
 	o.UpdatedAt = p.timeService.GetTimeNow().UnixNano()
 	o.Status = types.OrderStatusParked
 	o.Price = num.UintZero()
-	o.OriginalPrice = num.UintZero()
+	o.OriginalPrice = nil
 
 	p.parked = append(p.parked, o)
 	p.isParked[o.ID] = struct{}{}

--- a/core/matching/snapshot.go
+++ b/core/matching/snapshot.go
@@ -17,6 +17,7 @@ import (
 	"log"
 
 	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/num"
 	"code.vegaprotocol.io/vega/libs/proto"
 	"code.vegaprotocol.io/vega/logging"
 )
@@ -119,4 +120,16 @@ func (b *OrderBook) LoadState(_ context.Context, payload *types.Payload) ([]type
 		b.indicativePriceAndVolume = NewIndicativePriceAndVolume(b.log, b.buy, b.sell)
 	}
 	return nil, nil
+}
+
+// RestoreWithMarketPriceFactor takes the given market price factor and updates all the OriginalPrices
+// in the orders accordingly.
+func (b *OrderBook) RestoreWithMarketPriceFactor(priceFactor *num.Uint) {
+	for _, o := range b.ordersByID {
+		if o.Price.IsZero() {
+			continue
+		}
+		o.OriginalPrice = o.Price.Clone()
+		o.OriginalPrice.Div(o.Price, priceFactor)
+	}
 }

--- a/core/types/matching.go
+++ b/core/types/matching.go
@@ -183,7 +183,6 @@ func OrderFromProto(o *proto.Order) (*Order, error) {
 		Party:                o.PartyId,
 		Side:                 o.Side,
 		Price:                price,
-		OriginalPrice:        price.Clone(),
 		Size:                 o.Size,
 		Remaining:            o.Remaining,
 		TimeInForce:          o.TimeInForce,


### PR DESCRIPTION
closes #7112 

When we loaded from a snapshot we were just setting `order.OriginalPrice = order.Price.Clone()` instead of using the market's `priceFactor`. We now update all the order's orginal price in `PostRestore`.