### PR TITLE
fix: intermittent termination error when integation tests are finished

### DIFF
--- a/cmd/data-node/commands/start/node.go
+++ b/cmd/data-node/commands/start/node.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -120,7 +121,12 @@ func (l *NodeCommand) runNode([]string) error {
 	eg.Go(func() error { return grpcServer.Start(ctx, nil) })
 
 	// start the admin server
-	eg.Go(func() error { return adminServer.Start(ctx) })
+	eg.Go(func() error {
+		if err := adminServer.Start(ctx); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
 
 	// start gateway
 	if l.conf.GatewayEnabled {


### PR DESCRIPTION
Sorry, I overlooked the fact that `http.Server.Serve` always returns a non-nil error.