### PR TITLE
fix: reduce amount of liquidity orders events emitted

### DIFF
--- a/core/execution/2965_refresh_lp_orders_size_test.go
+++ b/core/execution/2965_refresh_lp_orders_size_test.go
@@ -244,12 +244,12 @@ func TestRefreshLiquidityProvisionOrdersSizes(t *testing.T) {
 				types.OrderStatusActive,
 				size - 20,
 			},
-			{
-				// this is the replacement order created
-				// by engine.
-				types.OrderStatusCancelled,
-				size - 20,
-			},
+			// {
+			// 	// this is the replacement order created
+			// 	// by engine.
+			// 	types.OrderStatusCancelled,
+			// 	size - 20,
+			// },
 			{
 				// this is the re-deployment
 				types.OrderStatusActive,

--- a/core/execution/2965_refresh_lp_orders_size_test.go
+++ b/core/execution/2965_refresh_lp_orders_size_test.go
@@ -244,12 +244,6 @@ func TestRefreshLiquidityProvisionOrdersSizes(t *testing.T) {
 				types.OrderStatusActive,
 				size - 20,
 			},
-			// {
-			// 	// this is the replacement order created
-			// 	// by engine.
-			// 	types.OrderStatusCancelled,
-			// 	size - 20,
-			// },
 			{
 				// this is the re-deployment
 				types.OrderStatusActive,

--- a/core/execution/order_test.go
+++ b/core/execution/order_test.go
@@ -1932,12 +1932,12 @@ func testPeggedOrderOutputMessages(t *testing.T) {
 	require.NotEmpty(t, limitOrder)
 	// force reference price  checks result in more events
 	// assert.Equal(t, int(28), int(tm.orderEventCount))
-	assert.Equal(t, 32, int(tm.orderEventCount))
+	assert.Equal(t, 31, int(tm.orderEventCount))
 
 	limitOrder2 := sendOrder(t, tm, &now, types.OrderTypeLimit, types.OrderTimeInForceGTC, 0, types.SideBuy, "user6", 1000, 80)
 	require.NotEmpty(t, limitOrder2)
 	// assert.Equal(t, int(35), int(tm.orderEventCount))
-	assert.Equal(t, 41, int(tm.orderEventCount))
+	assert.Equal(t, 39, int(tm.orderEventCount))
 }
 
 func testPeggedOrderOutputMessages2(t *testing.T) {
@@ -2004,25 +2004,25 @@ func testPeggedOrderOutputMessages2(t *testing.T) {
 	// Send normal order to unpark the pegged order
 	limitOrder := sendOrder(t, tm, &now, types.OrderTypeLimit, types.OrderTimeInForceGTC, 0, types.SideBuy, "user2", 1000, 120)
 	require.NotEmpty(t, limitOrder)
-	assert.Equal(t, 19, int(tm.orderEventCount))
+	assert.Equal(t, 17, int(tm.orderEventCount))
 	assert.Equal(t, types.OrderStatusActive, confirmation.Order.Status)
 
 	// Cancel the normal order to park the pegged order
 	tm.market.CancelOrder(ctx, "user2", limitOrder, vgcrypto.RandomHash())
 	require.Equal(t, types.OrderStatusParked, confirmation.Order.Status)
-	assert.Equal(t, 25, int(tm.orderEventCount))
+	assert.Equal(t, 21, int(tm.orderEventCount))
 
 	// Send a new normal order to unpark the pegged order
 	limitOrder2 := sendOrder(t, tm, &now, types.OrderTypeLimit, types.OrderTimeInForceGTC, 0, types.SideBuy, "user2", 1000, 80)
 	require.NotEmpty(t, limitOrder2)
 	require.Equal(t, types.OrderStatusActive, confirmation.Order.Status)
-	assert.Equal(t, 31, int(tm.orderEventCount))
+	assert.Equal(t, 25, int(tm.orderEventCount))
 
 	// Fill that order to park the pegged order
 	limitOrder3 := sendOrder(t, tm, &now, types.OrderTypeLimit, types.OrderTimeInForceGTC, 0, types.SideSell, "user1", 1000, 80)
 	require.NotEmpty(t, limitOrder3)
 	require.Equal(t, types.OrderStatusActive, confirmation.Order.Status)
-	assert.Equal(t, 38, int(tm.orderEventCount))
+	assert.Equal(t, 32, int(tm.orderEventCount))
 	// assert.Equal(t, int(34), int(tm.orderEventCount))
 }
 

--- a/core/execution/special_orders.go
+++ b/core/execution/special_orders.go
@@ -233,9 +233,10 @@ func (m *Market) updateLPOrders(
 		now       = m.timeService.GetTimeNow().UnixNano()
 	)
 
-	// now we gonna map all the all order which
-	// where to be cancelled, and just do nothing in
-	// those case.
+	// now we gonna map all the order which
+	// where to be cancelled. Then send events
+	// if they are to be cancelled, or do nothing
+	// if they are to be submitted again.
 	for _, v := range cancels {
 		for _, id := range v.OrderIDs {
 			cancelIDs[id] = struct{}{}

--- a/core/execution/special_orders.go
+++ b/core/execution/special_orders.go
@@ -229,6 +229,7 @@ func (m *Market) updateLPOrders(
 	var (
 		orderEvts []events.Event
 		cancelIDs = map[string]struct{}{}
+		submitIDs = map[string]struct{}{}
 		now       = m.timeService.GetTimeNow().UnixNano()
 	)
 
@@ -239,6 +240,13 @@ func (m *Market) updateLPOrders(
 		for _, id := range v.OrderIDs {
 			cancelIDs[id] = struct{}{}
 		}
+	}
+
+	// now we gonna map all the all order which
+	// where are to be submitted, to avoid cancelling them
+	// them submitting them
+	for _, v := range submits {
+		submitIDs[v.ID] = struct{}{}
 	}
 
 	subFn := func(order *types.Order) {
@@ -261,10 +269,14 @@ func (m *Market) updateLPOrders(
 	for _, order := range allOrders {
 		order.UpdatedAt = now
 
+		_, toCancel := cancelIDs[order.ID]
+		_, toSubmit := submitIDs[order.ID]
 		// these order were actually cancelled, just send the event
-		if _, ok := cancelIDs[order.ID]; ok {
-			order.Status = types.OrderStatusCancelled
-			orderEvts = append(orderEvts, events.NewOrderEvent(ctx, order))
+		if toCancel {
+			if !toSubmit {
+				order.Status = types.OrderStatusCancelled
+				orderEvts = append(orderEvts, events.NewOrderEvent(ctx, order))
+			}
 			continue
 		}
 


### PR DESCRIPTION
Looking at a run emitting 1.65k events per blocks, ~500 where order events, out of theose ~120 where just updating liqudity orders, out of these 60 where cancelling the order, to then re-submit it straight away. This ensure that no cancel order event is send while repricing LPs if not required.