### PR TITLE
fix: dehistory load was using incorrect database version when selecting constraints metadata

### DIFF
--- a/cmd/data-node/commands/dehistory/load.go
+++ b/cmd/data-node/commands/dehistory/load.go
@@ -115,7 +115,7 @@ func (cmd *loadCmd) Execute(_ []string) error {
 	if yes {
 		fmt.Printf("Loading history from block %d to %d...\n", from, to)
 
-		loaded, err := deHistoryService.LoadAllAvailableHistoryIntoDatanode(context.Background(), sqlstore.EmbedMigrations)
+		loaded, err := deHistoryService.LoadAllAvailableHistoryIntoDatanode(context.Background())
 		if err != nil {
 			return fmt.Errorf("failed to load all available history:%w", err)
 		}

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -101,7 +101,7 @@ func (l *NodeCommand) persistentPre([]string) (err error) {
 	}
 
 	if l.conf.SQLStore.WipeOnStartup {
-		if err = sqlstore.WipeDatabase(l.Log, l.conf.SQLStore.ConnectionConfig, sqlstore.EmbedMigrations); err != nil {
+		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(l.Log, l.conf.SQLStore.ConnectionConfig, sqlstore.EmbedMigrations); err != nil {
 			return fmt.Errorf("failed to wiped database:%w", err)
 		}
 		l.Log.Info("Wiped all existing data from the datanode")

--- a/datanode/dehistory/fsutil/fsutil.go
+++ b/datanode/dehistory/fsutil/fsutil.go
@@ -3,7 +3,6 @@ package fsutil
 import (
 	"archive/tar"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -12,8 +11,6 @@ import (
 
 	vgfs "code.vegaprotocol.io/vega/libs/fs"
 )
-
-var ErrMismatchedDeviceVersion = errors.New("mismatched device versions")
 
 // RemoveAllFromDirectoryIfExists used in place of os.RemoveAll when the directory should be emptied but not removed.
 func RemoveAllFromDirectoryIfExists(dir string) error {
@@ -135,66 +132,79 @@ func TarDirectoryWithDeterministicHeader(w io.Writer, devMajorVersion int64, sou
 	return nil
 }
 
-func DecompressAndUntarFile(compressedFilePath, decompressedFilesDestination string) (deviceMajVersion int64,
-	err error,
-) {
-	err = os.Mkdir(decompressedFilesDestination, fs.ModePerm)
+func GetSnapshotDatabaseVersion(snapshotFile string) (int64, error) {
+	sourceFile, err := os.Open(snapshotFile)
+	defer func() { _ = sourceFile.Close() }()
 	if err != nil {
-		return 0, fmt.Errorf("failed to make target diretory for uncompressed files %s: %w", decompressedFilesDestination, err)
+		return 0, fmt.Errorf("failed to open snapshot file %s: %w", snapshotFile, err)
+	}
+
+	zr, err := gzip.NewReader(sourceFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create zip file reader for file %s: %w", snapshotFile, err)
+	}
+
+	tr := tar.NewReader(zr)
+
+	header, err := tr.Next()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read source file header: %w", err)
+	}
+
+	return header.Devmajor, nil
+}
+
+func DecompressAndUntarFile(compressedFilePath, decompressedFilesDestination string) error {
+	err := os.Mkdir(decompressedFilesDestination, fs.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to make target diretory for uncompressed files %s: %w", decompressedFilesDestination, err)
 	}
 
 	sourceFile, err := os.Open(compressedFilePath)
 	defer func() { _ = sourceFile.Close() }()
 	if err != nil {
-		return 0, fmt.Errorf("failed to create source file %s: %w", compressedFilePath, err)
+		return fmt.Errorf("failed to create source file %s: %w", compressedFilePath, err)
 	}
 
 	zr, err := gzip.NewReader(sourceFile)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create zip file reader for file %s: %w", compressedFilePath, err)
+		return fmt.Errorf("failed to create zip file reader for file %s: %w", compressedFilePath, err)
 	}
 
-	deviceMajVersion, err = UntarFile(zr, decompressedFilesDestination)
+	err = UntarFile(zr, decompressedFilesDestination)
 	if err != nil {
-		return 0, err
+		return fmt.Errorf("failed to untar file %s: %w", compressedFilePath, err)
 	}
 
-	return deviceMajVersion, nil
+	return nil
 }
 
-func UntarFile(source io.Reader, decompressedFilesDestination string) (int64, error) {
+func UntarFile(source io.Reader, decompressedFilesDestination string) error {
 	tr := tar.NewReader(source)
 
-	deviceVersion := int64(-1)
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return 0, fmt.Errorf("failed to read source file: %w", err)
+			return fmt.Errorf("failed to read source file: %w", err)
 		}
 
 		targetFilePath := filepath.Join(decompressedFilesDestination, header.Name)
 
-		if deviceVersion == -1 {
-			deviceVersion = header.Devmajor
-		} else if header.Devmajor != deviceVersion {
-			return 0, ErrMismatchedDeviceVersion
-		}
-
 		fileToWrite, err := os.OpenFile(targetFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 		if err != nil {
-			return 0, fmt.Errorf("failed to open uncompressed targetFile file %s: %w", targetFilePath, err)
+			return fmt.Errorf("failed to open uncompressed targetFile file %s: %w", targetFilePath, err)
 		}
 
 		if _, err := io.Copy(fileToWrite, tr); err != nil {
-			return 0, fmt.Errorf("failed to copy compressed data to uncompressed target file %s:%w", targetFilePath, err)
+			return fmt.Errorf("failed to copy compressed data to uncompressed target file %s:%w", targetFilePath, err)
 		}
 
 		if err := fileToWrite.Close(); err != nil {
-			return 0, fmt.Errorf("failed to close uncompressed target file %s:%w", targetFilePath, err)
+			return fmt.Errorf("failed to close uncompressed target file %s:%w", targetFilePath, err)
 		}
 	}
-	return deviceVersion, nil
+	return nil
 }

--- a/datanode/dehistory/initialise_test.go
+++ b/datanode/dehistory/initialise_test.go
@@ -66,7 +66,7 @@ func TestInitialiseEmptyDataNode(t *testing.T) {
 
 	gomock.InOrder(first, second)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any(), sqlstore.EmbedMigrations).Times(1)
+	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{}, []int{})
 }
@@ -121,7 +121,7 @@ func TestInitialiseNonEmptyDataNode(t *testing.T) {
 
 	gomock.InOrder(first, second)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any(), sqlstore.EmbedMigrations).Times(1)
+	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{
 		FromHeight: 0,
@@ -214,7 +214,7 @@ func TestWhenMinimumBlockCountExceedsAvailableHistory(t *testing.T) {
 
 	gomock.InOrder(first, second)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any(), sqlstore.EmbedMigrations).Times(1)
+	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{}, []int{})
 }
@@ -240,7 +240,7 @@ func TestInitialiseToASpecifiedSegment(t *testing.T) {
 		HistorySegmentID: "segment1",
 	}, nil)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any(), sqlstore.EmbedMigrations).Times(1)
+	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{}, []int{})
 }

--- a/datanode/dehistory/mocks/dehistory_service_mock.go
+++ b/datanode/dehistory/mocks/dehistory_service_mock.go
@@ -6,7 +6,6 @@ package mocks
 
 import (
 	context "context"
-	fs "io/fs"
 	reflect "reflect"
 
 	dehistory "code.vegaprotocol.io/vega/datanode/dehistory"
@@ -71,16 +70,16 @@ func (mr *MockDeHistoryMockRecorder) GetMostRecentHistorySegmentFromPeers(arg0, 
 }
 
 // LoadAllAvailableHistoryIntoDatanode mocks base method.
-func (m *MockDeHistory) LoadAllAvailableHistoryIntoDatanode(arg0 context.Context, arg1 fs.FS) (snapshot.LoadResult, error) {
+func (m *MockDeHistory) LoadAllAvailableHistoryIntoDatanode(arg0 context.Context) (snapshot.LoadResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadAllAvailableHistoryIntoDatanode", arg0, arg1)
+	ret := m.ctrl.Call(m, "LoadAllAvailableHistoryIntoDatanode", arg0)
 	ret0, _ := ret[0].(snapshot.LoadResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadAllAvailableHistoryIntoDatanode indicates an expected call of LoadAllAvailableHistoryIntoDatanode.
-func (mr *MockDeHistoryMockRecorder) LoadAllAvailableHistoryIntoDatanode(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDeHistoryMockRecorder) LoadAllAvailableHistoryIntoDatanode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllAvailableHistoryIntoDatanode", reflect.TypeOf((*MockDeHistory)(nil).LoadAllAvailableHistoryIntoDatanode), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllAvailableHistoryIntoDatanode", reflect.TypeOf((*MockDeHistory)(nil).LoadAllAvailableHistoryIntoDatanode), arg0)
 }

--- a/datanode/dehistory/service.go
+++ b/datanode/dehistory/service.go
@@ -166,7 +166,7 @@ func (d *Service) GetSwarmKey() string {
 	return d.store.GetSwarmKey()
 }
 
-func (d *Service) LoadAllAvailableHistoryIntoDatanode(ctx context.Context, sqlFs fs.FS) (snapshot.LoadResult, error) {
+func (d *Service) LoadAllAvailableHistoryIntoDatanode(ctx context.Context) (snapshot.LoadResult, error) {
 	defer func() { _ = fsutil.RemoveAllFromDirectoryIfExists(d.snapshotsCopyFromDir) }()
 
 	err := os.MkdirAll(d.snapshotsCopyFromDir, fs.ModePerm)

--- a/datanode/dehistory/service_test.go
+++ b/datanode/dehistory/service_test.go
@@ -75,7 +75,8 @@ var (
 	postgresLog *bytes.Buffer
 
 	testMigrationsDir       string
-	testMigrationVersionNum int
+	highestMigrationNumber  int64
+	testMigrationVersionNum int64
 	sqlFs                   fs.FS
 )
 
@@ -84,6 +85,7 @@ func TestMain(t *testing.M) {
 	defer cancelOuterCtx()
 
 	testMigrationVersionNum, sqlFs = setupTestSQLMigrations()
+	highestMigrationNumber = testMigrationVersionNum - 1
 
 	var err error
 	snapshotsBackupDir, err = os.MkdirTemp("", "snapshotbackup")
@@ -123,7 +125,7 @@ func TestMain(t *testing.M) {
 
 		postgresLog = pgLog
 
-		emptyDatabase()
+		emptyDatabaseAndSetSchemaVersion(highestMigrationNumber)
 
 		// Do initial run to get the expected state of the datanode from just event playback
 		ctx, cancel := context.WithCancel(context.Background())
@@ -225,7 +227,7 @@ func TestMain(t *testing.M) {
 		// Here after exit of the broker because of protocol upgrade, we simulate a restart of the node by recreating
 		// the broker.
 		// First simulate a schema update
-		err = migrateDatabase(int64(testMigrationVersionNum))
+		err = migrateDatabase(testMigrationVersionNum)
 		if err != nil {
 			panic(err)
 		}
@@ -303,7 +305,9 @@ func TestMain(t *testing.M) {
 		storeCfg.UseIpfsDefaultPeers = false
 		storeCfg.StartWebUI = false
 
-		deHistoryStore, err = store.New(outerCtx, log, chainID, storeCfg, deHistoryHome, false)
+		storeLog := logging.NewTestLogger()
+		storeLog.SetLevel(logging.InfoLevel)
+		deHistoryStore, err = store.New(outerCtx, storeLog, chainID, storeCfg, deHistoryHome, false)
 		if err != nil {
 			panic(err)
 		}
@@ -362,12 +366,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmdNuP2pa7hBWjqLrUCs1GHV9EbXcLCd1oi5mR4xLghApc", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmXat11d8fRtQcbWb6jKaRQvjts9KScaUhU2F8vBMhoGWd", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmUuemAJ58XnLvf8hZCSq7kb7xQTJoXmymvuph4mv1GwwA", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmQDVXn7WKm5duxHiKmuWbXC8pif86dHM3xhiiDy3MtP2C", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmS5NuL3exbPEwFPZFunpPedwn1gJQnNSCKg7dSu4A12B8", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmPEfToxPV7jwJrFzPzsvN9UeYnzXq7j3aDpTFvYDeXARb", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmTwiAydX6jpjC5FdsJfJbHKPCnLYP5UWKqnTV19MrmUxN", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmSro2dKVSwwjKkxuh7HcwnYyMTS6Rca8jdTeXbSoP8H4u", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmTbi7GXNDBLcZ9HvQaEg7a6hqwDZmexYV5zGoNWHujo1Z", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmRLMtigPXmHYgL2dR4gm7WR5Hc5FJPFWS6UdBbT7YFRRg", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmZ4U259qcKaerBGUP9RVGX84R1euZcuV17hzs5ZJFiU7n", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmbBUczQPekVryAWBTdAuoaMk1xiUY792Y9uuzoQ7cwkDj", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {
@@ -382,7 +386,7 @@ func TestRestoringNodeThatAlreadyContainsData(t *testing.T) {
 	log := logging.NewTestLogger()
 
 	deHistoryStore.ResetIndex()
-	emptyDatabase()
+	emptyDatabaseAndSetSchemaVersion(highestMigrationNumber)
 
 	snapshotCopyFromPath := t.TempDir()
 	snapshotCopyToPath := t.TempDir()
@@ -428,7 +432,7 @@ func TestRestoringNodeThatAlreadyContainsData(t *testing.T) {
 
 	dehistoryService := setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1801), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(4000), loaded.LoadedToHeight)
@@ -499,7 +503,7 @@ func TestRestoringNodeWithHistoryFromBeforeTheNodesOldestBlockFails(t *testing.T
 
 	inputSnapshotService := setupSnapshotService(sqlConfig, snapshotCopyFromPath, snapshotCopyToPath)
 
-	emptyDatabase()
+	emptyDatabaseAndSetSchemaVersion(0)
 
 	historySegment := goldenSourceHistorySegment[4000]
 
@@ -509,7 +513,7 @@ func TestRestoringNodeWithHistoryFromBeforeTheNodesOldestBlockFails(t *testing.T
 	assert.Equal(t, int64(1000), blocksFetched)
 	dehistoryService := setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(3001), loaded.LoadedFromHeight)
@@ -529,7 +533,7 @@ func TestRestoringNodeWithHistoryFromBeforeTheNodesOldestBlockFails(t *testing.T
 	assert.Equal(t, int64(1000), blocksFetched)
 	dehistoryService = setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-	_, err = dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+	_, err = dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 	require.NotNil(t, err)
 }
 
@@ -540,7 +544,7 @@ func TestRestoringNodeWithExistingDataFailsWhenLoadingWouldResultInNonContiguous
 	log := logging.NewTestLogger()
 
 	deHistoryStore.ResetIndex()
-	emptyDatabase()
+	emptyDatabaseAndSetSchemaVersion(highestMigrationNumber)
 
 	snapshotCopyFromPath := t.TempDir()
 	snapshotCopyToPath := t.TempDir()
@@ -586,7 +590,7 @@ func TestRestoringNodeWithExistingDataFailsWhenLoadingWouldResultInNonContiguous
 
 	dehistoryService := setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-	_, err = dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+	_, err = dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 	require.NotNil(t, err)
 }
 
@@ -603,7 +607,7 @@ func TestRestoringFromDifferentHeightsWithFullHistory(t *testing.T) {
 	inputSnapshotService := setupSnapshotService(sqlConfig, snapshotCopyFromPath, snapshotCopyToPath)
 
 	for i := int64(0); i < numSnapshots; i++ {
-		emptyDatabase()
+		emptyDatabaseAndSetSchemaVersion(0)
 		fromHeight := expectedHistorySegmentsFromHeights[i]
 		toHeight := expectedHistorySegmentsToHeights[i]
 
@@ -616,7 +620,7 @@ func TestRestoringFromDifferentHeightsWithFullHistory(t *testing.T) {
 		assert.Equal(t, expectedBlocks, blocksFetched)
 		dehistoryService := setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-		loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+		loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 		require.NoError(t, err)
 
 		assert.Equal(t, int64(1), loaded.LoadedFromHeight)
@@ -636,7 +640,7 @@ func TestRestoreFromPartialHistoryAndProcessEvents(t *testing.T) {
 	var err error
 	log := logging.NewTestLogger()
 
-	emptyDatabase()
+	emptyDatabaseAndSetSchemaVersion(0)
 
 	fetched, err := fetchBlocks(ctx, log, deHistoryStore, goldenSourceHistorySegment[3000].HistorySegmentID, 1000)
 	require.NoError(t, err)
@@ -649,7 +653,7 @@ func TestRestoreFromPartialHistoryAndProcessEvents(t *testing.T) {
 
 	dehistoryService := setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2001), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(3000), loaded.LoadedToHeight)
@@ -722,7 +726,7 @@ func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 	var err error
 	log := logging.NewTestLogger()
 
-	emptyDatabase()
+	emptyDatabaseAndSetSchemaVersion(0)
 
 	fetched, err := fetchBlocks(ctx, log, deHistoryStore, goldenSourceHistorySegment[2000].HistorySegmentID, 2000)
 	require.NoError(t, err)
@@ -735,7 +739,7 @@ func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 
 	dehistoryService := setupDeHistoryService(ctx, log, inputSnapshotService, deHistoryStore, snapshotCopyFromPath, snapshotCopyToPath)
 
-	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx, sqlFs)
+	loaded, err := dehistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(2000), loaded.LoadedToHeight)
@@ -773,7 +777,7 @@ func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 
 	assert.Equal(t, int64(2500), lastCommittedBlockHeight)
 
-	err = migrateDatabase(int64(testMigrationVersionNum))
+	err = migrateDatabase(testMigrationVersionNum)
 	require.NoError(t, err)
 
 	// After protocol upgrade restart the broker
@@ -854,7 +858,7 @@ type sqlStoreBroker interface {
 	Receive(ctx context.Context) error
 }
 
-func emptyDatabase() {
+func emptyDatabaseAndSetSchemaVersion(schemaVersion int64) {
 	// For these we need a totally fresh database every time to ensure we model as closely as
 	// possible what happens in practice
 	var err error
@@ -873,7 +877,7 @@ func emptyDatabase() {
 	db.Close()
 
 	for i := 0; i < 5; i++ {
-		err = sqlstore.WipeDatabase(logging.NewTestLogger(), sqlConfig.ConnectionConfig, sqlFs)
+		err = sqlstore.WipeDatabaseAndMigrateSchemaToVersion(logging.NewTestLogger(), sqlConfig.ConnectionConfig, schemaVersion, sqlFs)
 		if err == nil {
 			break
 		}
@@ -1202,7 +1206,7 @@ func decompressEventFile() {
 	}
 }
 
-func setupTestSQLMigrations() (int, fs.FS) {
+func setupTestSQLMigrations() (int64, fs.FS) {
 	sourceMigrationsDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -1220,7 +1224,7 @@ func setupTestSQLMigrations() (int, fs.FS) {
 		panic(fmt.Errorf("failed to create migrations dir: %w", err))
 	}
 
-	var highestMigrationNumber int
+	var highestMigrationNumber int64
 	err = filepath.Walk(sourceMigrationsDir, func(path string, info os.FileInfo, err error) error {
 		if info != nil && !info.IsDir() {
 			if strings.HasSuffix(info.Name(), ".sql") {
@@ -1234,8 +1238,8 @@ func setupTestSQLMigrations() (int, fs.FS) {
 					return fmt.Errorf("expected first part of file name to be integer, is %s", split[0])
 				}
 
-				if migrationNum > highestMigrationNumber {
-					highestMigrationNumber = migrationNum
+				if int64(migrationNum) > highestMigrationNumber {
+					highestMigrationNumber = int64(migrationNum)
 				}
 
 				data, err := os.ReadFile(filepath.Join(sourceMigrationsDir, info.Name()))
@@ -1282,7 +1286,7 @@ func migrateDatabase(version int64) error {
 	defer db.Close()
 
 	goose.SetBaseFS(nil)
-	err = goose.UpTo(db, testMigrationsDir, version)
+	err = goose.UpTo(db, filepath.Join(testMigrationsDir, sqlstore.SQLMigrationsDir), version)
 	if err != nil {
 		return fmt.Errorf("failed to migrate up to version %d:%w", version, err)
 	}

--- a/datanode/dehistory/store/store.go
+++ b/datanode/dehistory/store/store.go
@@ -521,7 +521,7 @@ func (p *Store) extractHistorySegmentToStagingArea(ctx context.Context, toHeight
 	}
 	defer func() { _ = stagingFile.Close() }()
 
-	_, err = fsutil.UntarFile(stagingFile, p.stagingDir)
+	err = fsutil.UntarFile(stagingFile, p.stagingDir)
 	if err != nil {
 		return fmt.Errorf("failed to untar staging file:%w", err)
 	}
@@ -653,7 +653,7 @@ func (p *Store) FetchHistorySegment(ctx context.Context, historySegmentID string
 	if err != nil {
 		return SegmentIndexEntry{}, fmt.Errorf("failed to create history segment dir: %w", err)
 	}
-	_, err = fsutil.UntarFile(tarFile, historySegmentDir)
+	err = fsutil.UntarFile(tarFile, historySegmentDir)
 	if err != nil {
 		return SegmentIndexEntry{}, fmt.Errorf("failed to untar history segment:%w", err)
 	}

--- a/datanode/dehistory/testdata/testmigration.sql
+++ b/datanode/dehistory/testdata/testmigration.sql
@@ -5,5 +5,18 @@ Update trades set testref = 'nondefaulttestref';
 ALTER TABLE trades ALTER COLUMN testref SET DEFAULT 'defaulttestref';
 
 
+create table transfers2 (
+                            id bytea not null,
+                            tx_hash bytea not null,
+                            vega_time timestamp with time zone not null,
+                            from_account_id bytea NOT NULL REFERENCES accounts(id),
+                            to_account_id bytea NOT NULL REFERENCES accounts(id),
+                            primary key (id, vega_time)
+);
+
+create index on transfers2 (from_account_id);
+create index on transfers2 (to_account_id);
+
 -- +goose Down
 ALTER TABLE trades DROP COLUMN testref;
+DROP TABLE transfers2;

--- a/datanode/utils/databasetest/setup.go
+++ b/datanode/utils/databasetest/setup.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M, onSetupComplete func(sqlstore.Config, *sqlstore.Conn
 		}
 		defer embeddedPostgres.Stop()
 
-		if err = sqlstore.WipeDatabase(log, sqlConfig.ConnectionConfig, sqlFs); err != nil {
+		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(log, sqlConfig.ConnectionConfig, sqlFs); err != nil {
 			panic(err)
 		}
 


### PR DESCRIPTION
closes #7095   - also fixes up the unit tests that allowed this issue to slip through.