### PR TITLE
fix: when not increasing and within pow limit return base diff

### DIFF
--- a/core/pow/engine.go
+++ b/core/pow/engine.go
@@ -26,6 +26,7 @@ import (
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/libs/crypto"
 	"code.vegaprotocol.io/vega/libs/num"
+	"code.vegaprotocol.io/vega/libs/ptr"
 	"code.vegaprotocol.io/vega/logging"
 )
 
@@ -654,6 +655,10 @@ func (e *Engine) GetSpamStatistics(partyID string) *protoapi.PoWStatistic {
 
 func getMinDifficultyForNextTx(baseDifficulty, txPerBlock, seenTx, observedDifficulty uint, increaseDifficulty bool) *uint64 {
 	if !increaseDifficulty {
+		if seenTx < txPerBlock {
+			return ptr.From(uint64(baseDifficulty))
+		}
+		// they cannot submit any more against this block, do not return a next-difficulty
 		return nil
 	}
 

--- a/core/pow/engine_test.go
+++ b/core/pow/engine_test.go
@@ -544,6 +544,18 @@ func Test_ExpectedSpamDifficulty(t *testing.T) {
 			},
 			isNil: true,
 		},
+		{
+			name: "Expected difficulty when increaseDifficulty is false but fewer seen than allowed in block",
+			args: args{
+				spamPowDifficulty:         10,
+				spamPoWNumberOfTxPerBlock: 100,
+				seenTx:                    1,
+				observedDifficulty:        10,
+				increaseDifficulty:        false,
+			},
+			isNil: false,
+			want:  10,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Pinging the new pow stats endpoint on devnet, when increasing difficulty is turned off, we do not return any value for the next expected difficulty even if we are within the limit (and at least one txn has been sent in). Which implies that we cannot send in anymore against this block.

Example from devnet:

```
"pow": {
      "blockStates": [
        {
          "blockHeight": "1501",
          "blockHash": "05ef252ec033890f2ed611393c8cfe233ced162de9ec078e88c056b21e2986ea",
          "transactionsSeen": "1",
          "hashFunction": "sha3_24_rounds"
        },
        {
          "blockHeight": "1487",
          "blockHash": "ff34e9d3ed74262bd3d6d3ef33f75169015625dc61e8e35eaf7463c55fd58e77",
          "transactionsSeen": "1",
          "hashFunction": "sha3_24_rounds"
        },
        {
          "blockHeight": "1563",
          "blockHash": "c38b43a1d4c8b8ec200da5525241d6d2acb3eb96945a012b728cd8d26d7e79aa",
          "transactionsSeen": "0",
          "expectedDifficulty": "2",
          "hashFunction": "sha3_24_rounds"
        }
      ]
    }
```

There is just a case missing in `getMinDifficultyForNextTx`