### PR TITLE
feat: retry and panic on sync segment creation error

### DIFF
--- a/cmd/data-node/commands/networkhistory/fetch.go
+++ b/cmd/data-node/commands/networkhistory/fetch.go
@@ -32,7 +32,7 @@ func (cmd *fetchCmd) Execute(args []string) error {
 	defer log.AtExit()
 
 	if len(args) != 2 {
-		return errors.New("expected <start-history-segment-id> <num-blocks-to-fetch>")
+		return errors.New("expected <history-segment-id> <num-blocks-to-fetch>")
 	}
 
 	rootSegmentID := args[0]

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -130,7 +130,7 @@ func (cmd *loadCmd) Execute(_ []string) error {
 	if from < span.FromHeight && to <= span.ToHeight {
 		fmt.Printf("Available Network History data spans height %d to %d.  The from height is before the datanodes' block span, %d to %d."+
 			" To load history from before the datanodes oldest block you must specify the "+
-			" \"wipe-existing-data\" flag to wipe existing data from the datanode before loading.\n\n", from, to, span.FromHeight, span.ToHeight)
+			" \"--wipe-existing-data\" flag to wipe existing data from the datanode before loading.\n\n", from, to, span.FromHeight, span.ToHeight)
 
 		return nil
 	}

--- a/cmd/data-node/commands/networkhistory/networkhistory.go
+++ b/cmd/data-node/commands/networkhistory/networkhistory.go
@@ -23,7 +23,7 @@ type Cmd struct {
 	// Subcommands
 	Show                          showCmd              `command:"show" description:"shows network history segments currently stored by the node"`
 	Load                          loadCmd              `command:"load" description:"loads the most recent contiguous network history stored by the node into the datanode"`
-	Fetch                         fetchCmd             `command:"fetch" description:"fetch <start from history segment id> <blocks to fetch>, fetches the given number of blocks from network history"`
+	Fetch                         fetchCmd             `command:"fetch" description:"fetch <history segment id> <blocks to fetch>, fetches the given segment and all previous segments until <blocks to fetch> blocks have been retrieved"`
 	LatestHistorySegmentFromPeers latestHistorySegment `command:"latest-history-segment-from-peers" description:"latest-history-segment returns the id of the networks latest history segment"`
 	ListActivePeers               listActivePeers      `command:"list-active-peers" description:"list the active datanode peers"`
 	Copy                          copyCmd              `command:"copy" description:"copy a history segment from network history to a file"`

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/cenkalti/backoff"
 	"google.golang.org/grpc"
@@ -251,7 +252,8 @@ func (l *NodeCommand) preRun([]string) (err error) {
 
 	if l.conf.NetworkHistory.Enabled {
 		blockCommitHandler := networkhistory.NewBlockCommitHandler(l.Log, l.conf.NetworkHistory, l.snapshotService.SnapshotData,
-			bool(l.conf.Broker.UseEventFile), l.conf.Broker.FileEventSourceConfig.TimeBetweenBlocks.Duration)
+			bool(l.conf.Broker.UseEventFile), l.conf.Broker.FileEventSourceConfig.TimeBetweenBlocks.Duration,
+			5*time.Second, 6)
 		onBlockCommittedHandler = blockCommitHandler.OnBlockCommitted
 		protocolUpgradeHandler = networkhistory.NewProtocolUpgradeHandler(l.Log, l.protocolUpgradeService, eventReceiverSender,
 			l.networkHistoryService.CreateAndPublishSegment)

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	snapshotInterval     = int64(1000)
-	chainID              = "testnet"
+	chainID              = "testnet-001"
 	compressedEventsFile = "testdata/smoketest_to_block_5000.evts.gz"
 	numSnapshots         = 6
 	testMigrationSQL     = "testdata/testmigration.sql"
@@ -378,12 +378,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmagW5qcBTMh5edQB64RgD9xnRUZKFR2mFk5gPGc3mbdBF", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmP2fZP93i3pu9AQ7W3HxiZ8Uqowt3VidaoyjgURUDjec1", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmWLc9XcDz5bVTdqq1EHvyBb9GDLcrqfGVRGbEihrNuG32", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmU4o7LtH1rGmmPjN6UE6mezJ3TSZQqLwvKwSaAJC3Cdcw", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmQW6tiRSDqqKYs5MXwWoSYeEnP4cY84rWcDdDX68a4mMZ", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmUdJwB7t4aU3dtHTCj7VUP8L9mmfejN4RX9j2TsrtVRPf", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmNyT6STi3Y6xwZrM66V1s7MLuikovsD8AZF6ENGXCjka3", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmTAMJRJqE3hZZ5B9DWWCyHKyqhU64ZmmVsdpsY786HGB6", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmSBi1wSaPgfXFCGcihQGEV8jX8kvgXqakb19KzUk1ReiX", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmSVW2HE9rK2JZ5LszawifUrF2XcyCz7XVYjGhxSnRoMzt", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "Qmd69zrEr1NmwUXHcobozYFq7U4aN9dBCYMqiDgPMN9QDe", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmQhzwNaEWbhpdR7RUjHKkYGnBk5TCmJwct9v7oqKM1NDQ", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/networkhistory/snapshot/service_create_snapshot.go
+++ b/datanode/networkhistory/snapshot/service_create_snapshot.go
@@ -108,6 +108,7 @@ func (b *Service) createNewSnapshot(ctx context.Context, chainID string, toHeigh
 	// To ensure reads are isolated from this point forward execute a read on last block
 	_, err = sqlstore.GetLastBlockUsingConnection(ctx, copyDataTx)
 	if err != nil {
+		runAllInReverseOrder(cleanUp)
 		return MetaData{}, fmt.Errorf("failed to get last block using connection: %w", err)
 	}
 

--- a/datanode/networkhistory/testdata/update_test_evts_file.go
+++ b/datanode/networkhistory/testdata/update_test_evts_file.go
@@ -42,7 +42,7 @@ func main() {
 	config := broker.NewDefaultConfig()
 
 	fileEventSource, err := broker.NewFileEventSource(sourceFile, 0, config.FileEventSourceConfig.SendChannelBufferSize,
-		"testnet")
+		"testnet-001")
 	if err != nil {
 		panic(err)
 	}
@@ -66,6 +66,7 @@ func main() {
 		case event := <-eventsCh:
 			if event.Type() == events.TimeUpdate {
 				timeUpdate := event.(entities.TimeUpdateEvent)
+				fmt.Printf("Block: %d\n", timeUpdate.BlockNr())
 				if timeUpdate.BlockNr() > toHeight+1 {
 					fileClient.Close()
 					compressEventFile(EventFile, EventFile+".gz")
@@ -108,17 +109,4 @@ func compressEventFile(source string, target string) {
 	if _, err := io.Copy(zw, sourceFile); err != nil {
 		panic(err)
 	}
-}
-
-type chainInfo struct {
-	chainID string
-}
-
-func (t *chainInfo) SetChainID(s string) error {
-	t.chainID = s
-	return nil
-}
-
-func (t *chainInfo) GetChainID() (string, error) {
-	return t.chainID, nil
 }


### PR DESCRIPTION
closes #7360 the part of the segment creation code that is synchronous with the event processing now retries to create the segment on a failure, after 6 failed attempts it will panic.