### PR TITLE
fix: populate closed field in market snapshot state

### DIFF
--- a/core/execution/market_snapshot.go
+++ b/core/execution/market_snapshot.go
@@ -221,6 +221,7 @@ func (m *Market) getState() *types.ExecMarket {
 		SettlementData:             sp,
 		NextMTM:                    m.nextMTM.UnixNano(),
 		Parties:                    parties,
+		Closed:                     m.closed,
 	}
 
 	return em


### PR DESCRIPTION
The result of me being too careless here: https://github.com/vegaprotocol/vega/pull/7654

But at least the overnight tests caught it, so thats something.

Can confirm the value is now saved in the snapshot:
```
                            "timeWindowStart": "1677117082866635427",
                            "tradeValue": "900000000000000000000",
                            "avg": "4880000000000000000000",
                            "window": "1"
                        },
                        "settlementData": "90",
                        "nextMarkToMarket": "1677117162740199577",
                        "lastTradedPrice": "90000000000000000",
                        "parties": [
                            "03612a5cd330bd8b2e26b643e000de3effe4c9ffeca585de98a6bc04305c7ef1",
                            "4cc909817a8c93593591c7989b714eeb5165b84260e31d8989d2591788d3e0ca",
                            "529abd2edc3c2cb9ad61df4a672a397cf329ebeca5a4225ec90862f22df9e716",
                            "7d1703c70fe3db44b3913ec9e5b4eb274ad031d6c199bb3e7e01bfa16dfded46",
                            "c2bb13abaec2adeeaec971b583295345c99bcc9c912555636f6fcdc34b3387f9"
                        ],
                        "closed": true <-- HELLO!
                    }
                ]
            }
```