### PR TITLE
feat: send 1 margin levels events per transaction processing.

### DIFF
--- a/core/execution/liquidity_provision.go
+++ b/core/execution/liquidity_provision.go
@@ -36,6 +36,8 @@ func (m *Market) SubmitLiquidityProvision(
 	party, deterministicID string,
 ) (err error,
 ) {
+	defer m.onTxProcessed()
+
 	m.idgen = idgeneration.New(deterministicID)
 	defer func() { m.idgen = nil }()
 
@@ -205,6 +207,8 @@ func (m *Market) SubmitLiquidityProvision(
 
 // AmendLiquidityProvision forwards a LiquidityProvisionAmendment to the Liquidity Engine.
 func (m *Market) AmendLiquidityProvision(ctx context.Context, lpa *types.LiquidityProvisionAmendment, party string, deterministicID string) (err error) {
+	defer m.onTxProcessed()
+
 	m.idgen = idgeneration.New(deterministicID)
 	defer func() { m.idgen = nil }()
 
@@ -288,6 +292,8 @@ func (m *Market) AmendLiquidityProvision(ctx context.Context, lpa *types.Liquidi
 
 // CancelLiquidityProvision forwards a LiquidityProvisionCancel to the Liquidity Engine.
 func (m *Market) CancelLiquidityProvision(ctx context.Context, cancel *types.LiquidityProvisionCancellation, party string) (err error) {
+	defer m.onTxProcessed()
+
 	if !m.canSubmitCommitment() {
 		return ErrCommitmentSubmissionNotAllowed
 	}

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -738,6 +738,8 @@ func (m *Market) OnTick(ctx context.Context, t time.Time) bool {
 }
 
 func (m *Market) blockEnd(ctx context.Context) {
+	defer m.onTxProcessed()
+
 	// MTM if enough time has elapsed, we are not in auction, and we have a non-zero mark price.
 	// we MTM in leaveAuction before deploying LP orders like we did before, but we do update nextMTM there
 	var tID string

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -617,6 +617,10 @@ func (m *Market) Reject(ctx context.Context) error {
 	return nil
 }
 
+func (m *Market) onTxProcessed() {
+	m.risk.FlushMarginLevelsEvents()
+}
+
 // CanLeaveOpeningAuction checks if the market can leave the opening auction based on whether floating point consensus has been reached on all 3 vars.
 func (m *Market) CanLeaveOpeningAuction() bool {
 	boundFactorsInitialised := m.pMonitor.IsBoundFactorsInitialised()
@@ -633,6 +637,8 @@ func (m *Market) StartOpeningAuction(ctx context.Context) error {
 	if m.mkt.State != types.MarketStateProposed {
 		return ErrCannotStartOpeningAuctionForMarketNotInProposedState
 	}
+
+	defer m.onTxProcessed()
 
 	// now we start the opening auction
 	if m.as.AuctionStart() {
@@ -666,6 +672,8 @@ func (m *Market) PostRestore(ctx context.Context) error {
 // OnTick notifies the market of a new time event/update.
 // todo: make this a more generic function name e.g. OnTimeUpdateEvent
 func (m *Market) OnTick(ctx context.Context, t time.Time) bool {
+	defer m.onTxProcessed()
+
 	timer := metrics.NewTimeCounter(m.mkt.ID, "market", "OnTick")
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1335,6 +1343,8 @@ func (m *Market) SubmitOrderWithIDGeneratorAndOrderID(
 	idgen IDGenerator,
 	orderID string,
 ) (oc *types.OrderConfirmation, _ error) {
+	defer m.onTxProcessed()
+
 	m.idgen = idgen
 	defer func() { m.idgen = nil }()
 
@@ -2261,6 +2271,8 @@ func (m *Market) collateralAndRisk(ctx context.Context, settle []events.Transfer
 }
 
 func (m *Market) CancelAllOrders(ctx context.Context, partyID string) ([]*types.OrderCancellationConfirmation, error) {
+	defer m.onTxProcessed()
+
 	if !m.canTrade() {
 		return nil, ErrTradingNotAllowed
 	}
@@ -2337,6 +2349,8 @@ func (m *Market) CancelOrderWithIDGenerator(
 	partyID, orderID string,
 	idgen IDGenerator,
 ) (oc *types.OrderCancellationConfirmation, _ error) {
+	defer m.onTxProcessed()
+
 	m.idgen = idgen
 	defer func() { m.idgen = nil }()
 
@@ -2457,6 +2471,8 @@ func (m *Market) AmendOrderWithIDGenerator(
 	idgen IDGenerator,
 ) (oc *types.OrderConfirmation, _ error,
 ) {
+	defer m.onTxProcessed()
+
 	m.idgen = idgen
 	defer func() { m.idgen = nil }()
 

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -111,6 +111,7 @@ func newExecutionTestSetup() *executionTestSetup {
 	execsetup.ctrl = ctrl
 	execsetup.cfg = execution.NewDefaultConfig()
 	execsetup.cfg.Position.StreamPositionVerbose = true
+	execsetup.cfg.Risk.StreamMarginLevelsVerbose = true
 	execsetup.log = logging.NewTestLogger()
 	execsetup.timeService = stubs.NewTimeStub()
 	execsetup.broker = stubs.NewBrokerStub()

--- a/core/positions/engine.go
+++ b/core/positions/engine.go
@@ -88,7 +88,7 @@ func New(log *logging.Logger, config Config, marketID string, broker Broker) *En
 }
 
 func (e *Engine) FlushPositionEvents(ctx context.Context) {
-	if e.StreamPositionVerbose {
+	if e.StreamPositionVerbose || len(e.updatedPositions) <= 0 {
 		return
 	}
 

--- a/core/risk/config.go
+++ b/core/risk/config.go
@@ -25,14 +25,14 @@ const namedLogger = "risk"
 type Config struct {
 	Level encoding.LogLevel `long:"log-level"`
 
-	LogMarginUpdate encoding.Bool `long:"log-margin-update"`
+	StreamMarginLevelsVerbose encoding.Bool `long:"log-margin-update"`
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration, given a
 // pointer to a logger instance to be used for logging within the package.
 func NewDefaultConfig() Config {
 	return Config{
-		Level:           encoding.LogLevel{Level: logging.InfoLevel},
-		LogMarginUpdate: true,
+		Level:                     encoding.LogLevel{Level: logging.InfoLevel},
+		StreamMarginLevelsVerbose: false,
 	}
 }


### PR DESCRIPTION
With a sample of 1.65k event in a block, we send ~300 events for margin levels. This PR try to reduce this amount by sending the events only once per transaction per party which had their margin levels re-calculated.