### PR TITLE
Fix issue with LP order crossing on entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - [7607](https://github.com/vegaprotocol/vega/issues/7607) - Fix handling of removed transfers
 - [7622](https://github.com/vegaprotocol/vega/issues/7622) - Fix cleaning path for Visor when restarting data node
 - [7638](https://github.com/vegaprotocol/vega/issues/7638) - Add missing fields to position update resolver
+- [7647](https://github.com/vegaprotocol/vega/issues/7647) - Assure LP orders never trade on entry
 
 ## 0.67.2
 

--- a/core/execution/liquidity_provision.go
+++ b/core/execution/liquidity_provision.go
@@ -505,13 +505,14 @@ func (m *Market) repriceLiquidityOrder(side types.Side, reference types.PeggedRe
 
 func (m *Market) adjustPrice(side types.Side, referencePrice, offset, minLpPrice, maxLpPrice *num.Uint) *num.Uint {
 	offsetPrice := m.applyOffset(side, referencePrice, offset)
-	if offsetPrice.LT(minLpPrice) {
+	if offsetPrice.GTE(minLpPrice) && offsetPrice.LTE(maxLpPrice) {
+		return offsetPrice
+	}
+
+	if side == types.SideBuy {
 		return minLpPrice
 	}
-	if offsetPrice.GT(maxLpPrice) {
-		return maxLpPrice
-	}
-	return offsetPrice
+	return maxLpPrice
 }
 
 func (m *Market) applyOffset(side types.Side, referencePrice, offset *num.Uint) *num.Uint {
@@ -553,10 +554,21 @@ func (m *Market) computeValidLPVolumeRange(bestStaticBid, bestStaticAsk *num.Uin
 	if lb.IsNegative() || lb.IsZero() {
 		lb = m.minValidPrice()
 	}
-
 	if lb.GTE(ub) {
-		// if we ended up with overlapping upper and lower bound we set the upper bound to lower bound plus one.
-		ub = ub.Add(lb, num.UintOne())
+		// if we ended up with overlapping upper and lower bound we set the upper bound to lower bound plus one tick.
+		ub = ub.Add(lb, m.priceFactor)
+	}
+
+	// we can't have lower bound >= best static ask as then a buy order with that price would trade on entry
+	// so place it one tick to the left
+	if lb.GTE(bestStaticAsk) {
+		lb = num.UintZero().Sub(bestStaticAsk, m.priceFactor)
+	}
+
+	// we can't have upper bound <= best static bid as then a sell order with that price would trade on entry
+	// so place it one tick to the right
+	if ub.LTE(bestStaticBid) {
+		ub = num.UintZero().Add(bestStaticBid, m.priceFactor)
 	}
 
 	return lb, ub

--- a/core/integration/features/verified/Negative-Position-Decimal-Places.feature
+++ b/core/integration/features/verified/Negative-Position-Decimal-Places.feature
@@ -27,7 +27,7 @@ Feature: test negative PDP (position decimal places)
         And the markets:
             | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | decimal places | position decimal places | linear slippage factor | quadratic slippage factor | lp price range |
             | USD/DEC22 | USD        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 5              | -1                      | 1e6                    | 1e6                       | 0.99           |
-            | USD/DEC23 | USD        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 2              | -2                      | 1e6                    | 1e6                       | 0.05           |
+            | USD/DEC23 | USD        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 2              | -2                      | 1e6                    | 1e6                       | 0.000001       |
         And the parties deposit on asset's general account the following amount:
             | party  | asset | amount    |
             | party0 | ETH   | 5000000   |
@@ -208,45 +208,53 @@ Feature: test negative PDP (position decimal places)
             | party1 | USD/DEC22 | 1025        | 1127   | 1230    | 1435    |
             | party2 | USD/DEC22 | 4853        | 5338   | 5823    | 6794    |
 
-    Scenario: Issue with LP orders crossing on entry
-        
-        And the parties deposit on asset's general account the following amount:
-            | party  | asset | amount    |
-            | party0 | ETH   | 500000000000000   |
-        
-        Given the parties submit the following liquidity provision:
+    Scenario: Assure LP orders never trade on entry, even with spread of 1 tick and extremely small LP price range
+        Given the parties deposit on asset's general account the following amount:
+            | party  | asset | amount     |
+            | party0 | ETH   | 1000000000 |
+        And the parties submit the following liquidity provision:
             | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
-            | lp2 | party0 | USD/DEC23 | 40000000          | 0.001 | sell | MID              | 500        | 1      | submission |
-            | lp2 | party0 | USD/DEC23 | 40000000          | 0.001 | buy  | MID              | 500        | 1      |            |
-
-        # LP places limit orders which oversupply liquidity
+            | lp1 | party0 | USD/DEC23 | 40000000          | 0.001 | sell | MID              | 500        | 1      | submission |
+            | lp1 | party0 | USD/DEC23 | 40000000          | 0.001 | buy  | MID              | 500        | 1      |            |
         And the parties place the following orders:
-            | party  | market id | side | volume | price | type       | tif     |
-            | party0 | USD/DEC23 | sell | 1481   | 13    | TYPE_LIMIT | TIF_GTC |
-            | party0 | USD/DEC23 | buy  | 1206   | 8     | TYPE_LIMIT | TIF_GTC |
-
-        And the parties place the following orders:
-            | party  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
-            | party1 | USD/DEC23 | buy  | 5      | 8     | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
-            | party1 | USD/DEC23 | buy  | 1      | 9     | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
-            | party1 | USD/DEC23 | buy  | 10     | 10    | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-2  |
-            | party2 | USD/DEC23 | sell | 10     | 10    | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-3 |
-            | party2 | USD/DEC23 | sell | 1      | 10    | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-1 |
-            | party2 | USD/DEC23 | sell | 5      | 11    | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
+            | party  | market id | side | volume | price | resulting trades | type       | tif     |
+            | party1 | USD/DEC23 | buy  | 5      | 8     | 0                | TYPE_LIMIT | TIF_GTC |
+            | party1 | USD/DEC23 | buy  | 1      | 9     | 0                | TYPE_LIMIT | TIF_GTC |
+            | party1 | USD/DEC23 | buy  | 10     | 10    | 0                | TYPE_LIMIT | TIF_GTC |
+            | party2 | USD/DEC23 | sell | 10     | 10    | 0                | TYPE_LIMIT | TIF_GTC |
+            | party2 | USD/DEC23 | sell | 1      | 10    | 0                | TYPE_LIMIT | TIF_GTC |
+            | party2 | USD/DEC23 | sell | 5      | 11    | 0                | TYPE_LIMIT | TIF_GTC |
 
         When the opening auction period ends for market "USD/DEC23"
-        And the market data for the market "USD/DEC23" should be:
+        Then the market data for the market "USD/DEC23" should be:
             | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
             | 10         | TRADING_MODE_CONTINUOUS | 360000  | 8         | 13        | 35569000     | 40000000       | 10            |
+        And the order book should have the following volumes for market "USD/DEC23":
+            | side | price | volume |
+            | sell |    11 |      5 |
+            | sell |    10 |     40 |
+            | buy  |     9 |     46 |
+            | buy  |     8 |      5 |
 
-        And the parties place the following orders with ticks:
-            | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
-            | party3 | USD/DEC23 | sell | 1      | 9     | 1                | TYPE_LIMIT | TIF_GTC | buy-ref-3 |
+        When the parties place the following orders with ticks:
+            | party  | market id | side | volume | price | resulting trades | type       | tif     |
+            | party3 | USD/DEC23 | sell | 1      | 9     | 1                | TYPE_LIMIT | TIF_GTC |
+        Then the order book should have the following volumes for market "USD/DEC23":
+            | side | price | volume |
+            | sell |    11 |      5 |
+            | sell |    10 |     41 |
+            | buy  |     9 |     45 |
+            | buy  |     8 |      5 |
 
-        And the parties place the following orders with ticks:
-            | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
-            | party3 | USD/DEC23 | sell | 1      | 8     | 1                | TYPE_LIMIT | TIF_GTC | buy-ref-3 |
-
+        When the parties place the following orders with ticks:
+            | party  | market id | side | volume | price | resulting trades | type       | tif      |
+            | party3 | USD/DEC23 | buy  | 1      | 10     | 1                | TYPE_LIMIT | TIF_GTC |
+        Then the order book should have the following volumes for market "USD/DEC23":
+            | side | price | volume |
+            | sell |    11 |      5 |
+            | sell |    10 |     39 |
+            | buy  |    10 |     40 |
+            | buy  |     8 |      5 |
         And the market data for the market "USD/DEC23" should be:
             | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-            | 8          | TRADING_MODE_CONTINUOUS | 360000  | 8         | 13        | 34146240     | 40000000       | 12            |
+            | 10          | TRADING_MODE_CONTINUOUS | 360000  | 8        | 13        | 39125900     | 40000000       | 11            |

--- a/core/integration/features/verified/Negative-Position-Decimal-Places.feature
+++ b/core/integration/features/verified/Negative-Position-Decimal-Places.feature
@@ -25,8 +25,9 @@ Feature: test negative PDP (position decimal places)
             | horizon | probability | auction extension |
             | 360000  | 0.99        | 300               |
         And the markets:
-            | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | decimal places | position decimal places | linear slippage factor | quadratic slippage factor |
-            | USD/DEC22 | USD        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 5              | -1                      | 1e6                    | 1e6                       |
+            | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | decimal places | position decimal places | linear slippage factor | quadratic slippage factor | lp price range |
+            | USD/DEC22 | USD        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 5              | -1                      | 1e6                    | 1e6                       | 0.99           |
+            | USD/DEC23 | USD        | ETH   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 2              | -2                      | 1e6                    | 1e6                       | 0.05           |
         And the parties deposit on asset's general account the following amount:
             | party  | asset | amount    |
             | party0 | ETH   | 5000000   |
@@ -207,4 +208,45 @@ Feature: test negative PDP (position decimal places)
             | party1 | USD/DEC22 | 1025        | 1127   | 1230    | 1435    |
             | party2 | USD/DEC22 | 4853        | 5338   | 5823    | 6794    |
 
+    Scenario: Issue with LP orders crossing on entry
+        
+        And the parties deposit on asset's general account the following amount:
+            | party  | asset | amount    |
+            | party0 | ETH   | 500000000000000   |
+        
+        Given the parties submit the following liquidity provision:
+            | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
+            | lp2 | party0 | USD/DEC23 | 40000000          | 0.001 | sell | MID              | 500        | 1      | submission |
+            | lp2 | party0 | USD/DEC23 | 40000000          | 0.001 | buy  | MID              | 500        | 1      |            |
 
+        # LP places limit orders which oversupply liquidity
+        And the parties place the following orders:
+            | party  | market id | side | volume | price | type       | tif     |
+            | party0 | USD/DEC23 | sell | 1481   | 13    | TYPE_LIMIT | TIF_GTC |
+            | party0 | USD/DEC23 | buy  | 1206   | 8     | TYPE_LIMIT | TIF_GTC |
+
+        And the parties place the following orders:
+            | party  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
+            | party1 | USD/DEC23 | buy  | 5      | 8     | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
+            | party1 | USD/DEC23 | buy  | 1      | 9     | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
+            | party1 | USD/DEC23 | buy  | 10     | 10    | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-2  |
+            | party2 | USD/DEC23 | sell | 10     | 10    | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-3 |
+            | party2 | USD/DEC23 | sell | 1      | 10    | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-1 |
+            | party2 | USD/DEC23 | sell | 5      | 11    | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
+
+        When the opening auction period ends for market "USD/DEC23"
+        And the market data for the market "USD/DEC23" should be:
+            | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+            | 10         | TRADING_MODE_CONTINUOUS | 360000  | 8         | 13        | 35569000     | 40000000       | 10            |
+
+        And the parties place the following orders with ticks:
+            | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+            | party3 | USD/DEC23 | sell | 1      | 9     | 1                | TYPE_LIMIT | TIF_GTC | buy-ref-3 |
+
+        And the parties place the following orders with ticks:
+            | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+            | party3 | USD/DEC23 | sell | 1      | 8     | 1                | TYPE_LIMIT | TIF_GTC | buy-ref-3 |
+
+        And the market data for the market "USD/DEC23" should be:
+            | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+            | 8          | TRADING_MODE_CONTINUOUS | 360000  | 8         | 13        | 34146240     | 40000000       | 12            |


### PR DESCRIPTION
LP price range was disregarding best bid/ask (only considered MID), hence it was possible to create bounds that would result in LP orders crossing on entry, this PR fixes that issue.

Closes https://github.com/vegaprotocol/vega/issues/7647