### PR TITLE
chore: mention chain ID in datanode init help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [7279](https://github.com/vegaprotocol/vega/issues/7279) - Add `--archive` and `--lite` to `datanode init`
 - [7302](https://github.com/vegaprotocol/vega/issues/7302) - Add withdrawal minimal amount
 - [5487](https://github.com/vegaprotocol/vega/issues/5487) - Add `UPGRADING.md`
+- [7358](https://github.com/vegaprotocol/vega/issues/7358) - Improve `datanode init` and `vega init` help text
 - [7114](https://github.com/vegaprotocol/vega/issues/7114) - Expose user spam statistics via `API`
 - [7316](https://github.com/vegaprotocol/vega/issues/7316) - Add a bunch of database indexes following audit of queries
 - [7331](https://github.com/vegaprotocol/vega/issues/7331) - Control the decrease of the number of validators when network parameter is decreased

--- a/cmd/data-node/commands/init.go
+++ b/cmd/data-node/commands/init.go
@@ -27,7 +27,7 @@ import (
 type InitCmd struct {
 	config.VegaHomeFlag
 
-	Force   bool `short:"f" long:"force" description:"Erase exiting vega configuration at the specified path"`
+	Force   bool `short:"f" long:"force" description:"Erase existing vega configuration at the specified path"`
 	Archive bool `short:"a" long:"archive" description:"Disable database retention policies. Keep data indefinitely"`
 	Lite    bool `short:"l" long:"lite" description:"Set all database retention policies to one day only"`
 }

--- a/cmd/data-node/commands/init.go
+++ b/cmd/data-node/commands/init.go
@@ -34,6 +34,10 @@ type InitCmd struct {
 
 var initCmd InitCmd
 
+func (opts *InitCmd) Usage() string {
+	return "<ChainID> [options]"
+}
+
 func (opts *InitCmd) Execute(args []string) error {
 	logger := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
 	defer logger.AtExit()
@@ -99,7 +103,7 @@ func Init(ctx context.Context, parser *flags.Parser) error {
 	initCmd = InitCmd{}
 
 	short := "init <chain ID>"
-	long := "Generate the minimal configuration required for a vega data-node to start"
+	long := "Generate the minimal configuration required for a vega data-node to start. The Chain ID is required."
 
 	_, err := parser.AddCommand("init", short, long, &initCmd)
 	return err

--- a/cmd/vega/init.go
+++ b/cmd/vega/init.go
@@ -40,7 +40,7 @@ type InitCmd struct {
 	config.OutputFlag
 	config.Passphrase `long:"nodewallet-passphrase-file"`
 
-	Force bool `short:"f" long:"force" description:"Erase exiting vega configuration at the specified path"`
+	Force bool `short:"f" long:"force" description:"Erase existing vega configuration at the specified path"`
 
 	NoTendermint   bool   `long:"no-tendermint" description:"Disable tendermint configuration generation"`
 	TendermintHome string `long:"tendermint-home" required:"true" description:"Directory for tendermint config and data" default:"$HOME/.tendermint"`

--- a/cmd/vega/init.go
+++ b/cmd/vega/init.go
@@ -49,6 +49,10 @@ type InitCmd struct {
 
 var initCmd InitCmd
 
+func (opts *InitCmd) Usage() string {
+	return "<full | validator>"
+}
+
 func (opts *InitCmd) Execute(args []string) error {
 	logger := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
 	defer logger.AtExit()
@@ -222,7 +226,7 @@ func Init(ctx context.Context, parser *flags.Parser) error {
 
 	var (
 		short = "Initializes a vega node"
-		long  = "Generate the minimal configuration required for a vega node to start"
+		long  = "Generate the minimal configuration required for a vega node to start. You must specify 'full' or 'validator'"
 	)
 	_, err := parser.AddCommand("init", short, long, &initCmd)
 	return err


### PR DESCRIPTION
Closes #7358 

```
➜  vega git:(develop) ✗ go run ./cmd/vega datanode init --help
Usage:
  datanode [OPTIONS] init <ChainID> [options]

Generate the minimal configuration required for a vega data-node to start. The Chain ID is required.

Help Options:
  -h, --help         Show this help message

[init command options]
          --home=    Path to the custom home for vega
      -f, --force    Erase exiting vega configuration at the specified path
      -a, --archive  Disable database retention policies. Keep data indefinitely
      -l, --lite     Set all database retention policies to one day only
```

Also do something similar for `vega init` which requires `full` or `validator` to be specified.