### PR TITLE
fix: not all paths cleanly close the network history index store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [7745](https://github.com/vegaprotocol/vega/issues/7745) - Use margin after the application of a bond penalty to assess LP solvency
 - [7765](https://github.com/vegaprotocol/vega/issues/7765) - Assure pegged order won't get deployed with insufficient margin
 - [7786](https://github.com/vegaprotocol/vega/issues/7786) - Fix validation of order amendments (check for negative pegged offset)
+- [7750](https://github.com/vegaprotocol/vega/issues/7750) - Fix not all paths cleanly close network history index store.
 
 ## 0.68.0
 

--- a/cmd/data-node/commands/networkhistory/latest_history_segment.go
+++ b/cmd/data-node/commands/networkhistory/latest_history_segment.go
@@ -77,6 +77,7 @@ func (cmd *latestHistorySegment) Execute(_ []string) error {
 			handleErr(log, cmd.Output.IsJSON(), "failed to create network history store", err)
 			os.Exit(1)
 		}
+		defer networkHistoryStore.Stop()
 
 		segments, err := networkHistoryStore.ListAllIndexEntriesOldestFirst()
 		if err != nil {

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -111,6 +111,7 @@ func (cmd *loadCmd) Execute(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create network history store:%w", err)
 	}
+	defer networkHistoryStore.Stop()
 
 	networkHistoryService, err := networkhistory.NewWithStore(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory,
 		connPool, snapshotService, networkHistoryStore, cmd.Config.API.Port,

--- a/cmd/data-node/commands/start/node.go
+++ b/cmd/data-node/commands/start/node.go
@@ -141,6 +141,12 @@ func (l *NodeCommand) runNode([]string) error {
 	})
 
 	eg.Go(func() error {
+		defer func() {
+			if l.conf.NetworkHistory.Enabled {
+				l.networkHistoryService.Stop()
+			}
+		}()
+
 		return l.sqlBroker.Receive(ctx)
 	})
 
@@ -164,12 +170,7 @@ func (l *NodeCommand) runNode([]string) error {
 	nodeLog.Info("Vega data node startup complete")
 
 	err := eg.Wait()
-
 	if errors.Is(err, context.Canceled) {
-		if l.conf.NetworkHistory.Enabled {
-			l.networkHistoryService.Stop()
-		}
-
 		return nil
 	}
 


### PR DESCRIPTION
Closes #7750 

I managed to find a couple of where the level db is not closed in some of the CLI commands and this should fix those.

As far as I can see, if data-node is stopped gracefully, everything should close down properly, but it's possible I may have missed something.