### PR TITLE
Remove redundant margin update for all parties during auction

### DIFF
--- a/core/execution/margin.go
+++ b/core/execution/margin.go
@@ -114,63 +114,28 @@ func (m *Market) updateMargin(ctx context.Context, pos []events.MarketPosition) 
 		// add the required margin event
 		margins = append(margins, e)
 	}
-
 	// we should get any and all risk events we need here
 	return m.risk.UpdateMarginsOnSettlement(ctx, margins, price)
 }
 
 func (m *Market) marginsAuction(ctx context.Context, order *types.Order) ([]events.Risk, []events.MarketPosition, error) {
-	// 1. Get the price
 	price := m.getMarkPrice(order)
-	// m.log.Infof("calculating margins at %d for order at price %d", price, order.Price)
-	// 2. Get all positions - we have to update margins for all parties on the book so nobody can get distressed when we eventually do uncross
-	allPos := m.position.Positions()
-	// 3. get the asset and ID for this market
 	asset, _ := m.mkt.GetAsset()
 	mID := m.GetID()
-	// 3-b. Get position for the trader placing this order, if exists
-	if cPos, ok := m.position.GetPositionByPartyID(order.Party); ok {
-		e, err := m.collateral.GetPartyMargin(cPos, asset, mID)
-		if err != nil {
-			return nil, nil, err
-		}
-		_, closed := m.risk.UpdateMarginAuction(ctx, []events.Margin{e}, price.Clone())
-		if len(closed) > 0 {
-			// this order would take party below maintenance -> stop here
-			return nil, nil, ErrMarginCheckInsufficient
-		}
-		// we could transfer the funds for this party here, but we're handling all positions lower down, including this one
-		// this is just to stop all margins being updated based on a price that the party can't even manage
+	cPos, ok := m.position.GetPositionByPartyID(order.Party)
+	if !ok {
+		return nil, nil, nil
 	}
-	// 4. construct the events for all positions + margin balances
-	// at this point, we have established the order is going through
-	posEvts := make([]events.Margin, 0, len(allPos))
-	for _, p := range allPos {
-		e, err := m.collateral.GetPartyMargin(p, asset, mID)
-		if err != nil {
-			// this shouldn't happen
-			return nil, nil, err
-		}
-		posEvts = append(posEvts, e)
+	e, err := m.collateral.GetPartyMargin(cPos, asset, mID)
+	if err != nil {
+		return nil, nil, err
 	}
-	// 5. Get all the risk events
-	risk, closed := m.risk.UpdateMarginAuction(ctx, posEvts, price.Clone())
-	distressed := make(map[string]struct{}, len(closed))
-	mposEvts := make([]events.MarketPosition, 0, len(closed))
-	for _, e := range closed {
-		distressed[e.Party()] = struct{}{}
-		mposEvts = append(mposEvts, e)
+	risk, closed := m.risk.UpdateMarginAuction(ctx, []events.Margin{e}, price.Clone())
+	if len(closed) > 0 {
+		// this order would take party below maintenance -> stop here
+		return nil, nil, ErrMarginCheckInsufficient
 	}
-	// 6. Attempt margin updates where possible. If position is to be closed, append it to the closed slice we already have
-	riskTransfers := make([]events.Risk, 0, len(risk))
-	for _, ru := range risk {
-		// skip the parties with a shortfall/distressed
-		if _, ok := distressed[ru.Party()]; ok {
-			continue
-		}
-		riskTransfers = append(riskTransfers, ru)
-	}
-	return riskTransfers, mposEvts, nil
+	return risk, nil, nil
 }
 
 func (m *Market) margins(ctx context.Context, mpos *positions.MarketPosition, order *types.Order) ([]events.Risk, []events.MarketPosition, error) {

--- a/core/integration/features/auctions/opening-auction-price.feature
+++ b/core/integration/features/auctions/opening-auction-price.feature
@@ -65,8 +65,8 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party7 | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GFA | t7-s-1    |
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
-      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 28340   |
+      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 15680   |
+      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 15260   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
@@ -131,8 +131,8 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | lp1 | lpprov | ETH/DEC19 | 90000             | 0.1 | sell | MID              | 50         | 100    | submission |
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
-      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 27260   |
+      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 15680   |
+      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 15260   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
@@ -212,8 +212,8 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
-      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 27260   |
+      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 15680   |
+      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 15260   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
@@ -301,7 +301,7 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party2 | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2-s-3    |
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 27260   |
+      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 15260   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |

--- a/core/integration/features/auctions/opening-auction-uncross.feature
+++ b/core/integration/features/auctions/opening-auction-uncross.feature
@@ -30,8 +30,8 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | lp1 | lpprov | ETH/DEC19 | 90000             | 0.1 | sell | MID              | 50         | 100    | submission |
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
-      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 27260   |
+      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 15680   |
+      | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 15260   |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |

--- a/core/integration/features/closeouts/position-resolution-after-auction.feature
+++ b/core/integration/features/closeouts/position-resolution-after-auction.feature
@@ -30,7 +30,7 @@ Feature: Set up a market with an opening auction, then uncross the book so that 
       | lp1 | lp    | ETH/DEC19 | 160000            | 0.01 | sell | MID              | 50         | 100    | submission |
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
+      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 15680   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general |
       | party1 | BTC   | ETH/DEC19 | 13440  |  6560   |

--- a/core/integration/features/verified/0015-INSR-insurance_pool_balance_test.feature
+++ b/core/integration/features/verified/0015-INSR-insurance_pool_balance_test.feature
@@ -61,7 +61,7 @@ Feature: Test closeout type 1: margin >= cost of closeout
 
     Then the parties should have the following account balances:
       | party            | asset | market id | margin | general   |
-      | aux1             | USD   | ETH/DEC19 | 1350   | 999998650 |
+      | aux1             | USD   | ETH/DEC19 | 2400   | 999997600 |
       | aux2             | USD   | ETH/DEC19 | 660    | 999999340 |
       | sellSideProvider | USD   | ETH/DEC19 | 900000 | 999100000 |
       | buySideProvider  | USD   | ETH/DEC19 | 240000 | 999760000 |

--- a/core/integration/features/verified/0015-INSR-insurance_pool_balance_test.feature
+++ b/core/integration/features/verified/0015-INSR-insurance_pool_balance_test.feature
@@ -61,7 +61,7 @@ Feature: Test closeout type 1: margin >= cost of closeout
 
     Then the parties should have the following account balances:
       | party            | asset | market id | margin | general   |
-      | aux1             | USD   | ETH/DEC19 | 2400   | 999997600 |
+      | aux1             | USD   | ETH/DEC19 | 1350   | 999998650 |
       | aux2             | USD   | ETH/DEC19 | 660    | 999999340 |
       | sellSideProvider | USD   | ETH/DEC19 | 900000 | 999100000 |
       | buySideProvider  | USD   | ETH/DEC19 | 240000 | 999760000 |

--- a/core/integration/features/verified/Negative-Position-Decimal-Places.feature
+++ b/core/integration/features/verified/Negative-Position-Decimal-Places.feature
@@ -68,10 +68,9 @@ Feature: test negative PDP (position decimal places)
 
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |
-            | party0 | USD/DEC22 | 39126       | 43038  | 46951   | 63424   |
-            | party1 | USD/DEC22 | 8008        | 8808   | 9609    | 20820   |
-            | party2 | USD/DEC22 | 35570       | 39127  | 42684   | 92482   |
-
+            | party0 | USD/DEC22 | 39126       | 43038  | 46951   | 54776   |
+            | party1 | USD/DEC22 | 8008        | 8808   | 9609    | 11211   |
+            | party2 | USD/DEC22 | 35570       | 39127  | 42684   | 49798   |
 
     @Now
     Scenario: 002, test negative PDP when trading mode is continuous (0003-MTMK-014, 0003-MTMK-015, 0019-MCAL-010, 0029-FEES-014)
@@ -106,7 +105,7 @@ Feature: test negative PDP (position decimal places)
 
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
-            | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
+            | party0 | ETH   | USD/DEC22 | 821773 | 4142658  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1778   | 99998222 | 0     |
             | party2 | ETH   | USD/DEC22 | 6830   | 99993170 | 0     |
 
@@ -165,7 +164,7 @@ Feature: test negative PDP (position decimal places)
         #MTM with price change from 10 to 9, party1 has long position of volume 10, price 10 ->9, MTM -1*10*10*1=-100; party2 has short position of volume 10, price 10 ->9, MTM 10*10*1=100;
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
-            | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
+            | party0 | ETH   | USD/DEC22 | 568920 | 4395511  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1678   | 99998223 | 0     |
             | party2 | ETH   | USD/DEC22 | 6930   | 99993170 | 0     |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*9,1206*10*0.801225765*9)=474100
@@ -198,7 +197,7 @@ Feature: test negative PDP (position decimal places)
         #MTM with price change from 9 to 8, party1 has long position of volume 11, price 9 ->8, MTM -1*11*10*1=-110; party2 has short position of volume 10, price 10 ->9, MTM 10*10*1=100;
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
-            | party0 | ETH   | USD/DEC22 | 505706 | 4458726  | 35569 |
+            | party0 | ETH   | USD/DEC22 | 568920 | 4395512  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1230   | 99998561 | 0     |
             | party2 | ETH   | USD/DEC22 | 5823   | 99994377 | 0     |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*8,1206*10*0.801225765*8)=421422

--- a/core/integration/features/verified/Negative-Position-Decimal-Places.feature
+++ b/core/integration/features/verified/Negative-Position-Decimal-Places.feature
@@ -105,7 +105,7 @@ Feature: test negative PDP (position decimal places)
 
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
-            | party0 | ETH   | USD/DEC22 | 821773 | 4142658  | 35569 |
+            | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1778   | 99998222 | 0     |
             | party2 | ETH   | USD/DEC22 | 6830   | 99993170 | 0     |
 
@@ -164,7 +164,7 @@ Feature: test negative PDP (position decimal places)
         #MTM with price change from 10 to 9, party1 has long position of volume 10, price 10 ->9, MTM -1*10*10*1=-100; party2 has short position of volume 10, price 10 ->9, MTM 10*10*1=100;
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
-            | party0 | ETH   | USD/DEC22 | 568920 | 4395511  | 35569 |
+            | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1678   | 99998223 | 0     |
             | party2 | ETH   | USD/DEC22 | 6930   | 99993170 | 0     |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*9,1206*10*0.801225765*9)=474100
@@ -197,7 +197,7 @@ Feature: test negative PDP (position decimal places)
         #MTM with price change from 9 to 8, party1 has long position of volume 11, price 9 ->8, MTM -1*11*10*1=-110; party2 has short position of volume 10, price 10 ->9, MTM 10*10*1=100;
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
-            | party0 | ETH   | USD/DEC22 | 568920 | 4395512  | 35569 |
+            | party0 | ETH   | USD/DEC22 | 505706 | 4458726  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1230   | 99998561 | 0     |
             | party2 | ETH   | USD/DEC22 | 5823   | 99994377 | 0     |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*8,1206*10*0.801225765*8)=421422

--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -333,7 +333,6 @@ func (e *Engine) UpdateMarginsOnSettlement(
 	// var err error
 	// this will keep going until we've closed this channel
 	// this can be the result of an error, or being "finished"
-	auction := e.as.InAuction() || e.as.CanLeave()
 	for _, evt := range evts {
 		// before we do anything, see if the position is 0 now, but the margin balance is still set
 		// in which case the only response is to release the margin balance.
@@ -368,7 +367,7 @@ func (e *Engine) UpdateMarginsOnSettlement(
 		}
 		// channel is closed, and we've got a nil interface
 		var margins *types.MarginLevels
-		if !auction {
+		if !e.as.InAuction() || e.as.CanLeave() {
 			margins = e.calculateMargins(evt, markPrice, *e.factors, true, false)
 		} else {
 			margins = e.calculateAuctionMargins(evt, markPrice, *e.factors)
@@ -423,7 +422,7 @@ func (e *Engine) UpdateMarginsOnSettlement(
 			}
 		} else { // case 3 -> release some collateral
 			// collateral not relased in auction
-			if auction {
+			if e.as.InAuction() {
 				// propagate margins then continue
 				e.broker.Send(events.NewMarginLevelsEvent(ctx, *margins))
 				continue

--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -422,7 +422,7 @@ func (e *Engine) UpdateMarginsOnSettlement(
 			}
 		} else { // case 3 -> release some collateral
 			// collateral not relased in auction
-			if e.as.InAuction() {
+			if e.as.InAuction() && !e.as.CanLeave() {
 				// propagate margins then continue
 				e.broker.Send(events.NewMarginLevelsEvent(ctx, *margins))
 				continue

--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -333,6 +333,7 @@ func (e *Engine) UpdateMarginsOnSettlement(
 	// var err error
 	// this will keep going until we've closed this channel
 	// this can be the result of an error, or being "finished"
+	auction := e.as.InAuction() || e.as.CanLeave()
 	for _, evt := range evts {
 		// before we do anything, see if the position is 0 now, but the margin balance is still set
 		// in which case the only response is to release the margin balance.
@@ -367,7 +368,7 @@ func (e *Engine) UpdateMarginsOnSettlement(
 		}
 		// channel is closed, and we've got a nil interface
 		var margins *types.MarginLevels
-		if !e.as.InAuction() || e.as.CanLeave() {
+		if !auction {
 			margins = e.calculateMargins(evt, markPrice, *e.factors, true, false)
 		} else {
 			margins = e.calculateAuctionMargins(evt, markPrice, *e.factors)
@@ -421,6 +422,12 @@ func (e *Engine) UpdateMarginsOnSettlement(
 				MinAmount: minAmount,
 			}
 		} else { // case 3 -> release some collateral
+			// collateral not relased in auction
+			if auction {
+				// propagate margins then continue
+				e.broker.Send(events.NewMarginLevelsEvent(ctx, *margins))
+				continue
+			}
 			trnsfr = &types.Transfer{
 				Owner: evt.Party(),
 				Type:  types.TransferTypeMarginHigh,

--- a/core/risk/engine_test.go
+++ b/core/risk/engine_test.go
@@ -261,7 +261,7 @@ func testMarginOverflow(t *testing.T) {
 		market:  "ETH/DEC19",
 	}
 	eng.tsvc.EXPECT().GetTimeNow().Times(1)
-	eng.as.EXPECT().InAuction().Times(1).Return(false)
+	eng.as.EXPECT().InAuction().Times(2).Return(false)
 	eng.orderbook.EXPECT().GetCloseoutPrice(gomock.Any(), gomock.Any()).Times(1).
 		DoAndReturn(func(volume uint64, side types.Side) (*num.Uint, error) {
 			return markPrice.Clone(), nil
@@ -294,9 +294,9 @@ func testMarginOverflowAuctionEnd(t *testing.T) {
 	}
 	// we're still in auction...
 	eng.tsvc.EXPECT().GetTimeNow().Times(1)
-	eng.as.EXPECT().InAuction().Times(1).Return(true)
+	eng.as.EXPECT().InAuction().Times(2).Return(true)
 	// but the auction is ending
-	eng.as.EXPECT().CanLeave().Times(1).Return(true)
+	eng.as.EXPECT().CanLeave().Times(2).Return(true)
 	// eng.as.EXPECT().InAuction().AnyTimes().Return(false)
 	eng.orderbook.EXPECT().GetCloseoutPrice(gomock.Any(), gomock.Any()).Times(1).
 		DoAndReturn(func(volume uint64, side types.Side) (*num.Uint, error) {

--- a/core/risk/margins_calculation.go
+++ b/core/risk/margins_calculation.go
@@ -78,9 +78,6 @@ func (e *Engine) calculateAuctionMargins(m events.Margin, markPrice *num.Uint, r
 	} else {
 		addMarginLevels(ml, sMargin, e.scalingFactorsUint)
 	}
-	// this is a bit of a hack, perhaps, but it keeps the remaining flow in the core simple:
-	// artificially increase the release level so we never release the margin balance during auction
-	ml.CollateralReleaseLevel.AddSum(m.MarginBalance())
 	return ml
 }
 


### PR DESCRIPTION
Updating margins for all parties after every order during auction had no material impact on the margin figures:
  - during opening auction nobody has a position, so only the bit that calculates margin based on vwap of orders placed by a party is relevant (and that's not affect by other orders in any way)
  - during other auction types the vwap bit from above was the same, and for the position part we always used the `lastTradedPrice`, which does not change during auction. 

but it was generating a lot of events.

Also: removed the hack preventing margin release during auction and replaced it with a conditional statement based on the auction state.