### PR TITLE
Assure new parties get included in nearest MTM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [7673](https://github.com/vegaprotocol/vega/issues/7673) - Accept internal data sources without signers
 - [7483](https://github.com/vegaprotocol/vega/issues/7483) - Fix market data history returning 0 values for price monitoring bounds
 - [7732](https://github.com/vegaprotocol/vega/issues/7732) - Fix panic when amending orders
+- [7766](https://github.com/vegaprotocol/vega/issues/7766) - Fix orders from new parties not being included in the nearest MTM
 
 
 ## 0.68.0

--- a/core/integration/features/verified/closeout-lognormal.feature
+++ b/core/integration/features/verified/closeout-lognormal.feature
@@ -68,7 +68,7 @@ Feature: Closeout scenarios
       | trader2 | ETH/DEC19 | 321         | 481     | 642     | 963     |
       | lprov   | ETH/DEC19 | 800729      | 1201093 | 1601458 | 2402187 |
     # margin level_trader2= OrderSize*MarkPrice*RF = 40*10*0.801225765=321
-    # margin level_Lprov= OrderSize*MarkPrice*RF = max(223*10*3.55690359157934000,4040*10*0.801225765)=32370
+    # margin level_Lprov= OrderSize*MarkPrice*RF = max(96*10*3.55690359157934000,100000*10*0.801225765)=801225.765
 
 
     Then the parties should have the following account balances:
@@ -110,6 +110,10 @@ Feature: Closeout scenarios
       | auxiliary2 | ETH/DEC19 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC | sell-provider-1 |
     Then the mark price should be "100" for the market "ETH/DEC19"
     And the network moves ahead "1" blocks
+
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode                   | target stake | supplied stake |
+      | 100        | TRADING_MODE_MONITORING_AUCTION| 71138        |   100000       |
 
     Then the order book should have the following volumes for market "ETH/DEC19":
       | side | price | volume |

--- a/core/integration/features/verified/closeout-lognormal.feature
+++ b/core/integration/features/verified/closeout-lognormal.feature
@@ -111,10 +111,6 @@ Feature: Closeout scenarios
     Then the mark price should be "100" for the market "ETH/DEC19"
     And the network moves ahead "1" blocks
 
-    And the market data for the market "ETH/DEC19" should be:
-      | mark price | trading mode                   | target stake | supplied stake |
-      | 100        | TRADING_MODE_MONITORING_AUCTION| 71138        |   100000       |
-
     Then the order book should have the following volumes for market "ETH/DEC19":
       | side | price | volume |
       | buy  | 5     | 0      |

--- a/core/integration/features/verified/closeout-lognormal.feature
+++ b/core/integration/features/verified/closeout-lognormal.feature
@@ -113,18 +113,18 @@ Feature: Closeout scenarios
 
     Then the order book should have the following volumes for market "ETH/DEC19":
       | side | price | volume |
-      | buy  | 5     | 5      |
-      | buy  | 1     | 100000 |
+      | buy  | 5     | 0      |
+      | buy  | 1     | 0      |
       | sell | 1000  | 10     |
-      | sell | 1005  | 100    |
+      | sell | 1005  | 0      |
     #trader3 is closed out
     Then the parties should have the following account balances:
       | party   | asset | market id | margin | general |
-      | trader2 | USD   | ETH/DEC19 | 2161   | 0       |
+      | trader2 | USD   | ETH/DEC19 | 0   | 2000    |
     #trader2 has enough balance to maintain their position of 10 long, but not the order
     And the parties should have the following margin levels:
       | party   | market id | maintenance | search | initial | release |
-      | trader2 | ETH/DEC19 | 1771        | 2656   | 3542    | 5313    |
+      | trader2 | ETH/DEC19 | 0           | 0      | 0       | 0       |
       | trader3 | ETH/DEC19 | 0           | 0      | 0       | 0       |
 
     #trader2's order is canceled since mark price has moved from 10 to 100, hence margin level has increased by 10 times
@@ -132,7 +132,7 @@ Feature: Closeout scenarios
     # So they made a bit of profit
     Then the parties should have the following account balances:
       | party   | asset | market id | margin | general |
-      | trader2 | USD   | ETH/DEC19 | 2161   | 0       |
+      | trader2 | USD   | ETH/DEC19 | 0      | 2000    |
       | trader3 | USD   | ETH/DEC19 | 0      | 0       |
     And the insurance pool balance should be "0" for the market "ETH/DEC19"
 
@@ -141,11 +141,13 @@ Feature: Closeout scenarios
     Then the parties should have the following profit and loss:
       | party      | volume | unrealised pnl | realised pnl |
       | auxiliary1 | -10    | -900           | 0            |
-      | auxiliary2 | 0      | 0              | 900          |
-      | trader2    | 10     | 500            | -339         |
-      | trader3    | 0      | 0              | -162          |
-      | lprov      | 0      | 0              | 0            |
-    And the mark price should be "100" for the market "ETH/DEC19"
+      | auxiliary2 | 5      | 475            | 503          |
+      | trader2    | 0      | 0              | 0            |  
+      | trader3    | 0      | 0              | -162         |
+      | lprov      | 5      | 495            | -413         |
+       Then the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode                    | auction trigger                   | 
+      | 100        | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_LIQUIDITY |
 
   Scenario: Position becomes distressed upon exiting an auction (0012-POSR-007)
     Given the insurance pool balance should be "0" for the market "ETH/DEC19"

--- a/core/settlement/engine.go
+++ b/core/settlement/engine.go
@@ -291,7 +291,7 @@ func (e *Engine) SettleMTM(ctx context.Context, markPrice *num.Uint, positions [
 
 	for _, evt := range positions {
 		party := evt.Party()
-		current, lastSettledPrice := e.getOrCreateCurrentPosition(party, evt.Size(), evt.Price())
+		current, lastSettledPrice := e.getOrCreateCurrentPosition(party, evt.Size())
 		traded, hasTraded = trades[party]
 		tradeset := make([]events.TradeSettlement, 0, len(traded))
 		for _, t := range traded {
@@ -460,11 +460,11 @@ func (e *Engine) settleAll(assetDecimals uint32) ([]*types.Transfer, error) {
 	return aggregated, nil
 }
 
-func (e *Engine) getOrCreateCurrentPosition(party string, size int64, price *num.Uint) (int64, *num.Uint) {
+func (e *Engine) getOrCreateCurrentPosition(party string, size int64) (int64, *num.Uint) {
 	p, ok := e.settledPosition[party]
 	if !ok {
 		e.settledPosition[party] = size
-		return 0, price
+		return 0, num.UintZero()
 	}
 	return p, e.lastMarkPrice
 }


### PR DESCRIPTION
Currently if a new party posts an order they won't be included in the nearest MTM - we assume that position has already been marked to market at the current mark price, which need not be true (in fact it definitely won't be true if the mark price changes since previous). As shown in the impacted feature test it could result in that party becoming a closeout counter-party to the network, despite being distressed itself.

Closes https://github.com/vegaprotocol/vega/issues/7766