### PR TITLE
fix: add Access-Control-Expose-Headers to responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 ### 🐛 Fixes
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
+
+## Unreleased 0.67.2
+
+### 🐛 Fixes
+- [7387](https://github.com/vegaprotocol/vega/issues/7387) - Allow authorization headers in wallet service
+
+
 ## 0.67.1
 
 ### 🛠 Improvements

--- a/wallet/service/v2/response_writer.go
+++ b/wallet/service/v2/response_writer.go
@@ -41,6 +41,7 @@ func (lw *responseWriter) SetStatusCode(statusCode int) {
 func (lw *responseWriter) SetAuthorization(vwt VWT) {
 	lw.writer.Header().Set("Authorization", vwt.String())
 	lw.writer.Header().Set("Access-Control-Allow-Headers", "Authorization")
+	lw.writer.Header().Set("Access-Control-Expose-Headers", "Authorization")
 }
 
 func (lw *responseWriter) WriteHTTPResponse(response *Response) {

--- a/wallet/service/v2/response_writer.go
+++ b/wallet/service/v2/response_writer.go
@@ -40,6 +40,7 @@ func (lw *responseWriter) SetStatusCode(statusCode int) {
 
 func (lw *responseWriter) SetAuthorization(vwt VWT) {
 	lw.writer.Header().Set("Authorization", vwt.String())
+	lw.writer.Header().Set("Access-Control-Allow-Headers", "Authorization")
 }
 
 func (lw *responseWriter) WriteHTTPResponse(response *Response) {


### PR DESCRIPTION
the fetch api can't read the auth header by default, unless the server explicitly allows it by setting an [access-control-allow-headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)