### PR TITLE
fix: when gap fill loading dehistory only attempt to load data more recent than the datanode contains

### DIFF
--- a/datanode/dehistory/initialise.go
+++ b/datanode/dehistory/initialise.go
@@ -28,7 +28,7 @@ var ErrDeHistoryNotAvailable = errors.New("no decentralized history is available
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/dehistory_service_mock.go -package mocks code.vegaprotocol.io/vega/datanode/dehistory DeHistory
 type DeHistory interface {
 	FetchHistorySegment(ctx context.Context, historySegmentID string) (store.SegmentIndexEntry, error)
-	LoadAllAvailableHistoryIntoDatanode(ctx context.Context) (snapshot.LoadResult, error)
+	LoadDeHistoryIntoDatanode(ctx context.Context) (snapshot.LoadResult, error)
 	GetMostRecentHistorySegmentFromPeers(ctx context.Context, grpcAPIPorts []int) (*PeerResponse, map[string]*v2.GetMostRecentDeHistorySegmentResponse, error)
 }
 
@@ -99,7 +99,7 @@ func DatanodeFromDeHistory(parentCtx context.Context, cfg InitializationConfig, 
 	log.Infof("fetched %d blocks from decentralised history", blocksFetched)
 
 	log.Infof("loading history into the datanode")
-	loaded, err := deHistoryService.LoadAllAvailableHistoryIntoDatanode(ctx)
+	loaded, err := deHistoryService.LoadDeHistoryIntoDatanode(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load history into the datanode%w", err)
 	}

--- a/datanode/dehistory/initialise_test.go
+++ b/datanode/dehistory/initialise_test.go
@@ -66,7 +66,7 @@ func TestInitialiseEmptyDataNode(t *testing.T) {
 
 	gomock.InOrder(first, second)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
+	service.EXPECT().LoadDeHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{}, []int{})
 }
@@ -121,7 +121,7 @@ func TestInitialiseNonEmptyDataNode(t *testing.T) {
 
 	gomock.InOrder(first, second)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
+	service.EXPECT().LoadDeHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{
 		FromHeight: 0,
@@ -214,7 +214,7 @@ func TestWhenMinimumBlockCountExceedsAvailableHistory(t *testing.T) {
 
 	gomock.InOrder(first, second)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
+	service.EXPECT().LoadDeHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{}, []int{})
 }
@@ -240,7 +240,7 @@ func TestInitialiseToASpecifiedSegment(t *testing.T) {
 		HistorySegmentID: "segment1",
 	}, nil)
 
-	service.EXPECT().LoadAllAvailableHistoryIntoDatanode(gomock.Any()).Times(1)
+	service.EXPECT().LoadDeHistoryIntoDatanode(gomock.Any()).Times(1)
 
 	dehistory.DatanodeFromDeHistory(ctx, cfg, log, service, sqlstore.DatanodeBlockSpan{}, []int{})
 }

--- a/datanode/dehistory/mocks/dehistory_service_mock.go
+++ b/datanode/dehistory/mocks/dehistory_service_mock.go
@@ -69,17 +69,17 @@ func (mr *MockDeHistoryMockRecorder) GetMostRecentHistorySegmentFromPeers(arg0, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMostRecentHistorySegmentFromPeers", reflect.TypeOf((*MockDeHistory)(nil).GetMostRecentHistorySegmentFromPeers), arg0, arg1)
 }
 
-// LoadAllAvailableHistoryIntoDatanode mocks base method.
-func (m *MockDeHistory) LoadAllAvailableHistoryIntoDatanode(arg0 context.Context) (snapshot.LoadResult, error) {
+// LoadDeHistoryIntoDatanode mocks base method.
+func (m *MockDeHistory) LoadDeHistoryIntoDatanode(arg0 context.Context) (snapshot.LoadResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadAllAvailableHistoryIntoDatanode", arg0)
+	ret := m.ctrl.Call(m, "LoadDeHistoryIntoDatanode", arg0)
 	ret0, _ := ret[0].(snapshot.LoadResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadAllAvailableHistoryIntoDatanode indicates an expected call of LoadAllAvailableHistoryIntoDatanode.
-func (mr *MockDeHistoryMockRecorder) LoadAllAvailableHistoryIntoDatanode(arg0 interface{}) *gomock.Call {
+// LoadDeHistoryIntoDatanode indicates an expected call of LoadDeHistoryIntoDatanode.
+func (mr *MockDeHistoryMockRecorder) LoadDeHistoryIntoDatanode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAllAvailableHistoryIntoDatanode", reflect.TypeOf((*MockDeHistory)(nil).LoadAllAvailableHistoryIntoDatanode), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadDeHistoryIntoDatanode", reflect.TypeOf((*MockDeHistory)(nil).LoadDeHistoryIntoDatanode), arg0)
 }


### PR DESCRIPTION
closes #7233 

Previously on load it was pulling all dehistory into the staging directory and then attempting to load this, only history with height > than current datanode height would be loaded, however, it would check each segment (which was quite time consuming).  This change ensures just segments that contain data the datanode doesn't already contain are put into the staging area.   Also changed the load command to better handle the various scenarios  (datanode has no data, dehistory data has older history, datanode has older data)