### PR TITLE
fix: improve error text returned when the wallet blocks a transaction…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [7564](https://github.com/vegaprotocol/vega/issues/7564) - Add logging when database migrations are run
 - [7546](https://github.com/vegaprotocol/vega/issues/7546) - Visor automatically uses snapshot on core based on latest data node snapshot.
 - [7576](https://github.com/vegaprotocol/vega/issues/7576) - include the application version in the block hash
+- [7605](https://github.com/vegaprotocol/vega/issues/7605) - Return better error text when the wallet blocks a transaction due to spam rules
 - [7591](https://github.com/vegaprotocol/vega/issues/7591) - Add metadata and links to app to the network configuration
 
 ### 🐛 Fixes

--- a/wallet/api/client_send_transaction.go
+++ b/wallet/api/client_send_transaction.go
@@ -130,7 +130,7 @@ func (h *ClientSendTransaction) Handle(ctx context.Context, rawParams jsonrpc.Pa
 	err = h.spam.CheckSubmission(request, &stats)
 	if err != nil {
 		h.interactor.NotifyError(ctx, traceID, ApplicationError, fmt.Errorf("could not send transaction: %w", err))
-		return nil, applicationCancellationError(ErrTransactionBlockedBySpamRules)
+		return nil, applicationCancellationError(err)
 	}
 
 	// Sign the payload.

--- a/wallet/api/client_send_transaction_test.go
+++ b/wallet/api/client_send_transaction_test.go
@@ -596,7 +596,7 @@ func testFailingSpamChecksAbortsTheTransaction(t *testing.T) {
 	require.NotNil(t, errorDetails)
 	assert.Equal(t, api.ErrorCodeRequestHasBeenCancelledByApplication, errorDetails.Code)
 	assert.Equal(t, "Application error", errorDetails.Message)
-	assert.Equal(t, api.ErrTransactionBlockedBySpamRules.Error(), errorDetails.Data)
+	assert.Equal(t, assert.AnError.Error(), errorDetails.Data)
 	assert.Empty(t, result)
 }
 

--- a/wallet/api/client_sign_transaction.go
+++ b/wallet/api/client_sign_transaction.go
@@ -123,7 +123,7 @@ func (h *ClientSignTransaction) Handle(ctx context.Context, rawParams jsonrpc.Pa
 	err = h.spam.CheckSubmission(request, &stats)
 	if err != nil {
 		h.interactor.NotifyError(ctx, traceID, ApplicationError, fmt.Errorf("could not send transaction: %w", err))
-		return nil, applicationCancellationError(ErrTransactionBlockedBySpamRules)
+		return nil, applicationCancellationError(err)
 	}
 
 	// Sign the payload.

--- a/wallet/api/client_sign_transaction_test.go
+++ b/wallet/api/client_sign_transaction_test.go
@@ -29,6 +29,7 @@ func TestSignTransaction(t *testing.T) {
 	t.Run("Getting internal error during the review does not sign the transaction", testGettingInternalErrorDuringReviewDoesNotSignTransaction)
 	t.Run("No healthy node available does not sign the transaction", testNoHealthyNodeAvailableDoesNotSignTransaction)
 	t.Run("Failing to get spam statistics does not sign the transaction", testFailingToGetSpamStatsDoesNotSignTransaction)
+	t.Run("Failing spam check aborts signing the transaction", testFailingSpamChecksAbortsSigningTheTransaction)
 }
 
 func testSigningTransactionWithInvalidParamsFails(t *testing.T) {
@@ -427,7 +428,7 @@ func testFailingToGetSpamStatsDoesNotSignTransaction(t *testing.T) {
 	assert.Empty(t, result)
 }
 
-func TestFailingSpamChecksAbortsSigningTheTransaction(t *testing.T) {
+func testFailingSpamChecksAbortsSigningTheTransaction(t *testing.T) {
 	// given
 	ctx, traceID := clientContextForTest()
 	hostname := vgrand.RandomStr(5)
@@ -482,7 +483,7 @@ func TestFailingSpamChecksAbortsSigningTheTransaction(t *testing.T) {
 	require.NotNil(t, errorDetails)
 	assert.Equal(t, api.ErrorCodeRequestHasBeenCancelledByApplication, errorDetails.Code)
 	assert.Equal(t, "Application error", errorDetails.Message)
-	assert.Equal(t, api.ErrTransactionBlockedBySpamRules.Error(), errorDetails.Data)
+	assert.Equal(t, assert.AnError.Error(), errorDetails.Data)
 	assert.Empty(t, result)
 }
 

--- a/wallet/api/errors.go
+++ b/wallet/api/errors.go
@@ -148,7 +148,6 @@ var (
 	ErrSpecifyingNetworkAndLastBlockDataIsNotSupported    = errors.New("specifying a network and the last block data is not supported")
 	ErrSpecifyingNetworkAndNodeAddressIsNotSupported      = errors.New("specifying a network and a node address is not supported")
 	ErrSubmissionBlockHeightIsRequired                    = errors.New("the submission block height is required")
-	ErrTransactionBlockedBySpamRules                      = errors.New("the transaction will break the network's spam rules")
 	ErrTransactionIsNotValidJSON                          = errors.New("the transaction is not valid JSON")
 	ErrTransactionIsRequired                              = errors.New("the transaction is required")
 	ErrTransactionsPerBlockLimitReached                   = errors.New("the transaction per block limit has been reached")

--- a/wallet/api/spam/spam_test.go
+++ b/wallet/api/spam/spam_test.go
@@ -47,7 +47,7 @@ func testSpamPolicyBannedUtil(t *testing.T) {
 	for _, f := range policies {
 		s, req := getSimplePolicyStats(t, pubKey, f, banned)
 		err := p.CheckSubmission(req, s)
-		require.ErrorIs(t, err, spam.ErrPartyBanned)
+		require.Equal(t, err.Error(), "party is banned from submitting transactions of this type until forever")
 	}
 }
 
@@ -64,7 +64,7 @@ func testSpamPolicyWillGetBanned(t *testing.T) {
 	for _, f := range policies {
 		s, req := getSimplePolicyStats(t, pubKey, f, willBan)
 		err := p.CheckSubmission(req, s)
-		require.ErrorIs(t, err, spam.ErrPartyWillBeBanned)
+		require.Equal(t, err.Error(), "party has already submitted the maximum number of transactions of this type per epoch (100)")
 	}
 }
 
@@ -134,7 +134,7 @@ func testSpamPolicyPoWBan(t *testing.T) {
 
 		// we are at 88 so find to submit, but banned by PoW
 		err := p.CheckSubmission(req, s)
-		require.ErrorIs(t, err, spam.ErrPartyBannedPoW)
+		require.Equal(t, err.Error(), "party is banned from submitting all transactions until forever")
 	}
 }
 
@@ -151,7 +151,7 @@ func testSpamVotesSeparateProposals(t *testing.T) {
 
 	// we're at our max for the first proposal
 	err := p.CheckSubmission(req, s)
-	require.ErrorIs(t, err, spam.ErrPartyWillBeBanned)
+	require.Equal(t, err.Error(), "party has already submitted the maximum number of transactions of this type per epoch (100)")
 
 	// but can still submit against a different proposal
 	req = &walletpb.SubmitTransactionRequest{
@@ -199,7 +199,7 @@ func testOtherTransactionTypesNotBlock(t *testing.T) {
 	// but pow ban still applies
 	stats.PoW.BannedUntil = until
 	err = p.CheckSubmission(req, stats)
-	require.ErrorIs(t, err, spam.ErrPartyBannedPoW)
+	require.Equal(t, err.Error(), "party is banned from submitting all transactions until forever")
 }
 
 func getSimplePolicyStats(t *testing.T, pubKey, policy string, st nodetypes.SpamStatistic) (*nodetypes.SpamStatistics, *walletpb.SubmitTransactionRequest) {


### PR DESCRIPTION
closes #7605 

The blanket unhelpful error text:
```
the transaction will break the network’s spam rules
```

now can be one of the following:
```
party has already submitted the maximum number of transactions of this type per epoch (100)
party is banned from submitting transactions of this type until [some timestamp]
party is banned from submitting all transactions until [some timestamp]
```