### PR TITLE
Docs: update type_commit message

### DIFF
--- a/protos/sources/vega/api/v1/core.proto
+++ b/protos/sources/vega/api/v1/core.proto
@@ -97,10 +97,11 @@ message SubmitTransactionRequest {
     // The transaction will be submitted without waiting for response
     TYPE_ASYNC = 1;
     // The transaction will be submitted, and blocking until the
-    // tendermint mempool return a response
+    // tendermint mempool returns a response
     TYPE_SYNC = 2;
     // The transaction will submitted, and blocking until the tendermint
-    // network will have committed it into a block
+    // network will have committed it into a block. Used only for debugging,
+    // not for submitting transactions
     TYPE_COMMIT = 3;
   }
 
@@ -157,10 +158,11 @@ message SubmitRawTransactionRequest {
     // The transaction will be submitted without waiting for response
     TYPE_ASYNC = 1;
     // The transaction will be submitted, and blocking until the
-    // tendermint mempool return a response
+    // tendermint mempool returns a response
     TYPE_SYNC = 2;
     // The transaction will submitted, and blocking until the tendermint
-    // network will have committed it into a block
+    // network will have committed it into a block. Used only for debugging,
+    // not for submitting transactions
     TYPE_COMMIT = 3;
   }
 
@@ -208,7 +210,7 @@ message CheckRawTransactionResponse {
   string info = 7;
 }
 
-// Request for the current time of the vega network
+// Request for the current time of the Vega network
 message GetVegaTimeRequest {}
 
 // Response for the current consensus coordinated time on the Vega network, referred to as "VegaTime"
@@ -292,7 +294,7 @@ message Statistics {
   uint32 order_subscriptions = 21;
   // Current number of stream subscribers to trade data
   uint32 trade_subscriptions = 22;
-  // Current number of stream subscribers to candle-stick data
+  // Current number of stream subscribers to candlestick data
   uint32 candle_subscriptions = 23;
   // Current number of stream subscribers to market depth data
   uint32 market_depth_subscriptions = 24;

--- a/protos/vega/api/v1/core.pb.go
+++ b/protos/vega/api/v1/core.pb.go
@@ -32,10 +32,11 @@ const (
 	// The transaction will be submitted without waiting for response
 	SubmitTransactionRequest_TYPE_ASYNC SubmitTransactionRequest_Type = 1
 	// The transaction will be submitted, and blocking until the
-	// tendermint mempool return a response
+	// tendermint mempool returns a response
 	SubmitTransactionRequest_TYPE_SYNC SubmitTransactionRequest_Type = 2
 	// The transaction will submitted, and blocking until the tendermint
-	// network will have committed it into a block
+	// network will have committed it into a block. Used only for debugging,
+	// not for submitting transactions
 	SubmitTransactionRequest_TYPE_COMMIT SubmitTransactionRequest_Type = 3
 )
 
@@ -90,10 +91,11 @@ const (
 	// The transaction will be submitted without waiting for response
 	SubmitRawTransactionRequest_TYPE_ASYNC SubmitRawTransactionRequest_Type = 1
 	// The transaction will be submitted, and blocking until the
-	// tendermint mempool return a response
+	// tendermint mempool returns a response
 	SubmitRawTransactionRequest_TYPE_SYNC SubmitRawTransactionRequest_Type = 2
 	// The transaction will submitted, and blocking until the tendermint
-	// network will have committed it into a block
+	// network will have committed it into a block. Used only for debugging,
+	// not for submitting transactions
 	SubmitRawTransactionRequest_TYPE_COMMIT SubmitRawTransactionRequest_Type = 3
 )
 
@@ -861,7 +863,7 @@ func (x *CheckRawTransactionResponse) GetInfo() string {
 	return ""
 }
 
-// Request for the current time of the vega network
+// Request for the current time of the Vega network
 type GetVegaTimeRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1214,7 +1216,7 @@ type Statistics struct {
 	OrderSubscriptions uint32 `protobuf:"varint,21,opt,name=order_subscriptions,json=orderSubscriptions,proto3" json:"order_subscriptions,omitempty"`
 	// Current number of stream subscribers to trade data
 	TradeSubscriptions uint32 `protobuf:"varint,22,opt,name=trade_subscriptions,json=tradeSubscriptions,proto3" json:"trade_subscriptions,omitempty"`
-	// Current number of stream subscribers to candle-stick data
+	// Current number of stream subscribers to candlestick data
 	CandleSubscriptions uint32 `protobuf:"varint,23,opt,name=candle_subscriptions,json=candleSubscriptions,proto3" json:"candle_subscriptions,omitempty"`
 	// Current number of stream subscribers to market depth data
 	MarketDepthSubscriptions uint32 `protobuf:"varint,24,opt,name=market_depth_subscriptions,json=marketDepthSubscriptions,proto3" json:"market_depth_subscriptions,omitempty"`


### PR DESCRIPTION
Clarify that type_commit can only be used for debugging and should not be used to send a transaction to the network 