### PR TITLE
Add steps to check number of events

### DIFF
--- a/core/integration/features/closeouts/position-resolution-after-auction.feature
+++ b/core/integration/features/closeouts/position-resolution-after-auction.feature
@@ -55,7 +55,7 @@ Feature: Set up a market with an opening auction, then uncross the book so that 
     And the insurance pool balance should be "0" for the market "ETH/DEC19"
     And the parties should have the following account balances:
       | party  | asset | market id | margin |  general |   bond |
-      | party1 | BTC   | ETH/DEC19 | 0      |        0 |      0 |
+      | party1 | BTC   | ETH/DEC19 | 0      |        0 |        |
       |     lp | BTC   | ETH/DEC19 | 82560  | 99776968 | 160000 | 
     # sum of lp accounts = 100019528
     # lp started with 100000000, should've made 8*(10000-5900)=32800 in MTM gains following the closeout,

--- a/core/integration/features/margin/6202-release-excess-on-amend.feature
+++ b/core/integration/features/margin/6202-release-excess-on-amend.feature
@@ -59,9 +59,9 @@ Feature: test margin during amending orders
 
     # check the requried balances
     And the parties should have the following account balances:
-      | party  | asset | market id | margin | general  | bond |
-      | party1 | USD   | ETH/MAR22 | 19218  | 99980782 | 0    |
-      | party4 | USD   | ETH/MAR22 | 93902  | 99906098 | 0    |
+      | party  | asset | market id | margin | general  |
+      | party1 | USD   | ETH/MAR22 | 19218  | 99980782 |
+      | party4 | USD   | ETH/MAR22 | 93902  | 99906098 |
 
     #margin for party4: 20*1000*3.5569036=71139
 
@@ -77,9 +77,9 @@ Feature: test margin during amending orders
       | party4 | sell-ref-4 | 1100  | 20         | TIF_GTC |
 
     And the parties should have the following account balances:
-      | party  | asset | market id | margin | general  | bond |
-      | party1 | USD   | ETH/MAR22 | 1922   | 99998078 | 0    |
-      | party4 | USD   | ETH/MAR22 | 170732 | 99829268 | 0    |
+      | party  | asset | market id | margin | general  |
+      | party1 | USD   | ETH/MAR22 | 1922   | 99998078 |
+      | party4 | USD   | ETH/MAR22 | 170732 | 99829268 |
     #check the margin levels
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
@@ -93,8 +93,7 @@ Feature: test margin during amending orders
 
     And the network moves ahead "1" blocks
 
-
     And the parties should have the following account balances:
-      | party  | asset | market id | margin | general   | bond |
-      | party1 | USD   | ETH/MAR22 | 0      | 100000000 | 0    |
-      | party4 | USD   | ETH/MAR22 | 0      | 100000000 | 0    |
+      | party  | asset | market id | margin | general   |
+      | party1 | USD   | ETH/MAR22 | 0      | 100000000 |
+      | party4 | USD   | ETH/MAR22 | 0      | 100000000 |

--- a/core/integration/features/verified/0019-MCAL-margin_calculator-risk_parameters.feature
+++ b/core/integration/features/verified/0019-MCAL-margin_calculator-risk_parameters.feature
@@ -142,8 +142,8 @@ Feature: test risk model parameter change in margin calculation
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR21 | 9937   | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR21 | 3333   | 99984664 | 0     |
-      | party2 | USD   | ETH/MAR21 | 3645   | 99982284 | 0     |
+      | party1 | USD   | ETH/MAR21 | 3333   | 99984664 |       |
+      | party2 | USD   | ETH/MAR21 | 3645   | 99982284 |       |
 
     #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.145263949*1000 + 1*0.145263949*1000=2778
     Then the parties should have the following margin levels:
@@ -156,8 +156,8 @@ Feature: test risk model parameter change in margin calculation
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 19701  | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 4982   | 99984664 | 0     |
-      | party2 | USD   | ETH/MAR22 | 6232   | 99982284 | 0     |
+      | party1 | USD   | ETH/MAR22 | 4982   | 99984664 |       |
+      | party2 | USD   | ETH/MAR22 | 6232   | 99982284 |       |
 
     #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.270133394*1000 + 1*0.270133394*1000=4152
     Then the parties should have the following margin levels:
@@ -170,8 +170,8 @@ Feature: test risk model parameter change in margin calculation
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR23 | 13632  | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR23 | 4047   | 99984664 | 0     |
-      | party2 | USD   | ETH/MAR23 | 4670   | 99982284 | 0     |
+      | party1 | USD   | ETH/MAR23 | 4047   | 99984664 |       |
+      | party2 | USD   | ETH/MAR23 | 4670   | 99982284 |       |
 
     #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.199294303*1000 + 1*0.199294303*1000=3373
     Then the parties should have the following margin levels:
@@ -185,8 +185,8 @@ Feature: test risk model parameter change in margin calculation
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR24 | 8077   | 248653   | 50000 |
-      | party1 | USD   | ETH/MAR24 | 2974   | 99984664 | 0     |
-      | party2 | USD   | ETH/MAR24 | 3169   | 99982284 | 0     |
+      | party1 | USD   | ETH/MAR24 | 2974   | 99984664 |       |
+      | party2 | USD   | ETH/MAR24 | 3169   | 99982284 |       |
 
     #party1 margin level is: margin_position+margin_order = vol * (MarkPrice-ExitPrice)+ vol * rf * MarkPrice + order * rf * MarkPrice = 10 * (1000-882)+10*0.118078679*1000 + 1*0.118078679*1000=2479
     Then the parties should have the following margin levels:

--- a/core/integration/features/verified/0042-LIQF-fees_rewards.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards.feature
@@ -85,8 +85,8 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 1320   | 999988680 | 10000 |
-      | party1 | USD   | ETH/MAR22 | 1704   | 99998296  | 0     |
-      | party2 | USD   | ETH/MAR22 | 1692   | 99998308  | 0     |
+      | party1 | USD   | ETH/MAR22 | 1704   | 99998296  |       |
+      | party2 | USD   | ETH/MAR22 | 1692   | 99998308  |       |
 
     Then the network moves ahead "1" blocks
 
@@ -104,8 +104,8 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 2870   | 999986742 | 10000 |
-      | party1 | USD   | ETH/MAR22 | 1317   | 99998688  | 0     |
-      | party2 | USD   | ETH/MAR22 | 1932   | 99998411  | 0     |
+      | party1 | USD   | ETH/MAR22 | 1317   | 99998688  |       |
+      | party2 | USD   | ETH/MAR22 | 1932   | 99998411  |       |
 
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/MAR22"
     And the accumulated liquidity fees should be "20" for the market "ETH/MAR22"

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
@@ -86,8 +86,8 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 2870   | 999986742 | 10000 |
-      | party1 | USD   | ETH/MAR22 | 1317   | 99998688  | 0     |
-      | party2 | USD   | ETH/MAR22 | 1932   | 99998411  | 0     |
+      | party1 | USD   | ETH/MAR22 | 1317   | 99998688  |       |
+      | party2 | USD   | ETH/MAR22 | 1932   | 99998411  |       |
 
     And the accumulated liquidity fees should be "20" for the market "ETH/MAR22"
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
@@ -80,11 +80,19 @@ Feature: Test liquidity provider reward distribution; Check what happens when di
       | party | equity like share | average entry valuation |
       | lp1   | 1                 | 10000                   |
 
+
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 1320   | 999988680 | 10000 |
       | party1 | USD   | ETH/MAR22 | 1704   | 99998296  |       |
       | party2 | USD   | ETH/MAR22 | 1692   | 99998308  |       |
+
+    # party1 margin = 11*1000*0.1 + 10*(1000-968) = 1420
+    # party2 margin = 11*1000*0.1 + 10*(1031-1000)= 1410
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | initial |
+      | party1 | ETH/MAR22 | 1420        | 1704    |
+      | party2 | ETH/MAR22 | 1410        | 1692    |
 
     Then the network moves ahead "1" blocks
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_large_distribution_time.feature
@@ -83,8 +83,8 @@ Feature: Test liquidity provider reward distribution; Check what happens when di
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 1320   | 999988680 | 10000 |
-      | party1 | USD   | ETH/MAR22 | 2520   | 99997480  | 0     |
-      | party2 | USD   | ETH/MAR22 | 2520   | 99997480  | 0     |
+      | party1 | USD   | ETH/MAR22 | 1704   | 99998296  |       |
+      | party2 | USD   | ETH/MAR22 | 1692   | 99998308  |       |
 
     Then the network moves ahead "1" blocks
 
@@ -102,8 +102,8 @@ Feature: Test liquidity provider reward distribution; Check what happens when di
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 2870   | 999986742 | 10000 |
-      | party1 | USD   | ETH/MAR22 | 1317   | 99998688  | 0     |
-      | party2 | USD   | ETH/MAR22 | 1932   | 99998411  | 0     |
+      | party1 | USD   | ETH/MAR22 | 1317   | 99998688  |       |
+      | party2 | USD   | ETH/MAR22 | 1932   | 99998411  |       |
 
     Then the order book should have the following volumes for market "ETH/MAR22":
       | side | price | volume |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_multi_lps.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_multi_lps.feature
@@ -87,8 +87,8 @@ Feature: Test liquidity provider reward distribution when there are multiple liq
       | lp1    | USD   | ETH/MAR22 | 53353554   | 9999946636446 | 10000      |
       | lp2    | USD   | ETH/MAR22 | 53353554   | 9999945646446 | 1000000    |
       | lp3    | USD   | ETH/MAR22 | 4801819849 | 9994198180151 | 1000000000 |
-      | party1 | USD   | ETH/MAR22 | 228207540  | 999771792460  | 0          |
-      | party2 | USD   | ETH/MAR22 | 1120424632 | 98879575368   | 0          |
+      | party1 | USD   | ETH/MAR22 | 228207540  | 999771792460  |            |
+      | party2 | USD   | ETH/MAR22 | 1120424632 | 98879575368   |            |
 
     Then the network moves ahead "1" blocks
 
@@ -104,8 +104,8 @@ Feature: Test liquidity provider reward distribution when there are multiple liq
       | lp1    | USD   | ETH/MAR22 | 53353554   | 9999946636446 | 10000      |
       | lp2    | USD   | ETH/MAR22 | 53353554   | 9999945646446 | 1000000    |
       | lp3    | USD   | ETH/MAR22 | 4801819849 | 9994198180151 | 1000000000 |
-      | party1 | USD   | ETH/MAR22 | 548535540  | 999451544460  | 0          |
-      | party2 | USD   | ETH/MAR22 | 135109231  | 99864010769   | 0          |
+      | party1 | USD   | ETH/MAR22 | 548535540  | 999451544460  |            |
+      | party2 | USD   | ETH/MAR22 | 135109231  | 99864010769   |            |
 
     Then the order book should have the following volumes for market "ETH/MAR22":
       | side | price | volume |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -457,8 +457,8 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 170732 | 999789268 | 40000 |
-      | party1 | USD   | ETH/MAR22 | 10464  | 99989536  |     0 |
-      | party2 | USD   | ETH/MAR22 | 47374  | 99952626  |     0 |
+      | party1 | USD   | ETH/MAR22 | 10464  | 99989536  |       |
+      | party2 | USD   | ETH/MAR22 | 47374  | 99952626  |       |
 
     Then the network moves ahead "1" blocks
 

--- a/core/integration/features/verified/0070-MKTD-market-decimal-places.feature
+++ b/core/integration/features/verified/0070-MKTD-market-decimal-places.feature
@@ -94,14 +94,14 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond |
             | party0 | ETH   | USD/DEC21 | 4268   | 4985006  | 1000 |
-            | party1 | ETH   | USD/DEC21 | 1081   | 99996736 | 0    |
-            | party2 | ETH   | USD/DEC21 | 4268   | 99987196 | 0    |
+            | party1 | ETH   | USD/DEC21 | 1081   | 99996736 |      |
+            | party2 | ETH   | USD/DEC21 | 4268   | 99987196 |      |
             | party0 | ETH   | USD/DEC20 | 3884   | 4985006  | 1000 |
-            | party1 | ETH   | USD/DEC20 | 1081   | 99996736 | 0    |
-            | party2 | ETH   | USD/DEC20 | 4268   | 99987196 | 0    |
+            | party1 | ETH   | USD/DEC20 | 1081   | 99996736 |      |
+            | party2 | ETH   | USD/DEC20 | 4268   | 99987196 |      |
             | party0 | ETH   | USD/DEC19 | 3842   | 4985006  | 1000 |
-            | party1 | ETH   | USD/DEC19 | 1102   | 99996736 | 0    |
-            | party2 | ETH   | USD/DEC19 | 4268   | 99987196 | 0    |
+            | party1 | ETH   | USD/DEC19 | 1102   | 99996736 |      |
+            | party2 | ETH   | USD/DEC19 | 4268   | 99987196 |      |
 
     Scenario: 002: Users engage in a USD market auction, (0070-MKTD-003, 0070-MKTD-008)
         Given the parties submit the following liquidity provision:
@@ -124,8 +124,8 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | USD   | ETH/MAR22 | 342072 | 4622359  | 35569 |
-            | party1 | USD   | ETH/MAR22 | 20410  | 99979590 | 0     |
-            | party2 | USD   | ETH/MAR22 | 59979  | 99940021 | 0     |
+            | party1 | USD   | ETH/MAR22 | 20410  | 99979590 |       |
+            | party2 | USD   | ETH/MAR22 | 59979  | 99940021 |       |
         And the following trades should be executed:
             | buyer  | price | size | seller |
             | party1 | 10    | 10   | party2 |
@@ -150,8 +150,8 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC19 | 207439 | 4742561  | 50000 |
-            | party1 | ETH   | USD/DEC19 | 1292   | 99998708 | 0     |
-            | party2 | ETH   | USD/DEC19 | 5169   | 99994831 | 0     |
+            | party1 | ETH   | USD/DEC19 | 1292   | 99998708 |       |
+            | party2 | ETH   | USD/DEC19 | 5169   | 99994831 |       |
         And the following trades should be executed:
             | buyer  | price | size | seller |
             | party1 | 1000  | 10   | party2 |
@@ -177,8 +177,8 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond |
             | party0 | ETH   | USD/DEC20 | 2113   | 4997387  | 500  |
-            | party1 | ETH   | USD/DEC20 | 12     | 99999988 | 0    |
-            | party2 | ETH   | USD/DEC20 | 52     | 99999948 | 0    |
+            | party1 | ETH   | USD/DEC20 | 12     | 99999988 |      |
+            | party2 | ETH   | USD/DEC20 | 52     | 99999948 |      |
         And the following trades should be executed:
             | buyer  | price  | size | seller |
             | party1 | 100000 | 10   | party2 |
@@ -219,11 +219,11 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond   |
             | party0 | ETH   | USD/DEC20 | 422522 | 4451564  | 100000 |
-            | party1 | ETH   | USD/DEC20 | 12     | 99998696 | 0      |
-            | party2 | ETH   | USD/DEC20 | 52     | 99994779 | 0      |
+            | party1 | ETH   | USD/DEC20 | 12     | 99998696 |        |
+            | party2 | ETH   | USD/DEC20 | 52     | 99994779 |        |
             | party0 | ETH   | USD/DEC19 | 20914  | 4451564  | 5000   |
-            | party1 | ETH   | USD/DEC19 | 1292   | 99998696 | 0      |
-            | party2 | ETH   | USD/DEC19 | 5169   | 99994779 | 0      |
+            | party1 | ETH   | USD/DEC19 | 1292   | 99998696 |        |
+            | party2 | ETH   | USD/DEC19 | 5169   | 99994779 |        |
 
         When the parties deposit on asset's general account the following amount:
             | party  | asset | amount |
@@ -233,11 +233,11 @@ Feature: Allow markets to be specified with a smaller number of decimal places t
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond   |
             | party0 | ETH   | USD/DEC20 | 422522 | 4452564  | 100000 |
-            | party1 | ETH   | USD/DEC20 | 12     | 99999696 | 0      |
-            | party2 | ETH   | USD/DEC20 | 52     | 99995779 | 0      |
+            | party1 | ETH   | USD/DEC20 | 12     | 99999696 |        |
+            | party2 | ETH   | USD/DEC20 | 52     | 99995779 |        |
             | party0 | ETH   | USD/DEC19 | 20914  | 4452564  | 5000   |
-            | party1 | ETH   | USD/DEC19 | 1292   | 99999696 | 0      |
-            | party2 | ETH   | USD/DEC19 | 5169   | 99995779 | 0      |
+            | party1 | ETH   | USD/DEC19 | 1292   | 99999696 |        |
+            | party2 | ETH   | USD/DEC19 | 5169   | 99995779 |        |
 
     Scenario: 006: User checks prices after opening auction, (0070-MKTD-005)
 

--- a/core/integration/features/verified/Negative-Position-Decimal-Places.feature
+++ b/core/integration/features/verified/Negative-Position-Decimal-Places.feature
@@ -63,8 +63,8 @@ Feature: test negative PDP (position decimal places)
         Then the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond |
             | party0 | ETH   | USD/DEC22 | 46951  | 4952049  | 1000 |
-            | party1 | ETH   | USD/DEC22 | 9609   | 99990391 | 0    |
-            | party2 | ETH   | USD/DEC22 | 42684  | 99957316 | 0    |
+            | party1 | ETH   | USD/DEC22 | 9609   | 99990391 |      |
+            | party2 | ETH   | USD/DEC22 | 42684  | 99957316 |      |
 
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |
@@ -106,8 +106,8 @@ Feature: test negative PDP (position decimal places)
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
-            | party1 | ETH   | USD/DEC22 | 1778   | 99998222 | 0     |
-            | party2 | ETH   | USD/DEC22 | 6830   | 99993170 | 0     |
+            | party1 | ETH   | USD/DEC22 | 1778   | 99998222 |      |
+            | party2 | ETH   | USD/DEC22 | 6830   | 99993170 |      |
 
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |
@@ -165,8 +165,8 @@ Feature: test negative PDP (position decimal places)
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
-            | party1 | ETH   | USD/DEC22 | 1678   | 99998223 | 0     |
-            | party2 | ETH   | USD/DEC22 | 6930   | 99993170 | 0     |
+            | party1 | ETH   | USD/DEC22 | 1678   | 99998223 |       |
+            | party2 | ETH   | USD/DEC22 | 6930   | 99993170 |       |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*9,1206*10*0.801225765*9)=474100
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |
@@ -198,8 +198,8 @@ Feature: test negative PDP (position decimal places)
         And the parties should have the following account balances:
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC22 | 505706 | 4458726  | 35569 |
-            | party1 | ETH   | USD/DEC22 | 1230   | 99998561 | 0     |
-            | party2 | ETH   | USD/DEC22 | 5823   | 99994377 | 0     |
+            | party1 | ETH   | USD/DEC22 | 1230   | 99998561 |       |
+            | party2 | ETH   | USD/DEC22 | 5823   | 99994377 |       |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*8,1206*10*0.801225765*8)=421422
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |

--- a/core/integration/features/verified/closeout-LP_with_crazy_order.feature
+++ b/core/integration/features/verified/closeout-LP_with_crazy_order.feature
@@ -87,7 +87,7 @@ Feature: Closeout LP scenarios with a trader comes with a crazy order
 
     And the parties should have the following account balances:
       | party   | asset | market id | margin | general       | bond   |
-      | traderA | USD   | ETH/DEC20 | 13754  | 9999999985946 | 0      |
+      | traderA | USD   | ETH/DEC20 | 13754  | 9999999985946 |        |
       | traderB | USD   | ETH/DEC20 | 511138 | 2439156       | 150000 |
 
     When the parties place the following orders with ticks:
@@ -95,11 +95,11 @@ Feature: Closeout LP scenarios with a trader comes with a crazy order
       | traderC | ETH/DEC20 | sell | 120    | 45000000000 | 0                | TYPE_LIMIT | TIF_GTC |
 
     And the parties should have the following account balances:
-      | party   | asset | market id | margin        | general       | bond |
-      | traderA | USD   | ETH/DEC20 | 13754         | 9999999985946 | 0    |
-      | traderB | USD   | ETH/DEC20 | 0             | 0             | 0    |
+      | party   | asset | market id | margin        | general       |
+      | traderA | USD   | ETH/DEC20 | 13754         | 9999999985946 |
+      | traderB | USD   | ETH/DEC20 | 0             | 0             |
       # capping in action
-      | traderC | USD   | ETH/DEC20 | 1265600042684 | 8734403057610 | 0    |
+      | traderC | USD   | ETH/DEC20 | 1265600042684 | 8734403057610 |
 
     And the market data for the market "ETH/DEC20" should be:
       | mark price | trading mode            | auction trigger             | target stake | supplied stake | open interest |

--- a/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
@@ -74,8 +74,8 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 240854   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11425  | 99988575 | 0     |
-      | party2 | USD   | ETH/MAR22 | 51688  | 99948312 | 0     |
+      | party1 | USD   | ETH/MAR22 | 11425  | 99988575 |       |
+      | party2 | USD   | ETH/MAR22 | 51688  | 99948312 |       |
     #check the margin levels
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | initial |
@@ -106,8 +106,8 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 240854   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11425  | 99988575 | 0     |
-      | party2 | USD   | ETH/MAR22 | 264970 | 99734880 | 0     |
+      | party1 | USD   | ETH/MAR22 | 11425  | 99988575 |       |
+      | party2 | USD   | ETH/MAR22 | 264970 | 99734880 |       |
 
     And the insurance pool balance should be "0" for the market "ETH/MAR22"
 
@@ -130,9 +130,9 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 467474 | 2278     | 28537 |
-      | party1 | USD   | ETH/MAR22 | 107954 | 99891646 | 0     |
-      | party2 | USD   | ETH/MAR22 | 264970 | 99734960 | 0     |
-      | party3 | USD   | ETH/MAR22 | 28826  | 99971294 | 0     |
+      | party1 | USD   | ETH/MAR22 | 107954 | 99891646 |       |
+      | party2 | USD   | ETH/MAR22 | 264970 | 99734960 |       |
+      | party3 | USD   | ETH/MAR22 | 28826  | 99971294 |       |
 
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |

--- a/core/integration/features/verified/liquidity-provision-bond-account.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account.feature
@@ -76,8 +76,8 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 240854   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11415  | 99988585 | 0     |
-      | party2 | USD   | ETH/MAR22 | 51630  | 99948370 | 0     |
+      | party1 | USD   | ETH/MAR22 | 11415  | 99988585 |       |
+      | party2 | USD   | ETH/MAR22 | 51630  | 99948370 |       |
     #check the margin levels
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | initial |
@@ -109,8 +109,8 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 240854   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11415  | 99988585 | 0     |
-      | party2 | USD   | ETH/MAR22 | 264970 | 99734850 | 0     |
+      | party1 | USD   | ETH/MAR22 | 11415  | 99988585 |       |
+      | party2 | USD   | ETH/MAR22 | 264970 | 99734850 |       |
     #check the margin levels
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |
@@ -127,11 +127,11 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
 
     #check the requried balances
     And the parties should have the following account balances:
-      | party  | asset | market id | margin | general  | bond |
-      | party0 | USD   | ETH/MAR22 | 483322 | 0        | 0    |
-      | party1 | USD   | ETH/MAR22 | 107954 | 99891506 | 0    |
-      | party2 | USD   | ETH/MAR22 | 264970 | 99734930 | 0    |
-      | party3 | USD   | ETH/MAR22 | 28826  | 99971294 | 0    |
+      | party  | asset | market id | margin | general  |
+      | party0 | USD   | ETH/MAR22 | 483322 | 0        |
+      | party1 | USD   | ETH/MAR22 | 107954 | 99891506 |
+      | party2 | USD   | ETH/MAR22 | 264970 | 99734930 |
+      | party3 | USD   | ETH/MAR22 | 28826  | 99971294 |
 
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | search | initial | release |

--- a/core/integration/features/verified/risk-parameters-ranges-test.feature
+++ b/core/integration/features/verified/risk-parameters-ranges-test.feature
@@ -372,70 +372,70 @@ Feature: test risk model parameter ranges
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR0  | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR0  | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR0  | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR0  | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR0  | 47374  | 49999999589631 |       |
     # intial margin level for LP = 92*1000*1.2*3.5569036=392682
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR11 | 265987 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR11 | 12595  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR11 | 65605  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR11 | 12595  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR11 | 65605  | 49999999589631 |       |
     # intial margin level for LP = 92*1000*1.2*4.9256840 =543796
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR12 | 36284  | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR12 | 7350   | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR12 | 10286  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR12 | 7350   | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR12 | 10286  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR21 | 34     | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR21 | 1423   | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR21 | 1423   | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR21 | 1423   | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR21 | 1423   | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR22 | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR22 | 47374  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR31 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR31 | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR31 | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR31 | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR31 | 47374  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR32 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR32 | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR32 | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR32 | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR32 | 47374  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR41 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR41 | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR41 | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR41 | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR41 | 47374  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR42 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR42 | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR42 | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR42 | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR42 | 47374  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR43 | 192073 | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR43 | 11986  | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR43 | 47374  | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR43 | 11986  | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR43 | 47374  | 49999999589631 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR51 | 108    | 49999997803076 | 50000 |
-      | party1 | USD   | ETH/MAR51 | 1437   | 49999999893293 | 0     |
-      | party2 | USD   | ETH/MAR51 | 1437   | 49999999589631 | 0     |
+      | party1 | USD   | ETH/MAR51 | 1437   | 49999999893293 |       |
+      | party2 | USD   | ETH/MAR51 | 1437   | 49999999589631 |       |
 
   @Now
   Scenario: 002, test market ETH/MAR23 (tau=1)
@@ -495,8 +495,8 @@ Feature: test risk model parameter ranges
     And the parties should have the following account balances:
       | party  | asset | market id | margin    | general        | bond    |
       | party0 | USD   | ETH/MAR23 | 461953956 | 49999533046044 | 5000000 |
-      | party1 | USD   | ETH/MAR23 | 14558     | 49999999985442 | 0       |
-      | party2 | USD   | ETH/MAR23 | 1148316   | 49999998851684 | 0       |
+      | party1 | USD   | ETH/MAR23 | 14558     | 49999999985442 |         |
+      | party2 | USD   | ETH/MAR23 | 1148316   | 49999998851684 |         |
 
   # initial margin level for LP = 1000*9092*86.2176101*1.2=9.4e8
 
@@ -558,8 +558,8 @@ Feature: test risk model parameter ranges
     And the parties should have the following account balances:
       | party  | asset | market id | margin      | general        | bond   |
       | party0 | USD   | ETH/MAR52 | 20083423736 | 49979915976264 | 600000 |
-      | party1 | USD   | ETH/MAR52 | 133         | 49999999999867 | 0      |
-      | party2 | USD   | ETH/MAR52 | 7363922     | 49999992636078 | 0      |
+      | party1 | USD   | ETH/MAR52 | 133         | 49999999999867 |        |
+      | party2 | USD   | ETH/MAR52 | 7363922     | 49999992636078 |        |
 
 # initial margin level for LP = 10*114559*55787.2881561700*1.2=7.66e10
 

--- a/core/integration/features/verified/risk-parameters-sigma-test.feature
+++ b/core/integration/features/verified/risk-parameters-sigma-test.feature
@@ -86,8 +86,8 @@ Feature: test risk model parameter sigma
     And the parties should have the following account balances:
       | party  | asset | market id | margin         | general                     | bond      |
       | party0 | USD   | ETH/MAR53 | 74999925000000 | 499999999999924999975000000 | 100000000 |
-      | party1 | USD   | ETH/MAR53 | 148            | 4999999852                  | 0         |
-      | party2 | USD   | ETH/MAR53 | 164999835      | 4835000165                  | 0         |
+      | party1 | USD   | ETH/MAR53 | 148            | 4999999852                  |           |
+      | party2 | USD   | ETH/MAR53 | 164999835      | 4835000165                  |           |
 
     # mentainance margin level for LP: 10*22580646*999999=2.258e14
     # initial  margin level for LP: 10*22580646*999999 *1.5=3.38e14
@@ -141,8 +141,8 @@ Feature: test risk model parameter sigma
     And the parties should have the following account balances:
       | party  | asset | market id | margin   | general                     | bond     |
       | party0 | USD   | ETH/MAR0  | 41041689 | 499999999999999999948958311 | 10000000 |
-      | party1 | USD   | ETH/MAR0  | 1189     | 4999998811                  | 0        |
-      | party2 | USD   | ETH/MAR0  | 6397     | 4999993603                  | 0        |
+      | party1 | USD   | ETH/MAR0  | 1189     | 4999998811                  |          |
+      | party2 | USD   | ETH/MAR0  | 6397     | 4999993603                  |          |
 
     # mentainance margin level for LP: 181819*100*3.5569036=6.47e7
     # initial  margin level for LP: 181819*100*3.5569036 *1.2=9.7e7

--- a/core/integration/main_test.go
+++ b/core/integration/main_test.go
@@ -69,8 +69,6 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		// record accounts before step
 		execsetup.accountsBefore = execsetup.broker.GetAccounts()
 		execsetup.ledgerMovementsBefore = len(execsetup.broker.GetTransfers(false))
-		execsetup.depositsBefore = len(execsetup.broker.GetDeposits())
-		execsetup.withdrawalsBefore = len(execsetup.broker.GetWithdrawals())
 		execsetup.insurancePoolDepositsOverStep = make(map[string]*num.Int)
 
 		// don't record events before step if it's the step that's meant to assess number of events over a regular step
@@ -467,7 +465,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 }
 
 func reconcileAccounts() error {
-	return helpers.ReconcileAccountChanges(execsetup.accountsBefore, execsetup.broker.GetAccounts(), extractDepositsOverStep(), extractWithdrawalsOverStep(), execsetup.insurancePoolDepositsOverStep, extractLedgerEntriesOverStep())
+	return helpers.ReconcileAccountChanges(execsetup.collateralEngine, execsetup.accountsBefore, execsetup.broker.GetAccounts(), execsetup.insurancePoolDepositsOverStep, extractLedgerEntriesOverStep())
 }
 
 func extractLedgerEntriesOverStep() []*vega.LedgerEntry {
@@ -477,30 +475,6 @@ func extractLedgerEntriesOverStep() []*vega.LedgerEntry {
 	if n > 0 {
 		for i := execsetup.ledgerMovementsBefore; i < len(transfers); i++ {
 			ret = append(ret, transfers[i])
-		}
-	}
-	return ret
-}
-
-func extractDepositsOverStep() []vega.Deposit {
-	deposits := execsetup.broker.GetDeposits()
-	n := len(deposits) - execsetup.depositsBefore
-	ret := make([]vega.Deposit, 0, n)
-	if n > 0 {
-		for i := execsetup.depositsBefore; i < len(deposits); i++ {
-			ret = append(ret, deposits[i])
-		}
-	}
-	return ret
-}
-
-func extractWithdrawalsOverStep() []vega.Withdrawal {
-	withdrawals := execsetup.broker.GetWithdrawals()
-	n := len(withdrawals) - execsetup.withdrawalsBefore
-	ret := make([]vega.Withdrawal, 0, n)
-	if n > 0 {
-		for i := execsetup.withdrawalsBefore; i < len(withdrawals); i++ {
-			ret = append(ret, withdrawals[i])
 		}
 	}
 	return ret

--- a/core/integration/main_test.go
+++ b/core/integration/main_test.go
@@ -374,6 +374,9 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`there were "([0-9]+)" events emitted in this scenario so far`, func(eventCounter int) error {
 		return steps.ExpectingEventsInTheSecenarioSoFar(execsetup.broker, eventCounter)
 	})
+	s.Step(`fail`, func() {
+		reporter.Fatalf("fail step invoked")
+	})
 
 	// Debug steps
 	s.Step(`^debug accounts$`, func() error {
@@ -424,6 +427,10 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	})
 	s.Step(`^debug detailed orderbook volumes for market "([^"]*)"$`, func(mkt string) error {
 		return steps.DebugVolumesForMarketDetail(execsetup.log, execsetup.broker, mkt)
+	})
+	s.Step(`^debug last "([0-9]+)" events$`, func(eventCounter int) error {
+		steps.DebugLastNEvents(eventCounter, execsetup.broker, execsetup.log)
+		return nil
 	})
 
 	// Event steps

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -89,12 +89,13 @@ type executionTestSetup struct {
 	// keep track of net deposits/withdrawals (ignores asset type)
 	netDeposits *num.Uint
 
-	// record accounts before steps
+	// record parts of state before each step
 	accountsBefore                []protos.Account
 	ledgerMovementsBefore         int
 	depositsBefore                int
 	withdrawalsBefore             int
 	insurancePoolDepositsOverStep map[string]*num.Int
+	eventsBefore                  int
 
 	ntry           *notary.SnapshotNotary
 	stateVarEngine *stubs.StateVarStub

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -92,8 +92,6 @@ type executionTestSetup struct {
 	// record parts of state before each step
 	accountsBefore                []protos.Account
 	ledgerMovementsBefore         int
-	depositsBefore                int
-	withdrawalsBefore             int
 	insurancePoolDepositsOverStep map[string]*num.Int
 	eventsBefore                  int
 

--- a/core/integration/steps/debug_all_events.go
+++ b/core/integration/steps/debug_all_events.go
@@ -19,7 +19,7 @@ import (
 
 func DebugAllEvents(broker *stubs.BrokerStub, log *logging.Logger) {
 	log.Info("DUMPING EVENTS")
-	data := broker.GetAllEvents()
+	data := broker.GetAllEventsSinceCleared()
 	for _, a := range data {
 		log.Info(a.Type().String())
 	}

--- a/core/integration/steps/debug_all_events.go
+++ b/core/integration/steps/debug_all_events.go
@@ -24,3 +24,11 @@ func DebugAllEvents(broker *stubs.BrokerStub, log *logging.Logger) {
 		log.Info(a.Type().String())
 	}
 }
+
+func DebugLastNEvents(n int, broker *stubs.BrokerStub, log *logging.Logger) {
+	log.Infof("DUMPING LAST %d EVENTS", n)
+	data := broker.GetAllEvents()
+	for i := len(data) - n; i < len(data); i++ {
+		log.Info(data[i].Type().String())
+	}
+}

--- a/core/integration/steps/event_count.go
+++ b/core/integration/steps/event_count.go
@@ -1,0 +1,24 @@
+package steps
+
+import (
+	"fmt"
+
+	"code.vegaprotocol.io/vega/core/integration/stubs"
+)
+
+func ExpectingEventsOverStep(broker *stubs.BrokerStub, eventsBeforeStep, expected int) error {
+	actual := len(broker.GetAllEvents()) - eventsBeforeStep
+	if expected == actual {
+		return nil
+	}
+	return fmt.Errorf("expecting '%d' events generated over the last step, found '%d'", expected, actual)
+}
+
+func ExpectingEventsInTheSecenarioSoFar(broker *stubs.BrokerStub, expected int) error {
+	events := broker.GetAllEvents()
+	actual := len(events)
+	if expected == actual {
+		return nil
+	}
+	return fmt.Errorf("expecting '%d' events generated in the scenario so far, found '%d'", expected, actual)
+}

--- a/core/integration/steps/parties_deposit_assets.go
+++ b/core/integration/steps/parties_deposit_assets.go
@@ -36,7 +36,7 @@ func PartiesDepositTheFollowingAssets(
 	for _, r := range parseDepositAssetTable(table) {
 		row := depositAssetRow{row: r}
 		amount := row.Amount()
-		_, err := collateralEngine.Deposit(
+		res, err := collateralEngine.Deposit(
 			ctx,
 			row.Party(),
 			row.Asset(),
@@ -52,13 +52,7 @@ func PartiesDepositTheFollowingAssets(
 		}
 		netDeposits.Add(netDeposits, amount)
 		// emit an event manually here as we're not going via the banking flow in integration tests
-		broker.Send(events.NewDepositEvent(ctx,
-			types.Deposit{
-				PartyID: row.Party(),
-				Asset:   row.Asset(),
-				Amount:  amount,
-				Status:  types.DepositStatusFinalized,
-			}))
+		broker.Send(events.NewLedgerMovements(ctx, []*types.LedgerMovement{res}))
 	}
 	return nil
 }

--- a/core/integration/steps/parties_should_have_the_following_account_balances.go
+++ b/core/integration/steps/parties_should_have_the_following_account_balances.go
@@ -33,10 +33,6 @@ func PartiesShouldHaveTheFollowingAccountBalances(
 		if row.ExpectGeneralAccountBalance() && len(row.GeneralAccountBalance()) > 0 {
 			generalAccount, err := broker.GetPartyGeneralAccount(row.Party(), expectedAsset)
 			if err != nil {
-				if row.GeneralAccountBalance() == "0" {
-					// we coulnd't get the account but the expectation is 0 so it's fine
-					continue
-				}
 				return errCannotGetPartyGeneralAccount(row.Party(), expectedAsset, err)
 			}
 			if generalAccount.GetAsset() != expectedAsset {
@@ -54,10 +50,6 @@ func PartiesShouldHaveTheFollowingAccountBalances(
 			}
 			marginAccount, err := broker.GetPartyMarginAccount(row.Party(), row.MarketID())
 			if err != nil {
-				if row.MarginAccountBalance() == "0" {
-					// we coulnd't get the account but the expectation is 0 so it's fine
-					continue
-				}
 				return errCannotGetPartyMarginAccount(row.Party(), row.MarketID(), err)
 			}
 			if marginAccount.GetAsset() != expectedAsset {
@@ -76,10 +68,6 @@ func PartiesShouldHaveTheFollowingAccountBalances(
 			}
 			bondAcc, err := broker.GetPartyBondAccountForMarket(row.Party(), expectedAsset, row.MarketID())
 			if err != nil {
-				if row.BondAccountBalance() == "0" {
-					// we coulnd't get the account but the expectation is 0 so it's fine
-					continue
-				}
 				return errCannotGetPartyBondAccount(row.Party(), row.MarketID(), err)
 			}
 			if bondAcc.GetAsset() != expectedAsset {

--- a/core/integration/steps/total_of_events_should_be_emitted.go
+++ b/core/integration/steps/total_of_events_should_be_emitted.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TotalOfEventsShouldBeEmitted(broker *stubs.BrokerStub, eventCounter int) error {
-	allEventCount := len(broker.GetAllEvents())
+	allEventCount := len(broker.GetAllEventsSinceCleared())
 	if allEventCount == eventCounter {
 		return nil
 	}

--- a/core/integration/stubs/broker_stub.go
+++ b/core/integration/stubs/broker_stub.go
@@ -34,7 +34,8 @@ type BrokerStub struct {
 	data map[events.Type][]events.Event
 	subT map[events.Type][]broker.Subscriber
 
-	immdata map[events.Type][]events.Event
+	immdata      map[events.Type][]events.Event
+	immdataSlice []events.Event
 }
 
 func NewBrokerStub() *BrokerStub {
@@ -124,6 +125,7 @@ func (b *BrokerStub) Send(e events.Event) {
 	}
 	b.data[t] = append(b.data[t], e)
 	b.immdata[t] = append(b.immdata[t], e)
+	b.immdataSlice = append(b.immdataSlice, e)
 	b.mu.Unlock()
 }
 
@@ -139,12 +141,10 @@ func (b *BrokerStub) GetAllEventsSinceCleared() []events.Event {
 
 func (b *BrokerStub) GetAllEvents() []events.Event {
 	b.mu.Lock()
-	evs := []events.Event{}
-	for _, d := range b.immdata {
-		evs = append(evs, d...)
-	}
+	ret := make([]events.Event, len(b.immdataSlice))
+	copy(ret, b.immdataSlice)
 	b.mu.Unlock()
-	return evs
+	return ret
 }
 
 func (b *BrokerStub) GetBatch(t events.Type) []events.Event {

--- a/core/integration/stubs/broker_stub.go
+++ b/core/integration/stubs/broker_stub.go
@@ -127,10 +127,20 @@ func (b *BrokerStub) Send(e events.Event) {
 	b.mu.Unlock()
 }
 
-func (b *BrokerStub) GetAllEvents() []events.Event {
+func (b *BrokerStub) GetAllEventsSinceCleared() []events.Event {
 	b.mu.Lock()
 	evs := []events.Event{}
 	for _, d := range b.data {
+		evs = append(evs, d...)
+	}
+	b.mu.Unlock()
+	return evs
+}
+
+func (b *BrokerStub) GetAllEvents() []events.Event {
+	b.mu.Lock()
+	evs := []events.Event{}
+	for _, d := range b.immdata {
 		evs = append(evs, d...)
 	}
 	b.mu.Unlock()


### PR DESCRIPTION
- Additional cucumber steps for checking number of emitted events.

Also:
- Fix issue with account balance error which could be masked when an expectation of `0` was supplied for another account (`continue` in the loop) + modify tests to supply blank when not expecting a account to exist (now `0` means the account is expected to exist and to have a balance of `0`).
- Check account balance vs both account events and the collateral engine state.