### PR TITLE
feat: add API rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 - [6963](https://github.com/vegaprotocol/vega/issues/6963) - Remove the legacy fields from network API
 - [7361](https://github.com/vegaprotocol/vega/issues/7361) - Network history loading and current order set tracking - database requires database to be dropped
 - [6963](https://github.com/vegaprotocol/vega/issues/7382) - `IssueSignatures` is no longer a validator command and is now protected by the spam engine
+- [7445](https://github.com/vegaprotocol/vega/issues/7445) - Added rate limiting to `GRPC`, `Rest` and `GraphQL` `APIs`
 - [7542](https://github.com/vegaprotocol/vega/issues/7542) - Add optional slippage factors to market proposal and use them to cap slippage component of maintenance margin
+
+
 
 ### 🗑️ Deprecation
 - [7385](https://github.com/vegaprotocol/vega/issues/7385) - Deprecating the `X-Vega-Connection` HTTP header in `datanode` `API` and `REST` and `GraphQL` gateways.

--- a/datanode/api/config.go
+++ b/datanode/api/config.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/datanode/config/encoding"
+	"code.vegaprotocol.io/vega/datanode/ratelimit"
 	"code.vegaprotocol.io/vega/logging"
 )
 
@@ -35,6 +36,7 @@ type Config struct {
 	StreamRetries    int               `long:"stream-retries"`
 	CoreNodeIP       string            `long:"core-node-ip"`
 	CoreNodeGRPCPort int               `long:"core-node-grpc-port"`
+	RateLimit        ratelimit.Config  `group:"rate-limits"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
@@ -52,5 +54,6 @@ func NewDefaultConfig() Config {
 		StreamRetries:    3,
 		CoreNodeIP:       "127.0.0.1",
 		CoreNodeGRPCPort: 3002,
+		RateLimit:        ratelimit.NewDefaultConfig(),
 	}
 }

--- a/datanode/api/server.go
+++ b/datanode/api/server.go
@@ -23,6 +23,7 @@ import (
 	"code.vegaprotocol.io/vega/libs/subscribers"
 
 	"code.vegaprotocol.io/vega/datanode/networkhistory"
+	"code.vegaprotocol.io/vega/datanode/ratelimit"
 
 	"code.vegaprotocol.io/vega/core/events"
 	"code.vegaprotocol.io/vega/datanode/candlesv2"
@@ -354,9 +355,11 @@ func (g *GRPCServer) Start(ctx context.Context, lis net.Listener) error {
 		lis = tpcLis
 	}
 
+	rateLimit := ratelimit.NewFromConfig(&g.RateLimit, g.log)
 	intercept := grpc.ChainUnaryInterceptor(
 		remoteAddrInterceptor(g.log),
 		headersInterceptor(g.blockService.GetLastBlock, g.log),
+		rateLimit.GRPCInterceptor,
 	)
 
 	g.srv = grpc.NewServer(intercept)

--- a/datanode/gateway/config.go
+++ b/datanode/gateway/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"code.vegaprotocol.io/vega/datanode/config/encoding"
+	"code.vegaprotocol.io/vega/datanode/ratelimit"
 	libhttp "code.vegaprotocol.io/vega/libs/http"
 	"code.vegaprotocol.io/vega/logging"
 )
@@ -58,6 +59,7 @@ type Config struct {
 	AutoCertDomain           string                   `long:"auto-cert-domain" description:"Automatically generate and sign https certificate via LetsEncrypt"`
 	CertificateFile          string                   `long:"certificate-file" description:"Path to SSL certificate, if using HTTPS but not autocert"`
 	KeyFile                  string                   `long:"key-file" description:"Path to private key, if using HTTPS but not autocert"`
+	RateLimit                ratelimit.Config         `group:"RateLimits" namespace:"rate-limits"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
@@ -94,5 +96,6 @@ func NewDefaultConfig() Config {
 			AllowedOrigins: []string{"*"},
 			MaxAge:         7200,
 		},
+		RateLimit: ratelimit.NewDefaultConfig(),
 	}
 }

--- a/datanode/ratelimit/README.md
+++ b/datanode/ratelimit/README.md
@@ -1,0 +1,74 @@
+# Rate Limiting
+
+To prevent abuse of the APIs provided by datanode, we provide optional tooling to limit the rate
+of API requests.
+
+Currently the rate limiting is simply applied on a per-remote-ip address basis, though we may implement
+more sophisticated methods in the future.
+
+The rate limiting mechanism is based on a [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm.
+
+The idea is that:
+
+- Each IP address which connects to datanode is assigned a `bucket` of `tokens`
+- That bucket has a maximum capacity and is initially full of `tokens`
+- Each API request costs one token, which is removed from the bucket when the call is made
+- Datanode adds some number of tokens each seconds (the `rate` of the limiter) to the bucket _up to it's maximum capacity_
+
+On average over time, this enforces the average rate of API requests to not exceed `rate` requests/second. However it allows temporary periods of more intensive use; the maximum rate being to use the entire capacity of the bucket within one second. For this reason the capacity of the bucket is called the `burst`.
+
+There is an [IETF RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers) for clients to get information about the rate limiting status. We implement this by sending the following headers in each API response (success or failure)
+
+- `RateLimit-Limit` The maximum request limit within the time window (1s).
+- `RateLimit-Reset` The rate-limiter time window duration in seconds (always 1s).
+- `RateLimit-Remaining` The remaining tokens.
+
+Upon rejection, the following HTTP response headers are available to users:
+
+- `X-Rate-Limit-Limit` The maximum request limit.
+- `X-Rate-Limit-Duration` The rate-limiter duration.
+- `X-Rate-Limit-Request-Forwarded-For` The rejected request X-Forwarded-For.
+- `X-Rate-Limit-Request-Remote-Addr` The rejected request RemoteAddr.
+
+If a client continues to make requests despite having no tokens available, the response will be
+ - HTTP `429` `StatusTooManyRequests` for HTTP APIs
+ - gRPC `14` Unavailable for the gRPC API.
+
+**Each unsuccessful response will deduct a token from a separate bucket** with the same refill rate and capacity as the before.
+
+**Exhausting the supply of tokens in this second bucket will result in the client's IP address being banned for a period of time.**
+
+If the user is banned the reponse will be 
+ - HTTP 403 Forbidden for HTTP APIs
+ - gRPC 14 Unavailable for the gRPC API.
+
+## GraphQL, gRPC, and REST
+
+You can currently configure `GraphQL` and `GRPC` rate limiting separately. `REST` inherits and shares the limits of the GRPC API.
+
+There is a mechanism in places so that the `GRPC` `API` calls generated inside a `GraphQL` call are not rate limited a second time.
+
+## Configuration
+
+For example in datanode's `config.toml` the GRPC API rate limiting is configured
+```
+[API]
+  [API.RateLimit]
+    Enabled = true   # Set to false to disable rate limiting
+    Rate = 10.0      # Refill rate of token bucket per second i.e. limit of average request rate
+    Burst = 50       # Size of token bucket; maximum number of requests in short time window
+    TTL = "1h0m0s"   # Time after which inactive token buckets are reset
+    BanFor = "10m0s" # If IP continues to make requests after passing rate limit threshold,
+                     # ban for this duration. Setting to 0 seconds prevents banning.
+```
+
+That configuration will apply to gRPC and REST. GraphQL is configured separately in
+```
+[Gateway]
+  [Gateway.RateLimits]
+    Enabled = true
+    Rate = 10.0
+    Burst = 50
+    TTL = "1h0m0s"
+    BanFor = "10m0s"
+```

--- a/datanode/ratelimit/config.go
+++ b/datanode/ratelimit/config.go
@@ -1,0 +1,25 @@
+package ratelimit
+
+import (
+	"time"
+
+	"code.vegaprotocol.io/vega/datanode/config/encoding"
+)
+
+type Config struct {
+	Enabled bool              `long:"enabled" description:"Enable rate limit of API requests per IP address. Based on a 'token bucket' algorithm"`
+	Rate    float64           `long:"rate" description:"Refill rate of token bucket; maximum average request rate"`
+	Burst   int               `long:"burst" description:"Size of token bucket; maximum number of requests in short time window"`
+	TTL     encoding.Duration `long:"ttl" description:"Time after which inactive token buckets are reset"`
+	BanFor  encoding.Duration `long:"banfor" description:"If IP continues to make requests after passing rate limit threshold, ban for this duration. Setting to 0 seconds disables banning."`
+}
+
+func NewDefaultConfig() Config {
+	return Config{
+		Enabled: true,
+		Rate:    20,
+		Burst:   100,
+		TTL:     encoding.Duration{Duration: time.Hour},
+		BanFor:  encoding.Duration{Duration: 10 * time.Minute},
+	}
+}

--- a/datanode/ratelimit/naughtystep.go
+++ b/datanode/ratelimit/naughtystep.go
@@ -1,0 +1,92 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/didip/tollbooth/v7"
+	"github.com/didip/tollbooth/v7/limiter"
+	"go.uber.org/zap"
+)
+
+// naughtyStep is a struct for keeping track of bad behavior and bans.
+//
+// You get put on the naughty step if you make requests despite having run out of tokens.
+// The naughty step has it's own rate limiter, and its tokens are spent every time a failed
+// (due to rate limiting) API call is made. If you run out of naughty tokens, then you get
+// banned for a period of time.
+
+type naughtyStep struct {
+	log    *logging.Logger
+	lmt    *limiter.Limiter
+	bans   map[string]time.Time
+	mu     sync.RWMutex
+	banFor time.Duration
+}
+
+func newNaughtyStep(log *logging.Logger, rate float64, burst int, banFor, pruneEvery time.Duration) *naughtyStep {
+	limitOpts := limiter.ExpirableOptions{DefaultExpirationTTL: pruneEvery}
+	lmt := tollbooth.NewLimiter(rate, &limitOpts)
+	lmt.SetBurst(burst)
+
+	ns := naughtyStep{
+		log:    log,
+		lmt:    lmt,
+		bans:   make(map[string]time.Time),
+		banFor: banFor,
+	}
+
+	go func() {
+		for range time.Tick(pruneEvery) {
+			ns.prune()
+		}
+	}()
+
+	return &ns
+}
+
+func (n *naughtyStep) enabled() bool {
+	return n.banFor > 0
+}
+
+func (n *naughtyStep) smackBottom(ip string) {
+	if !n.enabled() {
+		return
+	}
+
+	if n.lmt.LimitReached(ip) {
+		n.ban(ip)
+		n.log.Info("banned for requesting past rate limit", zap.String("ip", ip))
+	}
+}
+
+func (n *naughtyStep) ban(ip string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.bans[ip] = time.Now().Add(n.banFor)
+}
+
+func (n *naughtyStep) isBanned(ip string) bool {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	if bannedUntil, ok := n.bans[ip]; ok {
+		if time.Now().Before(bannedUntil) {
+			return true
+		}
+	}
+	return false
+}
+
+func (n *naughtyStep) prune() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	for ip, until := range n.bans {
+		if time.Now().After(until) {
+			delete(n.bans, ip)
+		}
+	}
+}

--- a/datanode/ratelimit/ratelimit.go
+++ b/datanode/ratelimit/ratelimit.go
@@ -1,0 +1,196 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+
+	"code.vegaprotocol.io/vega/datanode/contextutil"
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/didip/tollbooth/v7"
+	"github.com/didip/tollbooth/v7/libstring"
+	"github.com/didip/tollbooth/v7/limiter"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	secret   string
+	banMsg   = "temporarily banned for continuing to request while rate limited"
+	limitMsg = "api request rate limit exceeded"
+)
+
+// init sets our random per-process secret generated at startup.
+//
+// If the "X-Rate-Limit-Secret": <secret> is present in GRPC metadata, rate limiting will not be applied.
+func init() {
+	secret = uuid.New().String()
+}
+
+// WithSecret is a GRPC dial option that adds the "X-Rate-Limit-Secret": <secret> header to all calls.
+func WithSecret() grpc.DialOption {
+	interceptor := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, "X-Rate-Limit-Secret", secret)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+	return grpc.WithUnaryInterceptor(interceptor)
+}
+
+type RateLimit struct {
+	lmt         *limiter.Limiter
+	cfg         atomic.Pointer[Config]
+	log         *logging.Logger
+	naughtyStep *naughtyStep
+}
+
+func NewFromConfig(cfg *Config, log *logging.Logger) *RateLimit {
+	limitOpts := limiter.ExpirableOptions{DefaultExpirationTTL: cfg.TTL.Duration}
+	lmt := tollbooth.NewLimiter(cfg.Rate, &limitOpts)
+	lmt.SetBurst(cfg.Burst)
+
+	// The naughty step limiter could have a different rate/burst but it seemed likely to add
+	// more confusion than it's worth to the configuration & these should be sensible.
+	ns := newNaughtyStep(log, cfg.Rate, cfg.Burst, cfg.BanFor.Duration, cfg.TTL.Duration)
+
+	r := &RateLimit{
+		lmt:         lmt,
+		naughtyStep: ns,
+	}
+	r.cfg.Store(cfg)
+	return r
+}
+
+func (r *RateLimit) ReloadConfig(cfg *Config) {
+	r.log.Info("updating rate limit configuration",
+		logging.String("old", fmt.Sprintf("%v", r.cfg.Load())),
+		logging.String("new", fmt.Sprintf("%v", cfg)))
+
+	r.cfg.Store(cfg)
+	r.lmt.SetBurst(cfg.Burst).
+		SetMax(cfg.Rate)
+	r.naughtyStep.lmt.SetBurst(cfg.Burst).
+		SetMax(cfg.Rate)
+	r.naughtyStep.banFor = cfg.BanFor.Duration
+}
+
+func (r *RateLimit) HTTPMiddleware(next http.Handler) http.Handler {
+	middle := func(w http.ResponseWriter, req *http.Request) {
+		if !r.cfg.Load().Enabled {
+			next.ServeHTTP(w, req)
+			return
+		}
+
+		ip := r.ipForRequest(req)
+
+		if r.naughtyStep.isBanned(ip) {
+			r.expressDisappointment(w, banMsg, http.StatusForbidden)
+			return
+		}
+
+		if httpError := tollbooth.LimitByRequest(r.lmt, w, req); httpError != nil {
+			r.naughtyStep.smackBottom(ip)
+			r.expressDisappointment(w, limitMsg, http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, req)
+	}
+	return http.HandlerFunc(middle)
+}
+
+func (r *RateLimit) expressDisappointment(w http.ResponseWriter, msg string, status int) {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write([]byte(msg))
+}
+
+func (r *RateLimit) ipForRequest(req *http.Request) string {
+	ip := libstring.RemoteIP(r.lmt.GetIPLookups(), r.lmt.GetForwardedForIndexFromBehind(), req)
+	return libstring.CanonicalizeIP(ip)
+}
+
+func (r *RateLimit) GRPCInterceptor(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (resp interface{}, err error) {
+	if !r.cfg.Load().Enabled {
+		return handler(ctx, req)
+	}
+
+	// Check if the client gave the secret in the metadata, if so skip rate limiting
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		mdSecrets := md.Get("X-Rate-Limit-Secret")
+		for _, mdSecret := range mdSecrets {
+			if mdSecret == secret {
+				return handler(ctx, req)
+			}
+		}
+	}
+
+	// Fish out IP address from context
+	addr, ok := contextutil.RemoteIPAddrFromContext(ctx)
+	if !ok {
+		// If we don't have an IP we can't rate limit
+		return handler(ctx, req)
+	}
+
+	ip, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		ip = addr
+	}
+	ip = libstring.CanonicalizeIP(ip)
+
+	// Check the naughty step
+	if r.naughtyStep.isBanned(ip) {
+		return nil, status.Error(codes.Unavailable, banMsg)
+	}
+
+	setRateLimitXResponseHeaders(ctx, r.log, r.lmt, ip)
+	if r.lmt.LimitReached(ip) {
+		r.naughtyStep.smackBottom(ip)
+		setRateLimitResponseHeaders(ctx, r.log, r.lmt, 0)
+		return nil, status.Error(codes.Unavailable, limitMsg)
+	}
+
+	tokensLeft := r.lmt.Tokens(ip)
+	setRateLimitResponseHeaders(ctx, r.log, r.lmt, tokensLeft)
+	return handler(ctx, req)
+}
+
+// setRateLimitXResponseHeaders sets the same set of headers that tollbooth adds to every HTTP response
+// when being used as a http server limiter.
+func setRateLimitXResponseHeaders(ctx context.Context, log *logging.Logger, lmt *limiter.Limiter, ip string) {
+	for _, h := range []metadata.MD{
+		metadata.Pairs("X-Rate-Limit-Limit", strconv.FormatFloat(lmt.GetMax(), 'f', -1, 64)),
+		metadata.Pairs("X-Rate-Limit-Duration", "1"),
+		metadata.Pairs("X-Rate-Limit-Request-Remote-Addr", ip),
+	} {
+		if errH := grpc.SetHeader(ctx, h); errH != nil {
+			log.Error("failed to set header", logging.Error(errH))
+		}
+	}
+}
+
+// setRateLimitResponseHeaders configures RateLimit-Limit, RateLimit-Remaining and RateLimit-Reset
+// as seen at https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers
+func setRateLimitResponseHeaders(ctx context.Context, log *logging.Logger, lmt *limiter.Limiter, tokensLeft int) {
+	for _, h := range []metadata.MD{
+		metadata.Pairs("RateLimit-Limit", fmt.Sprintf("%d", int(math.Round(lmt.GetMax())))),
+		metadata.Pairs("RateLimit-Reset", "1"),
+		metadata.Pairs("RateLimit-Remaining", fmt.Sprintf("%d", tokensLeft)),
+	} {
+		if errH := grpc.SetHeader(ctx, h); errH != nil {
+			log.Error("failed to set header", logging.Error(errH))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
+	github.com/didip/tollbooth/v7 v7.0.1
 	github.com/emirpasic/gods v1.18.1
 	github.com/felixge/fgprof v0.9.3
 	github.com/fergusstrange/embedded-postgres v1.17.0
@@ -124,6 +125,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-pkgz/expirable-cache v0.1.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
+github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -416,6 +418,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-pkgz/expirable-cache v0.1.0 h1:3bw0m8vlTK8qlwz5KXuygNBTkiKRTPrAGXU0Ej2AC1g=
+github.com/go-pkgz/expirable-cache v0.1.0/go.mod h1:GTrEl0X+q0mPNqN6dtcQXksACnzCBQ5k/k1SwXJsZKs=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=


### PR DESCRIPTION
This is possibly (probably) breaking for frontend & system tests - though it's easily disabled in the config.

I wrote a little doc on the implementation [here](https://github.com/vegaprotocol/vega/blob/develop/datanode/ratelimit/README.md). The executive summary is that graphql, grpc, and REST requests will by default,

- allow only 20 API calls/second on average 
- with a burst of up to 100 api calls in a short period of time

If you go over that, you'll get an appropriate error response. There are HTTP headers and gRPC metadata showing you after each request how close to the limit you are.

If the client continues making requests such that they are getting > 10 rate limited _error responses_ per second they will eventually get banned for a period of time (default 10 mins).

Pulled the defaults out of my bottom somewhat, very open to discussion on changing them.

Closes #7445 
