### PR TITLE
fix: add key for internal time sources

### DIFF
--- a/core/types/data_source_internal_tme.go
+++ b/core/types/data_source_internal_tme.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	vegapb "code.vegaprotocol.io/vega/protos/vega"
+	datapb "code.vegaprotocol.io/vega/protos/vega/data/v1"
 )
 
 // DataSourceSpecConfigurationTime is used internally.
@@ -41,9 +42,14 @@ func (s DataSourceSpecConfigurationTime) DeepClone() dataSourceType {
 }
 
 func DataSourceSpecConfigurationTimeFromProto(protoConfig *vegapb.DataSourceSpecConfigurationTime) *DataSourceSpecConfigurationTime {
-	return &DataSourceSpecConfigurationTime{
-		Conditions: DataSourceSpecConditionsFromProto(protoConfig.Conditions),
+	dst := &DataSourceSpecConfigurationTime{
+		Conditions: []*DataSourceSpecCondition{},
 	}
+	if protoConfig != nil {
+		dst.Conditions = DataSourceSpecConditionsFromProto(protoConfig.Conditions)
+	}
+
+	return dst
 }
 
 type DataSourceDefinitionInternalTime struct {
@@ -57,7 +63,10 @@ func (i *DataSourceDefinitionInternalTime) oneOfProto() interface{} {
 }
 
 func (i *DataSourceDefinitionInternalTime) IntoProto() *vegapb.DataSourceDefinitionInternal_Time {
-	ids := &vegapb.DataSourceSpecConfigurationTime{}
+	ids := &vegapb.DataSourceSpecConfigurationTime{
+		Conditions: []*datapb.Condition{},
+	}
+
 	if i.Time != nil {
 		ids = i.Time.IntoProto()
 	}

--- a/core/types/data_source_test.go
+++ b/core/types/data_source_test.go
@@ -1,0 +1,174 @@
+package types_test
+
+import (
+	"testing"
+
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/protos/vega"
+	vegapb "code.vegaprotocol.io/vega/protos/vega"
+	datapb "code.vegaprotocol.io/vega/protos/vega/data/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFilters(t *testing.T) {
+	t.Run("testGetFiltersExternal", func(t *testing.T) {
+		t.Run("NotEmpty", func(t *testing.T) {
+			dsd := &vegapb.DataSourceDefinition{
+				SourceType: &vegapb.DataSourceDefinition_External{
+					External: &vegapb.DataSourceDefinitionExternal{
+						SourceType: &vegapb.DataSourceDefinitionExternal_Oracle{
+							Oracle: &vegapb.DataSourceSpecConfiguration{
+								Signers: types.SignersIntoProto(
+									[]*types.Signer{
+										types.CreateSignerFromString("0xSOMEKEYX", types.DataSignerTypePubKey),
+										types.CreateSignerFromString("0xSOMEKEYY", types.DataSignerTypePubKey),
+									}),
+								Filters: []*datapb.Filter{
+									{
+										Key: &datapb.PropertyKey{
+											Name: "prices.ETH.value",
+											Type: datapb.PropertyKey_TYPE_INTEGER,
+										},
+										Conditions: []*datapb.Condition{
+											{
+												Operator: datapb.Condition_OPERATOR_EQUALS,
+												Value:    "ext-test-value-1",
+											},
+											{
+												Operator: datapb.Condition_OPERATOR_GREATER_THAN,
+												Value:    "ext-test-value-2",
+											},
+										},
+									},
+									{
+										Key: &datapb.PropertyKey{
+											Name: "key-name-string",
+											Type: datapb.PropertyKey_TYPE_STRING,
+										},
+										Conditions: []*datapb.Condition{
+											{
+												Operator: datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+												Value:    "ext-test-value-3",
+											},
+											{
+												Operator: datapb.Condition_OPERATOR_GREATER_THAN,
+												Value:    "ext-test-value-4",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dsdt := types.DataSourceDefinitionFromProto(dsd)
+			filters := dsdt.GetFilters()
+			assert.Equal(t, 2, len(filters))
+			assert.Equal(t, "prices.ETH.value", filters[0].Key.Name)
+			assert.Equal(t, datapb.PropertyKey_TYPE_INTEGER, filters[0].Key.Type)
+			assert.Equal(t, datapb.Condition_OPERATOR_EQUALS, filters[0].Conditions[0].Operator)
+			assert.Equal(t, "ext-test-value-1", filters[0].Conditions[0].Value)
+			assert.Equal(t, datapb.Condition_OPERATOR_GREATER_THAN, filters[0].Conditions[1].Operator)
+			assert.Equal(t, "ext-test-value-2", filters[0].Conditions[1].Value)
+
+			assert.Equal(t, "key-name-string", filters[1].Key.Name)
+			assert.Equal(t, datapb.PropertyKey_TYPE_STRING, filters[1].Key.Type)
+			assert.Equal(t, datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL, filters[1].Conditions[0].Operator)
+			assert.Equal(t, "ext-test-value-3", filters[1].Conditions[0].Value)
+
+			assert.Equal(t, datapb.Condition_OPERATOR_GREATER_THAN, filters[1].Conditions[1].Operator)
+			assert.Equal(t, "ext-test-value-4", filters[1].Conditions[1].Value)
+		})
+
+		t.Run("Empty", func(t *testing.T) {
+			dsd := &vegapb.DataSourceDefinition{
+				SourceType: &vegapb.DataSourceDefinition_External{},
+			}
+
+			dsdt := types.DataSourceDefinitionFromProto(dsd)
+			filters := dsdt.GetFilters()
+			assert.Equal(t, 0, len(filters))
+
+			dsd = &vegapb.DataSourceDefinition{
+				SourceType: &vegapb.DataSourceDefinition_External{
+					External: &vegapb.DataSourceDefinitionExternal{
+						SourceType: &vegapb.DataSourceDefinitionExternal_Oracle{
+							Oracle: nil,
+						},
+					},
+				},
+			}
+
+			dsdt = types.DataSourceDefinitionFromProto(dsd)
+			filters = dsdt.GetFilters()
+			assert.Equal(t, 0, len(filters))
+		})
+	})
+
+	t.Run("testGetFiltersInternal", func(t *testing.T) {
+		t.Run("NotEmpty", func(t *testing.T) {
+			dsd := &vegapb.DataSourceDefinition{
+				SourceType: &vegapb.DataSourceDefinition_Internal{
+					Internal: &vegapb.DataSourceDefinitionInternal{
+						SourceType: &vegapb.DataSourceDefinitionInternal_Time{
+							Time: &vega.DataSourceSpecConfigurationTime{
+								Conditions: []*datapb.Condition{
+									{
+										Operator: datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+										Value:    "int-test-value-1",
+									},
+									{
+										Operator: datapb.Condition_OPERATOR_GREATER_THAN,
+										Value:    "int-test-value-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dsdt := types.DataSourceDefinitionFromProto(dsd)
+			filters := dsdt.GetFilters()
+			// Ensure only a single filter has been created, that holds all given conditions
+			assert.Equal(t, 1, len(filters))
+
+			assert.Equal(t, "vegaprotocol.builtin.timestamp", filters[0].Key.Name)
+			assert.Equal(t, datapb.PropertyKey_TYPE_TIMESTAMP, filters[0].Key.Type)
+
+			assert.Equal(t, datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL, filters[0].Conditions[0].Operator)
+			assert.Equal(t, "int-test-value-1", filters[0].Conditions[0].Value)
+			assert.Equal(t, datapb.Condition_OPERATOR_GREATER_THAN, filters[0].Conditions[1].Operator)
+			assert.Equal(t, "int-test-value-2", filters[0].Conditions[1].Value)
+		})
+
+		t.Run("Empty", func(t *testing.T) {
+			dsd := &vegapb.DataSourceDefinition{
+				SourceType: &vegapb.DataSourceDefinition_Internal{},
+			}
+
+			dsdt := types.DataSourceDefinitionFromProto(dsd)
+			filters := dsdt.GetFilters()
+
+			assert.Equal(t, 0, len(filters))
+
+			dsd = &vegapb.DataSourceDefinition{
+				SourceType: &vegapb.DataSourceDefinition_Internal{
+					Internal: &vegapb.DataSourceDefinitionInternal{
+						SourceType: &vegapb.DataSourceDefinitionInternal_Time{
+							Time: &vega.DataSourceSpecConfigurationTime{
+								Conditions: []*datapb.Condition{},
+							},
+						},
+					},
+				},
+			}
+
+			dsdt = types.DataSourceDefinitionFromProto(dsd)
+			filters = dsdt.GetFilters()
+			assert.Equal(t, 0, len(filters))
+		})
+	})
+}


### PR DESCRIPTION
Adds missing key type and name for internal data sources.

```runtime error: invalid memory address or nil pointer dereference", "stack": "goroutine 548 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x65\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine.func2()\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:732 +0x4c\npanic({0x4550d00, 0x6f0fa40})\n\t/usr/local/go/src/runtime/panic.go:884 +0x212\ncode.vegaprotocol.io/vega/core/governance.validateFuture(0xc004f1e0f0, 0xc0014f3d90?, {0x53d1b10, 0xc001932300}, 0xc0014f3e40, 0x50?)\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/governance/market.go:249 +0x58c\ncode.vegaprotocol.io/vega/core/governance.validateNewInstrument(0x7f8367e41f18?, 0xc0014f3de8?, {0x53d1b10?, 0xc001932300?}, 0xedb9d2058?, 0xe0?)\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/governance/market.go:314 +0x4d\ncode.vegaprotocol.io/vega/core/governance.validateNewMarketChange(0xc00a178828, {0x53d1b10?, 0xc001932300?}, 0x0?, {0x53d53b8, 0xc0136bbc20}, 0x295be9?, 0x0?)\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/governance/market.go:398 +0x6b\ncode.vegaprotocol.io/vega/core/governance.(*Engine).validateChange(0xc0019304d0, 0xc0062d2690)\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/governance/engine.go:833 +0x171\ncode.vegaprotocol.io/vega/core/governance.(*Engine).validateOpenProposal(0xc0019304d0, 0xc00a6ae790)\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/governance/engine.go:707 +0x22b0\ncode.vegaprotocol.io/vega/core/governance.(*Engine).SubmitProposal(0xc0019304d0, {0x53c1fa0, 0xc0062d23f0}, {{0xc0040f6798?, 0xc00c9144a0?}, 0xc0062d2690?, 0xc00c9146e0?}, {0xc00bff5480, 0x40}, {0xc00be414c0, ...})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/governance/engine.go:453 +0x5ea\ncode.vegaprotocol.io/vega/core/processor.(*App).DeliverPropose(0xc000ddb600, {0x53c1fa0, 0xc0062d23f0}, {0x53e4408, 0xc009e0b900}, {0xc00bff5480, 0x40})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/processor/abci.go:1407 +0x5de\ncode.vegaprotocol.io/vega/core/processor.addDeterministicID.func1({0x53c1fa0, 0xc0062d23f0}, {0x53e4408, 0xc009e0b900})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/processor/abci.go:418 +0x103\ncode.vegaprotocol.io/vega/core/processor.(*App).CheckProposeW.func1({0x53c1fa0, 0xc0062d23f0}, {0x53e4408, 0xc009e0b900})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/processor/abci.go:429 +0x76\ncode.vegaprotocol.io/vega/core/processor.(*App).SendTransactionResult.func1({0x53c1fa0, 0xc0062d23f0}, {0x53e4408, 0xc009e0b900})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/processor/abci.go:470 +0x5c\ncode.vegaprotocol.io/vega/core/blockchain/abci.(*App).DeliverTx(0xc0019306e0, {{0xc0020ba380, 0x34a, 0x34a}})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/core/blockchain/abci/abci.go:140 +0x762\ncode.vegaprotocol.io/vega/cmd/vega/node.(*appW).DeliverTx(0xc009f65600?, {{0xc0020ba380?, 0x20?, 0xc009f65620?}})\n\t/jenkins/workspace/private/Deployments/stagnet1/Manage-Network/vega/cmd/vega/node/app_wrapper.go:37 +0x6c\ngithub.com/tendermint/tendermint/abci/client.(*localClient).DeliverTxAsync(0xc00107f0e0, {{0xc0020ba380?, 0x22f4b04?, 0xc00107f0e0?}})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/abci/client/local_client.go:93 +0x105\ngithub.com/tendermint/tendermint/proxy.(*appConnConsensus).DeliverTxAsync(0xc009988700?, {{0xc0020ba380?, 0x20?, 0xb?}})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/proxy/app_conn.go:85 +0x26\ngithub.com/tendermint/tendermint/state.execBlockOnProxyApp({0x53c05d0?, 0xc000014de8}, {0x53d3780, 0xc000d837d0}, 0xc007eb6d20, {0x53e4cf0, 0xc0003e7d10}, 0x904?)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/state/execution.go:320 +0x847\ngithub.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x1}, {0xc012719740, 0x7}}, {0xc006e6f140, 0x1a}, 0x1, 0x904, {{0xc009d04a80, ...}, ...}, ...}, ...)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/state/execution.go:140 +0x171\ngithub.com/tendermint/tendermint/consensus.(*State).finalizeCommit(0xc006c43180, 0x905)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1661 +0xafd\ngithub.com/tendermint/tendermint/consensus.(*State).tryFinalizeCommit(0xc006c43180, 0x905)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1570 +0x2ff\ngithub.com/tendermint/tendermint/consensus.(*State).enterCommit.func1()\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1505 +0xaa\ngithub.com/tendermint/tendermint/consensus.(*State).enterCommit(0xc006c43180, 0x905, 0x0)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1543 +0xccf\ngithub.com/tendermint/tendermint/consensus.(*State).addVote(0xc006c43180, 0xc0093b8aa0, {0xc006c49b00, 0x28})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:2165 +0x18dc\ngithub.com/tendermint/tendermint/consensus.(*State).tryAddVote(0xc006c43180, 0xc0093b8aa0, {0xc006c49b00?, 0xc0019f4c00?})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1963 +0x2c\ngithub.com/tendermint/tendermint/consensus.(*State).handleMsg(0xc006c43180, {{0x539e560?, 0xc00a193fa8?}, {0xc006c49b00?, 0x0?}})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:861 +0x170\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine(0xc006c43180, 0x0)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:768 +0x3f9\ncreated by github.com/tendermint/tendermint/consensus.(*State).OnStart\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:379```


```2023-03-08T13:36:54.524Z	ERROR	tendermint	consensus/state.go:732	CONSENSUS FAILURE!!!	{"err": "runtime error: invalid memory address or nil pointer dereference", "stack": "goroutine 203 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x65\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine.func2()\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:732 +0x4c\npanic({0x4548b60, 0x6effa40})\n\t/usr/local/go/src/runtime/panic.go:884 +0x212\ncode.vegaprotocol.io/vega/core/governance.validateFuture(0xc00a7faeb0, 0xc00b133d90?, {0x53c73f0, 0xc00023a9c0}, 0xc00b133e40, 0xe7?)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/market.go:249 +0x58c\ncode.vegaprotocol.io/vega/core/governance.validateNewInstrument(0x7fc125bbea68?, 0xc00b133de8?, {0x53c73f0?, 0xc00023a9c0?}, 0xedb9a8682?, 0xa0?)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/market.go:314 +0x4d\ncode.vegaprotocol.io/vega/core/governance.validateNewMarketChange(0xc00880ed30, {0x53c73f0?, 0xc00023a9c0?}, 0x0?, {0x53cac98, 0xc00216a480}, 0x0?, 0x0?)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/market.go:398 +0x6b\ncode.vegaprotocol.io/vega/core/governance.(*Engine).validateChange(0xc00034a840, 0xc0057a3740)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/engine.go:833 ```