### PR TITLE
fix: add logging when migrating database schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,13 @@
 - [7550](https://github.com/vegaprotocol/vega/issues/7550) - Update feature tests to use specify explicitly linear and quadratic slippage factors
 - [7558](https://github.com/vegaprotocol/vega/issues/7558) - Add `hypertable` for rewards
 - [7509](https://github.com/vegaprotocol/vega/issues/7509) - Automatically reconcile account balance changes with transfer events after each integration test step
+- [7564](https://github.com/vegaprotocol/vega/issues/7564) - Add logging when database migrations are run
 
 ### 🐛 Fixes
 - [7422](https://github.com/vegaprotocol/vega/issues/7422) - Fix missing `priceMonitoringParameters` and `liquidityMonitoringParameters` in `GraphQL` schema
 - [7462](https://github.com/vegaprotocol/vega/issues/7462) - Fix `BlockExplorer` `API` not returning details on transactions.
 - [7407](https://github.com/vegaprotocol/vega/issues/7407) - fix `ethereum` timestamp in stake linking in `graphql`
-- [7494](https://github.com/vegaprotocol/vega/issues/7494) - fix memory leak in event bus stream subscriber when consumer is slow 
+- [7494](https://github.com/vegaprotocol/vega/issues/7494) - fix memory leak in event bus stream subscriber when consumer is slow
 - [7420](https://github.com/vegaprotocol/vega/issues/7420) - `clearFeeActivity` now clears fee activity
 - [7420](https://github.com/vegaprotocol/vega/issues/7420) - set seed nonce for joining and leaving signatures during begin block
 - [7420](https://github.com/vegaprotocol/vega/issues/7515) - protect `vegawallet` with recovers to shield against file system oddities

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -85,7 +85,8 @@ func (cmd *loadCmd) Execute(args []string) error {
 	}
 
 	if hasSchema && cmd.WipeExistingData {
-		err := sqlstore.WipeDatabaseAndMigrateSchemaToVersion(log, cmd.Config.SQLStore.ConnectionConfig, 0, sqlstore.EmbedMigrations)
+		err := sqlstore.WipeDatabaseAndMigrateSchemaToVersion(log, cmd.Config.SQLStore.ConnectionConfig, 0,
+			sqlstore.EmbedMigrations, bool(cmd.Config.SQLStore.VerboseMigration))
 		if err != nil {
 			return fmt.Errorf("failed to wipe database and migrate schema to version: %w", err)
 		}
@@ -208,7 +209,7 @@ func (cmd *loadCmd) Execute(args []string) error {
 	loadLog := newLoadLog()
 	defer loadLog.AtExit()
 	loaded, err := networkHistoryService.LoadNetworkHistoryIntoDatanodeWithLog(context.Background(), loadLog, *contiguousHistory,
-		cmd.Config.SQLStore.ConnectionConfig, withIndexesAndOrderTriggers)
+		cmd.Config.SQLStore.ConnectionConfig, withIndexesAndOrderTriggers, bool(cmd.Config.SQLStore.VerboseMigration))
 	if err != nil {
 		return fmt.Errorf("failed to load all available history:%w", err)
 	}

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -93,7 +93,8 @@ func (l *NodeCommand) persistentPre([]string) (err error) {
 	}
 
 	if l.conf.SQLStore.WipeOnStartup {
-		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(l.Log, l.conf.SQLStore.ConnectionConfig, sqlstore.EmbedMigrations); err != nil {
+		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(l.Log, l.conf.SQLStore.ConnectionConfig, sqlstore.EmbedMigrations,
+			bool(l.conf.SQLStore.VerboseMigration)); err != nil {
 			return fmt.Errorf("failed to wiped database:%w", err)
 		}
 		l.Log.Info("Wiped all existing data from the datanode")
@@ -120,7 +121,8 @@ func (l *NodeCommand) persistentPre([]string) (err error) {
 			apiPorts = append(apiPorts, l.conf.NetworkHistory.Initialise.GrpcAPIPorts...)
 
 			if err = networkhistory.InitialiseDatanodeFromNetworkHistory(l.ctx, l.conf.NetworkHistory.Initialise,
-				l.Log, l.conf.SQLStore.ConnectionConfig, l.networkHistoryService, apiPorts); err != nil {
+				l.Log, l.conf.SQLStore.ConnectionConfig, l.networkHistoryService, apiPorts,
+				bool(l.conf.SQLStore.VerboseMigration)); err != nil {
 				return fmt.Errorf("failed to initialize datanode from network history: %w", err)
 			}
 

--- a/datanode/networkhistory/initialise_test.go
+++ b/datanode/networkhistory/initialise_test.go
@@ -87,9 +87,9 @@ func TestInitialiseEmptyDataNode(t *testing.T) {
 			TestSegment{HeightFrom: 0, HeightTo: 1000},
 			TestSegment{HeightFrom: 1001, HeightTo: 2000},
 		},
-	}, gomock.Any(), false).Times(1)
+	}, gomock.Any(), false, false).Times(1)
 
-	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{})
+	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{}, false)
 }
 
 func TestInitialiseNonEmptyDataNode(t *testing.T) {
@@ -140,7 +140,7 @@ func TestInitialiseNonEmptyDataNode(t *testing.T) {
 			TestSegment{HeightFrom: 2001, HeightTo: 3000},
 			TestSegment{HeightFrom: 3001, HeightTo: 4000},
 		},
-	}, gomock.Any(), true).Times(1)
+	}, gomock.Any(), true, false).Times(1)
 
 	service.EXPECT().GetDatanodeBlockSpan(gomock.Any()).Times(1).Return(sqlstore.DatanodeBlockSpan{
 		FromHeight: 0,
@@ -148,7 +148,7 @@ func TestInitialiseNonEmptyDataNode(t *testing.T) {
 		HasData:    true,
 	}, nil)
 
-	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{})
+	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{}, false)
 }
 
 func TestLoadingHistoryWithinDatanodeCurrentSpanDoesNothing(t *testing.T) {
@@ -184,7 +184,7 @@ func TestLoadingHistoryWithinDatanodeCurrentSpanDoesNothing(t *testing.T) {
 		HasData:    true,
 	}, nil)
 
-	assert.Nil(t, networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{}))
+	assert.Nil(t, networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{}, false))
 }
 
 func TestWhenMinimumBlockCountExceedsAvailableHistory(t *testing.T) {
@@ -236,10 +236,10 @@ func TestWhenMinimumBlockCountExceedsAvailableHistory(t *testing.T) {
 			TestSegment{HeightFrom: 0, HeightTo: 1000},
 			TestSegment{HeightFrom: 1001, HeightTo: 2000},
 		},
-	}, gomock.Any(), false).Times(1)
+	}, gomock.Any(), false, false).Times(1)
 
 	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig,
-		service, []int{})
+		service, []int{}, false)
 }
 
 func TestInitialiseToASpecifiedSegment(t *testing.T) {
@@ -269,10 +269,10 @@ func TestInitialiseToASpecifiedSegment(t *testing.T) {
 		SegmentsOldestFirst: []networkhistory.Segment{
 			TestSegment{HeightFrom: 0, HeightTo: 1000},
 		},
-	}, gomock.Any(), false).Times(1)
+	}, gomock.Any(), false, false).Times(1)
 
 	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig,
-		service, []int{})
+		service, []int{}, false)
 }
 
 func TestAutoInitialiseWhenNoActivePeers(t *testing.T) {
@@ -291,7 +291,7 @@ func TestAutoInitialiseWhenNoActivePeers(t *testing.T) {
 	service.EXPECT().GetDatanodeBlockSpan(gomock.Any()).Times(1).Return(sqlstore.DatanodeBlockSpan{}, nil)
 
 	assert.NotNil(t, networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig,
-		service, []int{}))
+		service, []int{}, false))
 }
 
 func TestAutoInitialiseWhenNoHistoryAvailableFromPeers(t *testing.T) {
@@ -310,7 +310,7 @@ func TestAutoInitialiseWhenNoHistoryAvailableFromPeers(t *testing.T) {
 	service.EXPECT().GetDatanodeBlockSpan(gomock.Any()).Times(1).Return(sqlstore.DatanodeBlockSpan{}, nil)
 
 	assert.NotNil(t, networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig,
-		service, []int{}))
+		service, []int{}, false))
 }
 
 func TestInitialiseEmptyDataNodeWhenMultipleContiguousHistories(t *testing.T) {
@@ -364,9 +364,9 @@ func TestInitialiseEmptyDataNodeWhenMultipleContiguousHistories(t *testing.T) {
 				TestSegment{HeightFrom: 5001, HeightTo: 6000},
 				TestSegment{HeightFrom: 6001, HeightTo: 7000},
 			},
-		}, gomock.Any(), false).Times(1)
+		}, gomock.Any(), false, false).Times(1)
 
-	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{})
+	networkhistory.InitialiseDatanodeFromNetworkHistory(ctx, cfg, log, sqlstore.NewDefaultConfig().ConnectionConfig, service, []int{}, false)
 }
 
 func TestSelectRootSegment(t *testing.T) {

--- a/datanode/networkhistory/mocks/networkhistory_service_mock.go
+++ b/datanode/networkhistory/mocks/networkhistory_service_mock.go
@@ -100,16 +100,16 @@ func (mr *MockNetworkHistoryMockRecorder) ListAllHistorySegments() *gomock.Call 
 }
 
 // LoadNetworkHistoryIntoDatanode mocks base method.
-func (m *MockNetworkHistory) LoadNetworkHistoryIntoDatanode(arg0 context.Context, arg1 networkhistory.ContiguousHistory, arg2 sqlstore.ConnectionConfig, arg3 bool) (snapshot.LoadResult, error) {
+func (m *MockNetworkHistory) LoadNetworkHistoryIntoDatanode(arg0 context.Context, arg1 networkhistory.ContiguousHistory, arg2 sqlstore.ConnectionConfig, arg3, arg4 bool) (snapshot.LoadResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadNetworkHistoryIntoDatanode", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "LoadNetworkHistoryIntoDatanode", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(snapshot.LoadResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadNetworkHistoryIntoDatanode indicates an expected call of LoadNetworkHistoryIntoDatanode.
-func (mr *MockNetworkHistoryMockRecorder) LoadNetworkHistoryIntoDatanode(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockNetworkHistoryMockRecorder) LoadNetworkHistoryIntoDatanode(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadNetworkHistoryIntoDatanode", reflect.TypeOf((*MockNetworkHistory)(nil).LoadNetworkHistoryIntoDatanode), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadNetworkHistoryIntoDatanode", reflect.TypeOf((*MockNetworkHistory)(nil).LoadNetworkHistoryIntoDatanode), arg0, arg1, arg2, arg3, arg4)
 }

--- a/datanode/networkhistory/service.go
+++ b/datanode/networkhistory/service.go
@@ -221,13 +221,13 @@ func (d *Service) GetSwarmKeySeed() string {
 }
 
 func (d *Service) LoadNetworkHistoryIntoDatanode(ctx context.Context, contiguousHistory ContiguousHistory,
-	connConfig sqlstore.ConnectionConfig, withIndexesAndOrderTriggers bool,
+	connConfig sqlstore.ConnectionConfig, withIndexesAndOrderTriggers, verbose bool,
 ) (snapshot.LoadResult, error) {
-	return d.LoadNetworkHistoryIntoDatanodeWithLog(ctx, d.log, contiguousHistory, connConfig, withIndexesAndOrderTriggers)
+	return d.LoadNetworkHistoryIntoDatanodeWithLog(ctx, d.log, contiguousHistory, connConfig, withIndexesAndOrderTriggers, verbose)
 }
 
 func (d *Service) LoadNetworkHistoryIntoDatanodeWithLog(ctx context.Context, loadLog snapshot.LoadLog, contiguousHistory ContiguousHistory,
-	connConfig sqlstore.ConnectionConfig, withIndexesAndOrderTriggers bool,
+	connConfig sqlstore.ConnectionConfig, withIndexesAndOrderTriggers, verbose bool,
 ) (snapshot.LoadResult, error) {
 	defer func() { _ = fsutil.RemoveAllFromDirectoryIfExists(d.snapshotsCopyFromDir) }()
 
@@ -262,7 +262,7 @@ func (d *Service) LoadNetworkHistoryIntoDatanodeWithLog(ctx context.Context, loa
 	}
 
 	loadResult, err := d.snapshotService.LoadSnapshotData(ctx, loadLog, currentStateSnapshot, historySnapshots, d.snapshotsCopyFromDir,
-		connConfig, withIndexesAndOrderTriggers)
+		connConfig, withIndexesAndOrderTriggers, verbose)
 	if err != nil {
 		return snapshot.LoadResult{}, fmt.Errorf("failed to load snapshot data:%w", err)
 	}

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -447,7 +447,7 @@ func TestRestoringNodeThatAlreadyContainsData(t *testing.T) {
 	require.NoError(t, err)
 
 	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, false)
+		sqlConfig.ConnectionConfig, false, false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1801), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(4000), loaded.LoadedToHeight)
@@ -530,7 +530,8 @@ func TestRestoringNodeWithDataOlderAndNewerThanItContainsLoadsTheNewerData(t *te
 	segments, err := networkhistoryService.ListAllHistorySegments()
 	require.NoError(t, err)
 
-	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments), sqlConfig.ConnectionConfig, false)
+	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
+		sqlConfig.ConnectionConfig, false, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(3001), loaded.LoadedFromHeight)
@@ -553,7 +554,7 @@ func TestRestoringNodeWithDataOlderAndNewerThanItContainsLoadsTheNewerData(t *te
 	require.NoError(t, err)
 
 	result, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, false)
+		sqlConfig.ConnectionConfig, false, false)
 	require.Nil(t, err)
 
 	assert.Equal(t, int64(4001), result.LoadedFromHeight)
@@ -591,7 +592,7 @@ func TestRestoringNodeWithHistoryOnlyFromBeforeTheNodesOldestBlockFails(t *testi
 	require.NoError(t, err)
 
 	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx,
-		*networkhistory.GetMostRecentContiguousHistory(segments), sqlConfig.ConnectionConfig, false)
+		*networkhistory.GetMostRecentContiguousHistory(segments), sqlConfig.ConnectionConfig, false, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(3001), loaded.LoadedFromHeight)
@@ -614,7 +615,7 @@ func TestRestoringNodeWithHistoryOnlyFromBeforeTheNodesOldestBlockFails(t *testi
 	require.NoError(t, err)
 
 	_, err = networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, false)
+		sqlConfig.ConnectionConfig, false, false)
 	require.NotNil(t, err)
 }
 
@@ -674,7 +675,7 @@ func TestRestoringNodeWithExistingDataFailsWhenLoadingWouldResultInNonContiguous
 	require.NoError(t, err)
 
 	_, err = networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, false)
+		sqlConfig.ConnectionConfig, false, false)
 	require.NotNil(t, err)
 }
 
@@ -707,7 +708,7 @@ func TestRestoringFromDifferentHeightsWithFullHistory(t *testing.T) {
 		require.NoError(t, err)
 
 		loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-			sqlConfig.ConnectionConfig, false)
+			sqlConfig.ConnectionConfig, false, false)
 		require.NoError(t, err)
 
 		assert.Equal(t, int64(1), loaded.LoadedFromHeight)
@@ -743,7 +744,7 @@ func TestRestoreFromPartialHistoryAndProcessEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, false)
+		sqlConfig.ConnectionConfig, false, false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2001), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(3000), loaded.LoadedToHeight)
@@ -832,7 +833,7 @@ func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, false)
+		sqlConfig.ConnectionConfig, false, false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(2000), loaded.LoadedToHeight)
@@ -932,7 +933,7 @@ func TestRestoreFromFullHistorySnapshotWithIndexesAndOrderTriggersAndProcessEven
 	require.NoError(t, err)
 
 	loaded, err := networkhistoryService.LoadNetworkHistoryIntoDatanode(ctx, *networkhistory.GetMostRecentContiguousHistory(segments),
-		sqlConfig.ConnectionConfig, true)
+		sqlConfig.ConnectionConfig, true, false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), loaded.LoadedFromHeight)
 	assert.Equal(t, int64(2000), loaded.LoadedToHeight)
@@ -1071,7 +1072,7 @@ func emptyDatabaseAndSetSchemaVersion(schemaVersion int64) {
 	db.Close()
 
 	for i := 0; i < 5; i++ {
-		err = sqlstore.WipeDatabaseAndMigrateSchemaToVersion(logging.NewTestLogger(), sqlConfig.ConnectionConfig, schemaVersion, sqlFs)
+		err = sqlstore.WipeDatabaseAndMigrateSchemaToVersion(logging.NewTestLogger(), sqlConfig.ConnectionConfig, schemaVersion, sqlFs, false)
 		if err == nil {
 			break
 		}

--- a/datanode/networkhistory/snapshot/service_load_snapshot.go
+++ b/datanode/networkhistory/snapshot/service_load_snapshot.go
@@ -41,7 +41,7 @@ type LoadLog interface {
 }
 
 func (b *Service) LoadSnapshotData(ctx context.Context, log LoadLog, currentStateSnapshot CurrentState,
-	contiguousHistory []History, sourceDir string, connConfig sqlstore.ConnectionConfig, withIndexesAndOrderTriggers bool,
+	contiguousHistory []History, sourceDir string, connConfig sqlstore.ConnectionConfig, withIndexesAndOrderTriggers, verbose bool,
 ) (LoadResult, error) {
 	datanodeBlockSpan, err := sqlstore.GetDatanodeBlockSpan(ctx, b.connPool)
 	if err != nil {
@@ -59,7 +59,7 @@ func (b *Service) LoadSnapshotData(ctx context.Context, log LoadLog, currentStat
 	if datanodeBlockSpan.HasData {
 		heightToLoadFrom = datanodeBlockSpan.ToHeight + 1
 	} else {
-		sqlstore.RevertToSchemaVersionZero(b.log, connConfig, sqlstore.EmbedMigrations)
+		sqlstore.RevertToSchemaVersionZero(b.log, connConfig, sqlstore.EmbedMigrations, verbose)
 		heightToLoadFrom = historyFromHeight
 	}
 

--- a/datanode/sqlstore/config.go
+++ b/datanode/sqlstore/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	LogRotationConfig                                  LogRotationConfig     `group:"LogRotationConfig" namespace:"LogRotationConfig"`
 	DisableMinRetentionPolicyCheckForUseInSysTestsOnly encoding.Bool         `long:"disable-min-retention-policy-use-in-sys-test-only" description:"Disables the minimum retention policy interval check - only for use in system tests"`
 	RetentionPeriod                                    RetentionPeriod       `long:"retention-period" description:"Set the retention level for the database. standard, archive, or lite"`
+	VerboseMigration                                   encoding.Bool         `long:"verbose-migration" description:"Enable verbose logging of SQL migrations"`
 }
 
 type ConnectionConfig struct {
@@ -139,6 +140,7 @@ func NewDefaultConfig() Config {
 			MaxSize: 100,
 			MaxAge:  2,
 		},
-		RetentionPeriod: RetentionPeriodStandard,
+		RetentionPeriod:  RetentionPeriodStandard,
+		VerboseMigration: false,
 	}
 }

--- a/datanode/sqlstore/sqlstore.go
+++ b/datanode/sqlstore/sqlstore.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 Gobalsky Labs Limited
+
 //
 // Use of this software is governed by the Business Source License included
 // in the LICENSE.DATANODE file and at https://www.mariadb.com/bsl11.
@@ -87,6 +88,7 @@ var defaultRetentionPolicies = map[RetentionPeriod][]RetentionPolicy{
 func MigrateToLatestSchema(log *logging.Logger, config Config) error {
 	goose.SetBaseFS(EmbedMigrations)
 	goose.SetLogger(log.Named("db migration").GooseLogger())
+	goose.SetVerbose(bool(config.VerboseMigration))
 
 	poolConfig, err := config.ConnectionConfig.GetPoolConfig()
 	if err != nil {
@@ -96,9 +98,11 @@ func MigrateToLatestSchema(log *logging.Logger, config Config) error {
 	db := stdlib.OpenDB(*poolConfig.ConnConfig)
 	defer db.Close()
 
+	log.Info("Checking database version and migrating sql schema to latest version, please wait...")
 	if err = goose.Up(db, SQLMigrationsDir); err != nil {
 		return fmt.Errorf("error migrating sql schema: %w", err)
 	}
+	log.Info("Sql schema migration completed successfully")
 
 	return nil
 }
@@ -106,6 +110,8 @@ func MigrateToLatestSchema(log *logging.Logger, config Config) error {
 func MigrateToSchemaVersion(log *logging.Logger, config Config, version int64, fs fs.FS) error {
 	goose.SetBaseFS(fs)
 	goose.SetLogger(log.Named("db migration").GooseLogger())
+	goose.SetVerbose(bool(config.VerboseMigration))
+	goose.SetVerbose(true)
 
 	poolConfig, err := config.ConnectionConfig.GetPoolConfig()
 	if err != nil {
@@ -115,16 +121,19 @@ func MigrateToSchemaVersion(log *logging.Logger, config Config, version int64, f
 	db := stdlib.OpenDB(*poolConfig.ConnConfig)
 	defer db.Close()
 
+	log.Infof("Checking database version and migrating sql schema to version %d, please wait...", version)
 	if err = goose.UpTo(db, SQLMigrationsDir, version); err != nil {
 		return fmt.Errorf("error migrating sql schema: %w", err)
 	}
+	log.Info("Sql schema migration completed successfully")
 
 	return nil
 }
 
-func RevertToSchemaVersionZero(log *logging.Logger, config ConnectionConfig, fs fs.FS) error {
+func RevertToSchemaVersionZero(log *logging.Logger, config ConnectionConfig, fs fs.FS, verbose bool) error {
 	goose.SetBaseFS(fs)
 	goose.SetLogger(log.Named("revert schema to version 0").GooseLogger())
+	goose.SetVerbose(verbose)
 
 	poolConfig, err := config.GetPoolConfig()
 	if err != nil {
@@ -134,16 +143,19 @@ func RevertToSchemaVersionZero(log *logging.Logger, config ConnectionConfig, fs 
 	db := stdlib.OpenDB(*poolConfig.ConnConfig)
 	defer db.Close()
 
+	log.Info("Checking database version and reverting sql schema to version 0, please wait...")
 	if err := goose.DownTo(db, SQLMigrationsDir, 0); err != nil {
 		return fmt.Errorf("failed to goose down the schema to version 0: %w", err)
 	}
+	log.Info("Sql schema migration completed successfully")
 
 	return nil
 }
 
-func WipeDatabaseAndMigrateSchemaToVersion(log *logging.Logger, config ConnectionConfig, version int64, fs fs.FS) error {
+func WipeDatabaseAndMigrateSchemaToVersion(log *logging.Logger, config ConnectionConfig, version int64, fs fs.FS, verbose bool) error {
 	goose.SetBaseFS(fs)
 	goose.SetLogger(log.Named("wipe database").GooseLogger())
+	goose.SetVerbose(verbose)
 
 	poolConfig, err := config.GetPoolConfig()
 	if err != nil {
@@ -158,6 +170,7 @@ func WipeDatabaseAndMigrateSchemaToVersion(log *logging.Logger, config Connectio
 		return err
 	}
 
+	log.Infof("Wiping database and migrating schema to version %d", version)
 	if currentVersion > 0 {
 		if err := goose.DownTo(db, SQLMigrationsDir, 0); err != nil {
 			return fmt.Errorf("failed to goose down the schema: %w", err)
@@ -169,13 +182,15 @@ func WipeDatabaseAndMigrateSchemaToVersion(log *logging.Logger, config Connectio
 			return fmt.Errorf("failed to goose up the schema: %w", err)
 		}
 	}
+	log.Info("Sql schema migration completed successfully")
 
 	return nil
 }
 
-func WipeDatabaseAndMigrateSchemaToLatestVersion(log *logging.Logger, config ConnectionConfig, fs fs.FS) error {
+func WipeDatabaseAndMigrateSchemaToLatestVersion(log *logging.Logger, config ConnectionConfig, fs fs.FS, verbose bool) error {
 	goose.SetBaseFS(fs)
 	goose.SetLogger(log.Named("wipe database").GooseLogger())
+	goose.SetVerbose(verbose)
 
 	poolConfig, err := config.GetPoolConfig()
 	if err != nil {
@@ -190,6 +205,7 @@ func WipeDatabaseAndMigrateSchemaToLatestVersion(log *logging.Logger, config Con
 		return err
 	}
 
+	log.Info("Wiping database and migrating schema to latest version")
 	if currentVersion > 0 {
 		if err := goose.DownTo(db, SQLMigrationsDir, 0); err != nil {
 			return fmt.Errorf("failed to goose down the schema: %w", err)
@@ -199,6 +215,8 @@ func WipeDatabaseAndMigrateSchemaToLatestVersion(log *logging.Logger, config Con
 	if err := goose.Up(db, SQLMigrationsDir); err != nil {
 		return fmt.Errorf("failed to goose up the schema: %w", err)
 	}
+	log.Info("Sql schema migration completed successfully")
+
 	return nil
 }
 

--- a/datanode/utils/databasetest/setup.go
+++ b/datanode/utils/databasetest/setup.go
@@ -77,7 +77,7 @@ func TestMain(m *testing.M, onSetupComplete func(sqlstore.Config, *sqlstore.Conn
 		}
 		defer embeddedPostgres.Stop()
 
-		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(log, sqlConfig.ConnectionConfig, sqlFs); err != nil {
+		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(log, sqlConfig.ConnectionConfig, sqlFs, false); err != nil {
 			panic(err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -326,7 +326,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/rpc v1.2.0
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect


### PR DESCRIPTION
Closes #7564 

Goose logging is extremely verbose, i.e. it prints out all the migrations scripts and more, so I've made it optional and added a configuration setting in the configs.

Otherwise, the migrations all end with the same message, and it's something visor can monitor for if a migration is taking place.