### PR TITLE
feat: park lp orders when not on book

### DIFF
--- a/core/execution/amend_lp_orders_test.go
+++ b/core/execution/amend_lp_orders_test.go
@@ -820,6 +820,5 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuri
 
 	err := tm.market.AmendLiquidityProvision(
 		ctx, lpSubmissionUpdate, lpparty, vgcrypto.RandomHash())
-	// require.EqualError(t, err, "margin would be below maintenance: insufficient margin")
 	require.EqualError(t, err, "commitment submission not allowed")
 }

--- a/core/execution/amend_lp_orders_test.go
+++ b/core/execution/amend_lp_orders_test.go
@@ -642,7 +642,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuction(t *testing.T) {
 		// only 4 cancellations
 		i := 0
 		for _, o := range found {
-			expectedStatus := types.OrderStatusCancelled
+			expectedStatus := types.OrderStatusParked
 			assert.Equal(t,
 				expectedStatus.String(),
 				o.Status.String(),
@@ -792,7 +792,7 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuri
 		// 4 cancellations
 		i := 0
 		for _, o := range found {
-			expectedStatus := types.OrderStatusCancelled
+			expectedStatus := types.OrderStatusParked
 			assert.Equal(t,
 				expectedStatus.String(),
 				o.Status.String(),
@@ -820,5 +820,6 @@ func TestDeployedCommitmentIsUndeployedWhenEnteringAuctionAndMarginCheckFailDuri
 
 	err := tm.market.AmendLiquidityProvision(
 		ctx, lpSubmissionUpdate, lpparty, vgcrypto.RandomHash())
-	require.EqualError(t, err, "margin would be below maintenance: insufficient margin")
+	// require.EqualError(t, err, "margin would be below maintenance: insufficient margin")
+	require.EqualError(t, err, "commitment submission not allowed")
 }

--- a/core/execution/liquidity_provision_test.go
+++ b/core/execution/liquidity_provision_test.go
@@ -2066,10 +2066,6 @@ func TestSubmit(t *testing.T) {
 				}
 			}
 
-			for _, v := range found {
-				fmt.Printf("FOUND: %v\n", v)
-			}
-
 			assert.Len(t, found, 2)
 
 			// the manually submitted limit order should replace the automatically deployed LP order

--- a/core/execution/liquidity_provision_test.go
+++ b/core/execution/liquidity_provision_test.go
@@ -2066,6 +2066,10 @@ func TestSubmit(t *testing.T) {
 				}
 			}
 
+			for _, v := range found {
+				fmt.Printf("FOUND: %v\n", v)
+			}
+
 			assert.Len(t, found, 2)
 
 			// the manually submitted limit order should replace the automatically deployed LP order
@@ -2083,7 +2087,7 @@ func TestSubmit(t *testing.T) {
 				},
 				{
 					size:   expiringOrder.Size,
-					status: types.OrderStatusCancelled,
+					status: types.OrderStatusParked,
 					ref:    lpSubmission.Reference,
 					found:  false,
 				},

--- a/core/execution/special_orders.go
+++ b/core/execution/special_orders.go
@@ -194,7 +194,6 @@ func (m *Market) repriceAllSpecialOrders(
 	newOrders, cancels := m.liquidity.Update(
 		ctx, minLpPrice, maxLpPrice, m.repriceLiquidityOrder)
 
-	//	m.liquidity.ClearLPOrders()
 	return m.updateLPOrders(ctx, lpOrders, newOrders, cancels)
 }
 
@@ -220,13 +219,12 @@ func (m *Market) stopAllSpecialOrders(
 	)
 
 	// now we just get the list of all LPs to be cancelled
-	cancels := m.liquidity.UndeployLPs(ctx, updatedOrders)
-	_ = cancels
+	_ = m.liquidity.UndeployLPs(ctx, updatedOrders)
 	lpOrders := m.matching.GetAllLiquidityOrders()
 	m.removeLPOrdersFromBook(ctx, lpOrders)
-
 	now := m.timeService.GetTimeNow().UnixNano()
 	evts := make([]events.Event, 0, len(lpOrders))
+
 	for _, o := range lpOrders {
 		o.Status = types.OrderStatusParked
 		o.UpdatedAt = now
@@ -234,22 +232,6 @@ func (m *Market) stopAllSpecialOrders(
 	}
 
 	m.broker.SendBatch(evts)
-
-	// for _, cancel := range cancels {
-	// 	for _, orderID := range cancel.OrderIDs {
-	// 		if _, err := m.cancelOrder(ctx, cancel.Party, orderID); err != nil {
-	// 			// here we panic, an order which should be in a the market
-	// 			// appears not to be. there's either an issue in the liquidity
-	// 			// engine and we are trying to remove a non-existing order
-	// 			// or the market lost track of the order
-	// 			m.log.Panic("unable to amend a liquidity order",
-	// 				logging.OrderID(orderID),
-	// 				logging.PartyID(cancel.Party),
-	// 				logging.MarketID(market),
-	// 				logging.Error(err))
-	// 		}
-	// 	}
-	// }
 }
 
 func (m *Market) updateLPOrders(
@@ -309,7 +291,6 @@ func (m *Market) updateLPOrders(
 		// these order were actually cancelled, just send the event
 		if toCancel {
 			if !toSubmit {
-				// order.Status = types.OrderStatusCancelled
 				order.Status = types.OrderStatusParked
 				orderEvts = append(orderEvts, events.NewOrderEvent(ctx, order))
 			}

--- a/core/liquidity/engine.go
+++ b/core/liquidity/engine.go
@@ -674,7 +674,8 @@ func (e *Engine) buildOrder(side types.Side, price *num.Uint, partyID, marketID 
 		Reference:            ref,
 		LiquidityProvisionID: lpID,
 	}
-	return order.Create(e.timeService.GetTimeNow())
+	p, _ := e.provisions.Get(partyID)
+	return order.Create(p.CreatedAt)
 }
 
 func (e *Engine) undeployOrdersFromShape(

--- a/core/types/matching.go
+++ b/core/types/matching.go
@@ -202,8 +202,8 @@ func OrderFromProto(o *proto.Order) (*Order, error) {
 
 // Create sets the creation time (CreatedAt) to t and returns the
 // updated order.
-func (o *Order) Create(t time.Time) *Order {
-	o.CreatedAt = t.UnixNano()
+func (o *Order) Create(t int64) *Order {
+	o.CreatedAt = t
 	return o
 }
 

--- a/protos/sources/vega/vega.proto
+++ b/protos/sources/vega/vega.proto
@@ -165,7 +165,8 @@ message Order {
     STATUS_REJECTED = 6;
     // Used for closed partially filled IOC orders
     STATUS_PARTIALLY_FILLED = 7;
-    // Order has been removed from the order book and has been parked, this applies to pegged orders only
+    // Order has been removed from the order book and has been parked,
+    // this applies to pegged orders and liquidity orders (orders created from a liquidity provision shape)
     STATUS_PARKED = 8;
 
     // Note: If adding an enum value, add a matching entry in:

--- a/protos/vega/vega.pb.go
+++ b/protos/vega/vega.pb.go
@@ -1235,7 +1235,8 @@ const (
 	Order_STATUS_REJECTED Order_Status = 6
 	// Used for closed partially filled IOC orders
 	Order_STATUS_PARTIALLY_FILLED Order_Status = 7
-	// Order has been removed from the order book and has been parked, this applies to pegged orders only
+	// Order has been removed from the order book and has been parked,
+	// this applies to pegged orders and liquidity orders (orders created from a liquidity provision shape)
 	Order_STATUS_PARKED Order_Status = 8
 )
 


### PR DESCRIPTION
This PR does 2 things:
- set the status of LP order to parked while they are undeployed
- set the createdAt field of lp orders to the creation date of the LiquidityProvision