### PR TITLE
fix: prevent panic if wallet/core mismatch

### DIFF
--- a/wallet/api/node/adapters/insecure_grpc_adapter.go
+++ b/wallet/api/node/adapters/insecure_grpc_adapter.go
@@ -23,6 +23,11 @@ func (c *InsecureGRPCAdapter) Host() string {
 }
 
 func toSpamStatistic(st *apipb.SpamStatistic) *nodetypes.SpamStatistic {
+	if st == nil {
+		// can happen if pointing to an older version of core where this
+		// particular spam statistic doesn't exist yet
+		return &nodetypes.SpamStatistic{}
+	}
 	return &nodetypes.SpamStatistic{
 		CountForEpoch: st.CountForEpoch,
 		MaxForEpoch:   st.MaxForEpoch,


### PR DESCRIPTION
The `IssuesSignatures` spam statistic was added recently.

If the latest wallet is being used with a version of core _before_ this spam statistic was added the wallet will panic. This protects against it, and will mean that the wallet has no eyes on that particular stats, but using mismatched wallet versions does come with a warning.