### PR TITLE
fix: only allow new txn if replay is finished and was successful

### DIFF
--- a/core/blockchain/nullchain/nullchain.go
+++ b/core/blockchain/nullchain/nullchain.go
@@ -160,12 +160,11 @@ func (n *NullBlockchain) StartChain() error {
 	if n.cfg.Replay.Replay {
 		n.log.Info("nullchain is replaying chain", logging.String("replay-file", n.cfg.Replay.ReplayFile))
 		n.replaying.Store(true)
-		defer n.replaying.Store(false)
-
 		blockHeight, blockTime, err := r.replayChain(n.blockHeight, n.genesis.ChainID)
 		if err != nil {
 			return err
 		}
+		n.replaying.Store(false)
 
 		n.log.Info("nullchain finished replaying chain", logging.Int64("block-height", blockHeight))
 		if blockHeight != 0 {


### PR DESCRIPTION
Fixes an edge case when replaying nullchain from a file.

When replay panics (which is usually expected since the replay functionality exists to be able to reproduce panics) there is a slim period of time during shutdown of the node where the nullchain will accept new transactions. In the case where, for example, a state-var transactions is on its ways this can cause a subsequent panic which muddies up the logs hiding the original panic:
```
2023-01-09T11:11:21.886Z	INFO	root	blockchain/server.go:48	Stopping blockchain server
2023-01-09T11:11:21.886Z	DEBUG	nullchain	nullchain/nullchain.go:409	transaction added to block: 1 of 1
2023-01-09T11:11:21.886Z	DEBUG	nullchain	nullchain/nullchain.go:218	processing block 1 with 1 transactions
2023-01-09T11:11:21.886Z	DEBUG	nullchain	nullchain/nullchain.go:322	sending BeginBlock	{"height": 1, "time": "2021-11-29 11:23:58.259067 +0000 UTC"}
2023-01-09T11:11:21.886Z	DEBUG	processor	processor/abci.go:750	entering begin block	{"at": "2023-01-09T11:11:21.886Z", "height": 1}
2023-01-09T11:11:21.886Z	DEBUG	oracles	oracles/engine.go:108	no subscriber matches the oracle data	{"signers": [], "data": "vegaprotocol.builtin.timestamp:1638185038"}
2023-01-09T11:11:21.886Z	DEBUG	execution	execution/engine.go:771	updating engine on new time update
2023/01/09 11:11:21 invalid state enecountered in price monitoring engine{error 26 0  received a time that's before the last received time}
2023-01-09T11:11:21.886Z	DEBUG	processor	processor/abci.go:751	leaving begin block	{"at": "2023-01-09T11:11:21.886Z"}
panic: invalid state enecountered in price monitoring engine{error 26 0  received a time that's before the last received time}
```

which isn't great.

The fix is to only allow new transactions into the nullchain if replay has finished AND was successful.