### PR TITLE
Memory leak and CPU spikes on data streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [7468](https://github.com/vegaprotocol/vega/issues/7468) - `Datanode` network history load command only prompts when run from a terminal
 - [7164](https://github.com/vegaprotocol/vega/issues/7164) - The command `vega wallet transaction send` now returns verbose errors
 - [7514](https://github.com/vegaprotocol/vega/issues/7514) - Network names cannot contain `/`, `\` or start with a `.`
+- [7519](https://github.com/vegaprotocol/vega/issues/7519) - Fix memory leak and increased CPU usage when streaming data.
 
 ## 0.67.2
 

--- a/datanode/api/event_observer.go
+++ b/datanode/api/event_observer.go
@@ -122,6 +122,7 @@ func observeEvents(
 	ch <-chan []*eventspb.BusEvent,
 ) error {
 	sentEventStatTicker := time.NewTicker(time.Second)
+	defer sentEventStatTicker.Stop()
 	publishedEvents := eventStats{}
 
 	for {
@@ -154,6 +155,7 @@ func observeEventsWithAck(
 	bCh chan<- int,
 ) error {
 	sentEventStatTicker := time.NewTicker(time.Second)
+	defer sentEventStatTicker.Stop()
 	publishedEvents := eventStats{}
 
 	for {

--- a/datanode/api/observe.go
+++ b/datanode/api/observe.go
@@ -27,6 +27,7 @@ func observe[T any](ctx context.Context, log *logging.Logger, eventType string, 
 	defer metrics.StartActiveSubscriptionCountGRPC(eventType)()
 
 	publishedEventStatTicker := time.NewTicker(time.Second)
+	dever publishedEventStatTicker.Stop()
 	var publishedEvents int64
 
 	var err error
@@ -72,6 +73,7 @@ func observeBatch[T any](ctx context.Context, log *logging.Logger, eventType str
 	defer metrics.StartActiveSubscriptionCountGRPC(eventType)()
 
 	publishedEventStatTicker := time.NewTicker(time.Second)
+	defer pubshedEventStatTicker.Stop()
 	var publishedEvents int64
 	var err error
 	for {

--- a/datanode/api/observe.go
+++ b/datanode/api/observe.go
@@ -27,7 +27,7 @@ func observe[T any](ctx context.Context, log *logging.Logger, eventType string, 
 	defer metrics.StartActiveSubscriptionCountGRPC(eventType)()
 
 	publishedEventStatTicker := time.NewTicker(time.Second)
-	dever publishedEventStatTicker.Stop()
+	defer publishedEventStatTicker.Stop()
 	var publishedEvents int64
 
 	var err error
@@ -73,7 +73,7 @@ func observeBatch[T any](ctx context.Context, log *logging.Logger, eventType str
 	defer metrics.StartActiveSubscriptionCountGRPC(eventType)()
 
 	publishedEventStatTicker := time.NewTicker(time.Second)
-	defer pubshedEventStatTicker.Stop()
+	defer publishedEventStatTicker.Stop()
 	var publishedEvents int64
 	var err error
 	for {

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -661,6 +661,7 @@ func (t *tradingDataServiceV2) ObserveCandleData(req *v2.ObserveCandleDataReques
 	}
 
 	publishedEventStatTicker := time.NewTicker(time.Second)
+	defer publishedEventStatTicker.Stop()
 	var publishedEvents int64
 
 	for {

--- a/datanode/gateway/graphql/market_data_resolvers.go
+++ b/datanode/gateway/graphql/market_data_resolvers.go
@@ -386,7 +386,7 @@ func (r *mySubscriptionResolver) MarketsDepth(ctx context.Context, marketIds []s
 		return nil, err
 	}
 
-	return grpcStreamToGraphQlChannel[*v2.ObserveMarketsDepthResponse](r.log, "marketsDepth", stream,
+	return grpcStreamToGraphQlChannel[*v2.ObserveMarketsDepthResponse](ctx, r.log, "marketsDepth", stream,
 		func(md *v2.ObserveMarketsDepthResponse) []*types.MarketDepth {
 			return md.MarketDepth
 		}), nil
@@ -401,7 +401,7 @@ func (r *mySubscriptionResolver) MarketsDepthUpdate(ctx context.Context, marketI
 		return nil, err
 	}
 
-	return grpcStreamToGraphQlChannel[*v2.ObserveMarketsDepthUpdatesResponse](r.log, "marketsDepthUpdate", stream,
+	return grpcStreamToGraphQlChannel[*v2.ObserveMarketsDepthUpdatesResponse](ctx, r.log, "marketsDepthUpdate", stream,
 		func(md *v2.ObserveMarketsDepthUpdatesResponse) []*types.MarketDepthUpdate {
 			return md.Update
 		}), nil
@@ -416,7 +416,7 @@ func (r *mySubscriptionResolver) MarketsData(ctx context.Context, marketIds []st
 		return nil, err
 	}
 
-	return grpcStreamToGraphQlChannel[*v2.ObserveMarketsDataResponse](r.log, "marketsdata", stream,
+	return grpcStreamToGraphQlChannel[*v2.ObserveMarketsDataResponse](ctx, r.log, "marketsdata", stream,
 		func(md *v2.ObserveMarketsDataResponse) []*types.MarketData {
 			return md.MarketData
 		}), nil
@@ -427,7 +427,9 @@ type grpcStream[T any] interface {
 	grpc.ClientStream
 }
 
-func grpcStreamToGraphQlChannel[T any, Y any](log *logging.Logger, observableType string, stream grpcStream[T], grpcStreamTypeToGraphQlType func(T) Y) chan Y {
+func grpcStreamToGraphQlChannel[T any, Y any](ctx context.Context, log *logging.Logger, observableType string, stream grpcStream[T], grpcStreamTypeToGraphQlType func(T) Y) chan Y {
+	// should be just a wrapped version of ctx, but let's check both
+	sCtx := stream.Context()
 	c := make(chan Y)
 	go func() {
 		defer func() {
@@ -444,7 +446,17 @@ func grpcStreamToGraphQlChannel[T any, Y any](log *logging.Logger, observableTyp
 				log.Error(observableType+": stream closed", logging.Error(err))
 				break
 			}
-			c <- grpcStreamTypeToGraphQlType(md)
+			select {
+			case c <- grpcStreamTypeToGraphQlType(md):
+				log.Debugf("%s: data sent", observableType)
+				continue
+			case <-sCtx.Done():
+				log.Debugf("%s: stream closed by server", observableType)
+				break
+			case <-ctx.Done():
+				log.Debugf("%s: stream closed", observableType)
+				break
+			}
 		}
 	}()
 	return c


### PR DESCRIPTION
Fixes #7519 

Tickers need a `Stop` call or they leak memory, added some checks on the request and stream contexts on graphQL subscriptions in case the connection was closed between receiving and sending the data.