### PR TITLE
7816 require slippage factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [7731](https://github.com/vegaprotocol/vega/issues/7731) - Upgrade the interplanetary file system library to latest release
 - [7802](https://github.com/vegaprotocol/vega/issues/7802) - Split liquidity auction trigger into two cases
 - [7728](https://github.com/vegaprotocol/vega/issues/7728) - Remove current order flag from table - adds restrictions to how orders can be paged
+- [7816](https://github.com/vegaprotocol/vega/issues/7816) - Require slippage factors to alays be set
 
 ### 🗑️ Deprecation
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [7731](https://github.com/vegaprotocol/vega/issues/7731) - Upgrade the interplanetary file system library to latest release
 - [7802](https://github.com/vegaprotocol/vega/issues/7802) - Split liquidity auction trigger into two cases
 - [7728](https://github.com/vegaprotocol/vega/issues/7728) - Remove current order flag from table - adds restrictions to how orders can be paged
-- [7816](https://github.com/vegaprotocol/vega/issues/7816) - Require slippage factors to alays be set
+- [7816](https://github.com/vegaprotocol/vega/issues/7816) - Require slippage factors to always be set
 
 ### 🗑️ Deprecation
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -

--- a/core/integration/features/closeouts/position-resolution-after-auction.feature
+++ b/core/integration/features/closeouts/position-resolution-after-auction.feature
@@ -1,11 +1,11 @@
 Feature: Set up a market with an opening auction, then uncross the book so that the part trading in auction becomes distressed 
   Background:
     Given the markets:
-      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config          |
-      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future |
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-4 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 0.1                    | 0.1                       |
     And the parties deposit on asset's general account the following amount:
       | party   | asset | amount    |
-      | party1  | BTC   |     20000 |
+      | party1  | BTC   | 20000     |
       | party2a | BTC   | 100000000 |
       | party2b | BTC   | 100000000 |
       | party2c | BTC   | 100000000 |

--- a/core/integration/features/price_monitoring/price-monitoring-bounds.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-bounds.feature
@@ -152,8 +152,8 @@ Feature: Price monitoring triggers test on or around monitoring bounds with deci
     # 9000000001   11000000000
     # Update price monitoring bounds
     When the markets are updated:
-      | id        | price monitoring            |
-      | ETH/DEC20 | my-updated-price-monitoring |
+      | id        | price monitoring            | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC20 | my-updated-price-monitoring | 0.001                  | 0                         |
     Then the market data for the market "ETH/DEC20" should be:
       | mark price  | trading mode            | horizon | min bound  | max bound   | target stake    | supplied stake   | open interest |
       | 10000000000 | TRADING_MODE_CONTINUOUS | 5       | 9000000001 | 11000000000 | 743400000000000 | 9000000000000000 | 1             |
@@ -206,8 +206,8 @@ Feature: Price monitoring triggers test on or around monitoring bounds with deci
 
     # Update price monitoring bounds
     When the markets are updated:
-      | id        | price monitoring              |
-      | ETH/DEC20 | my-updated-price-monitoring   |
+      | id        | price monitoring            | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC20 | my-updated-price-monitoring | 0.001                  | 0                         |
     Then the market data for the market "ETH/DEC20" should be:
       | mark price  | trading mode            | horizon | min bound  | max bound   | target stake    | supplied stake   | open interest |
       | 10000000000 | TRADING_MODE_CONTINUOUS | 5       | 9000000001 | 11000000000 | 743400000000000 | 9000000000000000 | 1             |

--- a/core/integration/features/price_monitoring/price-monitoring-bounds.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-bounds.feature
@@ -15,8 +15,8 @@ Feature: Price monitoring triggers test on or around monitoring bounds with deci
       | risk aversion | tau                    | mu | r     | sigma |
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
-      | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring      | data source config          | decimal places |
-      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring   | default-eth-for-future | 5              |
+      | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring    | data source config     | decimal places | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 5              | 0.001                  | 0                         |
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 1     |

--- a/core/integration/features/verified/0015-INSR-insurance_pool_balance_test.feature
+++ b/core/integration/features/verified/0015-INSR-insurance_pool_balance_test.feature
@@ -337,8 +337,8 @@ Feature: Test closeout type 1: margin >= cost of closeout
       | 1.2           | 1.5            | 2              |
 
     And the markets:
-      | id        | quote name | asset | risk model                | margin calculator   | auction duration | fees         | price monitoring | data source config     |
-      | ETH/DEC19 | ETH        | USD   | lognormal-risk-model-fish | margin-calculator-1 | 1                | default-none | default-none     | default-eth-for-future |
+      | id        | quote name | asset | risk model                | margin calculator   | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC19 | ETH        | USD   | lognormal-risk-model-fish | margin-calculator-1 | 1                | default-none | default-none     | default-eth-for-future | 0.001                  | 0                         |
 
     And the following network parameters are set:
       | name                                    | value |

--- a/core/integration/features/verified/0026-AUCT-auction_interaction.feature
+++ b/core/integration/features/verified/0026-AUCT-auction_interaction.feature
@@ -155,8 +155,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -224,8 +224,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -300,8 +300,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -545,8 +545,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -638,8 +638,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -747,8 +747,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     Then the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |
@@ -805,8 +805,8 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.8              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 0.5                    | 0                         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type    |

--- a/core/integration/features/verified/0034-PROB-liquidity_TauScaling.feature
+++ b/core/integration/features/verified/0034-PROB-liquidity_TauScaling.feature
@@ -29,8 +29,8 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
       | 100000  | 0.99        | 3                 |
 
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range |
-      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 100            |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 100            | 0.001                  | 0                         |
 
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |
@@ -144,8 +144,8 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
       | 100000  | 0.99        | 3                 |
 
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range |
-      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              | 0.001                  | 0                         |
 
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |
@@ -244,8 +244,8 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
       | 100000  | 0.99        | 3                 |
 
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range |
-      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              | 0.001                  | 0                         |
 
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |
@@ -346,8 +346,8 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
 
 
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range |
-      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              | 0.001                  | 0                         |
 
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |
@@ -447,8 +447,8 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
 
 
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range |
-      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              | 0.001                  | 0                         |
 
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |
@@ -547,8 +547,8 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
       | 100000  | 0.99        | 3                 |
 
     And the markets:
-      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range |
-      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              |
+      | id        | quote name | asset | risk model              | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | ETH        | USD   | log-normal-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1              | 0.001                  | 0                         |
 
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount       |

--- a/core/integration/features/verified/0041-TSK-target_stake.feature
+++ b/core/integration/features/verified/0041-TSK-target_stake.feature
@@ -47,8 +47,8 @@ Feature: Target stake
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.0              | 10s         | 1.5            |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 1e6                    | 1e6                       |
 
     # put some volume on the book so that others can increase their
     # positions and close out if needed too
@@ -197,8 +197,8 @@ Feature: Target stake
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.0              | 20s         | 1.5            |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 1e6                    | 1e6                       |
 
     # put some volume on the book so that others can increase their
     # positions and close out if needed too
@@ -270,8 +270,8 @@ Feature: Target stake
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.0              | 10s         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 1e6                    | 1e6                       |
 
     # target_stake = 110 x 140 x 1 x 0.1 =1540
     And the target stake should be "1540" for the market "ETH/DEC21"
@@ -289,8 +289,8 @@ Feature: Target stake
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.0              | 10s         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 1e6                    | 1e6                       |
 
     When the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
@@ -337,8 +337,8 @@ Feature: Target stake
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 1.0              | 10s         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/DEC21 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC21 | updated-lqm-params   | 1e6                    | 1e6                       |
     And the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | lp_1  | ETH/DEC21 | buy  | 1000   | 90    | 0                | TYPE_LIMIT | TIF_GTC | lp_1_0    |

--- a/core/integration/features/verified/liquidity-provision-bond-account.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account.feature
@@ -34,8 +34,8 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.24             | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/MAR22 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | updated-lqm-params   | 0.7                    | 0                         |
     And the following network parameters are set:
       | name                                  | value |
       | market.liquidity.bondPenaltyParameter | 0.2   |
@@ -170,8 +170,8 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.1              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/MAR22 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR22 | updated-lqm-params   | 0.7                    | 0                         |
     And the following network parameters are set:
       | name                                  | value |
       | market.liquidity.bondPenaltyParameter | 0.5   |

--- a/core/integration/features/verified/risk-parameters-ranges-test.feature
+++ b/core/integration/features/verified/risk-parameters-ranges-test.feature
@@ -130,21 +130,21 @@ Feature: test risk model parameter ranges
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.1              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/MAR0  | updated-lqm-params   |
-      | ETH/MAR11 | updated-lqm-params   |
-      | ETH/MAR12 | updated-lqm-params   |
-      | ETH/MAR21 | updated-lqm-params   |
-      | ETH/MAR22 | updated-lqm-params   |
-      | ETH/MAR23 | updated-lqm-params   |
-      | ETH/MAR31 | updated-lqm-params   |
-      | ETH/MAR32 | updated-lqm-params   |
-      | ETH/MAR41 | updated-lqm-params   |
-      | ETH/MAR42 | updated-lqm-params   |
-      | ETH/MAR43 | updated-lqm-params   |
-      | ETH/MAR51 | updated-lqm-params   |
-      | ETH/MAR52 | updated-lqm-params   |
-      | ETH/MAR53 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR0  | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR11 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR12 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR21 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR22 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR23 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR31 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR32 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR41 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR42 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR43 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR51 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR52 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR53 | updated-lqm-params   | 1e6                    | 1e6                       |
 
     And the following network parameters are set:
       | name                                  | value |
@@ -444,21 +444,21 @@ Feature: test risk model parameter ranges
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.1              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/MAR0  | updated-lqm-params   |
-      | ETH/MAR11 | updated-lqm-params   |
-      | ETH/MAR12 | updated-lqm-params   |
-      | ETH/MAR21 | updated-lqm-params   |
-      | ETH/MAR22 | updated-lqm-params   |
-      | ETH/MAR23 | updated-lqm-params   |
-      | ETH/MAR32 | updated-lqm-params   |
-      | ETH/MAR31 | updated-lqm-params   |
-      | ETH/MAR41 | updated-lqm-params   |
-      | ETH/MAR42 | updated-lqm-params   |
-      | ETH/MAR43 | updated-lqm-params   |
-      | ETH/MAR51 | updated-lqm-params   |
-      | ETH/MAR52 | updated-lqm-params   |
-      | ETH/MAR53 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR0  | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR11 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR12 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR21 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR22 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR23 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR32 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR31 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR41 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR42 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR43 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR51 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR52 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR53 | updated-lqm-params   | 1e6                    | 1e6                       |
 
     And the following network parameters are set:
       | name                                  | value |
@@ -507,21 +507,21 @@ Feature: test risk model parameter ranges
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.1              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/MAR0  | updated-lqm-params   |
-      | ETH/MAR11 | updated-lqm-params   |
-      | ETH/MAR12 | updated-lqm-params   |
-      | ETH/MAR21 | updated-lqm-params   |
-      | ETH/MAR22 | updated-lqm-params   |
-      | ETH/MAR23 | updated-lqm-params   |
-      | ETH/MAR31 | updated-lqm-params   |
-      | ETH/MAR32 | updated-lqm-params   |
-      | ETH/MAR41 | updated-lqm-params   |
-      | ETH/MAR42 | updated-lqm-params   |
-      | ETH/MAR43 | updated-lqm-params   |
-      | ETH/MAR51 | updated-lqm-params   |
-      | ETH/MAR52 | updated-lqm-params   |
-      | ETH/MAR53 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR0  | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR11 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR12 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR21 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR22 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR23 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR31 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR32 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR41 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR42 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR43 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR51 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR52 | updated-lqm-params   | 1e6                    | 1e6                       |
+      | ETH/MAR53 | updated-lqm-params   | 1e6                    | 1e6                       |
     And the following network parameters are set:
       | name                                  | value |
       | market.liquidity.bondPenaltyParameter | 0.2   |

--- a/core/integration/features/verified/risk-parameters-sigma-test.feature
+++ b/core/integration/features/verified/risk-parameters-sigma-test.feature
@@ -47,8 +47,8 @@ Feature: test risk model parameter sigma
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.1              | 24h         | 1              |
     When the markets are updated:
-      | id        | liquidity monitoring |
-      | ETH/MAR53 | updated-lqm-params   |
+      | id        | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR53 | updated-lqm-params   | 1e6                    | 1e6                       |
     And the following network parameters are set:
       | name                                  | value |
       | market.liquidity.bondPenaltyParameter | 0.2   |
@@ -103,8 +103,8 @@ Feature: test risk model parameter sigma
       | name               | triggering ratio | time window | scaling factor |
       | updated-lqm-params | 0.1              | 24h         | 1              |
     When the markets are updated:
-      | id       | liquidity monitoring |
-      | ETH/MAR0 | updated-lqm-params   |
+      | id       | liquidity monitoring | linear slippage factor | quadratic slippage factor |
+      | ETH/MAR0 | updated-lqm-params   | 1e6                    | 1e6                       |
     And the following network parameters are set:
       | name                                  | value |
       | market.liquidity.bondPenaltyParameter | 0.2   |

--- a/core/integration/steps/the_markets.go
+++ b/core/integration/steps/the_markets.go
@@ -419,14 +419,14 @@ func parseMarketsTable(table *godog.Table) []RowWrapper {
 func parseMarketsUpdateTable(table *godog.Table) []RowWrapper {
 	return StrictParseTable(table, []string{
 		"id",
+		"linear slippage factor", // slippage factors must be explicitly set to avoid setting them to hard-coded defaults
+		"quadratic slippage factor",
 	}, []string{
 		"data source config",   // product update
 		"price monitoring",     // price monitoring update
 		"risk model",           // risk model update
 		"liquidity monitoring", // liquidity monitoring update
 		"lp price range",
-		"linear slippage factor",
-		"quadratic slippage factor",
 	})
 }
 

--- a/core/integration/steps/the_markets.go
+++ b/core/integration/steps/the_markets.go
@@ -406,13 +406,13 @@ func parseMarketsTable(table *godog.Table) []RowWrapper {
 		"price monitoring",
 		"margin calculator",
 		"auction duration",
+		"linear slippage factor",
+		"quadratic slippage factor",
 	}, []string{
 		"decimal places",
 		"position decimal places",
 		"liquidity monitoring",
 		"lp price range",
-		"linear slippage factor",
-		"quadratic slippage factor",
 	})
 }
 
@@ -542,7 +542,7 @@ func (r marketRow) lpPriceRange() float64 {
 func (r marketRow) linearSlippageFactor() float64 {
 	if !r.row.HasColumn("linear slippage factor") {
 		// set to 0.1 by default
-		return 0.1
+		return 0.001
 	}
 	return r.row.MustF64("linear slippage factor")
 }
@@ -550,7 +550,7 @@ func (r marketRow) linearSlippageFactor() float64 {
 func (r marketRow) quadraticSlippageFactor() float64 {
 	if !r.row.HasColumn("quadratic slippage factor") {
 		// set to 0.1 by default
-		return 0.1
+		return 0.0
 	}
 	return r.row.MustF64("quadratic slippage factor")
 }

--- a/core/risk/engine_test.go
+++ b/core/risk/engine_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var DefaultSlippageFactor = num.DecimalFromFloat(0.1)
+
 func peggedOrderCounterForTest(int64) {}
 
 type MLEvent interface {
@@ -395,7 +397,7 @@ func testMarginWithOrderInBook(t *testing.T) {
 	statevar := mocks.NewMockStateVarEngine(ctrl)
 	statevar.EXPECT().RegisterStateVariable(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	statevar.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any())
-	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, ts, broker, "mktid", "ETH", statevar, num.DecimalFromInt64(1), false, nil, types.DefaultSlippageFactor, types.DefaultSlippageFactor)
+	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, ts, broker, "mktid", "ETH", statevar, num.DecimalFromInt64(1), false, nil, DefaultSlippageFactor, DefaultSlippageFactor)
 	evt := testMargin{
 		party:   "tx",
 		size:    10,
@@ -499,7 +501,7 @@ func testMarginWithOrderInBook2(t *testing.T) {
 	statevar := mocks.NewMockStateVarEngine(ctrl)
 	statevar.EXPECT().RegisterStateVariable(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	statevar.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any())
-	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, ts, broker, "mktid", "ETH", statevar, num.DecimalFromInt64(1), false, nil, types.DefaultSlippageFactor, types.DefaultSlippageFactor)
+	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, ts, broker, "mktid", "ETH", statevar, num.DecimalFromInt64(1), false, nil, DefaultSlippageFactor, DefaultSlippageFactor)
 	evt := testMargin{
 		party:   "tx",
 		size:    13,
@@ -610,7 +612,7 @@ func testMarginWithOrderInBookAfterParamsUpdate(t *testing.T) {
 	statevarEngine.EXPECT().RegisterStateVariable(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	statevarEngine.EXPECT().NewEvent(gomock.Any(), gomock.Any(), gomock.Any())
 	asset := "ETH"
-	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, ts, broker, marketID, asset, statevarEngine, num.DecimalFromInt64(1), false, nil, types.DefaultSlippageFactor, types.DefaultSlippageFactor)
+	testE := risk.NewEngine(log, conf.Execution.Risk, mc, model, book, as, ts, broker, marketID, asset, statevarEngine, num.DecimalFromInt64(1), false, nil, DefaultSlippageFactor, DefaultSlippageFactor)
 
 	evt := testMargin{
 		party:   "tx",
@@ -756,8 +758,8 @@ func getTestEngine(t *testing.T) *testEngine {
 		num.DecimalFromInt64(1),
 		false,
 		nil,
-		types.DefaultSlippageFactor,
-		types.DefaultSlippageFactor,
+		DefaultSlippageFactor,
+		DefaultSlippageFactor,
 	)
 
 	return &testEngine{

--- a/core/types/governance_new_market.go
+++ b/core/types/governance_new_market.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	ErrInvalidCommitmentAmount = errors.New("invalid commitment amount")
+	ErrMissingSlippageFactor   = errors.New("slippage factor not specified")
 	DefaultSlippageFactor      = num.MustDecimalFromString("0.1")
 )
 
@@ -240,17 +241,16 @@ func NewMarketConfigurationFromProto(p *vegapb.NewMarketConfiguration) (*NewMark
 	linearSlippageFactor := DefaultSlippageFactor
 	quadraticSlippageFactor := DefaultSlippageFactor
 	var err error
-	if len(p.LinearSlippageFactor) > 0 {
-		linearSlippageFactor, err = num.DecimalFromString(p.LinearSlippageFactor)
-		if err != nil {
-			return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
-		}
+	if len(p.LinearSlippageFactor) == 0 || len(p.QuadraticSlippageFactor) == 0 {
+		return nil, ErrMissingSlippageFactor
 	}
-	if len(p.QuadraticSlippageFactor) > 0 {
-		quadraticSlippageFactor, err = num.DecimalFromString(p.QuadraticSlippageFactor)
-		if err != nil {
-			return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
-		}
+	linearSlippageFactor, err = num.DecimalFromString(p.LinearSlippageFactor)
+	if err != nil {
+		return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
+	}
+	quadraticSlippageFactor, err = num.DecimalFromString(p.QuadraticSlippageFactor)
+	if err != nil {
+		return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
 	}
 
 	r := &NewMarketConfiguration{

--- a/core/types/governance_new_market.go
+++ b/core/types/governance_new_market.go
@@ -24,7 +24,6 @@ import (
 var (
 	ErrInvalidCommitmentAmount = errors.New("invalid commitment amount")
 	ErrMissingSlippageFactor   = errors.New("slippage factor not specified")
-	DefaultSlippageFactor      = num.MustDecimalFromString("0.1")
 )
 
 type ProposalTermsNewMarket struct {
@@ -238,17 +237,14 @@ func NewMarketConfigurationFromProto(p *vegapb.NewMarketConfiguration) (*NewMark
 	}
 	lppr, _ := num.DecimalFromString(p.LpPriceRange)
 
-	linearSlippageFactor := DefaultSlippageFactor
-	quadraticSlippageFactor := DefaultSlippageFactor
-	var err error
 	if len(p.LinearSlippageFactor) == 0 || len(p.QuadraticSlippageFactor) == 0 {
 		return nil, ErrMissingSlippageFactor
 	}
-	linearSlippageFactor, err = num.DecimalFromString(p.LinearSlippageFactor)
+	linearSlippageFactor, err := num.DecimalFromString(p.LinearSlippageFactor)
 	if err != nil {
 		return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
 	}
-	quadraticSlippageFactor, err = num.DecimalFromString(p.QuadraticSlippageFactor)
+	quadraticSlippageFactor, err := num.DecimalFromString(p.QuadraticSlippageFactor)
 	if err != nil {
 		return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
 	}

--- a/core/types/governance_update_market.go
+++ b/core/types/governance_update_market.go
@@ -223,20 +223,16 @@ func UpdateMarketConfigurationFromProto(p *vegapb.UpdateMarketConfiguration) (*U
 	}
 
 	lppr, _ := num.DecimalFromString(p.LpPriceRange)
-	linearSlippageFactor := DefaultSlippageFactor
-	quadraticSlippageFactor := DefaultSlippageFactor
-	var err error
-	if len(p.LinearSlippageFactor) > 0 {
-		linearSlippageFactor, err = num.DecimalFromString(p.LinearSlippageFactor)
-		if err != nil {
-			return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
-		}
+	if len(p.LinearSlippageFactor) == 0 || len(p.QuadraticSlippageFactor) == 0 {
+		return nil, ErrMissingSlippageFactor
 	}
-	if len(p.QuadraticSlippageFactor) > 0 {
-		quadraticSlippageFactor, err = num.DecimalFromString(p.QuadraticSlippageFactor)
-		if err != nil {
-			return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
-		}
+	linearSlippageFactor, err := num.DecimalFromString(p.LinearSlippageFactor)
+	if err != nil {
+		return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
+	}
+	quadraticSlippageFactor, err := num.DecimalFromString(p.QuadraticSlippageFactor)
+	if err != nil {
+		return nil, fmt.Errorf("error getting new market configuration from proto: %w", err)
 	}
 
 	r := &UpdateMarketConfiguration{


### PR DESCRIPTION
Closes #7816 

Makes slippage factors required in system & integration tests

This probably will require some work on the system-test side
