### PR TITLE
feat: include the ap version in the block hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - [7509](https://github.com/vegaprotocol/vega/issues/7509) - Automatically reconcile account balance changes with transfer events after each integration test step
 - [7564](https://github.com/vegaprotocol/vega/issues/7564) - Add logging when database migrations are run
 - [7546](https://github.com/vegaprotocol/vega/issues/7546) - Visor automatically uses snapshot on core based on latest data node snapshot.
-- [7576](https://github.com/vegaprotocol/vega/issues/7576) - include the ap version in the block hash
+- [7576](https://github.com/vegaprotocol/vega/issues/7576) - include the application version in the block hash
 
 ### 🐛 Fixes
 - [7422](https://github.com/vegaprotocol/vega/issues/7422) - Fix missing `priceMonitoringParameters` and `liquidityMonitoringParameters` in `GraphQL` schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [7509](https://github.com/vegaprotocol/vega/issues/7509) - Automatically reconcile account balance changes with transfer events after each integration test step
 - [7564](https://github.com/vegaprotocol/vega/issues/7564) - Add logging when database migrations are run
 - [7546](https://github.com/vegaprotocol/vega/issues/7546) - Visor automatically uses snapshot on core based on latest data node snapshot.
+- [7576](https://github.com/vegaprotocol/vega/issues/7576) - include the ap version in the block hash
 
 ### 🐛 Fixes
 - [7422](https://github.com/vegaprotocol/vega/issues/7422) - Fix missing `priceMonitoringParameters` and `liquidityMonitoringParameters` in `GraphQL` schema

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -882,7 +882,8 @@ func (app *App) OnCommit() (resp tmtypes.ResponseCommit) {
 	resp.Data = snapHash
 
 	if len(snapHash) == 0 {
-		resp.Data = app.exec.Hash()
+		resp.Data = crypto.Hash([]byte(app.version))
+		resp.Data = append(resp.Data, app.exec.Hash()...)
 		resp.Data = append(resp.Data, app.delegation.Hash()...)
 		resp.Data = append(resp.Data, app.gov.Hash()...)
 		resp.Data = append(resp.Data, app.stakingAccounts.Hash()...)


### PR DESCRIPTION
Closes #7576

Include application version to the block hash such that nodes running with an older/newer version then the latest will fall out of consensus. 