### PR TITLE
feat: archive and roll event buffer files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [7386](https://github.com/vegaprotocol/vega/issues/7386) - Add indexed filtering by command type to block explorer
 - [6962](https://github.com/vegaprotocol/vega/issues/6962) - Add a dedicated configuration for the wallet service
 - [7434](https://github.com/vegaprotocol/vega/issues/7434) - Update design architecture diagram
+- [7517](https://github.com/vegaprotocol/vega/issues/7517) - Archive and roll event buffer files
 - [7429](https://github.com/vegaprotocol/vega/issues/7429) - Do not mark wallet and network as incompatible when the patch version doesn't match
 - [6650](https://github.com/vegaprotocol/vega/issues/6650) - Add ability to filter rewards with `fromEpoch` and `toEpoch`
 - [7429](https://github.com/vegaprotocol/vega/issues/7359) - `vega wallet` will not send in a transaction if it will result in a party becoming banned

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -238,7 +238,15 @@ func (l *NodeCommand) preRun([]string) (err error) {
 			l.Log.Error("failed to create path for buffered event source", logging.Error(err))
 			return err
 		}
-		eventSource, err = broker.NewBufferedEventSource(l.Log, l.conf.Broker.BufferedEventSourceConfig, eventReceiverSender, bufferFilePath)
+
+		archiveFilesPath, err := l.vegaPaths.CreateStatePathFor(paths.DataNodeArchivedEventBufferHome)
+		if err != nil {
+			l.Log.Error("failed to create archive path for buffered event source", logging.Error(err))
+			return err
+		}
+
+		eventSource, err = broker.NewBufferedEventSource(l.ctx, l.Log, l.conf.Broker.BufferedEventSourceConfig, eventReceiverSender,
+			bufferFilePath, archiveFilesPath)
 		if err != nil {
 			l.Log.Error("unable to initialise file buffered event source", logging.Error(err))
 			return err

--- a/datanode/broker/buffered_event_source_test.go
+++ b/datanode/broker/buffered_event_source_test.go
@@ -3,8 +3,12 @@ package broker
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,22 +18,157 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_RemoveOldArchiveFilesIfDirectoryFull(t *testing.T) {
+	path := t.TempDir()
+	file1, err := os.Create(filepath.Join(path, "datanode-buffer-2023-02-09-20-44-35-1675975475798831800-seqnumspan-1-1000000.gz"))
+	assert.NoError(t, err)
+	defer func() { _ = file1.Close() }()
+
+	for i := 0; i < 100; i++ {
+		file1.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	file2, err := os.Create(filepath.Join(path, "datanode-buffer-2023-02-09-20-44-41-1675975481217000775-seqnumspan-1000001-2000000.gz"))
+	assert.NoError(t, err)
+	defer func() { _ = file2.Close() }()
+
+	for i := 0; i < 100; i++ {
+		file2.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	file3, err := os.Create(filepath.Join(path, "datanode-buffer-2023-02-09-20-44-46-1675975486620295637-seqnumspan-2000001-3000000.gz"))
+	defer func() { _ = file3.Close() }()
+
+	assert.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		file3.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	file4, err := os.Create(filepath.Join(path, "datanode-buffer-2023-02-09-20-45-02-1675975502197534094-seqnumspan-3000001-4000000.gz"))
+	defer func() { _ = file4.Close() }()
+	assert.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		file4.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	var preCleanUpSize int64
+	err = filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() {
+			preCleanUpSize += info.Size()
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+
+	removeOldArchiveFilesIfDirectoryFull(path, preCleanUpSize/2+1)
+	var postRemoveFiles []fs.FileInfo
+	err = filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() {
+			postRemoveFiles = append(postRemoveFiles, info)
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+
+	sort.Slice(postRemoveFiles, func(i, j int) bool {
+		return strings.Compare(postRemoveFiles[i].Name(), postRemoveFiles[j].Name()) < 0
+	})
+
+	assert.Equal(t, 2, len(postRemoveFiles))
+	assert.Equal(t, "datanode-buffer-2023-02-09-20-44-46-1675975486620295637-seqnumspan-2000001-3000000.gz", postRemoveFiles[0].Name())
+	assert.Equal(t, "datanode-buffer-2023-02-09-20-45-02-1675975502197534094-seqnumspan-3000001-4000000.gz", postRemoveFiles[1].Name())
+}
+
+func Test_CompressUncompressedFilesInDir(t *testing.T) {
+	path := t.TempDir()
+	file1, err := os.Create(filepath.Join(path, "1"))
+	assert.NoError(t, err)
+	defer func() { _ = file1.Close() }()
+
+	for i := 0; i < 100; i++ {
+		file1.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	file2, err := os.Create(filepath.Join(path, "2"))
+	assert.NoError(t, err)
+	defer func() { _ = file2.Close() }()
+
+	for i := 0; i < 100; i++ {
+		file2.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	file3, err := os.Create(filepath.Join(path, "3.gz"))
+	defer func() { _ = file3.Close() }()
+
+	assert.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		file3.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	file4, err := os.Create(filepath.Join(path, "4.gz"))
+	defer func() { _ = file4.Close() }()
+	assert.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		file4.WriteString("A LOAD LOAD OF OLD OLD COBBLERS")
+	}
+
+	var preCompressFiles []fs.FileInfo
+	err = filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() {
+			preCompressFiles = append(preCompressFiles, info)
+		}
+		return nil
+	})
+	sort.Slice(preCompressFiles, func(i, j int) bool {
+		return strings.Compare(preCompressFiles[i].Name(), preCompressFiles[j].Name()) < 0
+	})
+
+	assert.NoError(t, err)
+
+	compressUncompressedFilesInDir(path)
+
+	var postCompressFiles []fs.FileInfo
+	err = filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() {
+			postCompressFiles = append(postCompressFiles, info)
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	sort.Slice(postCompressFiles, func(i, j int) bool {
+		return strings.Compare(postCompressFiles[i].Name(), postCompressFiles[j].Name()) < 0
+	})
+
+	assert.Equal(t, len(preCompressFiles), len(postCompressFiles))
+
+	assert.Equal(t, preCompressFiles[0].Name()+".gz", postCompressFiles[0].Name())
+	assert.Equal(t, preCompressFiles[1].Name()+".gz", postCompressFiles[1].Name())
+	assert.Equal(t, preCompressFiles[2].Name(), postCompressFiles[2].Name())
+	assert.Equal(t, preCompressFiles[3].Name(), postCompressFiles[3].Name())
+
+	assert.Greater(t, preCompressFiles[0].Size(), postCompressFiles[0].Size())
+	assert.Greater(t, preCompressFiles[1].Size(), postCompressFiles[1].Size())
+	assert.Equal(t, preCompressFiles[2].Size(), postCompressFiles[2].Size())
+	assert.Equal(t, preCompressFiles[3].Size(), postCompressFiles[3].Size())
+}
+
 func Test_FileBufferedEventSource_BufferingDisabledWhenEventsPerFileIsZero(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	path := t.TempDir()
+	archivePath := t.TempDir()
 
 	eventSource := &testEventSource{
 		eventsCh: make(chan events.Event, 1000),
 		errCh:    make(chan error),
 	}
 
-	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         0,
 		SendChannelBufferSize: 1000,
 		MaxBufferedEvents:     10000,
-	}, eventSource, path)
+	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
 
@@ -43,7 +182,7 @@ func Test_FileBufferedEventSource_BufferingDisabledWhenEventsPerFileIsZero(t *te
 
 	// This check consumes all events, and after each event buffer file is read it checks that it is removed
 	for i := 0; i < numberOfEventsToSend; i++ {
-		files, _ := ioutil.ReadDir(path)
+		files, _ := os.ReadDir(path)
 		assert.Equal(t, 0, len(files))
 		e := <-evtCh
 		r := e.(*events.Asset)
@@ -52,16 +191,19 @@ func Test_FileBufferedEventSource_BufferingDisabledWhenEventsPerFileIsZero(t *te
 }
 
 func Test_FileBufferedEventSource_ErrorSentOnPathError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	eventSource := &testEventSource{
 		eventsCh: make(chan events.Event),
 		errCh:    make(chan error),
 	}
 
-	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         10,
 		SendChannelBufferSize: 0,
 		MaxBufferedEvents:     10000,
-	}, eventSource, "thepaththatdoesntexist")
+	}, eventSource, "thepaththatdoesntexist", "")
 
 	assert.NoError(t, err)
 
@@ -73,18 +215,22 @@ func Test_FileBufferedEventSource_ErrorSentOnPathError(t *testing.T) {
 }
 
 func Test_FileBufferedEventSource_ErrorsArePassedThrough(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	path := t.TempDir()
+	archivePath := t.TempDir()
 
 	eventSource := &testEventSource{
 		eventsCh: make(chan events.Event),
 		errCh:    make(chan error),
 	}
 
-	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         10,
 		SendChannelBufferSize: 0,
 		MaxBufferedEvents:     10000,
-	}, eventSource, path)
+	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
 
@@ -96,18 +242,22 @@ func Test_FileBufferedEventSource_ErrorsArePassedThrough(t *testing.T) {
 }
 
 func Test_FileBufferedEventSource_EventsAreBufferedAndPassedThrough(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	path := t.TempDir()
+	archivePath := t.TempDir()
 
 	eventSource := &testEventSource{
 		eventsCh: make(chan events.Event),
 		errCh:    make(chan error),
 	}
 
-	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         10,
 		SendChannelBufferSize: 0,
 		MaxBufferedEvents:     10000,
-	}, eventSource, path)
+	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
 
@@ -138,6 +288,7 @@ func Test_FileBufferedEventSource_RollsBufferFiles(t *testing.T) {
 	defer cancel()
 
 	path := t.TempDir()
+	archivePath := t.TempDir()
 
 	eventSource := &testEventSource{
 		eventsCh: make(chan events.Event),
@@ -145,11 +296,11 @@ func Test_FileBufferedEventSource_RollsBufferFiles(t *testing.T) {
 	}
 
 	eventsPerFile := 10
-	fb, err := NewBufferedEventSource(logging.NewTestLogger(), BufferedEventSourceConfig{
+	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         eventsPerFile,
 		SendChannelBufferSize: 0,
 		MaxBufferedEvents:     10000,
-	}, eventSource, path)
+	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
 
@@ -178,7 +329,7 @@ func Test_FileBufferedEventSource_RollsBufferFiles(t *testing.T) {
 				return files[i].ModTime().Before(files[j].ModTime())
 			})
 			for j, f := range files {
-				expectedFilename := fmt.Sprintf("datanode-buffer-%d-%d", (j+i/eventsPerFile)*eventsPerFile+1, (j+1+i/eventsPerFile)*eventsPerFile)
+				expectedFilename := fmt.Sprintf("datanode-buffer-%d-%d.bevt", (j+i/eventsPerFile)*eventsPerFile+1, (j+1+i/eventsPerFile)*eventsPerFile)
 				assert.Equal(t, expectedFilename, f.Name())
 			}
 		}

--- a/datanode/broker/config.go
+++ b/datanode/broker/config.go
@@ -51,14 +51,17 @@ func NewDefaultConfig() Config {
 			File:                  "vega.evt",
 			TimeBetweenBlocks:     encoding.Duration{Duration: 1 * time.Second},
 			SendChannelBufferSize: 1000,
+			IsBufferFile:          false,
 		},
 		UseEventFile:           false,
 		PanicOnError:           false,
 		UseBufferedEventSource: true,
 		BufferedEventSourceConfig: BufferedEventSourceConfig{
-			EventsPerFile:         10_000_000,
-			SendChannelBufferSize: 10_000,
-			MaxBufferedEvents:     100_000_000,
+			EventsPerFile:           10_000_000,
+			SendChannelBufferSize:   10_000,
+			MaxBufferedEvents:       100_000_000,
+			Archive:                 true,
+			ArchiveMaximumSizeBytes: 10_000_000_000,
 		},
 		EventBusClientBufferSize: 100000,
 	}
@@ -68,6 +71,7 @@ type FileEventSourceConfig struct {
 	File                  string            `long:"file" description:"the event file"`
 	TimeBetweenBlocks     encoding.Duration `string:"time-between-blocks" description:"the time between sending blocks"`
 	SendChannelBufferSize int               `long:"send-buffer-size" description:"size of channel buffer used to send events to broker "`
+	IsBufferFile          bool              `long:"is-buffer-file" description:"if true the source file is a data-node buffer file"`
 }
 
 type SocketConfig struct {
@@ -78,7 +82,9 @@ type SocketConfig struct {
 }
 
 type BufferedEventSourceConfig struct {
-	EventsPerFile         int `long:"events-per-file" description:"the number of events to store in a file buffer, set to 0 to disable the buffer"`
-	SendChannelBufferSize int `long:"send-buffer-size" description:"sink event channel buffer size"`
-	MaxBufferedEvents     int `long:"max-buffered-events" description:"max number of events that can be buffered, after this point events will no longer be buffered"`
+	EventsPerFile           int   `long:"events-per-file" description:"the number of events to store in a file buffer, set to 0 to disable the buffer"`
+	SendChannelBufferSize   int   `long:"send-buffer-size" description:"sink event channel buffer size"`
+	MaxBufferedEvents       int   `long:"max-buffered-events" description:"max number of events that can be buffered, after this point events will no longer be buffered"`
+	Archive                 bool  `long:"archive" description:"archives event buffer files after they have been read, default false"`
+	ArchiveMaximumSizeBytes int64 `long:"archive-maximum-size" description:"the maximum size of the archive directory"`
 }

--- a/datanode/sqlstore/sqlstore.go
+++ b/datanode/sqlstore/sqlstore.go
@@ -201,30 +201,6 @@ func WipeDatabaseAndMigrateSchemaToLatestVersion(log *logging.Logger, config Con
 	return nil
 }
 
-func CreateVegaSchema(log *logging.Logger, connConfig ConnectionConfig) error {
-	goose.SetBaseFS(EmbedMigrations)
-	goose.SetLogger(log.Named("snapshot schema creation").GooseLogger())
-
-	poolConfig, err := connConfig.GetPoolConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get connection configuration: %w", err)
-	}
-
-	db := stdlib.OpenDB(*poolConfig.ConnConfig)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			log.Errorf("error when closing connection used to create vega schema:%w", err)
-		}
-	}()
-
-	if err := goose.Up(db, SQLMigrationsDir); err != nil {
-		return fmt.Errorf("failed to create schema: %w", err)
-	}
-
-	return nil
-}
-
 func HasVegaSchema(ctx context.Context, conn Connection) (bool, error) {
 	tableNames, err := GetAllTableNames(ctx, conn)
 	if err != nil {

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -289,6 +289,9 @@ var (
 	// DataNodeEventBufferHome is the folder containing event buffer files.
 	DataNodeEventBufferHome = StatePath(filepath.Join(DataNodeStateHome.String(), "eventsbuffer"))
 
+	// DataNodeArchivedEventBufferHome is the folder containing archived event buffer files.
+	DataNodeArchivedEventBufferHome = StatePath(filepath.Join(DataNodeStateHome.String(), "archivedeventbuffers"))
+
 	// NodeStateHome is the folder containing the state of the node.
 	NodeStateHome = StatePath("node")
 


### PR DESCRIPTION
closes #7517 

This change adds functionality to the datanode to optinally archive the event buffer files that are already created.  This is part 1 of 2 part change, part 1 is the archiving of the files, part 2 will be the change to allow the datanode to read archive buffer files (buffer file format is different from that of the core's file event dumper).

Originally, was going to just move the files into an archive directory and rely on ops to setup the compression and rolling of the files, however on reflection it will  be exceptionally useful to always be able to get a datanodes recent events in the event of a bug/issue.  Combined with load a recent network history segment this will allow us to replay any scenario.  For this reason I opted to make archiving on by default with a max archive dir size of 10GB.

  @vegaprotocol/ops @fkondej the maximum size of the archive can be configure and turned on and off using the following properties.   Ideally the maximum size would be set as a percentage of the available disk space in out env so we can hold onto as much event history as possible without it impacting anything.  As a guide a reasonable number would be say 100GB although more is always better.

`Archive = true 
 ArchiveMaximumSizeBytes = 10000000 
`
Which is part of the buffered event source config, e.g:

`  [Broker.BufferedEventSourceConfig]
    EventsPerFile = 100000
    SendChannelBufferSize = 10000
    MaxBufferedEvents = 100000000
    Archive = true 
    ArchiveMaximumSizeBytes = 10000000 
`

