### PR TITLE
chore: fix the way we're not waiting for slow unnecessary validators

### DIFF
--- a/core/blockchain/abci/tm_node.go
+++ b/core/blockchain/abci/tm_node.go
@@ -139,7 +139,7 @@ func loadConfig(homeDir string) (*config.Config, error) {
 
 // we want to force validators to skip timeout on commit so they don't wait after consensus has been reached.
 func overwriteConfig(config *config.Config) {
-	config.Consensus.SkipTimeoutCommit = true
+	config.Consensus.TimeoutCommit = 0
 	config.Consensus.CreateEmptyBlocks = true
 	// enforce using priority mempool
 	config.Mempool.Version = "v1"


### PR DESCRIPTION
this is based on the following observation - we want to move on to the next round as soon as possible - meaning as soon as we have consensus. This can only be achieved by setting the `timeout_commit` to 0. For posterity the meaning of these flags is as follows:

`skip_timeout_commit` - when **all** validator's precommit were seen, move to the next round regardless of the value of `timeout_commit`.
`timeout_commit` - how long to wait to the next round **after** achieving consensus for height H

So for example: 
1. if `timeout_commit`=1s and `skip_timeout_commit` is true, we will move to the next round after min(consensus_time+1s, received_all_precommit_time)
2. if `timeout_commit`=1s and `skip_timeout_commit` is false, we will move to the next round after consensus_time+1s
3. if `timeout_commit`=0 we will move to the next round as soon as there is consensus on block H