### PR TITLE
fix: reannouncing node in the same epoch kills data node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [7765](https://github.com/vegaprotocol/vega/issues/7765) - Assure pegged order won't get deployed with insufficient margin
 - [7786](https://github.com/vegaprotocol/vega/issues/7786) - Fix validation of order amendments (check for negative pegged offset)
 - [7750](https://github.com/vegaprotocol/vega/issues/7750) - Fix not all paths cleanly close network history index store.
+- [7805](https://github.com/vegaprotocol/vega/issues/7805) - Fix re-announcing node in the same epoch kills data node.
 
 ## 0.68.0
 

--- a/datanode/sqlstore/node.go
+++ b/datanode/sqlstore/node.go
@@ -123,7 +123,17 @@ func (store *Node) UpsertRanking(ctx context.Context, rs *entities.RankingScore,
 			tx_hash,
 			vega_time)
 		VALUES
-			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		ON CONFLICT (node_id, epoch_seq) DO UPDATE
+		SET
+			stake_score = EXCLUDED.stake_score,
+		    performance_score = EXCLUDED.performance_score,
+		    ranking_score = EXCLUDED.ranking_score,
+		    voting_power = EXCLUDED.voting_power,
+		    previous_status = EXCLUDED.previous_status,
+		    status = EXCLUDED.status,
+		    tx_hash = EXCLUDED.tx_hash,
+		    vega_time = EXCLUDED.vega_time`,
 		aux.NodeID,
 		rs.EpochSeq,
 		rs.StakeScore,


### PR DESCRIPTION
Close #7805 