### PR TITLE
fix: do not update existing markets when changing global default Liqu…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
                 "--godog.format",
                 "pretty",
                 "-test.run",
-                "${workspaceFolder}/integration/features/settlement/settlement_at_expiry.feature"
+                "${workspaceFolder}/core/integration/features/settlement/settlement_at_expiry.feature"
             ]
         },
         {
@@ -20,13 +20,13 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/integration/main_test.go",
+            "program": "${workspaceFolder}/core/integration/main_test.go",
             "_comment": "  * * *  change to your .feature file and specify line at which Scenario starts  * * *  ",
             "args": [
                 "--godog.format",
                 "pretty",
                 "-test.run",
-                "${workspaceFolder}/integration/features/settlement/settlement_at_expiry.feature:23"
+                "${workspaceFolder}/core/integration/features/settlement/settlement_at_expiry.feature:23"
             ]
         }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [7207](https://github.com/vegaprotocol/vega/issues/7207) - Fix panic, return on error in pool configuration
 - [7213](https://github.com/vegaprotocol/vega/issues/7213) - Implement separate `DB` for snapshots `metadata`
 - [7220](https://github.com/vegaprotocol/vega/issues/7220) - Fix panic when LP is closed out
+- [7235](https://github.com/vegaprotocol/vega/issues/7235) - Do not update existing markets when changing global default `LiquidityMonitoringParameters`
 - [7029](https://github.com/vegaprotocol/vega/issues/7029) - Added admin `API` for Data Node to secure some `dehistory` commands
 - [7239](https://github.com/vegaprotocol/vega/issues/7239) - Added upper and lower bounds for floating point engine updates
 - [7075](https://github.com/vegaprotocol/vega/issues/7075) - Remove unused expiry field in withdrawal

--- a/core/execution/engine.go
+++ b/core/execution/engine.go
@@ -937,34 +937,6 @@ func (e *Engine) OnMarketValueWindowLengthUpdate(_ context.Context, d time.Durat
 	return nil
 }
 
-func (e *Engine) OnMarketTargetStakeScalingFactorUpdate(_ context.Context, d num.Decimal) error {
-	if e.log.IsDebug() {
-		e.log.Debug("update market stake scaling factor",
-			logging.Decimal("scaling-factor", d),
-		)
-	}
-
-	for _, mkt := range e.marketsCpy {
-		if err := mkt.OnMarketTargetStakeScalingFactorUpdate(d); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (e *Engine) OnMarketTargetStakeTimeWindowUpdate(_ context.Context, d time.Duration) error {
-	if e.log.IsDebug() {
-		e.log.Debug("update market stake time window",
-			logging.Duration("time-window", d),
-		)
-	}
-
-	for _, mkt := range e.marketsCpy {
-		mkt.OnMarketTargetStakeTimeWindowUpdate(d)
-	}
-	return nil
-}
-
 func (e *Engine) OnMarketLiquidityProvidersFeeDistributionTimeStep(_ context.Context, d time.Duration) error {
 	if e.log.IsDebug() {
 		e.log.Debug("update liquidity providers fee distribution time step",
@@ -1014,19 +986,6 @@ func (e *Engine) OnMarketLiquidityMaximumLiquidityFeeFactorLevelUpdate(
 
 	e.npv.maxLiquidityFee = d
 
-	return nil
-}
-
-func (e *Engine) OnMarketLiquidityTargetStakeTriggeringRatio(ctx context.Context, d num.Decimal) error {
-	if e.log.IsDebug() {
-		e.log.Debug("update target stake triggering ratio",
-			logging.Decimal("max-liquidity-fee", d),
-		)
-	}
-
-	for _, mkt := range e.marketsCpy {
-		mkt.OnMarketLiquidityTargetStakeTriggeringRatio(ctx, d)
-	}
 	return nil
 }
 

--- a/core/integration/features/auctions/enter-leave-liquidity-auction.feature
+++ b/core/integration/features/auctions/enter-leave-liquidity-auction.feature
@@ -1,15 +1,15 @@
 Feature: Ensure we can enter and leave liquidity auction
 
   Background:
-
-    Given the markets:
-      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config          |
-      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future |
-    And the following network parameters are set:
+    Given the following network parameters are set:
       | name                              | value |
       | market.auction.minimumDuration    | 1     |
       | market.stake.target.scalingFactor | 1     |
       | limits.markets.maxPeggedOrders    | 1500  |
+    And the markets:
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config          |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future |
+    
 
 
   Scenario: 001, LP only provides LP orders

--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -24,11 +24,6 @@ Feature: Test liquidity provider reward distribution
     And the oracle spec for trading termination filtering data from "0xCAFECAFE" named "ethDec21Oracle":
       | property           | type         | binding             |
       | trading.terminated | TYPE_BOOLEAN | trading termination |
-    And the markets:
-      | id        | quote name | asset | risk model             | margin calculator         | auction duration | fees          | price monitoring   | data source config |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1    | default-margin-calculator | 2                | fees-config-1 | price-monitoring-1 | ethDec21Oracle     |
-      | ETH/DEC22 | ETH        | ETH   | lognormal-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring-2 | ethDec21Oracle     |
-
     And the following network parameters are set:
       | name                                                | value |
       | market.value.windowLength                           | 1h    |
@@ -38,6 +33,10 @@ Feature: Test liquidity provider reward distribution
       | market.liquidity.providers.fee.distributionTimeStep | 10m   |
       | network.markPriceUpdateMaximumFrequency             | 1s    |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model             | margin calculator         | auction duration | fees          | price monitoring   | data source config |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1    | default-margin-calculator | 2                | fees-config-1 | price-monitoring-1 | ethDec21Oracle     |
+      | ETH/DEC22 | ETH        | ETH   | lognormal-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring-2 | ethDec21Oracle     |
     And the average block duration is "1"
 
   Scenario: 1 LP joining at start, checking liquidity rewards over 3 periods, 1 period with no trades

--- a/core/integration/features/liquidity-provision/lp-margin-post-auction.feature
+++ b/core/integration/features/liquidity-provision/lp-margin-post-auction.feature
@@ -11,6 +11,12 @@ Feature: Assure LP margin is correct
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 3600    | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1.5   |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.24  |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
@@ -25,13 +31,8 @@ Feature: Assure LP margin is correct
       | network.markPriceUpdateMaximumFrequency | 0s    |
 
   Scenario: Assure LP margin is released when opening auction concludes with a price lower than indicative uncrossing price at the time of LP submission
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1.5   |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.24  |
-    And the average block duration is "1"
+
+    Given the average block duration is "1"
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
       | lp1 | party0 | ETH/MAR22 | 50000             | 0.001 | sell | ASK              | 500        | 17     | submission |

--- a/core/integration/features/liquidity-provision/verify-CcySiska.feature
+++ b/core/integration/features/liquidity-provision/verify-CcySiska.feature
@@ -18,6 +18,13 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1000    | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.1   |
+      | network.markPriceUpdateMaximumFrequency       | 0s    |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config | lp price range |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | ethDec21Oracle     |          0.014 |
@@ -27,13 +34,6 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
       | party1 | USD   | 100000000 |
       | party2 | USD   | 100000000 |
       | party3 | USD   | 100000000 |
-    And the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
-      | network.markPriceUpdateMaximumFrequency       | 0s    |
     And the average block duration is "1"
     And the parties place the following orders with ticks:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference  |

--- a/core/integration/features/margin/6202-release-excess-on-amend.feature
+++ b/core/integration/features/margin/6202-release-excess-on-amend.feature
@@ -11,6 +11,12 @@ Feature: test margin during amending orders
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.1   |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
@@ -29,14 +35,7 @@ Feature: test margin during amending orders
   @MTMDelta
   Scenario: 001, reduce order size, 0011-MARA-004
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
-
-    And the average block duration is "1"
+    Given the average block duration is "1"
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |

--- a/core/integration/features/verified/0011-MARA-016017.feature
+++ b/core/integration/features/verified/0011-MARA-016017.feature
@@ -13,14 +13,14 @@ Feature: check pegged GTT and GTC in auction
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 36600   | 0.99        | 300               |
-    And the markets:
-      | id        | quote name | asset | risk model              | margin calculator   | auction duration | fees         | price monitoring   | data source config     |
-      | ETH/DEC19 | ETH        | ETH   | log-normal-risk-model-1 | margin-calculator-0 | 1                | default-none | price-monitoring-1 | default-eth-for-future |
     And the following network parameters are set:
       | name                              | value |
       | market.auction.minimumDuration    | 1     |
       | market.stake.target.scalingFactor | 1     |
       | limits.markets.maxPeggedOrders    | 1500  |
+    And the markets:
+      | id        | quote name | asset | risk model              | margin calculator   | auction duration | fees         | price monitoring   | data source config     |
+      | ETH/DEC19 | ETH        | ETH   | log-normal-risk-model-1 | margin-calculator-0 | 1                | default-none | price-monitoring-1 | default-eth-for-future |
 
   Scenario: 001, Pegged GTC (good till time) (parked in auction), Pegged orders will be [parked] if placed during [an auction], with time priority preserved. 0011-MARA-017
     Given the parties deposit on asset's general account the following amount:

--- a/core/integration/features/verified/0019-MCAL-margin_calculator-risk_parameters.feature
+++ b/core/integration/features/verified/0019-MCAL-margin_calculator-risk_parameters.feature
@@ -35,7 +35,12 @@ Feature: test risk model parameter change in margin calculation
     And the following network parameters are set:
       | name                                    | value |
       | network.markPriceUpdateMaximumFrequency | 0s    |
-
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.1   |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config          |
       | ETH/MAR21 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
@@ -52,14 +57,7 @@ Feature: test risk model parameter change in margin calculation
 
   Scenario: lognormal risk model in 4 markets with different risk parameters , 0010-MARG-012, 0010-MARG-013, 0010-MARG-014
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
-
-    And the average block duration is "1"
+    Given the average block duration is "1"
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |

--- a/core/integration/features/verified/0026-AUCT-auction_interaction.feature
+++ b/core/integration/features/verified/0026-AUCT-auction_interaction.feature
@@ -151,9 +151,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
 
   Scenario: When trying to exit opening auction liquidity monitoring is triggered due to insufficient supplied stake  (0026-AUCT-004, 0026-AUCT-005)
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -217,9 +220,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | 1000       | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 1000         | 1000           | 10            |
 
   Scenario: Once market is in continuous trading mode: post a persistent order that should trigger liquidity auction (not enough target stake), appropriate event is sent and market in TRADING_MODE_MONITORING_AUCTION (0026-AUCT-005, 0035-LIQM-003)
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -290,9 +296,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 3030         | 10000          | 30            |
 
   Scenario: Once market is in continuous trading mode: post a non-persistent order that should trigger liquidity auction (not enough target stake), still goes through, but auction is triggered the next block
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -524,9 +533,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
 
   Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> leave auction mode (0068-MATC-033,0026-AUCT-005)
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -614,9 +626,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 100     | 1010      | 1030      | 3468         | 4080           | 34            |
 
   Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity monitoring -> leave auction mode (0068-MATC-033,0026-AUCT-005)
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -720,9 +735,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | 1020       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 4488         | 4488           | 44            |
 
   Scenario: Once market is in continuous trading mode: enter price monitoring auction -> extend with liquidity monitoring auction -> leave auction mode (0068-MATC-033,0026-AUCT-005)
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     Then the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -775,9 +793,12 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
 
   Scenario: Once market is in continuous trading mode: enter liquidity monitoring auction -> extend with price monitoring auction -> extend with liquidity auction -> leave auction mode (0068-MATC-033, 0026-AUCT-005)
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.liquidity.targetstake.triggering.ratio | 0.8   |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.8            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |

--- a/core/integration/features/verified/0041-TSK-target_stake.feature
+++ b/core/integration/features/verified/0041-TSK-target_stake.feature
@@ -42,10 +42,13 @@ Feature: Target stake
       | tt_4  | BTC   | 100000000 |
 
   Scenario: Max open interest changes over time (0041-TSTK-002, 0041-TSTK-003, 0042-LIQF-007)
-    Given the following network parameters are set:
-      | name                              | value |
-      | market.stake.target.timeWindow    | 10s   |
-      | market.stake.target.scalingFactor | 1.5   |
+
+    Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.0            | 10s         | 1.5              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     # put some volume on the book so that others can increase their
     # positions and close out if needed too
@@ -189,10 +192,13 @@ Feature: Target stake
     And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
   Scenario: Max open interest changes over time, testing change of timewindow (0041-TSTK-001; 0041-TSTK-004; 0041-TSTK-005)
-    Given the following network parameters are set:
-      | name                              | value |
-      | market.stake.target.timeWindow    | 20s   |
-      | market.stake.target.scalingFactor | 1.5   |
+
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.0            | 20s         | 1.5              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     # put some volume on the book so that others can increase their
     # positions and close out if needed too
@@ -260,10 +266,12 @@ Feature: Target stake
     # target_stake = 110 x 140 x 1.5 x 0.1=2310
     And the target stake should be "2310" for the market "ETH/DEC21"
 
-    When the following network parameters are set:
-      | name                              | value |
-      | market.stake.target.timeWindow    | 10s   |
-      | market.stake.target.scalingFactor | 1     |
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.0            | 10s         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     # target_stake = 110 x 140 x 1 x 0.1 =1540
     And the target stake should be "1540" for the market "ETH/DEC21"
@@ -276,10 +284,13 @@ Feature: Target stake
     And the target stake should be "1870" for the market "ETH/DEC21"
 
   Scenario: Target stake is calculate correctly during auction in presence of wash trades
-    Given the following network parameters are set:
-      | name                              | value |
-      | market.stake.target.timeWindow    | 10s   |
-      | market.stake.target.scalingFactor | 1     |
+
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.0            | 10s         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/DEC21 | updated-lqm-params   |
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards.feature
@@ -13,10 +13,6 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the price monitoring named "price-monitoring":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 3                 |
-    And the markets:
-      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config     |
-      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
-
     And the following network parameters are set:
       | name                                                | value |
       | market.value.windowLength                           | 1h    |
@@ -25,6 +21,9 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market.liquidity.targetstake.triggering.ratio       | 0     |
       | market.liquidity.providers.fee.distributionTimeStep | 10m   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config     |
+      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
 
     Given the average block duration is "2"
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
@@ -13,10 +13,6 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the price monitoring named "price-monitoring":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 3                 |
-    And the markets:
-      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config          |
-      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
-
     And the following network parameters are set:
       | name                                                | value |
       | market.value.windowLength                           | 1h    |
@@ -25,6 +21,9 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market.liquidity.targetstake.triggering.ratio       | 0     |
       | market.liquidity.providers.fee.distributionTimeStep | 10m   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config          |
+      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
 
     # block duration of 2 seconds
     And the average block duration is "2"

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
@@ -11,9 +11,6 @@ Feature:
     And the price monitoring named "price-monitoring":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 3                 |
-    And the markets:
-      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config          |
-      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
     And the following network parameters are set:
       | name                                                | value |
       | market.value.windowLength                           | 1h    |
@@ -22,6 +19,9 @@ Feature:
       | market.liquidity.targetstake.triggering.ratio       | 0     |
       | market.liquidity.providers.fee.distributionTimeStep | 10m   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config          |
+      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
 
 
   @VirtStake

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
@@ -11,10 +11,6 @@ Feature: Test liquidity provider reward distribution; Check what happens when di
     And the price monitoring named "price-monitoring":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 3                 |
-    And the markets:
-      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config          |
-      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
-
     And the following network parameters are set:
       | name                                                | value  |
       | market.value.windowLength                           | 1h     |
@@ -23,6 +19,9 @@ Feature: Test liquidity provider reward distribution; Check what happens when di
       | market.liquidity.targetstake.triggering.ratio       | 0      |
       | market.liquidity.providers.fee.distributionTimeStep | 720h   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring | data source config          |
+      | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
 
     Given the average block duration is "2"
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_multi_lps.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_multi_lps.feature
@@ -19,10 +19,6 @@ Feature: Test liquidity provider reward distribution when there are multiple liq
     And the price monitoring named "price-monitoring":
       | horizon | probability | auction extension |
       | 3600    | 0.99        | 3                 |
-    And the markets:
-      | id        | quote name | asset | risk model            | margin calculator   | auction duration | fees          | price monitoring | data source config     |
-      | ETH/MAR22 | USD        | USD   | log-normal-risk-model | margin-calculator-1 | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
-
     And the following network parameters are set:
       | name                                                | value |
       | market.value.windowLength                           | 1h    |
@@ -31,6 +27,9 @@ Feature: Test liquidity provider reward distribution when there are multiple liq
       | market.liquidity.targetstake.triggering.ratio       | 1     |
       | market.liquidity.providers.fee.distributionTimeStep | 10s   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model            | margin calculator   | auction duration | fees          | price monitoring | data source config     |
+      | ETH/MAR22 | USD        | USD   | log-normal-risk-model | margin-calculator-1 | 2                | fees-config-1 | price-monitoring | default-eth-for-future |
 
     Given the average block duration is "2"
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -394,10 +394,6 @@ Scenario: 001: 0070-MKTD-007, 0042-LIQF-001, 0018-RSKM-005, 0018-RSKM-008
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 100000  | 0.99        | 3                 |
-    And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config          |
-      | ETH/MAR22 | USD        | USD   | log-normal-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
-
     And the following network parameters are set:
       | name                                                | value |
       | market.value.windowLength                           | 1h    |
@@ -406,6 +402,9 @@ Scenario: 001: 0070-MKTD-007, 0042-LIQF-001, 0018-RSKM-005, 0018-RSKM-008
       | market.liquidity.targetstake.triggering.ratio       | 0     |
       | market.liquidity.providers.fee.distributionTimeStep | 10m   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
+    And the markets:
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     |
+      | ETH/MAR22 | USD        | USD   | log-normal-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
 
     Given the average block duration is "2"
 

--- a/core/integration/features/verified/Issue-6004-ProbOfTrading_Refactoring.feature
+++ b/core/integration/features/verified/Issue-6004-ProbOfTrading_Refactoring.feature
@@ -11,6 +11,14 @@ Feature: test probability of trading used in LP vol when best bid/ask is changin
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 10000   | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.1   |
+      | market.liquidity.stakeToCcyVolume             | 1.0   |
+      | network.markPriceUpdateMaximumFrequency       | 0s    |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config          |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | default-none | default-eth-for-future |
@@ -20,15 +28,6 @@ Feature: test probability of trading used in LP vol when best bid/ask is changin
       | party1 | USD   | 10000000000 |
       | party2 | USD   | 10000000000 |
       | party3 | USD   | 10000000000 |
-
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
-      | market.liquidity.stakeToCcyVolume             | 1.0   |
-      | network.markPriceUpdateMaximumFrequency       | 0s    |
 
    And the average block duration is "1"
 

--- a/core/integration/features/verified/Test-PnL.feature
+++ b/core/integration/features/verified/Test-PnL.feature
@@ -17,6 +17,12 @@ Feature: check if the realised PnL and unreaslied PnL is calculated according to
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1000    | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.1   |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
@@ -26,13 +32,6 @@ Feature: check if the realised PnL and unreaslied PnL is calculated according to
       | party1 | USD   | 100000000 |
       | party2 | USD   | 100000000 |
       | party3 | USD   | 100000000 |
-
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 
@@ -124,6 +123,12 @@ Feature: check if the realised PnL and unreaslied PnL is calculated according to
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1000    | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.2   |
+      | market.liquidity.targetstake.triggering.ratio | 0.1   |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | ethDec21Oracle     |
@@ -133,13 +138,6 @@ Feature: check if the realised PnL and unreaslied PnL is calculated according to
       | party1 | USD   | 100000000 |
       | party2 | USD   | 100000000 |
       | party3 | USD   | 100000000 |
-
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 

--- a/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
@@ -14,6 +14,12 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 300               |
+    And the following network parameters are set:
+      | name                                          | value |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.bondPenaltyParameter         | 0.1   |
+      | market.liquidity.targetstake.triggering.ratio | 0.24  |
     And the markets:
       | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | decimal places | position decimal places |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              | 2                       |
@@ -30,14 +36,7 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
     @Now
   Scenario: Bond slashing on LP (0044-LIME-002, 0035-LIQM-004, 0044-LIME-009 )
 
-    Given the following network parameters are set:
-      | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
-      | market.liquidity.bondPenaltyParameter         | 0.1   |
-      | market.liquidity.targetstake.triggering.ratio | 0.24  |
-
-    And the average block duration is "1"
+    Given the average block duration is "1"
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee | side | pegged reference | proportion | offset | lp type    |

--- a/core/integration/features/verified/liquidity-provision-bond-account.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account.feature
@@ -11,8 +11,8 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     And the price monitoring named "price-monitoring-1":
       | horizon | probability | auction extension |
       | 1       | 0.99        | 300               |
-    And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config          |
+   And the markets:
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     |
       | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future |
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount    |
@@ -27,12 +27,16 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     @Now
    Scenario: 001, LP gets distressed during continuous trading, no DPD setting (0044-LIME-002, 0035-LIQM-004)
 
-   Given the following network parameters are set:
+
+   Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.24            | 24h          | 1              |
+   When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR22 | updated-lqm-params   |
+   And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.24  |
 
    And the average block duration is "1"
 
@@ -152,12 +156,16 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     @Now
 Scenario: 002, LP gets slashed twice during continuous trading, 0044-LIME-002, No DPD setting
 
-   Given the following network parameters are set:
+
+   Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.1              | 24h          | 1              |
+   When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR22 | updated-lqm-params   |
+   And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.5   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
    And the average block duration is "1"
 

--- a/core/integration/features/verified/risk-parameters-ranges-test.feature
+++ b/core/integration/features/verified/risk-parameters-ranges-test.feature
@@ -126,12 +126,29 @@ Feature: test risk model parameter ranges
   @Now
   Scenario: 001, test different value of risk parameters within defined ranges in different market, AC: 0018-RSKM-001
 
+    Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.1            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR0  | updated-lqm-params   |
+      | ETH/MAR11 | updated-lqm-params   |
+      | ETH/MAR12 | updated-lqm-params   |
+      | ETH/MAR21 | updated-lqm-params   |
+      | ETH/MAR22 | updated-lqm-params   |
+      | ETH/MAR23 | updated-lqm-params   |
+      | ETH/MAR31 | updated-lqm-params   |
+      | ETH/MAR32 | updated-lqm-params   |
+      | ETH/MAR41 | updated-lqm-params   |
+      | ETH/MAR42 | updated-lqm-params   |
+      | ETH/MAR43 | updated-lqm-params   |
+      | ETH/MAR51 | updated-lqm-params   |
+      | ETH/MAR52 | updated-lqm-params   |
+      | ETH/MAR53 | updated-lqm-params   |
+
     And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 
@@ -416,12 +433,29 @@ Feature: test risk model parameter ranges
   @Now
   Scenario: 002, test market ETH/MAR23 (tau=1)
 
+    Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.1              | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR0  | updated-lqm-params   |
+      | ETH/MAR11 | updated-lqm-params   |
+      | ETH/MAR12 | updated-lqm-params   |
+      | ETH/MAR21 | updated-lqm-params   |
+      | ETH/MAR22 | updated-lqm-params   |
+      | ETH/MAR23 | updated-lqm-params   |
+      | ETH/MAR32 | updated-lqm-params   |
+      | ETH/MAR31 | updated-lqm-params   |
+      | ETH/MAR41 | updated-lqm-params   |
+      | ETH/MAR42 | updated-lqm-params   |
+      | ETH/MAR43 | updated-lqm-params   |
+      | ETH/MAR51 | updated-lqm-params   |
+      | ETH/MAR52 | updated-lqm-params   |
+      | ETH/MAR53 | updated-lqm-params   |
+
     And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 
@@ -461,12 +495,29 @@ Feature: test risk model parameter ranges
 
   @Now
   Scenario: 003, test market ETH/MAR52(sigma=10),
+
+    Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.1              | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR0  | updated-lqm-params   |
+      | ETH/MAR11 | updated-lqm-params   |
+      | ETH/MAR12 | updated-lqm-params   |
+      | ETH/MAR21 | updated-lqm-params   |
+      | ETH/MAR22 | updated-lqm-params   |
+      | ETH/MAR23 | updated-lqm-params   |
+      | ETH/MAR31 | updated-lqm-params   |
+      | ETH/MAR32 | updated-lqm-params   |
+      | ETH/MAR41 | updated-lqm-params   |
+      | ETH/MAR42 | updated-lqm-params   |
+      | ETH/MAR43 | updated-lqm-params   |
+      | ETH/MAR51 | updated-lqm-params   |
+      | ETH/MAR52 | updated-lqm-params   |
+      | ETH/MAR53 | updated-lqm-params   |
     And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 

--- a/core/integration/features/verified/risk-parameters-sigma-test.feature
+++ b/core/integration/features/verified/risk-parameters-sigma-test.feature
@@ -42,12 +42,16 @@ Feature: test risk model parameter sigma
 
   @Now
   Scenario: 001, test market ETH/MAR53(sigma=50),
+
+    Given the liquidity monitoring parameters:
+      | name                | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.1              | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR53 | updated-lqm-params   |
     And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 
@@ -94,12 +98,16 @@ Feature: test risk model parameter sigma
 
   @Now
   Scenario: 002, test market ETH/MAR0 (kind of "normal" risk parameters setting),
+
+    Given the liquidity monitoring parameters:
+      | name              | triggering ratio | time window | scaling factor |
+      | updated-lqm-params  | 0.1            | 24h         | 1              |
+    When the markets are updated:
+      | id        | liquidity monitoring |
+      | ETH/MAR0 | updated-lqm-params   |
     And the following network parameters are set:
       | name                                          | value |
-      | market.stake.target.timeWindow                | 24h   |
-      | market.stake.target.scalingFactor             | 1     |
       | market.liquidity.bondPenaltyParameter         | 0.2   |
-      | market.liquidity.targetstake.triggering.ratio | 0.1   |
 
     And the average block duration is "1"
 

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -258,14 +258,6 @@ func (e *executionTestSetup) registerNetParamsCallbacks() error {
 			Watcher: e.executionEngine.OnMarketValueWindowLengthUpdate,
 		},
 		netparams.WatchParam{
-			Param:   netparams.MarketTargetStakeScalingFactor,
-			Watcher: e.executionEngine.OnMarketTargetStakeScalingFactorUpdate,
-		},
-		netparams.WatchParam{
-			Param:   netparams.MarketTargetStakeTimeWindow,
-			Watcher: e.executionEngine.OnMarketTargetStakeTimeWindowUpdate,
-		},
-		netparams.WatchParam{
 			Param:   netparams.MarketLiquidityProvidersFeeDistribitionTimeStep,
 			Watcher: e.executionEngine.OnMarketLiquidityProvidersFeeDistributionTimeStep,
 		},
@@ -280,10 +272,6 @@ func (e *executionTestSetup) registerNetParamsCallbacks() error {
 		netparams.WatchParam{
 			Param:   netparams.MarketLiquidityBondPenaltyParameter,
 			Watcher: e.executionEngine.OnMarketLiquidityBondPenaltyUpdate,
-		},
-		netparams.WatchParam{
-			Param:   netparams.MarketLiquidityTargetStakeTriggeringRatio,
-			Watcher: e.executionEngine.OnMarketLiquidityTargetStakeTriggeringRatio,
 		},
 		netparams.WatchParam{
 			Param:   netparams.MarketAuctionMinimumDuration,

--- a/core/integration/steps/network_params.go
+++ b/core/integration/steps/network_params.go
@@ -21,12 +21,18 @@ import (
 	"code.vegaprotocol.io/vega/core/netparams"
 )
 
+var unwatched = map[string]struct{}{
+	netparams.MarketLiquidityTargetStakeTriggeringRatio: {},
+	netparams.MarketTargetStakeScalingFactor:            {},
+	netparams.MarketTargetStakeTimeWindow:               {},
+}
+
 func TheFollowingNetworkParametersAreSet(netParams *netparams.Store, table *godog.Table) error {
 	ctx := context.Background()
 	for _, row := range parseNetworkParametersTable(table) {
 		name := row.MustStr("name")
 
-		if !netParams.AnyWatchers(name) {
+		if _, ok := unwatched[name]; !ok && !netParams.AnyWatchers(name) {
 			return errNoWatchersSpecified(name)
 		}
 

--- a/core/integration/steps/the_liquidity_monitoring.go
+++ b/core/integration/steps/the_liquidity_monitoring.go
@@ -57,7 +57,7 @@ func (r liquidityMonitoringRow) name() string {
 }
 
 func (r liquidityMonitoringRow) timeWindow() int64 {
-	tw := r.row.MustDuration("time window")
+	tw := r.row.MustDurationStr("time window")
 	return int64(tw.Seconds())
 }
 

--- a/core/integration/steps/the_markets.go
+++ b/core/integration/steps/the_markets.go
@@ -399,10 +399,10 @@ func parseMarketsUpdateTable(table *godog.Table) []RowWrapper {
 	return StrictParseTable(table, []string{
 		"id",
 	}, []string{
-		"data source config",    // product update
-		"price monitoring",      // price monitoring update
-		"risk model",            // risk model update
-		"liquidity monitoring ", // liquidity monitoring update
+		"data source config",   // product update
+		"price monitoring",     // price monitoring update
+		"risk model",           // risk model update
+		"liquidity monitoring", // liquidity monitoring update
 		"lp price range",
 	})
 }

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -519,14 +519,6 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 			Watcher: svcs.executionEngine.OnMarketValueWindowLengthUpdate,
 		},
 		{
-			Param:   netparams.MarketTargetStakeScalingFactor,
-			Watcher: svcs.executionEngine.OnMarketTargetStakeScalingFactorUpdate,
-		},
-		{
-			Param:   netparams.MarketTargetStakeTimeWindow,
-			Watcher: svcs.executionEngine.OnMarketTargetStakeTimeWindowUpdate,
-		},
-		{
 			Param: netparams.BlockchainsEthereumConfig,
 			Watcher: func(ctx context.Context, cfg interface{}) error {
 				ethCfg, err := types.EthereumConfigFromUntypedProto(cfg)
@@ -568,10 +560,6 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 		{
 			Param:   netparams.MarketLiquidityBondPenaltyParameter,
 			Watcher: svcs.executionEngine.OnMarketLiquidityBondPenaltyUpdate,
-		},
-		{
-			Param:   netparams.MarketLiquidityTargetStakeTriggeringRatio,
-			Watcher: svcs.executionEngine.OnMarketLiquidityTargetStakeTriggeringRatio,
 		},
 		{
 			Param:   netparams.MarketAuctionMinimumDuration,


### PR DESCRIPTION
closes #7235 

relates to [0035-LIQM-009](https://github.com/vegaprotocol/specs/blob/master/protocol/0035-LIQM-liquidity_monitoring.md#0035-LIQM-009)

The network parameters:
```
netparams.MarketLiquidityTargetStakeTriggeringRatio
netparams.MarketTargetStakeScalingFactor
netparams.MarketTargetStakeTimeWindow
```
are used as default values when a market is created if the market definition itself does not contain `LiquidityMonitoringParameters`. 

The bug was that when those network parameters were updated, we propagated the new value to all existing markets. It now does not propagate anything when updated and the new value is only used for new markets created after that point.

The fix caused a lot of integration tests to fail because scenario setups were creating markets _then_ setting the network parameters, where now they need to set the network parameter _then_ create the markets. Scenarios that do need to update a market's LIQM mid flow now do so via a proper MarketUpdate. No numbers have changed in any of the tests.
