### PR TITLE
fix: restore settlement data if not nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [7420](https://github.com/vegaprotocol/vega/issues/7420) - `clearFeeActivity` now clears fee activity
 - [7399](https://github.com/vegaprotocol/vega/issues/7399) - Fix issue where market cache not working after restoring from network history
 - [7169](https://github.com/vegaprotocol/vega/issues/7169) - Fix migration, account for existing position data
-
+- [7427](https://github.com/vegaprotocol/vega/issues/7427) - Fix nil pointer panic on settlement of restored markets.
 
 ## 0.67.2
 

--- a/core/execution/market_snapshot.go
+++ b/core/execution/market_snapshot.go
@@ -162,6 +162,10 @@ func NewMarketFromSnapshot(
 	market.assetDP = uint32(assetDetails.DecimalPlaces())
 	market.tradableInstrument.Instrument.Product.NotifyOnTradingTerminated(market.tradingTerminated)
 	market.tradableInstrument.Instrument.Product.NotifyOnSettlementData(market.settlementData)
+	if em.SettlementData != nil {
+		// ensure oracle has the settlement data
+		market.tradableInstrument.Instrument.Product.RestoreSettlementData(em.SettlementData.Clone())
+	}
 	liqEngine.SetGetStaticPricesFunc(market.getBestStaticPricesDecimal)
 
 	if mkt.State == types.MarketStateTradingTerminated {

--- a/core/execution/snapshot_test.go
+++ b/core/execution/snapshot_test.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"testing"
 	"time"
 
@@ -44,6 +45,10 @@ type snapshotTestData struct {
 	oracleEngine   *oracles.Engine
 	snapshotEngine *snp.Engine
 	timeService    *stubs.TimeStub
+}
+
+type stubIDGen struct {
+	calls int
 }
 
 // TestSnapshotOraclesTerminatingMarketFromSnapshot tests that market loaded from snapshot can be terminated with its oracle.
@@ -124,7 +129,7 @@ func TestSnapshotOraclesTerminatingMarketFromSnapshot(t *testing.T) {
 // the settlement data will be sent before the snapshot is taken, to ensure settlement data is restored correctly.
 func TestSnapshotOraclesTerminatingMarketSettleAfterSnapshot(t *testing.T) {
 	now := time.Now()
-	exec := getEngine(t, now)
+	exec := getEngineWithParties(t, now, num.NewUint(1000000000), "lp", "p1", "p2", "p3", "p4")
 	pubKey := &types.SignerPubKey{
 		PubKey: &types.PubKey{
 			Key: "0xDEADBEEF",
@@ -140,12 +145,78 @@ func TestSnapshotOraclesTerminatingMarketSettleAfterSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.MarketStateActive, mktState)
 
+	idgen := &stubIDGen{}
+	// now let's submit some orders and get market to trade continuously
+	lpSubmission := &types.LiquidityProvisionSubmission{
+		MarketID:         mkt.ID,
+		CommitmentAmount: num.NewUint(1000000),
+		Fee:              num.DecimalFromFloat(0.01),
+		Reference:        "lp1",
+		Buys: []*types.LiquidityOrder{
+			newLiquidityOrder(types.PeggedReferenceMid, 10, 5),
+		},
+		Sells: []*types.LiquidityOrder{
+			newLiquidityOrder(types.PeggedReferenceMid, 10, 5),
+		},
+	}
+	// submit LP
+	vgctx := vgcontext.WithTraceID(context.Background(), hex.EncodeToString([]byte("0deadbeef")))
+	_ = exec.engine.SubmitLiquidityProvision(vgctx, lpSubmission, "lp", idgen.NextID())
+	// uncrossing orders
+	os1 := &types.OrderSubmission{
+		MarketID:    mkt.ID,
+		Price:       num.NewUint(99),
+		Size:        1,
+		Side:        types.SideBuy,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Type:        types.OrderTypeLimit,
+		Reference:   "o1",
+	}
+	os2 := &types.OrderSubmission{
+		MarketID:    mkt.ID,
+		Price:       num.NewUint(99),
+		Size:        1,
+		Side:        types.SideSell,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Type:        types.OrderTypeLimit,
+		Reference:   "o2",
+	}
+	_, _ = exec.engine.SubmitOrder(vgctx, os1, "p1", idgen, "o1p1")
+	_, _ = exec.engine.SubmitOrder(vgctx, os2, "p2", idgen, "o2p2")
+	// have some volume on the book
+	os1 = &types.OrderSubmission{
+		MarketID:    mkt.ID,
+		Price:       num.NewUint(85),
+		Size:        1,
+		Side:        types.SideBuy,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Type:        types.OrderTypeLimit,
+		Reference:   "o3",
+	}
+	os2 = &types.OrderSubmission{
+		MarketID:    mkt.ID,
+		Price:       num.NewUint(110),
+		Size:        1,
+		Side:        types.SideSell,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Type:        types.OrderTypeLimit,
+		Reference:   "o4",
+	}
+	_, _ = exec.engine.SubmitOrder(vgctx, os1, "p3", idgen, "o3p3")
+	_, _ = exec.engine.SubmitOrder(vgctx, os2, "p4", idgen, "o4p4")
+
+	// OK, we now have stuff on the book, so we should be able to leave opening auction
+	now = now.Add(60 * time.Second) // move ahead 1 minute
+	// We probably need to add a hash to this context
+	vgctx = vgcontext.WithTraceID(context.Background(), hex.EncodeToString([]byte("1deadbeef")))
+	exec.engine.OnTick(vgctx, now)
 	pubKeys := []*types.Signer{
 		types.CreateSignerFromString(pubKey.PubKey.Key, types.DataSignerTypePubKey),
 	}
 
 	// provide settlement data for first market
-	exec.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
+	vgctx = vgcontext.WithTraceID(context.Background(), hex.EncodeToString([]byte("2deadbeef")))
+	exec.oracleEngine.BroadcastData(vgctx, oracles.OracleData{
 		Signers: pubKeys,
 		Data:    map[string]string{"prices.ETH.value": "100"},
 	})
@@ -155,18 +226,20 @@ func TestSnapshotOraclesTerminatingMarketSettleAfterSnapshot(t *testing.T) {
 	exec2 := getEngine(t, now)
 	snap := &snapshot.Payload{}
 	proto.Unmarshal(state, snap)
-	_, _ = exec2.engine.LoadState(context.Background(), types.PayloadFromProto(snap))
+	vgctx = vgcontext.WithTraceID(context.Background(), hex.EncodeToString([]byte("3deadbeef")))
+	_, _ = exec2.engine.LoadState(vgctx, types.PayloadFromProto(snap))
 
 	state2, _, _ := exec2.engine.GetState("")
 	// the states should match
 	require.True(t, bytes.Equal(state, state2))
 
-	exec.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
+	vgctx = vgcontext.WithTraceID(context.Background(), hex.EncodeToString([]byte("3deadbeef")))
+	exec.oracleEngine.BroadcastData(vgctx, oracles.OracleData{
 		Signers: pubKeys,
 		Data:    map[string]string{"trading.terminated": "true"},
 	})
 
-	exec2.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
+	exec2.oracleEngine.BroadcastData(vgctx, oracles.OracleData{
 		Signers: pubKeys,
 		Data:    map[string]string{"trading.terminated": "true"},
 	})
@@ -194,6 +267,14 @@ func TestSnapshotOraclesTerminatingMarketFromSnapshotAfterSettlementData(t *test
 	err := exec.engine.SubmitMarket(context.Background(), mkt, "")
 	require.NoError(t, err)
 
+	err = exec.engine.StartOpeningAuction(context.Background(), mkt.ID)
+	require.NoError(t, err)
+	mktState, err := exec.engine.GetMarketState("MarketID")
+	require.NoError(t, err)
+	require.Equal(t, types.MarketStateActive, mktState)
+
+	// set up market to get to continuous trading
+
 	// settlement data arrives first
 	exec.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
 		Signers: pubKeys,
@@ -212,18 +293,6 @@ func TestSnapshotOraclesTerminatingMarketFromSnapshotAfterSettlementData(t *test
 	// take a snapshot on the loaded engine
 	state2, _, _ := exec2.engine.GetState("")
 	require.True(t, bytes.Equal(state, state2))
-
-	err = exec.engine.StartOpeningAuction(context.Background(), mkt.ID)
-	require.NoError(t, err)
-	mktState, err := exec.engine.GetMarketState("MarketID")
-	require.NoError(t, err)
-	require.Equal(t, types.MarketStateActive, mktState)
-
-	err = exec2.engine.StartOpeningAuction(context.Background(), mkt.ID)
-	require.NoError(t, err)
-	mktState, err = exec2.engine.GetMarketState("MarketID")
-	require.NoError(t, err)
-	require.Equal(t, types.MarketStateActive, mktState)
 
 	// terminate the market to lead to settlement
 	exec.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
@@ -499,4 +568,62 @@ func getEngine(t *testing.T, now time.Time) *snapshotTestData {
 		snapshotEngine: snapshotEngine,
 		timeService:    timeService,
 	}
+}
+
+func getEngineWithParties(t *testing.T, now time.Time, balance *num.Uint, parties ...string) *snapshotTestData {
+	t.Helper()
+	// ctrl := gomock.NewController(t)
+	cfg := execution.NewDefaultConfig()
+	log := logging.NewTestLogger()
+	broker := stubs.NewBrokerStub()
+	timeService := stubs.NewTimeStub()
+	timeService.SetTime(now)
+	collateralEngine := collateral.New(log, collateral.NewDefaultConfig(), timeService, broker)
+	oracleEngine := oracles.NewEngine(log, oracles.NewDefaultConfig(), timeService, broker)
+
+	epochEngine := epochtime.NewService(log, epochtime.NewDefaultConfig(), broker)
+	marketActivityTracker := execution.NewMarketActivityTracker(logging.NewTestLogger(), epochEngine)
+
+	ethAsset := types.Asset{
+		ID: "Ethereum/Ether",
+		Details: &types.AssetDetails{
+			Name:   "Ethereum/Ether",
+			Symbol: "Ethereum/Ether",
+		},
+	}
+	collateralEngine.EnableAsset(context.Background(), ethAsset)
+	for _, p := range parties {
+		_, _ = collateralEngine.Deposit(context.Background(), p, ethAsset.ID, balance.Clone())
+	}
+
+	eng := execution.NewEngine(
+		log,
+		cfg,
+		timeService,
+		collateralEngine,
+		oracleEngine,
+		broker,
+		stubs.NewStateVar(),
+		marketActivityTracker,
+		stubs.NewAssetStub(),
+	)
+
+	statsData := stats.New(log, stats.NewDefaultConfig())
+	config := snp.NewDefaultConfig()
+	config.Storage = "memory"
+	snapshotEngine, _ := snp.New(context.Background(), &paths.DefaultPaths{}, config, log, timeService, statsData.Blockchain)
+	snapshotEngine.AddProviders(eng)
+	snapshotEngine.ClearAndInitialise()
+
+	return &snapshotTestData{
+		engine:         eng,
+		oracleEngine:   oracleEngine,
+		snapshotEngine: snapshotEngine,
+		timeService:    timeService,
+	}
+}
+
+func (s *stubIDGen) NextID() string {
+	s.calls++
+	return hex.EncodeToString([]byte(fmt.Sprintf("deadb33f%d", s.calls)))
 }

--- a/core/products/future.go
+++ b/core/products/future.go
@@ -114,6 +114,10 @@ func (f *Future) NotifyOnTradingTerminated(listener func(context.Context, bool))
 	f.tradingTerminationListener = listener
 }
 
+func (f *Future) RestoreSettlementData(settleData *num.Numeric) {
+	f.oracle.data.settlData = settleData
+}
+
 func (f *Future) ScaleSettlementDataToDecimalPlaces(price *num.Numeric, dp uint32) (*num.Uint, error) {
 	if !price.SupportDecimalPlaces(int64(dp)) {
 		return nil, ErrSettlementDataDecimalsNotSupportedByAsset

--- a/core/products/products.go
+++ b/core/products/products.go
@@ -50,6 +50,7 @@ type Product interface {
 	NotifyOnSettlementData(listener func(context.Context, *num.Numeric))
 	UnsubscribeTradingTerminated(ctx context.Context)
 	UnsubscribeSettlementData(ctx context.Context)
+	RestoreSettlementData(*num.Numeric)
 }
 
 // New instance a new product from a Market framework product configuration.


### PR DESCRIPTION
Closes #7427 

When restoring a market from snapshots, settlement data has to be set on the oracle, too