### PR TITLE
feat: update version check in the docker release of wallet

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Sanity check docker image
         run: |
-          docker run --rm vegaprotocol/${{ matrix.app }}:local version
+          docker run --rm vegaprotocol/${{ matrix.app }}:local version || docker run --rm vegaprotocol/${{ matrix.app }}:local software version
 
       - name: Build and push to Docker registries
         id: docker_build


### PR DESCRIPTION
There was breaking change for the wallet. Now we have the following commands to check versions:

- `vega version`
- `vegawallet software version`