### PR TITLE
feat: reduce amount of events send byt the position engine

### DIFF
--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -742,7 +742,6 @@ func (m *Market) OnTick(ctx context.Context, t time.Time) bool {
 	m.updateMarketValueProxy()
 	m.updateLiquidityScores()
 	m.updateLiquidityFee(ctx)
-	m.position.FlushPositionEvents(ctx)
 	m.broker.Send(events.NewMarketTick(ctx, m.mkt.ID, t))
 	return m.closed
 }
@@ -788,6 +787,8 @@ func (m *Market) blockEnd(ctx context.Context) {
 		m.lastTradedPrice = mp.Clone()
 	}
 	m.releaseExcessMargin(ctx, m.position.Positions()...)
+	// send position events
+	m.position.FlushPositionEvents(ctx)
 }
 
 func (m *Market) updateMarketValueProxy() {

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -742,6 +742,7 @@ func (m *Market) OnTick(ctx context.Context, t time.Time) bool {
 	m.updateMarketValueProxy()
 	m.updateLiquidityScores()
 	m.updateLiquidityFee(ctx)
+	m.position.FlushPositionEvents(ctx)
 	m.broker.Send(events.NewMarketTick(ctx, m.mkt.ID, t))
 	return m.closed
 }

--- a/core/execution/market_test.go
+++ b/core/execution/market_test.go
@@ -206,6 +206,7 @@ func (tm *testMarket) Run(ctx context.Context, mktCfg types.Market) *testMarket 
 		feeConfig        = fee.NewDefaultConfig()
 		liquidityConfig  = liquidity.NewDefaultConfig()
 	)
+	positionConfig.StreamPositionVerbose = true
 
 	oracleEngine := oracles.NewEngine(tm.log, oracles.NewDefaultConfig(), tm.timeService, tm.broker)
 

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -111,6 +111,7 @@ func newExecutionTestSetup() *executionTestSetup {
 	ctrl := gomock.NewController(&reporter)
 	execsetup.ctrl = ctrl
 	execsetup.cfg = execution.NewDefaultConfig()
+	execsetup.cfg.Position.StreamPositionVerbose = true
 	execsetup.log = logging.NewTestLogger()
 	execsetup.timeService = stubs.NewTimeStub()
 	execsetup.broker = stubs.NewBrokerStub()

--- a/core/positions/config.go
+++ b/core/positions/config.go
@@ -23,15 +23,15 @@ const namedLogger = "position"
 
 // Config represents the configuration of the position engine.
 type Config struct {
-	Level             encoding.LogLevel `long:"log-level"`
-	LogPositionUpdate encoding.Bool     `long:"log-position-update"`
+	Level                 encoding.LogLevel `long:"log-level"`
+	StreamPositionVerbose encoding.Bool     `long:"log-position-update"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
 // pointer to a logger instance to be used for logging within the package.
 func NewDefaultConfig() Config {
 	return Config{
-		Level:             encoding.LogLevel{Level: logging.InfoLevel},
-		LogPositionUpdate: true,
+		Level:                 encoding.LogLevel{Level: logging.InfoLevel},
+		StreamPositionVerbose: false,
 	}
 }

--- a/core/positions/engine.go
+++ b/core/positions/engine.go
@@ -113,7 +113,7 @@ func (e *Engine) sendBufferedPosition(ctx context.Context) {
 	}
 
 	e.broker.SendBatch(evts)
-	e.updatedPositions = map[string]struct{}{}
+	e.updatedPositions = make(map[string]struct{}, len(e.updatedPositions))
 }
 
 func (e *Engine) sendPosition(ctx context.Context, pos *MarketPosition) {


### PR DESCRIPTION
In a block with 1.65k events, ~610 are position state events ~540 are order events.
As of now the position engine stream events every single time a position is updated. However this is a really chatty implementation. This introduce a configuration to only send updates at the end of the block, and allow sending position on every position update for debuging.

This reduce basically the amount for the initial block from 1.65k events to ~1.05k