### PR TITLE
Improve bond penalty mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [7732](https://github.com/vegaprotocol/vega/issues/7732) - Fix panic when amending orders
 - [7766](https://github.com/vegaprotocol/vega/issues/7766) - Fix orders from new parties not being included in the nearest MTM
 - [7499](https://github.com/vegaprotocol/vega/issues/7499) - Implement transaction check functionality to wallet
+- [7745](https://github.com/vegaprotocol/vega/issues/7745) - Use margin after the application of a bond penalty to assess LP solvency
 
 
 ## 0.68.0

--- a/core/collateral/engine.go
+++ b/core/collateral/engine.go
@@ -66,7 +66,7 @@ var (
 	// ErrNotEnoughFundsToWithdraw a party requested to withdraw more than on its general account.
 	ErrNotEnoughFundsToWithdraw = errors.New("not enough funds to withdraw")
 	// ErrAttemptingToDeleteAccountWithNonZeroBalance an attempt to delete an account with remaining funds has been made.
-	ErrAttemptingToDeleteAccountWithNonZeroBalance = errors.New("not enough funds to withdraw")
+	ErrAttemptingToDeleteAccountWithNonZeroBalance = errors.New("attempting to delete an account with non-zero balance")
 )
 
 // Broker send events

--- a/core/collateral/engine.go
+++ b/core/collateral/engine.go
@@ -65,8 +65,6 @@ var (
 	ErrInvalidTransferTypeForFeeRequest = errors.New("an invalid transfer type was send to build a fee transfer request")
 	// ErrNotEnoughFundsToWithdraw a party requested to withdraw more than on its general account.
 	ErrNotEnoughFundsToWithdraw = errors.New("not enough funds to withdraw")
-	// ErrAttemptingToDeleteAccountWithNonZeroBalance an attempt to delete an account with remaining funds has been made.
-	ErrAttemptingToDeleteAccountWithNonZeroBalance = errors.New("attempting to delete an account with non-zero balance")
 )
 
 // Broker send events
@@ -1343,7 +1341,7 @@ func (e *Engine) RemoveBondAccount(partyID, marketID, asset string) error {
 		return ErrAccountDoesNotExist
 	}
 	if !bondAcc.Balance.IsZero() {
-		return ErrAttemptingToDeleteAccountWithNonZeroBalance
+		e.log.Panic("attempting to delete a bond account with non-zero balance")
 	}
 	e.removeAccount(bondID)
 	return nil

--- a/core/collateral/engine_test.go
+++ b/core/collateral/engine_test.go
@@ -275,8 +275,7 @@ func TestDeleteBondAccount(t *testing.T) {
 	err = eng.UpdateBalance(context.Background(), bnd, bal)
 	require.Nil(t, err)
 
-	err = eng.RemoveBondAccount(party, testMarketID, testMarketAsset)
-	require.EqualError(t, err, collateral.ErrAttemptingToDeleteAccountWithNonZeroBalance.Error())
+	require.Panics(t, func() { eng.RemoveBondAccount(party, testMarketID, testMarketAsset) })
 
 	transfer := &types.Transfer{
 		Owner: party,

--- a/core/execution/amend_lp_orders_test.go
+++ b/core/execution/amend_lp_orders_test.go
@@ -531,10 +531,10 @@ func TestCancelUndeployedCommitmentDuringAuction(t *testing.T) {
 			ctx, lpSubmissionCancel, lpparty),
 	)
 
-	t.Run("bond account is updated with the new commitment", func(t *testing.T) {
+	t.Run("bond account doesn't exist any more", func(t *testing.T) {
 		acc, err := tm.collateralEngine.GetPartyBondAccount(tm.market.GetID(), lpparty, tm.asset)
-		assert.NoError(t, err)
-		assert.Equal(t, num.UintZero(), acc.Balance)
+		assert.ErrorContains(t, err, "account does not exist")
+		assert.Nil(t, acc)
 	})
 }
 

--- a/core/execution/collateral.go
+++ b/core/execution/collateral.go
@@ -154,6 +154,9 @@ func (m *Market) bondSlashing(ctx context.Context, closed ...events.Margin) ([]*
 	asset, _ := m.mkt.GetAsset()
 	ret := make([]*types.LedgerMovement, 0, len(closed))
 	for _, c := range closed {
+		if !m.liquidity.IsLiquidityProvider(c.Party()) {
+			continue
+		}
 		penalty, _ := num.UintFromDecimal(
 			num.DecimalFromUint(c.MarginShortFall()).Mul(m.bondPenaltyFactor).Floor(),
 		)

--- a/core/execution/liquidity_provision.go
+++ b/core/execution/liquidity_provision.go
@@ -658,6 +658,7 @@ func (m *Market) cancelLiquidityProvision(
 			return err
 		}
 		m.broker.Send(events.NewLedgerMovements(ctx, []*types.LedgerMovement{tresp}))
+		m.collateral.RemoveBondAccount(party, m.GetID(), asset)
 	}
 
 	// now let's update the fee selection

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -146,6 +146,7 @@ type MarketCollateral interface {
 	GetPartyGeneralAccount(party, asset string) (*types.Account, error)
 	GetPartyBondAccount(market, partyID, asset string) (*types.Account, error)
 	BondUpdate(ctx context.Context, market string, transfer *types.Transfer) (*types.LedgerMovement, error)
+	RemoveBondAccount(partyID, marketID, asset string) error
 	MarginUpdateOnOrder(ctx context.Context, marketID string, update events.Risk) (*types.LedgerMovement, events.Margin, error)
 	GetPartyMargin(pos events.MarketPosition, asset, marketID string) (events.Margin, error)
 	GetPartyMarginAccount(market, party, asset string) (*types.Account, error)

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -1738,18 +1738,18 @@ func (m *Market) confirmMTM(
 				asset, _ := m.mkt.GetAsset()
 				closedRecalculated := make([]events.Margin, 0, len(closed))
 				for _, c := range closed {
-					recalculated := c
 					if pos, ok := m.position.GetPositionByPartyID(c.Party()); ok {
 						margin, err := m.collateral.GetPartyMargin(pos, asset, m.mkt.ID)
 						if err != nil {
 							m.log.Error("couldn't get party margin",
 								logging.PartyID(c.Party()),
 								logging.Error(err))
+							// keep old value if we weren't able to recalculate
+							closedRecalculated = append(closedRecalculated, c)
 							continue
 						}
-						recalculated = margin
+						closedRecalculated = append(closedRecalculated, margin)
 					}
-					closedRecalculated = append(closedRecalculated, recalculated)
 				}
 				closed = closedRecalculated
 			}

--- a/core/execution/mocks/mocks.go
+++ b/core/execution/mocks/mocks.go
@@ -520,6 +520,20 @@ func (mr *MockCollateralMockRecorder) MarkToMarket(arg0, arg1, arg2, arg3 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkToMarket", reflect.TypeOf((*MockCollateral)(nil).MarkToMarket), arg0, arg1, arg2, arg3)
 }
 
+// RemoveBondAccount mocks base method.
+func (m *MockCollateral) RemoveBondAccount(arg0, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveBondAccount", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveBondAccount indicates an expected call of RemoveBondAccount.
+func (mr *MockCollateralMockRecorder) RemoveBondAccount(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveBondAccount", reflect.TypeOf((*MockCollateral)(nil).RemoveBondAccount), arg0, arg1, arg2)
+}
+
 // RemoveDistressed mocks base method.
 func (m *MockCollateral) RemoveDistressed(arg0 context.Context, arg1 []events.MarketPosition, arg2, arg3 string) (*types.LedgerMovement, error) {
 	m.ctrl.T.Helper()

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
@@ -282,7 +282,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | party  | volume | unrealised pnl | realised pnl |
       | party0 | 0      | 0              | -2178        |
    
-    And the accumulated liquidity fees should be "24" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "42" for the market "ETH/DEC21"
 
     # assure that closing out one LP doesn't prevent fees from being fully distributed
     When the network moves ahead "100" blocks

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
@@ -104,8 +104,8 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | party3 | ETH/DEC21 | buy  | 474    | 1055  | 1                | TYPE_LIMIT | TIF_FOK |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 0      | 0       | 0    |
-    And the insurance pool balance should be "5724" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 1782   | 0       | 0    |
+    And the insurance pool balance should be "3942" for the market "ETH/DEC21"
 
     Then the liquidity provisions should have the following states:
       | id  | party  | market    | commitment amount | status           |

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
@@ -100,33 +100,34 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | party3 | ETH/DEC21 | buy  | 5      | 1055  | 1                | TYPE_LIMIT | TIF_FOK |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1729   | 0       | 0    |
-    And the insurance pool balance should be "3977" for the market "ETH/DEC21"
-
-    Then the liquidity provisions should have the following states:
+      | party0 | ETH   | ETH/DEC21 | 0      | 0       | 0    |
+    And the parties should have the following profit and loss:
+      | party  | volume | unrealised pnl | realised pnl |
+      | party0 | 0      | 0              | -1819        |
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance |
+      | party0 | ETH/DEC21 | 0           |
+    And the insurance pool balance should be "4847" for the market "ETH/DEC21"
+    And the liquidity provisions should have the following states:
       | id  | party  | market    | commitment amount | status           |
       | lp1 | party0 | ETH/DEC21 | 5000              | STATUS_CANCELLED |
-
-    # existing LP position not liquidated as there isn't enough volume on the book
-    Then the parties should have the following profit and loss:
-      | party  | volume | unrealised pnl | realised pnl |
-      | party0 | -17    | -90            | 0            |
-      # | party0 | 0      | -90            | 0            |
-    Then the parties should have the following margin levels:
-      | party  | market id | maintenance |
-      | party0 | ETH/DEC21 | 2559        |
-    Then the parties should have the following account balances:
-      | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1729   | 0       | 0    |
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode                    | target stake | supplied stake | open interest |
+      | 1055       | TRADING_MODE_MONITORING_AUCTION | 2954         | 0              | 28            |
     And the order book should have the following volumes for market "ETH/DEC21":
       | side | price | volume |
-      | sell | 1100  | 1000   |
+      | sell | 1100  | 983    |
       | buy  | 990   | 1      |
       | buy  | 900   | 1000   |
     And the accumulated liquidity fees should be "23" for the market "ETH/DEC21"
 
     # Make sure that at no point fees get distributed since the LP has been closed out
     Then the network moves ahead "12" blocks
+
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | trading mode                    | target stake | supplied stake | open interest |
+      | 1055       | TRADING_MODE_MONITORING_AUCTION | 2954         | 0              | 28            |
+
     And the accumulated liquidity fees should be "23" for the market "ETH/DEC21"
 
   Scenario: 002, LP gets distressed after auction

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
@@ -427,7 +427,6 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
       | party0 | ETH   | ETH/DEC21 | 0      | 0       | 0    |
-    # party0 only able to cover portion of the fees due to excessive bond slashing
     And the accumulated liquidity fees should be "45" for the market "ETH/DEC21"
     And the insurance pool balance should be "4765" for the market "ETH/DEC21"
     Then the order book should have the following volumes for market "ETH/DEC21":

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
@@ -43,11 +43,11 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
 
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
-      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
+      | party1 | ETH/DEC21 | buy  | 1000   | 900   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
       | party1 | ETH/DEC21 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-1  |
       | party1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | buy-ref-2  |
       | party2 | ETH/DEC21 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-1 |
-      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
+      | party2 | ETH/DEC21 | sell | 1000   | 1100  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-2 |
       | party2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | sell-ref-3 |
 
     When the opening auction period ends for market "ETH/DEC21"
@@ -80,32 +80,28 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | party3 | ETH/DEC21 | buy  | 5      | 1055  | 1                | TYPE_LIMIT | TIF_FOK |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 1488   | 0       | 3348 |
-    And the insurance pool balance should be "826" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 1530   | 0       | 3264 |
+    And the insurance pool balance should be "868" for the market "ETH/DEC21"
 
     When the parties place the following orders with ticks:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party3 | ETH/DEC21 | buy  | 5      | 1055  | 1                | TYPE_LIMIT | TIF_FOK |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 2253   | 0       | 1862 |
-    And the insurance pool balance should be "1569" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 2527   | 0       | 1314 |
+    And the insurance pool balance should be "1843" for the market "ETH/DEC21"
+
+    Then the liquidity provisions should have the following states:
+      | id  | party  | market    | commitment amount | status        |
+      | lp1 | party0 | ETH/DEC21 | 5000              | STATUS_ACTIVE |
 
     When the parties place the following orders with ticks:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party3 | ETH/DEC21 | buy  | 5      | 1055  | 1                | TYPE_LIMIT | TIF_FOK |
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 2928   | 0       | 556  |
-    And the insurance pool balance should be "2222" for the market "ETH/DEC21"
-
-    When the parties place the following orders with ticks:
-      | party  | market id | side | volume | price | resulting trades | type       | tif     |
-      | party3 | ETH/DEC21 | buy  | 5      | 1055  | 1                | TYPE_LIMIT | TIF_FOK |
-    Then the parties should have the following account balances:
-      | party  | asset | market id | margin | general | bond |
-      | party0 | ETH   | ETH/DEC21 | 233    | 0       | 0    |
-    And the insurance pool balance should be "5495" for the market "ETH/DEC21"
+      | party0 | ETH   | ETH/DEC21 | 1729   | 0       | 0    |
+    And the insurance pool balance should be "3977" for the market "ETH/DEC21"
 
     Then the liquidity provisions should have the following states:
       | id  | party  | market    | commitment amount | status           |
@@ -114,17 +110,24 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     # existing LP position not liquidated as there isn't enough volume on the book
     Then the parties should have the following profit and loss:
       | party  | volume | unrealised pnl | realised pnl |
-      | party0 | -22    | -90            | 0            |
+      | party0 | -17    | -90            | 0            |
+      # | party0 | 0      | -90            | 0            |
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance |
+      | party0 | ETH/DEC21 | 2559        |
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin | general | bond |
+      | party0 | ETH   | ETH/DEC21 | 1729   | 0       | 0    |
     And the order book should have the following volumes for market "ETH/DEC21":
       | side | price | volume |
-      | sell | 1100  | 1      |
+      | sell | 1100  | 1000   |
       | buy  | 990   | 1      |
-      | buy  | 900   | 1      |
-    And the accumulated liquidity fees should be "29" for the market "ETH/DEC21"
+      | buy  | 900   | 1000   |
+    And the accumulated liquidity fees should be "23" for the market "ETH/DEC21"
 
     # Make sure that at no point fees get distributed since the LP has been closed out
     Then the network moves ahead "12" blocks
-    And the accumulated liquidity fees should be "29" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "23" for the market "ETH/DEC21"
 
   Scenario: 002, LP gets distressed after auction
     Given the simple risk model named "simple-risk-model-2":
@@ -288,7 +291,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
   Scenario: 003, 2 LPs on the market, LP1 gets distressed and closed-out during continuous trading (0042-LIQF-014)
     Given the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.01           | 1e6                    | 1e6                       |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.01           | 5e-2                   | 0                       |
     And the parties deposit on asset's general account the following amount:
       | party   | asset | amount     |
       | party0  | ETH   | 5721       |
@@ -423,10 +426,9 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     Then the parties should have the following account balances:
       | party  | asset | market id | margin | general | bond |
       | party0 | ETH   | ETH/DEC21 | 0      | 0       | 0    |
-    And the insurance pool balance should be "4848" for the market "ETH/DEC21"
     # party0 only able to cover portion of the fees due to excessive bond slashing
-    And the accumulated liquidity fees should be "23" for the market "ETH/DEC21"
-
+    And the accumulated liquidity fees should be "45" for the market "ETH/DEC21"
+    And the insurance pool balance should be "4765" for the market "ETH/DEC21"
     Then the order book should have the following volumes for market "ETH/DEC21":
       | side | price | volume |
       | buy  | 900   | 1      |
@@ -438,14 +440,14 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
     #lp1(party0) is closed-out, some of the sell orders had been used for close-out trade
     Then the parties should have the following profit and loss:
       | party   | volume | unrealised pnl | realised pnl |
-      | party0  | 0      | 0              | -1316        |
+      | party0  | 0      | 0              | -1331        |
       | party10 | -5     | 0              | 0            |
 
     Then the liquidity provisions should have the following states:
       | id  | party  | market    | commitment amount | status           |
       | lp1 | party0 | ETH/DEC21 | 5000              | STATUS_CANCELLED |
 
-    And the accumulated liquidity fees should be "23" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "45" for the market "ETH/DEC21"
   
     # Make sure that at no point fees get distributed since the LP has been closed out
     Then the network moves ahead "12" blocks


### PR DESCRIPTION
- We were not recalculating margin events following the application of a bond penalty, which meant LP could be falsely perceived as having sufficient collateral during margin check.
- We never deleted a bond account, but logic within collateral engine uses the existence of it to assert that someone is an LP. That means parties that used to be LPs would get a bond penalty applied whenever they had a margin shortfall.

Closes https://github.com/vegaprotocol/vega/issues/7745