### PR TITLE
fix: set newest first in stream order pagination

### DIFF
--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -2190,7 +2190,7 @@ func (t *tradingDataServiceV2) ObserveOrders(req *v2.ObserveOrdersRequest, srv v
 }
 
 func (t *tradingDataServiceV2) sendOrdersSnapshot(ctx context.Context, req *v2.ObserveOrdersRequest, srv v2.TradingDataService_ObserveOrdersServer) error {
-	orders, pageInfo, err := t.orderService.ListOrders(ctx, req.PartyId, req.MarketId, nil, true, entities.CursorPagination{},
+	orders, pageInfo, err := t.orderService.ListOrders(ctx, req.PartyId, req.MarketId, nil, true, entities.CursorPagination{NewestFirst: true},
 		entities.DateRange{}, entities.OrderFilter{})
 	if err != nil {
 		return errors.Wrap(err, "fetching orders initial image")


### PR DESCRIPTION
Setting  the NewestFirst field first in ListOrders for the orders stream initial snapshot.