### PR TITLE
chore: add wallet validation for one off to account type

### DIFF
--- a/commands/transfer_funds.go
+++ b/commands/transfer_funds.go
@@ -78,6 +78,9 @@ func checkTransfer(cmd *commandspb.Transfer) (e Errors) {
 	} else {
 		switch k := cmd.Kind.(type) {
 		case *commandspb.Transfer_OneOff:
+			if cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_GLOBAL_REWARD && cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_GENERAL && cmd.ToAccountType != vega.AccountType_ACCOUNT_TYPE_UNSPECIFIED {
+				errs.AddForProperty("transfer.to_account_type", errors.New("account type is not valid for one off transfer"))
+			}
 			if k.OneOff.GetDeliverOn() < 0 {
 				errs.AddForProperty("transfer.kind.deliver_on", ErrMustBePositiveOrZero)
 			}

--- a/commands/transfer_funds_test.go
+++ b/commands/transfer_funds_test.go
@@ -380,13 +380,50 @@ func TestTransferFunds(t *testing.T) {
 		},
 	}
 
+	invalidAccountTypesForOneOff := []vega.AccountType{
+		vega.AccountType_ACCOUNT_TYPE_INSURANCE,
+		vega.AccountType_ACCOUNT_TYPE_SETTLEMENT,
+		vega.AccountType_ACCOUNT_TYPE_MARGIN,
+		vega.AccountType_ACCOUNT_TYPE_FEES_INFRASTRUCTURE,
+		vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY,
+		vega.AccountType_ACCOUNT_TYPE_FEES_MAKER,
+		vega.AccountType_ACCOUNT_TYPE_BOND,
+		vega.AccountType_ACCOUNT_TYPE_EXTERNAL,
+		vega.AccountType_ACCOUNT_TYPE_GLOBAL_INSURANCE,
+		vega.AccountType_ACCOUNT_TYPE_PENDING_TRANSFERS,
+		vega.AccountType_ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES,
+		vega.AccountType_ACCOUNT_TYPE_REWARD_LP_RECEIVED_FEES,
+		vega.AccountType_ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS,
+		vega.AccountType_ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES,
+	}
+
+	for _, at := range invalidAccountTypesForOneOff {
+		cases = append(cases, struct {
+			transfer  commandspb.Transfer
+			errString string
+		}{
+			transfer: commandspb.Transfer{
+				FromAccountType: vega.AccountType_ACCOUNT_TYPE_GENERAL,
+				ToAccountType:   at,
+				Kind: &commandspb.Transfer_OneOff{
+					OneOff: &commandspb.OneOffTransfer{},
+				},
+				To:        "84e2b15102a8d6c1c6b4bdf40af8a0dc21b040eaaa1c94cd10d17604b75fdc35",
+				Asset:     "",
+				Amount:    "1",
+				Reference: "testing",
+			},
+			errString: "transfer.to_account_type (account type is not valid for one off transfer)",
+		})
+	}
+
 	for _, c := range cases {
 		err := commands.CheckTransfer(&c.transfer)
 		if len(c.errString) <= 0 {
 			assert.NoError(t, err)
 			continue
 		}
-		assert.EqualError(t, err, c.errString)
+		assert.Contains(t, err.Error(), c.errString)
 	}
 }
 


### PR DESCRIPTION
Added wallet validation to prevent users from submitting invalid transfers to accounts not allowed for one-off transfers. 