### PR TITLE
fix: wallet recovers in file store reads and writes to protect from F…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [7407](https://github.com/vegaprotocol/vega/issues/7407) - fix `ethereum` timestamp in stake linking in `graphql`
 - [7420](https://github.com/vegaprotocol/vega/issues/7420) - `clearFeeActivity` now clears fee activity
 - [7420](https://github.com/vegaprotocol/vega/issues/7420) - set seed nonce for joining and leaving signatures during begin block
+- [7420](https://github.com/vegaprotocol/vega/issues/7515) - protect `vegawallet` with recovers to shield against file system oddities
 - [7399](https://github.com/vegaprotocol/vega/issues/7399) - Fix issue where market cache not working after restoring from network history
 - [7410](https://github.com/vegaprotocol/vega/issues/7410) - Return underlying error when parsing a command failed in the wallet API version 2
 - [7169](https://github.com/vegaprotocol/vega/issues/7169) - Fix migration, account for existing position data

--- a/wallet/service/v2/connections/store/v1/file_store.go
+++ b/wallet/service/v2/connections/store/v1/file_store.go
@@ -173,7 +173,7 @@ func (s *FileStore) Close() {
 func (s *FileStore) readTokensFile() (tokens tokensFile, rerr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			tokens, rerr = tokensFile{}, fmt.Errorf("unexpected fs issues reading tokens file: %s", r)
+			tokens, rerr = tokensFile{}, fmt.Errorf("a system error occurred while reading the tokens file: %s", r)
 		}
 	}()
 
@@ -205,7 +205,7 @@ func (s *FileStore) readTokensFile() (tokens tokensFile, rerr error) {
 func (s *FileStore) writeTokensFile(tokens tokensFile) (rerr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			rerr = fmt.Errorf("unexpected fs issues writing tokens file: %s", r)
+			rerr = fmt.Errorf("a system error occurred while writing the tokens file:: %s", r)
 		}
 	}()
 	if err := paths.WriteEncryptedFile(s.tokensFilePath, s.passphrase, tokens); err != nil {

--- a/wallet/wallet/store/v1/file_store.go
+++ b/wallet/wallet/store/v1/file_store.go
@@ -357,7 +357,7 @@ func (s *FileStore) GetWalletPath(name string) string {
 func (s *FileStore) writeWallet(w wallet.Wallet, passphrase string) (rerr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			rerr = fmt.Errorf("unexpected fs issues writing wallet file: %s", r)
+			rerr = fmt.Errorf("a system error occurred while writing the wallet file: %s", r)
 		}
 	}()
 	if err := ensureValidWalletName(w.Name()); err != nil {
@@ -390,7 +390,7 @@ func (s *FileStore) walletPath(name string) string {
 func (s *FileStore) readWalletFile(name string, passphrase string) (hd *wallet.HDWallet, rerr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			hd, rerr = nil, fmt.Errorf("unexpected fs issues reading wallet file: %s", r)
+			hd, rerr = nil, fmt.Errorf("a system error occurred while reading the wallet file: %s", r)
 		}
 	}()
 


### PR DESCRIPTION
closes #7515 

Recovers have been added to functions that read/write the wallet/api-token encrypted files from the file-system to protect against external factors creating malformed files while the service is running. Before any sort of issue would panic and kill the wallet service as the file-watcher would notify of any changes and try to reload the file.