### PR TITLE
feat: reduce memory footprint of market depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 🐛 Fixes
 - [7535](https://github.com/vegaprotocol/vega/issues/7535) - Fix network history load takes an increasingly long time to complete
 - [7659](https://github.com/vegaprotocol/vega/issues/7659) - Tidy up REST documentation for consistency
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [7665](https://github.com/vegaprotocol/vega/issues/7665) - Reduce memory footprint of the market depth API.
 
 
 ## 0.68.0

--- a/datanode/service/market_depth.go
+++ b/datanode/service/market_depth.go
@@ -150,7 +150,7 @@ func (m *MarketDepth) AddOrder(order *types.Order, vegaTime time.Time, sequenceN
 		// so we need to create a new MarketDepth
 		md = &entities.MarketDepth{
 			MarketID:   order.MarketID,
-			LiveOrders: map[string]*types.Order{},
+			LiveOrders: map[string]*entities.SlimOrder{},
 		}
 		md.SequenceNumber = m.sequenceNumber
 		m.marketDepths[order.MarketID] = md
@@ -206,14 +206,6 @@ func (m *MarketDepth) ObserveDepthUpdates(ctx context.Context, retries int, mark
 /*****************************************************************************/
 /*                 FUNCTIONS TO HELP WITH UNIT TESTING                       */
 /*****************************************************************************/
-
-func (m *MarketDepth) GetAllOrders(market string) map[string]*types.Order {
-	md := m.marketDepths[market]
-	if md != nil {
-		return md.LiveOrders
-	}
-	return nil
-}
 
 // GetOrderCount returns the number of live orders for the given market.
 func (m *MarketDepth) GetOrderCount(market string) int64 {

--- a/datanode/service/market_depth_test.go
+++ b/datanode/service/market_depth_test.go
@@ -432,7 +432,7 @@ func TestPartialMatchOrders(t *testing.T) {
 	assert.Equal(t, 0, mds.GetSellPriceLevels("M"))
 	assert.Equal(t, int64(1), mds.GetOrderCount("M"))
 
-	assert.Equal(t, uint64(1), mds.GetVolumeAtPrice("M", types.SideBuy, 100))
+	assert.Equal(t, int(1), int(mds.GetVolumeAtPrice("M", types.SideBuy, 100)))
 	assert.Equal(t, uint64(1), mds.GetOrderCountAtPrice("M", types.SideBuy, 100))
 }
 


### PR DESCRIPTION
For info, the size of the Order type is 196 bytes + 32*2 (the 2 prices) + eventually 36 more in case of a pegged order, so at least 252 bytes per orders, this reduce it to 32+16. It removes as well quite a bunch of copy, which could help


close #7665  