### PR TITLE
fix: update price_monitoring tests

### DIFF
--- a/core/integration/features/price_monitoring/2668-price-monitoring.feature
+++ b/core/integration/features/price_monitoring/2668-price-monitoring.feature
@@ -10,7 +10,7 @@ Feature: Price monitoring test for issue 2668
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 0.8   |
     And the markets:
       | id        | quote name | asset | risk model               | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 1e-4                    | 1e-4                       |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 300   |

--- a/core/integration/features/price_monitoring/2681-price-monitoring.feature
+++ b/core/integration/features/price_monitoring/2681-price-monitoring.feature
@@ -10,7 +10,7 @@ Feature: Price monitoring test for issue 2681
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 0.8   |
     And the markets:
       | id        | quote name | asset | risk model               | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 1e-4                   | 1e-4                       |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 1     |

--- a/core/integration/features/price_monitoring/price-monitoring-for-system-test.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-for-system-test.feature
@@ -11,7 +11,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
       | id        | quote name | asset | risk model               | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 6                | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 6                | default-none | my-price-monitoring | default-eth-for-future | 1e-4                   | 1e-4                      |
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 6     |

--- a/core/integration/features/price_monitoring/price-monitoring-lognormal2.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-lognormal2.feature
@@ -11,7 +11,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
       | id        | quote name | asset | risk model               | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 3600             | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 3600             | default-none | my-price-monitoring | default-eth-for-future | 1E-4                   | 1E-4                       |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 100   |


### PR DESCRIPTION
## Description:

Changes in 7588-exit-price breaks existing feature tests.

PR fixes feature tests in the `integration/features/price_monitoring` directory.

## Changes:
- `2688-price-monitoring.feature` - slippage factors decreased
- `2681-price-monitoring.feature` - slippage factors decreased
- `price-monitoring-for-system-test.feature` - slippage factors decreased
- `price-monitoring-lognormal2.feature` - slippage factors decreased

## Testing:
```
go test -v ./integration/... --godog.format=pretty $(pwd)/integration/features/price_monitoring
```