### PR TITLE
feat: Reorder lines in risk engine model update

### DIFF
--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -152,8 +152,8 @@ func (e *Engine) OnMarginScalingFactorsUpdate(sf *types.ScalingFactors) error {
 func (e *Engine) UpdateModel(stateVarEngine StateVarEngine, calculator *types.MarginCalculator, model Model) {
 	e.scalingFactorsUint = scalingFactorsUintFromDecimals(calculator.ScalingFactors)
 	e.factors = model.DefaultRiskFactors()
-	stateVarEngine.NewEvent(e.asset, e.mktID, statevar.EventTypeMarketUpdated)
 	e.model = model
+	stateVarEngine.NewEvent(e.asset, e.mktID, statevar.EventTypeMarketUpdated)
 }
 
 // ReloadConf update the internal configuration of the risk engine.


### PR DESCRIPTION
Reordering lines in engine model update to ensure the engine has been fully updated before risk numbers are recalculated