### PR TITLE
refactor: mtm after all orders back on book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - [7536](https://github.com/vegaprotocol/vega/issues/7536) - Ensure all errors are displayed when the wallet service cannot bind
 - [7540](https://github.com/vegaprotocol/vega/issues/7540) - Prevent the double appending of the `http` scheme when ensuring port binding
 - [7549](https://github.com/vegaprotocol/vega/issues/7549) - Switch proof-of-work ban error from an internal error to an application error on the wallet API
+- [7543](https://github.com/vegaprotocol/vega/issues/7543) - Initiate post-auction close out only when all the parked orders get redeployed
 
 ## 0.67.2
 

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -1141,11 +1141,12 @@ func (m *Market) leaveAuction(ctx context.Context, now time.Time) {
 		cmp := m.getLastTradedPrice()
 		m.markPrice = cmp.Clone()
 		mcmp := num.UintZero().Div(cmp, m.priceFactor) // create the market representation of the price
+		// checkForReferenceMoves has already been called with updatedOrders so passing an empty array in now
 		m.confirmMTM(ctx, &types.Order{
 			ID:            m.idgen.NextID(),
 			Price:         cmp,
 			OriginalPrice: mcmp,
-		}, updatedOrders, false)
+		}, []*types.Order{}, false)
 		// set next MTM
 		m.nextMTM = m.timeService.GetTimeNow().Add(m.mtmDelta)
 	}

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -2115,7 +2115,7 @@ func (m *Market) zeroOutNetwork(ctx context.Context, parties []events.MarketPosi
 	}
 
 	tradeEvts := make([]events.Event, 0, len(parties))
-	for i, party := range parties {
+	for _, party := range parties {
 		tSide, nSide := types.SideSell, types.SideSell // one of them will have to sell
 		if party.Size() < 0 {
 			tSide = types.SideBuy
@@ -2146,7 +2146,7 @@ func (m *Market) zeroOutNetwork(ctx context.Context, parties []events.MarketPosi
 			Price:         settleOrder.Price.Clone(), // average price
 			OriginalPrice: settleOrder.OriginalPrice.Clone(),
 			CreatedAt:     now,
-			Reference:     fmt.Sprintf("distressed-%d", i),
+			Reference:     fmt.Sprintf("distressed-%s", party.Party()),
 			TimeInForce:   types.OrderTimeInForceFOK, // this is an all-or-nothing order, so TIME_IN_FORCE == FOK
 			Type:          types.OrderTypeNetwork,
 		}

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -1128,8 +1128,9 @@ func (m *Market) leaveAuction(ctx context.Context, now time.Time) {
 	if !m.as.InAuction() {
 		// only send the auction-left event if we actually *left* the auction.
 		m.broker.Send(endEvt)
-		// now that we're left the auction, we can mark all positions using the
-		// margin calculation method appropriate for non-auction mode
+		// now that we've left the auction and all the orders have been unparked,
+		// we can mark all positions using the margin calculation method appropriate
+		// for non-auction mode and carry out any closeouts if need be
 		m.markPrice = m.getLastTradedPrice().Clone()
 		m.confirmMTM(ctx, false)
 		// set next MTM

--- a/core/execution/special_orders.go
+++ b/core/execution/special_orders.go
@@ -400,7 +400,7 @@ func (m *Market) applyBondPenaltiesAndLiquidationExcludingPending(
 			cancelled[v.Party()] = struct{}{}
 		}
 
-		_, err := m.resolveClosedOutParties(ctx, reallyClosed, nil) // no order ID here
+		_, err := m.resolveClosedOutParties(ctx, reallyClosed)
 		if err != nil {
 			m.log.Error("unable to closed out parties",
 				logging.String("market-id", m.GetID()),

--- a/core/integration/features/auctions/opening-auction-price.feature
+++ b/core/integration/features/auctions/opening-auction-price.feature
@@ -71,11 +71,7 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
       | party2 | BTC   | ETH/DEC19 | 13080  | 99986920 |
-    # values before uint
-    #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
     When the opening auction period ends for market "ETH/DEC19"
-    ## We're seeing these events twice for some reason
-    Then debug trades
     Then the following trades should be executed:
       | buyer  | price | size | seller |
       | party1 | 10000 | 1    | party5 |
@@ -83,7 +79,6 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party1 | 10000 | 1    | party2 |
       | party1 | 10000 | 4    | party2 |
     And the mark price should be "10000" for the market "ETH/DEC19"
-    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
     And the orders should have the following status:
       | party  | reference | status           |
       | party1 | t1-b-1    | STATUS_FILLED    |
@@ -94,16 +89,14 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party2 | t2-s-3    | STATUS_FILLED    |
       | party5 | t5-s-1    | STATUS_FILLED    |
       | party6 | t6-b-1    | STATUS_CANCELLED |
-
     And the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party2 | ETH/DEC19 | 16000       | 17600  | 19200   | 22400   |
-    #| party7 | ETH/DEC19 | 0           | 0      | 0       | 0       |
-    Then debug transfers
+      | party2 | ETH/DEC19 | 39200       | 43120  | 47040   | 54880   |
+      | party1 | ETH/DEC19 | 45900       | 50490  | 55080   | 64260   |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
-      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
-      | party1 | BTC   | ETH/DEC19 | 108000 | 99892000 |
+      | party2 | BTC   | ETH/DEC19 | 47040  | 99952960 |
+      | party1 | BTC   | ETH/DEC19 | 55080  | 99944920 |
     And the market data for the market "ETH/DEC19" should be:
       | mark price | trading mode            | horizon | min bound | max bound | ref price |
       | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9997      | 10002     | 10000     |
@@ -144,8 +137,6 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
       | party2 | BTC   | ETH/DEC19 | 13080  | 99986920 |
-    # values before uint
-    #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
     # moves forwards several blocks
     When the opening auction period ends for market "ETH/DEC19"
     ## We're seeing these events twice for some reason
@@ -168,12 +159,12 @@ Feature: Set up a market, create indiciative price different to actual opening a
     When the network moves ahead "1" blocks
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
-      | party2 | ETH/DEC19 | 16000       | 17600  | 19200   | 22400   |
+      | party2 | ETH/DEC19 | 39200       | 43120  | 47040   | 54880   |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
-      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
-      | party1 | BTC   | ETH/DEC19 | 96000  | 99904000 |
+      | party2 | BTC   | ETH/DEC19 | 47040  | 99952960 |
+      | party1 | BTC   | ETH/DEC19 | 48960  | 99951040 |
     And the market data for the market "ETH/DEC19" should be:
       | mark price | trading mode            | horizon | min bound | max bound | ref price |
       | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9997      | 10002     | 10000     |
@@ -227,8 +218,6 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
       | party2 | BTC   | ETH/DEC19 | 13080  | 99986920 |
-    # values before uint
-    #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
     When the opening auction period ends for market "ETH/DEC19"
     ## We're seeing these events twice for some reason
     Then the following trades should be executed:
@@ -238,7 +227,6 @@ Feature: Set up a market, create indiciative price different to actual opening a
       | party1 | 10000 | 1    | party2 |
       | party1 | 10000 | 4    | party2 |
     And the mark price should be "10000" for the market "ETH/DEC19"
-    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
     And the orders should have the following status:
       | party  | reference | status           |
       | party1 | t1-b-1    | STATUS_FILLED    |
@@ -252,14 +240,17 @@ Feature: Set up a market, create indiciative price different to actual opening a
 
     When the network moves ahead "1" blocks
     Then the parties should have the following margin levels:
-      | party  | market id | maintenance | search | initial | release |
-      | party2 | ETH/DEC19 | 16000       | 17600  | 19200   | 22400   |
+      | party  | market id | maintenance | initial |
+      | party2 | ETH/DEC19 | 39200       | 47040   |
+      | party1 | ETH/DEC19 | 45900       | 55080   |
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
-      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
-      | party1 | BTC   | ETH/DEC19 | 108000 | 99892000 |
-    # values before uint
-    #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+      | party2 | BTC   | ETH/DEC19 | 47040  | 99952960 |
+      | party1 | BTC   | ETH/DEC19 | 55080  | 99944920 |
+    Then the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party2 | -8     | 0              | 0            |
+      | party1 |  9     | 0              | 0            |
     And the market data for the market "ETH/DEC19" should be:
       | mark price | trading mode            | horizon | min bound | max bound | ref price |
       | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9997      | 10002     | 10000     |
@@ -344,8 +335,8 @@ Feature: Set up a market, create indiciative price different to actual opening a
     When the network moves ahead "1" blocks
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
-      | party2 | BTC   | ETH/DEC19 | 19200  | 99980800 |
-      | party1 | BTC   | ETH/DEC19 | 84000  | 99916000 |
+      | party2 | BTC   | ETH/DEC19 | 47040  | 99952960 |
+      | party1 | BTC   | ETH/DEC19 | 42840  | 99957160 |
     And the market data for the market "ETH/DEC19" should be:
       | mark price | trading mode            | horizon | min bound | max bound | ref price |
       | 10000      | TRADING_MODE_CONTINUOUS | 5       | 9997      | 10002     | 10000     |

--- a/core/integration/features/auctions/opening-auction-uncross.feature
+++ b/core/integration/features/auctions/opening-auction-uncross.feature
@@ -5,7 +5,6 @@ Feature: Set up a market, with an opening auction, then uncross the book
     Given the markets:
       | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
       | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e6                    | 1e6                       |
-    # setup accounts
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount    |
       | party1 | BTC   | 100000000 |
@@ -15,7 +14,6 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | lpprov | BTC   | 100000000 |
 
   Scenario: set up 2 parties with balance
-    # place orders and generate trades
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
@@ -34,34 +32,25 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | party  | market id | maintenance | search | initial | release |
       | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
       | party2 | ETH/DEC19 | 10900       | 11990  | 13080   | 27260   |
-    # values before uint stuff
-    #| party1 | ETH/DEC19 | 25201       | 27721  | 30241   | 65521   |
-    #| party2 | ETH/DEC19 | 23899       | 26289  | 28679   | 57458   |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general  |
       | party1 | BTC   | ETH/DEC19 | 13440  | 99986560 |
       | party2 | BTC   | ETH/DEC19 | 13080  | 99986920 |
-    # values before uint
-    #| party1 | BTC   | ETH/DEC19 | 30241  | 99969759 |
     When the parties withdraw the following assets:
       | party  | asset | amount   |
-      | party1 | BTC   | 99969760 |
-      | party2 | BTC   | 99971320 |
+      | party1 | BTC   | 99949760 |
+      | party2 | BTC   | 99951320 |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general |
-      | party1 | BTC   | ETH/DEC19 | 13440  | 16800   |
-      | party2 | BTC   | ETH/DEC19 | 13080  | 15600   |
-    # values before uint
-    #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+      | party1 | BTC   | ETH/DEC19 | 13440  | 36800   |
+      | party2 | BTC   | ETH/DEC19 | 13080  | 35600   |
     Then the opening auction period ends for market "ETH/DEC19"
-    ## We're seeing these events twice for some reason
     And the following trades should be executed:
       | buyer  | price | size | seller |
       | party1 | 10000 | 3    | party2 |
       | party1 | 10000 | 2    | party2 |
       | party1 | 10000 | 3    | party2 |
     And the mark price should be "10000" for the market "ETH/DEC19"
-    ## Network for distressed party1 -> cancelled, nothing on the book is remaining
     When the network moves ahead "1" blocks
     Then the orders should have the following status:
       | party  | reference | status           |
@@ -71,20 +60,12 @@ Feature: Set up a market, with an opening auction, then uncross the book
       | party2 | t2-s-2    | STATUS_CANCELLED |
       | party1 | t1-b-3    | STATUS_CANCELLED |
       | party2 | t2-s-3    | STATUS_FILLED    |
-    And debug transfers
-    # After changes to margin calc in auction, these transfers and balances have changed
-    #And the following transfers should happen:
-    #  | from   | to     | from account        | to account           | market id | amount | asset |
-    #  | party2 | party2 | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_GENERAL | ETH/DEC19 | 9480   | BTC   |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general |
-      | party2 | BTC   | ETH/DEC19 | 19200  | 9480    |
-      | party1 | BTC   | ETH/DEC19 | 30240  | 0       |
-  # values before uint
-  #| party1 | BTC   | ETH/DEC19 | 30241  | 0       |
+      | party2 | BTC   | ETH/DEC19 | 47040  | 1640    |
+      | party1 | BTC   | ETH/DEC19 | 48960  | 1280    |
 
   Scenario: Uncross auction via order amendment
-    # place orders and generate trades
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party3 | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |

--- a/core/integration/features/closeouts/position-resolution-after-auction.feature
+++ b/core/integration/features/closeouts/position-resolution-after-auction.feature
@@ -1,0 +1,63 @@
+Feature: Set up a market with an opening auction, then uncross the book so that the part trading in auction becomes distressed 
+  Background:
+    Given the markets:
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config          |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future |
+    And the parties deposit on asset's general account the following amount:
+      | party   | asset | amount    |
+      | party1  | BTC   |     20000 |
+      | party2a | BTC   | 100000000 |
+      | party2b | BTC   | 100000000 |
+      | party2c | BTC   | 100000000 |
+      | party3  | BTC   | 100000000 |
+      | party4  | BTC   | 100000000 |
+      | lp      | BTC   | 100000000 |
+
+  Scenario:
+    When the parties place the following orders:
+      | party   | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party3  | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party4  | ETH/DEC19 | sell | 1      | 11000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+      | party1  | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-1    |
+      | party2a | ETH/DEC19 | sell | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t2a-s-1   |
+      | party1  | ETH/DEC19 | buy  | 5      | 10000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2b | ETH/DEC19 | sell | 5      | 10001 | 0                | TYPE_LIMIT | TIF_GFA | t2b-s-2   |
+      | party1  | ETH/DEC19 | buy  | 4      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t1-b-3    |
+      | party2c | ETH/DEC19 | sell | 3      | 3000  | 0                | TYPE_LIMIT | TIF_GFA | t2c-s-3   |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee  | side | pegged reference | proportion | offset | lp type    |
+      | lp1 | lp    | ETH/DEC19 | 160000            | 0.01 | buy  | MID              | 50         | 100    | submission |
+      | lp1 | lp    | ETH/DEC19 | 160000            | 0.01 | sell | MID              | 50         | 100    | submission |
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | search | initial | release |
+      | party1 | ETH/DEC19 | 11200       | 12320  | 13440   | 29120   |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general |
+      | party1 | BTC   | ETH/DEC19 | 13440  |  6560   |
+    When the opening auction period ends for market "ETH/DEC19"
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | auction trigger            | extension trigger           | target stake | supplied stake | open interest |
+      | 10000      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED| AUCTION_TRIGGER_UNSPECIFIED | 160000       | 160000         | 8             |
+    And the following trades should be executed:
+      | buyer   | price | size | seller  |
+      | party1  | 10000 | 3    | party2a |
+      | party1  | 10000 | 2    | party2a |
+      | party1  | 10000 | 3    | party2c |
+      | lp      | 5900  | 8    | network |
+      | network | 5900  | 8    | party1  |
+    Then the parties should have the following profit and loss:
+      | party   | volume | unrealised pnl | realised pnl |
+      | party2a | -5     | 0              |            0 |
+      | party2c | -3     | 0              |            0 |
+      | party1  | 0      | 0              |       -20000 |
+      | lp      | 8      | 32800          |       -13272 |
+    And the accumulated liquidity fees should be "472" for the market "ETH/DEC19"
+    And the insurance pool balance should be "0" for the market "ETH/DEC19"
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin |  general |   bond |
+      | party1 | BTC   | ETH/DEC19 | 0      |        0 |      0 |
+      |     lp | BTC   | ETH/DEC19 | 82560  | 99776968 | 160000 | 
+    # sum of lp accounts = 100019528
+    # lp started with 100000000, should've made 8*(10000-5900)=32800 in MTM gains following the closeout,
+    # but party1 only had 20000, of which 472 has been put towards liquidity fees, 
+    # so only the leftover 19528 was transferred to lp in MTM gains, hence the -13272 realised pnl

--- a/core/integration/features/fees/trading-fees-pdp.feature
+++ b/core/integration/features/fees/trading-fees-pdp.feature
@@ -88,7 +88,6 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party   | asset | market id | margin | general |
       | trader3 | ETH   | ETH/DEC21 | 1330   | 8686    |
-      #| trader3 | ETH   | ETH/DEC21 | 1082   | 8934    |
       | trader4 | ETH   | ETH/DEC21 | 718    | 8958    |
 
     And the accumulated infrastructure fees should be "7" for the asset "ETH"
@@ -194,9 +193,7 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader3a | ETH   | ETH/DEC21 | 846    | 9165    |
-      #| trader3a | ETH   | ETH/DEC21 | 721    | 9290    |
       | trader3b | ETH   | ETH/DEC21 | 363    | 9643    |
-      #| trader3b | ETH   | ETH/DEC21 | 361    | 9645    |
       | trader4  | ETH   | ETH/DEC21 | 718    | 8955    |
 
     And the accumulated infrastructure fees should be "8" for the asset "ETH"
@@ -266,9 +263,7 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader3a | ETH   | ETH/DEC21 | 690    | 9321    |
-      #| trader3a | ETH   | ETH/DEC21 | 480    | 9531    |
       | trader3b | ETH   | ETH/DEC21 | 339    | 9667    |
-    #| trader3b | ETH   | ETH/DEC21 | 240    | 9766    |
 
     And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the accumulated liquidity fees should be "5" for the market "ETH/DEC21"
@@ -846,14 +841,12 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader3a | ETH   | ETH/DEC21 | 3372   | 6644    |
-      #| trader3a | ETH   | ETH/DEC21 | 1010   | 9006    |
       | trader4  | ETH   | ETH/DEC21 | 5271   | 4702    |
 
+    #maitenance_margin_trader3a: 4*((1002-492)*4)/4 + 4*0.2*1002=2842
     Then the parties should have the following margin levels:
-      | party    | market id | maintenance | search | initial | release |
-      | trader3a | ETH/DEC21 | 2810        | 3091   | 3372    | 3934    |
-
-    #maitenance_margin_trader3a: 4*((1002-500)*4)/4 + 4*0.2*1002=2810
+      | party    | market id | maintenance | initial |
+      | trader3a | ETH/DEC21 | 2842        | 3410    |
 
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -890,7 +883,7 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader3a | ETH   | ETH/DEC21 | 3242   | 6364    |
-      | trader4  | ETH   | ETH/DEC21 | 7140   | 3239    |
+      | trader4  | ETH   | ETH/DEC21 | 7188   | 3191    |
 
     Then the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             |
@@ -990,13 +983,12 @@ Feature: Fees calculations
     #| trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 2      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 4393        | 4832   | 5271    | 6150    |
+      | party   | market id | maintenance | initial | 
+      | trader4 | ETH/DEC21 | 4421        | 5305    | 
 
     And the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader3a | ETH   | ETH/DEC21 | 3372   | 1644    |
-      #| trader3a | ETH   | ETH/DEC21 | 1010   | 4006    |
       | trader4  | ETH   | ETH/DEC21 | 5234   | 0       |
 
     # We apparently left auction
@@ -1100,12 +1092,13 @@ Feature: Fees calculations
       | trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 1      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 2380        | 2618   | 2856    | 3332    |
+      | party    | market id | maintenance | initial |
+      | trader3a | ETH/DEC21 | 1170        | 1404    |
+      | trader4  | ETH/DEC21 | 2390        | 2868    |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 1392   | 3504    |
+      | trader3a | ETH   | ETH/DEC21 | 1404   | 3492    |
       | trader4  | ETH   | ETH/DEC21 | 2756   | 0       |
 
     Then the market data for the market "ETH/DEC21" should be:
@@ -1286,10 +1279,13 @@ Feature: Fees calculations
       | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE |
 
     Then the network moves ahead "301" blocks
-
     Then the following trades should be executed:
-      | buyer    | price | size | seller  |
-      | trader3a | 900   | 200  | trader4 |
+      | buyer    | price | size | seller   |
+      | trader3a | 1002  | 100  | trader4  |
+      | trader3a | 900   | 200  | trader4  |
+      | aux1     | 500   | 100  | network  |
+      | aux1     | 490   | 200  | network  |
+      | network  | 493   | 300  | trader3a |
 
     # For trader3a & 4- Sharing IF and LP
     # trade_value_for_fee_purposes for trader3a = size_of_trade * price_of_trade = 2 * 900 = 1800
@@ -1310,11 +1306,11 @@ Feature: Fees calculations
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 1597   | 0       |
-      | trader4  | ETH   | ETH/DEC21 | 3801   | 0       |
+      | trader3a | ETH   | ETH/DEC21 |      0 | 0       |
+      | trader4  | ETH   | ETH/DEC21 |   3801 | 0       |
 
     Then the market data for the market "ETH/DEC21" should be:
-      | trading mode            | auction trigger             |
+      | trading mode            | auction trigger             | 
       | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED |
 
   Scenario: WIP - Testing fees in Price auction session trading with insufficient balance in their general and margin account, then the trade does not go ahead
@@ -1412,8 +1408,8 @@ Feature: Fees calculations
       | trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 2      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 4760        | 5236   | 5712    | 6664    |
+      | party   | market id | maintenance | initial |
+      | trader4 | ETH/DEC21 | 4788        | 5745    |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
@@ -1541,8 +1537,6 @@ Feature: Fees calculations
       | aux2     | ETH   | 1000000000000 |
       | trader3a | ETH   | 10000         |
       | trader3b | ETH   | 30000         |
-    # | trader3a | ETH   | 9750         |
-    # | trader3b | ETH   | 29750         |
 
     Then the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |

--- a/core/integration/features/liquidity-provision/verify-CcySiska.feature
+++ b/core/integration/features/liquidity-provision/verify-CcySiska.feature
@@ -82,8 +82,8 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | initial  |
       | party0 | ETH/MAR22 | 35078184    | 42093820 |
-      | party1 | ETH/MAR22 | 44388       | 53265    |
-      | party2 | ETH/MAR22 | 187709      | 225250   |
+      | party1 | ETH/MAR22 | 42338       | 50805    |
+      | party2 | ETH/MAR22 | 185609      | 222730   |
 
     Then the parties should have the following account balances:
       | party  | asset | market id | margin   | general   |
@@ -139,8 +139,8 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | initial  |
       | party0 | ETH/MAR22 | 8771325     | 10525590 |
-      | party1 | ETH/MAR22 | 44388       | 53265    |
-      | party2 | ETH/MAR22 | 187709      | 225250   |
+      | party1 | ETH/MAR22 | 42338       | 50805    |
+      | party2 | ETH/MAR22 | 185609      | 222730   |
 
     Then the parties should have the following account balances:
       | party  | asset | market id | margin   | general   |

--- a/core/integration/features/rewards/multi_asset_multi_market_fees_rewards.feature
+++ b/core/integration/features/rewards/multi_asset_multi_market_fees_rewards.feature
@@ -232,13 +232,13 @@ Feature: Fees rewards with multiple markets and assets
       | lpprov | party1 | 1089  | 7    |
       | party2 | party1 | 1030  | 5    |
 
-    Then "party1" should have general account balance of "599979904" for asset "ETH"
+    Then "party1" should have general account balance of "599979308" for asset "ETH"
     Then "party2" should have general account balance of "599994774" for asset "ETH"
     Then "lp1" should have general account balance of "5999984128" for asset "ETH"
     Then "lp2" should have general account balance of "5999995630" for asset "ETH"
 
     Then "party1" should have general account balance of "299987176" for asset "BTC"
-    Then "party2" should have general account balance of "299986327" for asset "BTC"
+    Then "party2" should have general account balance of "299986599" for asset "BTC"
     Then "lp1" should have general account balance of "2999990841" for asset "BTC"
     Then "lp2" should have general account balance of "2999997067" for asset "BTC"
 

--- a/core/integration/features/verified/0019-MCAL-margin_calculator-risk_parameters.feature
+++ b/core/integration/features/verified/0019-MCAL-margin_calculator-risk_parameters.feature
@@ -142,58 +142,57 @@ Feature: test risk model parameter change in margin calculation
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR21 | 9937   | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR21 | 3117   | 99985528 | 0     |
-      | party2 | USD   | ETH/MAR21 | 3429   | 99983148 | 0     |
+      | party1 | USD   | ETH/MAR21 | 3333   | 99984664 | 0     |
+      | party2 | USD   | ETH/MAR21 | 3645   | 99982284 | 0     |
 
-    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-900)+10*0.145263949*1000 + 1*0.145263949*1000=2598
+    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.145263949*1000 + 1*0.145263949*1000=2778
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
       | party0 | ETH/MAR21 | 8281        | 9109   | 9937    | 11593   |
-      | party1 | ETH/MAR21 | 2598        | 2857   | 3117    | 3637    |
-      | party2 | ETH/MAR21 | 2858        | 3143   | 3429    | 4001    |
+      | party1 | ETH/MAR21 | 2778        | 3055   | 3333    | 3889    |
+      | party2 | ETH/MAR21 | 3038        | 3341   | 3645    | 4253    |
 
     # risk model 002: check the required balances
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 19701  | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 4766   | 99985528 | 0     |
-      | party2 | USD   | ETH/MAR22 | 6016   | 99983148 | 0     |
+      | party1 | USD   | ETH/MAR22 | 4982   | 99984664 | 0     |
+      | party2 | USD   | ETH/MAR22 | 6232   | 99982284 | 0     |
 
-    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-900)+10*0.270133394*1000 + 1*0.270133394*1000=3972
+    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.270133394*1000 + 1*0.270133394*1000=4152
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
       | party0 | ETH/MAR22 | 16418       | 18059  | 19701   | 22985   |
-      | party1 | ETH/MAR22 | 3972        | 4369   | 4766    | 5560    |
-      | party2 | ETH/MAR22 | 5014        | 5515   | 6016    | 7019    |
+      | party1 | ETH/MAR22 | 4152        | 4567   | 4982    | 5812    |
+      | party2 | ETH/MAR22 | 5194        | 5713   | 6232    | 7271    |
 
     #risk model 003: check the required balances
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR23 | 13632  | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR23 | 3831   | 99985528 | 0     |
-      | party2 | USD   | ETH/MAR23 | 4454   | 99983148 | 0     |
+      | party1 | USD   | ETH/MAR23 | 4047   | 99984664 | 0     |
+      | party2 | USD   | ETH/MAR23 | 4670   | 99982284 | 0     |
 
-    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-900)+10*0.24649034405344100*1000 + 1*0.24649034405344100*1000=3712
+    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.199294303*1000 + 1*0.199294303*1000=3373
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
       | party0 | ETH/MAR23 | 11360       | 12496  | 13632   | 15904   |
-      | party1 | ETH/MAR23 | 3193        | 3512   | 3831    | 4470    |
-      | party2 | ETH/MAR23 | 3712        | 4083   | 4454    | 5196    |
-
+      | party1 | ETH/MAR23 | 3373        | 3710   | 4047    | 4722    |
+      | party2 | ETH/MAR23 | 3892        | 4281   | 4670    | 5448    |
+      # | party1 | ETH/MAR23 | 3193        | 3512   | 3831    | 4470    |
+      # | party2 | ETH/MAR23 | 3712        | 4083   | 4454    | 5196    |
     # risk model 004: check the required balances
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR24 | 8077   | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR24 | 2758   | 99985528 | 0     |
-      | party2 | USD   | ETH/MAR24 | 2953   | 99983148 | 0     |
+      | party1 | USD   | ETH/MAR24 | 2974   | 99984664 | 0     |
+      | party2 | USD   | ETH/MAR24 | 3169   | 99982284 | 0     |
 
-    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-900)+10*0.118078679*1000 + 1*0.118078679*1000=2299
+    #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.118078679*1000 + 1*0.118078679*1000=2479
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
       | party0 | ETH/MAR24 | 6731        | 7404   | 8077    | 9423    |
-      | party1 | ETH/MAR24 | 2299        | 2528   | 2758    | 3218    |
-      | party2 | ETH/MAR24 | 2461        | 2707   | 2953    | 3445    |
-
-
+      | party1 | ETH/MAR24 | 2479        | 2726   | 2974    | 3470    |
+      | party2 | ETH/MAR24 | 2641        | 2905   | 3169    | 3697    |
 
 

--- a/core/integration/features/verified/0029-FEES-trading_fees.feature
+++ b/core/integration/features/verified/0029-FEES-trading_fees.feature
@@ -844,8 +844,8 @@ Feature: Fees calculations
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 5900   | 4110    |
-      | trader4  | ETH   | ETH/DEC21 | 9225   | 742     |
+      | trader3a | ETH   | ETH/DEC21 | 5976   | 4034    |
+      | trader4  | ETH   | ETH/DEC21 | 9292   | 675     |
 
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -984,12 +984,12 @@ Feature: Fees calculations
       | trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 2      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 4393        | 4832   | 5271    | 6150    |
+      | party   | market id | maintenance | initial |
+      | trader4 | ETH/DEC21 | 4421        | 5305    |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 3372   | 1622    |
+      | trader3a | ETH   | ETH/DEC21 | 3410   | 1584    |
       | trader4  | ETH   | ETH/DEC21 | 5255   | 0       |
 
     Then the market data for the market "ETH/DEC21" should be:
@@ -1085,12 +1085,13 @@ Feature: Fees calculations
       | trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 1      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 2380        | 2618   | 2856    | 3332    |
+      | party    | market id | maintenance | initial |
+      | trader3a | ETH/DEC21 | 1170        | 1404    |
+      | trader4  | ETH/DEC21 | 2390        | 2868    |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 1392   | 3504    |
+      | trader3a | ETH   | ETH/DEC21 | 1404   | 3492    |
       | trader4  | ETH   | ETH/DEC21 | 2756   | 0       |
 
     Then the market data for the market "ETH/DEC21" should be:
@@ -1197,8 +1198,8 @@ Feature: Fees calculations
       | trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 2      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 4393        | 4832   | 5271    | 6150    |
+      | party   | market id | maintenance | initial |
+      | trader4 | ETH/DEC21 | 4421        | 5305    |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
@@ -1282,7 +1283,11 @@ Feature: Fees calculations
 
     Then the following trades should be executed:
       | buyer    | price | size | seller  |
+      | trader3a | 1002  | 1    | trader4 |
       | trader3a | 900   | 2    | trader4 |
+      | aux1     | 500   | 1    | network |
+      | aux1     | 490   | 2    | network |
+      | network  | 493   | 3    | trader3a |
 
     # For trader3a & 4- Sharing IF and LP
     # trade_value_for_fee_purposes for trader3a = size_of_trade * price_of_trade = 2 * 900 = 1800
@@ -1303,7 +1308,7 @@ Feature: Fees calculations
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 1597   | 0       |
+      | trader3a | ETH   | ETH/DEC21 |    0   | 0       |
       | trader4  | ETH   | ETH/DEC21 | 3801   | 0       |
 
     Then the market data for the market "ETH/DEC21" should be:
@@ -1401,8 +1406,8 @@ Feature: Fees calculations
       | trader3a | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY      | ETH/DEC21 | 2      | ETH   |
 
     Then the parties should have the following margin levels:
-      | party   | market id | maintenance | search | initial | release |
-      | trader4 | ETH/DEC21 | 4760        | 5236   | 5712    | 6664    |
+      | party   | market id | maintenance | initial |
+      | trader4 | ETH/DEC21 | 4788        | 5745    |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards.feature
@@ -85,8 +85,8 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 1320   | 999988680 | 10000 |
-      | party1 | USD   | ETH/MAR22 | 2520   | 99997480  | 0     |
-      | party2 | USD   | ETH/MAR22 | 2520   | 99997480  | 0     |
+      | party1 | USD   | ETH/MAR22 | 1704   | 99998296  | 0     |
+      | party2 | USD   | ETH/MAR22 | 1692   | 99998308  | 0     |
 
     Then the network moves ahead "1" blocks
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
@@ -631,8 +631,8 @@ Feature:
 
     Then the following trades should be executed:
       | buyer  | price | size | seller |
-      | party1 | 1001  | 19   | lp1    |
-      | party1 | 1001  | 1    | lp2    |
+      | party1 | 1001  | 19   | lp2    |
+      | party1 | 1001  | 1    | lp1    |
 
     # CALCULATION:
     # liquidity_fee = trades * ceil(volume/trades * price * liquidity_fee_factor) = ceil(19 * 1001 * 0.001) + ceil(1 * 1001 * 0.001) = 22

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
@@ -631,8 +631,8 @@ Feature:
 
     Then the following trades should be executed:
       | buyer  | price | size | seller |
-      | party1 | 1001  | 19   | lp2    |
-      | party1 | 1001  | 1    | lp1    |
+      | party1 | 1001  | 19   | lp1    |
+      | party1 | 1001  | 1    | lp2    |
 
     # CALCULATION:
     # liquidity_fee = trades * ceil(volume/trades * price * liquidity_fee_factor) = ceil(19 * 1001 * 0.001) + ceil(1 * 1001 * 0.001) = 22

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -336,7 +336,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
 
     And the parties should have the following account balances:
       | party | asset | market id | margin  | general        | bond    |
-      | lp1   | ETH   | USD/DEC21 | 4695112 | 99999983469540 | 1000000 |
+      | lp1   | ETH   | USD/DEC21 | 5127063 | 99999980896617 | 1000000 |
       | lp1   | USD   |           |         | 100000000000   |         |
 
     # amend LP commintment amount

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -143,15 +143,15 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     And the parties should have the following account balances:
       | party  | asset | market id | margin     | general        | bond       |
       | lp1    | ETH   | USD/DEC19 | 4134260182 | 99984597723110 | 1000000000 |
-      | lp1    | USD   | USD/DEC19 | 4134260182 | 100000000000   |            |
+      | lp1    | USD   |           |            | 100000000000   |            |
       | lp1    | ETH   | USD/DEC20 | 4133756526 | 99984597723110 | 1000000000 |
-      | lp1    | USD   | USD/DEC20 | 4133756526 | 100000000000   |            |
+      | lp1    | USD   |           |            | 100000000000   |            |
       | lp1    | ETH   | USD/DEC21 | 4134260182 | 99984597723110 | 1000000000 |
-      | lp1    | USD   | USD/DEC21 | 4134260182 | 100000000000   | 1000000000 |
-      | party1 | ETH   | USD/DEC19 | 1176961234 | 9996469116298  |            |
-      | party1 | USD   | USD/DEC19 | 1176961234 | 10000000000    |            |
+      | lp1    | USD   |           |            | 100000000000   |            |
+      | party1 | ETH   | USD/DEC19 | 1047352495 | 9996857942515  |            |
+      | party1 | USD   |           |            | 10000000000    |            |
       | party2 | ETH   | USD/DEC19 | 4737795542 | 9985786613374  |            |
-      | party2 | USD   | USD/DEC19 | 4737795542 | 10000000000    |            |
+      | party2 | USD   |           |            | 10000000000    |            |
 
   Scenario: 002: 0070-MKTD-007, 0042-LIQF-001, 0038-OLIQ-002; 0038-OLIQ-006; 0019-MCAL-008, check updated version of dpd feature in 0038-OLIQ-liquidity_provision_order_type.md
 
@@ -299,15 +299,15 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     And the parties should have the following account balances:
       | party  | asset | market id | margin     | general        | bond    |
       | lp1    | ETH   | USD/DEC19 | 4695112    | 99999983469540 | 1000000 |
-      | lp1    | USD   | USD/DEC19 | 4695112    | 100000000000   |         |
+      | lp1    | USD   |           |            | 100000000000   |         |
       | lp1    | ETH   | USD/DEC20 | 4140236    | 99999983469540 | 1000000 |
-      | lp1    | USD   | USD/DEC20 | 4140236    | 100000000000   |         |
+      | lp1    | USD   |           |            | 100000000000   |         |
       | lp1    | ETH   | USD/DEC21 | 4695112    | 99999983469540 | 1000000 |
-      | lp1    | USD   | USD/DEC21 | 4695112    | 100000000000   |         |
-      | party1 | ETH   | USD/DEC19 | 1176961234 | 9996469116298  |         |
-      | party1 | USD   | USD/DEC19 | 1176961234 | 10000000000    |         |
+      | lp1    | USD   |           |            | 100000000000   |         |
+      | party1 | ETH   | USD/DEC19 | 1179036394 | 9996462886930  |         |
+      | party1 | USD   |           |            | 10000000000    |         |
       | party2 | ETH   | USD/DEC19 | 4737795542 | 9985786613374  |         |
-      | party2 | USD   | USD/DEC19 | 4737795542 | 10000000000    |         |
+      | party2 | USD   |           |            | 10000000000    |         |
 
     Then the parties place the following orders:
       | party  | market id | side | volume | price   | resulting trades | type       | tif     |
@@ -336,8 +336,8 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
 
     And the parties should have the following account balances:
       | party | asset | market id | margin  | general        | bond    |
-      | lp1   | ETH   | USD/DEC21 | 5127063 | 99999980896617 | 1000000 |
-      | lp1   | USD   | USD/DEC21 | 5127063 | 100000000000   |         |
+      | lp1   | ETH   | USD/DEC21 | 4695112 | 99999983469540 | 1000000 |
+      | lp1   | USD   |           |         | 100000000000   |         |
 
     # amend LP commintment amount
     And the parties submit the following liquidity provision:
@@ -457,8 +457,8 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 170732 | 999789268 | 40000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 99988230  | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 99952626  | 0     |
+      | party1 | USD   | ETH/MAR22 | 10464  | 99989536  |     0 |
+      | party2 | USD   | ETH/MAR22 | 47374  | 99952626  |     0 |
 
     Then the network moves ahead "1" blocks
 

--- a/core/integration/features/verified/0070-MKTD-market-decimal-places.feature
+++ b/core/integration/features/verified/0070-MKTD-market-decimal-places.feature
@@ -94,13 +94,13 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond |
             | party0 | ETH   | USD/DEC21 | 4268   | 4985006  | 1000 |
-            | party1 | ETH   | USD/DEC21 | 1081   | 99996757 | 0    |
+            | party1 | ETH   | USD/DEC21 | 1081   | 99996736 | 0    |
             | party2 | ETH   | USD/DEC21 | 4268   | 99987196 | 0    |
             | party0 | ETH   | USD/DEC20 | 3884   | 4985006  | 1000 |
-            | party1 | ETH   | USD/DEC20 | 1081   | 99996757 | 0    |
+            | party1 | ETH   | USD/DEC20 | 1081   | 99996736 | 0    |
             | party2 | ETH   | USD/DEC20 | 4268   | 99987196 | 0    |
             | party0 | ETH   | USD/DEC19 | 3842   | 4985006  | 1000 |
-            | party1 | ETH   | USD/DEC19 | 1081   | 99996757 | 0    |
+            | party1 | ETH   | USD/DEC19 | 1102   | 99996736 | 0    |
             | party2 | ETH   | USD/DEC19 | 4268   | 99987196 | 0    |
 
     Scenario: 002: Users engage in a USD market auction, (0070-MKTD-003, 0070-MKTD-008)
@@ -124,8 +124,8 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | USD   | ETH/MAR22 | 342072 | 4622359  | 35569 |
-            | party1 | USD   | ETH/MAR22 | 12730  | 99987270 | 0     |
-            | party2 | USD   | ETH/MAR22 | 51630  | 99948370 | 0     |
+            | party1 | USD   | ETH/MAR22 | 20410  | 99979590 | 0     |
+            | party2 | USD   | ETH/MAR22 | 59979  | 99940021 | 0     |
         And the following trades should be executed:
             | buyer  | price | size | seller |
             | party1 | 10    | 10   | party2 |
@@ -150,7 +150,7 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC19 | 207439 | 4742561  | 50000 |
-            | party1 | ETH   | USD/DEC19 | 1273   | 99998727 | 0     |
+            | party1 | ETH   | USD/DEC19 | 1292   | 99998708 | 0     |
             | party2 | ETH   | USD/DEC19 | 5169   | 99994831 | 0     |
         And the following trades should be executed:
             | buyer  | price | size | seller |
@@ -219,10 +219,10 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond   |
             | party0 | ETH   | USD/DEC20 | 422522 | 4451564  | 100000 |
-            | party1 | ETH   | USD/DEC20 | 12     | 99998715 | 0      |
+            | party1 | ETH   | USD/DEC20 | 12     | 99998696 | 0      |
             | party2 | ETH   | USD/DEC20 | 52     | 99994779 | 0      |
             | party0 | ETH   | USD/DEC19 | 20914  | 4451564  | 5000   |
-            | party1 | ETH   | USD/DEC19 | 1273   | 99998715 | 0      |
+            | party1 | ETH   | USD/DEC19 | 1292   | 99998696 | 0      |
             | party2 | ETH   | USD/DEC19 | 5169   | 99994779 | 0      |
 
         When the parties deposit on asset's general account the following amount:
@@ -233,10 +233,10 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond   |
             | party0 | ETH   | USD/DEC20 | 422522 | 4452564  | 100000 |
-            | party1 | ETH   | USD/DEC20 | 12     | 99999715 | 0      |
+            | party1 | ETH   | USD/DEC20 | 12     | 99999696 | 0      |
             | party2 | ETH   | USD/DEC20 | 52     | 99995779 | 0      |
             | party0 | ETH   | USD/DEC19 | 20914  | 4452564  | 5000   |
-            | party1 | ETH   | USD/DEC19 | 1273   | 99999715 | 0      |
+            | party1 | ETH   | USD/DEC19 | 1292   | 99999696 | 0      |
             | party2 | ETH   | USD/DEC19 | 5169   | 99995779 | 0      |
 
     Scenario: 006: User checks prices after opening auction, (0070-MKTD-005)

--- a/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
@@ -78,10 +78,10 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
       | party2 | USD   | ETH/MAR22 | 51688  | 99948312 | 0     |
     #check the margin levels
     Then the parties should have the following margin levels:
-      | party  | market id | maintenance | search | initial | release |
-      | party0 | ETH/MAR22 | 174289      | 191717 | 209146  | 244004  |
-      | party1 | ETH/MAR22 | 10159       | 11174  | 12190   | 14222   |
-      | party2 | ETH/MAR22 | 43233       | 47556  | 51879   | 60526   |
+      | party  | market id | maintenance | initial |
+      | party0 | ETH/MAR22 | 174289      | 209146  |
+      | party1 | ETH/MAR22 | 9889        | 11866   |
+      | party2 | ETH/MAR22 | 42963       | 51555   |
     #check position (party0 has no position)
     Then the parties should have the following profit and loss:
       | party  | volume | unrealised pnl | realised pnl |

--- a/core/integration/features/verified/liquidity-provision-bond-account.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account.feature
@@ -80,10 +80,10 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
       | party2 | USD   | ETH/MAR22 | 51630  | 99948370 | 0     |
     #check the margin levels
     Then the parties should have the following margin levels:
-      | party  | market id | maintenance | search | initial | release |
-      | party0 | ETH/MAR22 | 174289      | 191717 | 209146  | 244004  |
-      | party1 | ETH/MAR22 | 10159       | 11174  | 12190   | 14222   |
-      | party2 | ETH/MAR22 | 43233       | 47556  | 51879   | 60526   |
+      | party  | market id | maintenance | initial |
+      | party0 | ETH/MAR22 | 174289      | 209146  |
+      | party1 | ETH/MAR22 | 9889        | 11866   |
+      | party2 | ETH/MAR22 | 42963       | 51555   |
     #check position (party0 has no position)
     Then the parties should have the following profit and loss:
       | party  | volume | unrealised pnl | realised pnl |

--- a/core/integration/features/verified/risk-parameters-ranges-test.feature
+++ b/core/integration/features/verified/risk-parameters-ranges-test.feature
@@ -372,63 +372,70 @@ Feature: test risk model parameter ranges
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR0  | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR0  | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR0  | 47374  | 49999999590279 | 0     |
+      | party1 | USD   | ETH/MAR0  | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR0  | 47374  | 49999999589631 | 0     |
     # intial margin level for LP = 92*1000*1.2*3.5569036=392682
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR11 | 265987 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR11 | 12379  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR11 | 65605  | 49999999590279 | 0     |
+      | party1 | USD   | ETH/MAR11 | 12595  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR11 | 65605  | 49999999589631 | 0     |
     # intial margin level for LP = 92*1000*1.2*4.9256840 =543796
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR12 | 36284  | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR12 | 7134   | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR12 | 10070  | 49999999590279 | 0     |
+      | party1 | USD   | ETH/MAR12 | 7350   | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR12 | 10286  | 49999999589631 | 0     |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR21 | 34     | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR21 | 1207   | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR21 | 1207   | 49999999590279 | 0     |
+      | party1 | USD   | ETH/MAR21 | 1423   | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR21 | 1423   | 49999999589631 | 0     |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999590279 | 0     |
+      | party1 | USD   | ETH/MAR22 | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR22 | 47374  | 49999999589631 | 0     |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
-      | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999590279 | 0     |
+      | party0 | USD   | ETH/MAR31 | 192073 | 49999997803076 | 50000 |
+      | party1 | USD   | ETH/MAR31 | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR31 | 47374  | 49999999589631 | 0     |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
-      | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999590279 | 0     |
+      | party0 | USD   | ETH/MAR32 | 192073 | 49999997803076 | 50000 |
+      | party1 | USD   | ETH/MAR32 | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR32 | 47374  | 49999999589631 | 0     |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
-      | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999590279 | 0     |
-    And the parties should have the following account balances:
-      | party  | asset | market id | margin | general        | bond  |
-      | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999590279 | 0     |
+      | party0 | USD   | ETH/MAR41 | 192073 | 49999997803076 | 50000 |
+      | party1 | USD   | ETH/MAR41 | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR41 | 47374  | 49999999589631 | 0     |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
-      | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11770  | 49999999895669 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999590279 | 0     |
+      | party0 | USD   | ETH/MAR42 | 192073 | 49999997803076 | 50000 |
+      | party1 | USD   | ETH/MAR42 | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR42 | 47374  | 49999999589631 | 0     |
+
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general        | bond  |
+      | party0 | USD   | ETH/MAR43 | 192073 | 49999997803076 | 50000 |
+      | party1 | USD   | ETH/MAR43 | 11986  | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR43 | 47374  | 49999999589631 | 0     |
+
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin | general        | bond  |
+      | party0 | USD   | ETH/MAR51 | 108    | 49999997803076 | 50000 |
+      | party1 | USD   | ETH/MAR51 | 1437   | 49999999893293 | 0     |
+      | party2 | USD   | ETH/MAR51 | 1437   | 49999999589631 | 0     |
 
   @Now
   Scenario: 002, test market ETH/MAR23 (tau=1)
@@ -488,7 +495,7 @@ Feature: test risk model parameter ranges
     And the parties should have the following account balances:
       | party  | asset | market id | margin    | general        | bond    |
       | party0 | USD   | ETH/MAR23 | 461953956 | 49999533046044 | 5000000 |
-      | party1 | USD   | ETH/MAR23 | 14342     | 49999999985658 | 0       |
+      | party1 | USD   | ETH/MAR23 | 14558     | 49999999985442 | 0       |
       | party2 | USD   | ETH/MAR23 | 1148316   | 49999998851684 | 0       |
 
   # initial margin level for LP = 1000*9092*86.2176101*1.2=9.4e8

--- a/core/integration/steps/parties_should_have_the_following_account_balances.go
+++ b/core/integration/steps/parties_should_have_the_following_account_balances.go
@@ -153,7 +153,6 @@ func errMismatchedAccountBalances(row accountBalancesRow, marginAccountBal, gene
 			"bond account balance":    bondAccBal,
 		},
 	)
-
 }
 
 func parseAccountBalancesTable(table *godog.Table) []RowWrapper {

--- a/core/integration/steps/parties_should_have_the_following_account_balances.go
+++ b/core/integration/steps/parties_should_have_the_following_account_balances.go
@@ -92,7 +92,7 @@ func PartiesShouldHaveTheFollowingAccountBalances(
 		}
 
 		if hasError {
-			return errMismatchedAccountBalances(row, actMarAccBal, actGenAccBal, actGenAccBal)
+			return errMismatchedAccountBalances(row, actMarAccBal, actGenAccBal, actBondAccBal)
 		}
 	}
 	return nil

--- a/core/integration/steps/parties_should_have_the_following_account_balances.go
+++ b/core/integration/steps/parties_should_have_the_following_account_balances.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cucumber/godog"
 
 	"code.vegaprotocol.io/vega/core/integration/stubs"
-	types "code.vegaprotocol.io/vega/protos/vega"
 )
 
 func PartiesShouldHaveTheFollowingAccountBalances(
@@ -29,32 +28,71 @@ func PartiesShouldHaveTheFollowingAccountBalances(
 		row := accountBalancesRow{row: r}
 		var hasError bool
 
-		generalAccount, err := broker.GetPartyGeneralAccount(row.Party(), row.Asset())
-		if err != nil {
-			return errCannotGetPartyGeneralAccount(row.Party(), row.Asset(), err)
-		}
-		if generalAccount.GetBalance() != row.GeneralAccountBalance() {
-			hasError = true
-		}
-
-		marginAccount, err := broker.GetPartyMarginAccount(row.Party(), row.MarketID())
-		if err != nil {
-			return errCannotGetPartyMarginAccount(row.Party(), row.Asset(), err)
-		}
-		// check bond
-		var bondAcc types.Account
-		if row.ExpectBondAccountBalance() {
-			bondAcc, err = broker.GetPartyBondAccountForMarket(row.Party(), row.Asset(), row.MarketID())
-			if err == nil && bondAcc.Balance != row.BondAccountBalance() {
+		var actGenAccBal, actMarAccBal, actBondAccBal string
+		expectedAsset := row.Asset()
+		if row.ExpectGeneralAccountBalance() && len(row.GeneralAccountBalance()) > 0 {
+			generalAccount, err := broker.GetPartyGeneralAccount(row.Party(), expectedAsset)
+			if err != nil {
+				if row.GeneralAccountBalance() == "0" {
+					// we coulnd't get the account but the expectation is 0 so it's fine
+					continue
+				}
+				return errCannotGetPartyGeneralAccount(row.Party(), expectedAsset, err)
+			}
+			if generalAccount.GetAsset() != expectedAsset {
+				return errWrongGeneralAccountAsset(row.Party(), expectedAsset, generalAccount.GetAsset())
+			}
+			actGenAccBal = generalAccount.GetBalance()
+			if actGenAccBal != row.GeneralAccountBalance() {
 				hasError = true
 			}
 		}
-		if marginAccount.GetBalance() != row.MarginAccountBalance() {
-			hasError = true
+
+		if row.ExpectMarginAccountBalance() && len(row.MarginAccountBalance()) > 0 {
+			if !row.ExpectMarketID() {
+				return fmt.Errorf("market id must be specified when expected margin account balance is supplied")
+			}
+			marginAccount, err := broker.GetPartyMarginAccount(row.Party(), row.MarketID())
+			if err != nil {
+				if row.MarginAccountBalance() == "0" {
+					// we coulnd't get the account but the expectation is 0 so it's fine
+					continue
+				}
+				return errCannotGetPartyMarginAccount(row.Party(), row.MarketID(), err)
+			}
+			if marginAccount.GetAsset() != expectedAsset {
+				return errWrongMarketAccountAsset(marginAccount.GetType().String(), row.Party(), row.MarketID(), expectedAsset, marginAccount.GetAsset())
+			}
+			actMarAccBal = marginAccount.GetBalance()
+			if actMarAccBal != row.MarginAccountBalance() {
+				hasError = true
+			}
+		}
+
+		// check bond
+		if row.ExpectBondAccountBalance() && len(row.BondAccountBalance()) > 0 {
+			if !row.ExpectMarketID() {
+				return fmt.Errorf("market id must be specified when expected bond account balance is supplied")
+			}
+			bondAcc, err := broker.GetPartyBondAccountForMarket(row.Party(), expectedAsset, row.MarketID())
+			if err != nil {
+				if row.BondAccountBalance() == "0" {
+					// we coulnd't get the account but the expectation is 0 so it's fine
+					continue
+				}
+				return errCannotGetPartyBondAccount(row.Party(), row.MarketID(), err)
+			}
+			if bondAcc.GetAsset() != expectedAsset {
+				return errWrongMarketAccountAsset(bondAcc.GetType().String(), row.Party(), row.MarketID(), expectedAsset, bondAcc.GetAsset())
+			}
+			actBondAccBal = bondAcc.GetBalance()
+			if actBondAccBal != row.BondAccountBalance() {
+				hasError = true
+			}
 		}
 
 		if hasError {
-			return errMismatchedAccountBalances(row, marginAccount, generalAccount, bondAcc)
+			return errMismatchedAccountBalances(row, actMarAccBal, actGenAccBal, actGenAccBal)
 		}
 	}
 	return nil
@@ -66,50 +104,66 @@ func errCannotGetPartyGeneralAccount(party, asset string, err error) error {
 	)
 }
 
-func errCannotGetPartyMarginAccount(party, asset string, err error) error {
-	return fmt.Errorf("couldn't get margin account for party(%s) and asset(%s): %s",
-		party, asset, err.Error(),
+func errCannotGetPartyMarginAccount(party, market string, err error) error {
+	return fmt.Errorf("couldn't get margin account for party(%s) and market(%s): %s",
+		party, market, err.Error(),
 	)
 }
 
-func errMismatchedAccountBalances(row accountBalancesRow, marginAccount, generalAccount, bondAcc types.Account) error {
-	// if bond account was given
-	if bondAcc.Type == types.AccountType_ACCOUNT_TYPE_BOND {
-		return formatDiff(
-			fmt.Sprintf("account balances did not match for party(%s)", row.Party()),
-			map[string]string{
-				"margin account balance":  row.MarginAccountBalance(),
-				"general account balance": row.GeneralAccountBalance(),
-				"bond account balance":    row.BondAccountBalance(),
-			},
-			map[string]string{
-				"margin account balance":  marginAccount.GetBalance(),
-				"general account balance": generalAccount.GetBalance(),
-				"bond account balance":    bondAcc.Balance,
-			},
-		)
+func errCannotGetPartyBondAccount(party, market string, err error) error {
+	return fmt.Errorf("couldn't get bond account for party(%s) and market(%s): %s",
+		party, market, err.Error(),
+	)
+}
+
+func errWrongMarketAccountAsset(account, party, market, expectedAsset, actualAsset string) error {
+	return fmt.Errorf("%s account for party(%s) in market(%s) uses '%s' asset, but '%s' was expected",
+		account, party, market, actualAsset, expectedAsset,
+	)
+}
+
+func errWrongGeneralAccountAsset(party, expectedAsset, actualAsset string) error {
+	return fmt.Errorf("general account for party(%s) uses '%s' asset, but '%s' was expected",
+		party, actualAsset, expectedAsset,
+	)
+}
+
+func errMismatchedAccountBalances(row accountBalancesRow, marginAccountBal, generalAccountBal, bondAccBal string) error {
+	var expMarginAccountBal, expGeneralAccountBal, expBondAccountBal string
+	if row.ExpectGeneralAccountBalance() {
+		expGeneralAccountBal = row.GeneralAccountBalance()
 	}
+	if row.ExpectMarginAccountBalance() {
+		expMarginAccountBal = row.MarginAccountBalance()
+	}
+	if row.ExpectBondAccountBalance() {
+		expBondAccountBal = row.BondAccountBalance()
+	}
+
 	return formatDiff(
 		fmt.Sprintf("account balances did not match for party(%s)", row.Party()),
 		map[string]string{
-			"margin account balance":  row.MarginAccountBalance(),
-			"general account balance": row.GeneralAccountBalance(),
+			"margin account balance":  expMarginAccountBal,
+			"general account balance": expGeneralAccountBal,
+			"bond account balance":    expBondAccountBal,
 		},
 		map[string]string{
-			"margin account balance":  marginAccount.GetBalance(),
-			"general account balance": generalAccount.GetBalance(),
+			"margin account balance":  marginAccountBal,
+			"general account balance": generalAccountBal,
+			"bond account balance":    bondAccBal,
 		},
 	)
+
 }
 
 func parseAccountBalancesTable(table *godog.Table) []RowWrapper {
 	return StrictParseTable(table, []string{
 		"party",
 		"asset",
+	}, []string{
 		"market id",
 		"margin",
 		"general",
-	}, []string{
 		"bond",
 	})
 }
@@ -140,6 +194,22 @@ func (r accountBalancesRow) GeneralAccountBalance() string {
 
 func (r accountBalancesRow) ExpectBondAccountBalance() bool {
 	return r.row.HasColumn("bond")
+}
+
+func (r accountBalancesRow) ExpectGeneralAccountBalance() bool {
+	return r.row.HasColumn("general")
+}
+
+func (r accountBalancesRow) ExpectMarginAccountBalance() bool {
+	return r.row.HasColumn("margin")
+}
+
+func (r accountBalancesRow) ExpectAsset() bool {
+	return r.row.HasColumn("asset")
+}
+
+func (r accountBalancesRow) ExpectMarketID() bool {
+	return r.row.HasColumn("market id")
 }
 
 func (r accountBalancesRow) BondAccountBalance() string {


### PR DESCRIPTION
- Moved after-auction MTM check (and hence closeouts) to a point after all the parked orders have been redeployed.
- Integration test changes are due to a different slippage component:
    - margin requirements usually grow as a result (as before the slippage was calculated on a sparse order book),
    - however they can also diminish if LPs use orders pegged to MID (then the slippage can be less than it used to).
- Simplified `confirmMTM` signature to avoid passing in dummy objects.
- Improved account balance cucumber step so that checks for parties with accounts denominated in multiple assets look sensibly.

closes #7543 