### PR TITLE
fix: return correct timestamp for stake linking in graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [7407](https://github.com/vegaprotocol/vega/issues/7407) - fix ethereum timestamp in stake linking in graphql
 
 
 ## 0.67.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🐛 Fixes
-- [7407](https://github.com/vegaprotocol/vega/issues/7407) - fix ethereum timestamp in stake linking in graphql
+- [7407](https://github.com/vegaprotocol/vega/issues/7407) - fix `ethereum` timestamp in stake linking in `graphql`
 
 
 ## 0.67.2

--- a/datanode/gateway/graphql/staking.go
+++ b/datanode/gateway/graphql/staking.go
@@ -14,6 +14,7 @@ package gql
 
 import (
 	"context"
+	"time"
 
 	"code.vegaprotocol.io/vega/libs/ptr"
 	v2 "code.vegaprotocol.io/vega/protos/data-node/api/v2"
@@ -24,7 +25,8 @@ import (
 type stakeLinkingResolver VegaResolverRoot
 
 func (s *stakeLinkingResolver) Timestamp(_ context.Context, obj *eventspb.StakeLinking) (int64, error) {
-	return obj.Ts, nil
+	// returning the time in nano as the timestamp marshallar expects it that way
+	return time.Unix(obj.Ts, 0).UnixNano(), nil
 }
 
 func (s *stakeLinkingResolver) Party(_ context.Context, obj *eventspb.StakeLinking) (*vgproto.Party, error) {


### PR DESCRIPTION
Closes #7407 