### PR TITLE
fix: Ignore oracle messages while market is in proposed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Fixes
 - [7188](https://github.com/vegaprotocol/vega/issues/7188) - Reset liquidity score even if fees accrued in a period were 0.
 - [7189](https://github.com/vegaprotocol/vega/issues/7189) - Include LP orders outside PM price range but within LP price in the liquidity score.
+- [7195](https://github.com/vegaprotocol/vega/issues/7195) - Ignore oracle messages while market is in proposed state
 
 ## 0.65.0
 

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -3225,7 +3225,12 @@ func (m *Market) tradingTerminated(ctx context.Context, tt bool) {
 
 	m.tradableInstrument.Instrument.Product.UnsubscribeTradingTerminated(ctx)
 
-	if m.mkt.State != types.MarketStateProposed && m.mkt.State != types.MarketStatePending {
+	// ignore trading termination while the governance proposal hasn't been enacted
+	if m.mkt.State == types.MarketStateProposed {
+		return
+	}
+
+	if m.mkt.State != types.MarketStatePending {
 		// we're either going to set state to trading terminated
 		// or we'll be performing the final settlement (setting market status to settled)
 		// in both cases, we want to MTM any pending trades


### PR DESCRIPTION
Closes #7195 