### PR TITLE
fix: protocolupgrade required majority should allow equality

### DIFF
--- a/core/protocolupgrade/engine.go
+++ b/core/protocolupgrade/engine.go
@@ -258,7 +258,7 @@ func (e *Engine) isAccepted(p *protocolUpgradeProposal) bool {
 	for k := range p.accepted {
 		ratio = ratio.Add(num.DecimalFromInt64(e.topology.GetVotingPower(k)).Div(totalD))
 	}
-	return ratio.GreaterThan(e.requiredMajority)
+	return ratio.GreaterThanOrEqual(e.requiredMajority)
 }
 
 func (e *Engine) getProposalIDs() []string {


### PR DESCRIPTION
I have a system test where I set `validators.vote.required` to `1` and had every validator vote and the upgrade proposal was rejected, even though we met the required threshold of everybody.

Test passing (ignore the red in the teardown, I'm having problems with the events scanners in the system tests):
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/36747/pipeline