### PR TITLE
fix: set nonce for joining and leaving signatures at the start of eac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Fixes
 - [7407](https://github.com/vegaprotocol/vega/issues/7407) - fix `ethereum` timestamp in stake linking in `graphql`
 - [7420](https://github.com/vegaprotocol/vega/issues/7420) - `clearFeeActivity` now clears fee activity
+- [7420](https://github.com/vegaprotocol/vega/issues/7420) - set seed nonce for joining and leaving signatures during begin block
 - [7399](https://github.com/vegaprotocol/vega/issues/7399) - Fix issue where market cache not working after restoring from network history
 - [7169](https://github.com/vegaprotocol/vega/issues/7169) - Fix migration, account for existing position data
 

--- a/core/validators/mocks/mocks.go
+++ b/core/validators/mocks/mocks.go
@@ -646,6 +646,18 @@ func (mr *MockSignaturesMockRecorder) SerialisePendingSignatures() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerialisePendingSignatures", reflect.TypeOf((*MockSignatures)(nil).SerialisePendingSignatures))
 }
 
+// SetNonce mocks base method.
+func (m *MockSignatures) SetNonce(arg0 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNonce", arg0)
+}
+
+// SetNonce indicates an expected call of SetNonce.
+func (mr *MockSignaturesMockRecorder) SetNonce(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonce", reflect.TypeOf((*MockSignatures)(nil).SetNonce), arg0)
+}
+
 // MockMultiSigTopology is a mock of MultiSigTopology interface.
 type MockMultiSigTopology struct {
 	ctrl     *gomock.Controller

--- a/core/validators/signatures.go
+++ b/core/validators/signatures.go
@@ -39,6 +39,7 @@ type Signatures interface {
 		previousState map[string]StatusAddress,
 		newState map[string]StatusAddress,
 	)
+	SetNonce(currentTime time.Time)
 	PrepareValidatorSignatures(ctx context.Context, validators []NodeIDAddress, epochSeq uint64, added bool)
 	EmitValidatorAddedSignatures(ctx context.Context, submitter, nodeID string, currentTime time.Time) error
 	EmitValidatorRemovedSignatures(ctx context.Context, submitter, nodeID string, currentTime time.Time) error
@@ -158,7 +159,6 @@ func (s *ERC20Signatures) PreparePromotionsSignatures(
 		}
 	}
 
-	s.SetNonce(currentTime)
 	s.PrepareValidatorSignatures(ctx, toAdd, epochSeq, true)
 	s.PrepareValidatorSignatures(ctx, toRemove, epochSeq, false)
 

--- a/core/validators/topology.go
+++ b/core/validators/topology.go
@@ -452,12 +452,14 @@ func (t *Topology) BeginBlock(ctx context.Context, req abcitypes.RequestBeginBlo
 
 	// resetting the seed every block, to both get some more unpredictability and still deterministic
 	// and play nicely with snapshot
-	t.rng = rand.New(rand.NewSource(t.timeService.GetTimeNow().Unix()))
+	currentTime := t.timeService.GetTimeNow()
+	t.rng = rand.New(rand.NewSource(currentTime.Unix()))
 
 	t.checkHeartbeat(ctx)
 	t.validatorPerformance.BeginBlock(ctx, hex.EncodeToString(req.Header.ProposerAddress))
 	t.currentBlockHeight = uint64(req.Header.Height)
 
+	t.signatures.SetNonce(currentTime)
 	t.signatures.ClearStaleSignatures()
 	t.keyRotationBeginBlockLocked(ctx)
 	t.ethereumKeyRotationBeginBlockLocked(ctx)


### PR DESCRIPTION
When creating signature bundles for adding/removing a validator from the multisig contract we create a nonce from some hash of the current block time. For every bundle created in that block the nonce is incremented by one (e.g if a slot change means 10 nodes get demoted the nonce for promotion `i` will be  `num.NewUint(uint64(t.Unix()) + 1) + i` In the current code the call to `SetNonce(currentTime)` happens in the joining/leaving flow and only if a set change happens.

The problem is that adding/removing bundles are also generated during an ethereum key rotation, _but we do not to call SetNonce()_. What this means is that first ethereum key rotation in the network will use a nonce of `0` if no promotions/demotions have happened (or that last nonce + 1 if a promotion or demotion did happen).

The problem occurs if we then restore from a snapshot and another key rotation is performed. The key-rotation code will not call `SetNonce()` and the restored node will used use a nonce of 0 again, which will differ from the nonces used by the other nodes. This is not good.

The fix is that we now always call `SetNonce()` in the topology engines `BeginBlock()` call so that whatever happens the nonce will be seeded correctly (even if unused for that block).