### PR TITLE
fix: catch network import urls that are clearly incorrect and suggest…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [7696](https://github.com/vegaprotocol/vega/issues/7696) - Cache `ListMarket` store queries
 - [7413](https://github.com/vegaprotocol/vega/issues/7413) - Add foreign block height to stake linkings in `GraphQL`
 - [7675](https://github.com/vegaprotocol/vega/issues/7675) - Migrate to comet `bft`
+- [7792](https://github.com/vegaprotocol/vega/issues/7792) - An attempt to import a network when the `url` is to `github` and not the raw file contents is caught early with a suggested `url`
 - [7722](https://github.com/vegaprotocol/vega/issues/7722) - Send a reason for a passphrase request through the wallet's `interactor`
 - [5967](https://github.com/vegaprotocol/vega/issues/5967) - Do not ask for wallet passphrase if it has already been unlocked.
 - [5967](https://github.com/vegaprotocol/vega/issues/5967) - Preselect the wallet during connection is there is only one.


### PR DESCRIPTION
closes #7792 

In response to https://vegaprotocol.slack.com/archives/C02KSKW6Y3F/p1678205971703379

It is quite common for people to paste a _slightly_ wrong URL from github when importing a network into the wallet.  For example this:
https://github.com/vegaprotocol/networks-internal/blob/main/fairground/vegawallet-fairground.toml

when they should use:
https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/fairground/vegawallet-fairground.toml

The error you get when picking the wrong one is some generic "can't decode toml" one. We now check a given URL before importing and if it looks like they've used the github URL that is not the raw-content form, we error early and suggest (hopefully) the correct one.