### PR TITLE
fix: update closeouts tests

### DIFF
--- a/core/integration/features/closeouts/1847-closeout-short-with-fees.feature
+++ b/core/integration/features/closeouts/1847-closeout-short-with-fees.feature
@@ -7,7 +7,7 @@ Feature: Short close-out test (see ln 449 of system-tests/grpc/trading/tradesTes
       | 0.00025   | 0.0005             |
     And the markets:
       | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees           | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | my-fees-config | default-none     | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | my-fees-config | default-none     | default-eth-for-future | 1e4                    | 1e4                       |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 1     |
@@ -17,11 +17,11 @@ Feature: Short close-out test (see ln 449 of system-tests/grpc/trading/tradesTes
     # setup accounts
     Given the parties deposit on asset's general account the following amount:
       | party    | asset | amount    |
-      | tt_12    | BTC   | 10000000  |
-      | tt_13    | BTC   | 10000000  |
-      | tt_14    | BTC   | 10000000  |
+      | tt_12    | BTC   | 100000000 |
+      | tt_13    | BTC   | 100000000 |
+      | tt_14    | BTC   | 100000000 |
       | tt_15    | BTC   | 100       |
-      | tt_16    | BTC   | 10000000  |
+      | tt_16    | BTC   | 100000000 |
       | tt_aux   | BTC   | 100000000 |
       | t2_aux   | BTC   | 100000000 |
       | party-lp | BTC   | 100000000 |
@@ -47,6 +47,10 @@ Feature: Short close-out test (see ln 449 of system-tests/grpc/trading/tradesTes
       | tt_14 | ETH/DEC19 | sell | 2      | 50    | 0                | TYPE_LIMIT | TIF_GTC | tt_14-2   |            |
       | tt_15 | ETH/DEC19 | sell | 2      | 20    | 0                | TYPE_LIMIT | TIF_GTC | tt_15-1   |            |
       | tt_16 | ETH/DEC19 | buy  | 2      | 20    | 1                | TYPE_LIMIT | TIF_GTC | tt_16-1   |            |
+
+    Then the parties should have the following account balances:
+      | party | asset | market id | margin | general |
+      | tt_15 | BTC   | ETH/DEC19 | 76     | 25       |
 
     When the parties place the following orders "1" blocks apart:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |

--- a/core/integration/features/closeouts/network-order-and-trades-sub.feature
+++ b/core/integration/features/closeouts/network-order-and-trades-sub.feature
@@ -4,7 +4,7 @@ Feature: Ensure network party are generated
 
     Given the markets:
       | id        | quote name | asset | risk model                  | margin calculator                  | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-2 | default-overkill-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-2 | default-overkill-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e3                    | 1e3                       |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 1     |
@@ -16,7 +16,7 @@ Feature: Ensure network party are generated
       | party            | asset | amount        |
       | sellSideProvider | BTC   | 1000000000000 |
       | buySideProvider  | BTC   | 1000000000000 |
-      | designatedLooser | BTC   | 12000         |
+      | designatedLoser  | BTC   | 12000         |
       | aux              | BTC   | 1000000000000 |
       | aux2             | BTC   | 1000000000000 |
 
@@ -35,7 +35,7 @@ Feature: Ensure network party are generated
     # insurance pool generation - trade
     When the parties place the following orders "1" blocks apart:
       | party            | market id | side | volume | price | resulting trades | type       | tif     | reference |
-      | designatedLooser | ETH/DEC19 | buy  | 290    | 150   | 1                | TYPE_LIMIT | TIF_GTC | ref-1     |
+      | designatedLoser  | ETH/DEC19 | buy  | 290    | 150   | 1                | TYPE_LIMIT | TIF_GTC | ref-1     |
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
 
     # insurance pool generation - modify order book
@@ -60,5 +60,5 @@ Feature: Ensure network party are generated
     # check the network trade happened
     Then the following network trades should be executed:
       | party            | aggressor side | volume |
-      | designatedLooser | buy            | 290    |
+      | designatedLoser  | buy            | 290    |
       | buySideProvider  | sell           | 290    |


### PR DESCRIPTION
## Description:

Changes in 7588-exit-price breaks existing feature tests.

PR fixes feature tests in the `integration/features/closeouts` directory.

## Changes:
- `1857-closeout-short-with fees` - slippage factors decreased and account balances increased
- `network-order-and-trades-sub.feature` - slippage factors decreased

## Testing:
```
go test -v ./integration/... --godog.format=pretty $(pwd)/integration/features/closeouts
```