### PR TITLE
fix: make network config props optional where they can be missing

### DIFF
--- a/wallet/api/openrpc.json
+++ b/wallet/api/openrpc.json
@@ -3501,9 +3501,7 @@
         "type": "object",
         "description": "The API configuration for the network.",
         "required": [
-          "grpcConfig",
-          "graphQLConfig",
-          "restConfig"
+          "grpcConfig"
         ],
         "properties": {
           "grpcConfig": {


### PR DESCRIPTION
Closes: n/a

Make graphQLConfig and restConfig optinal so we dont fail on the frontend when they are missing from the response