### PR TITLE
fix: avoid panic for malformed withdrawal

### DIFF
--- a/core/processor/process_withdraw.go
+++ b/core/processor/process_withdraw.go
@@ -36,6 +36,9 @@ func (app *App) processWithdraw(ctx context.Context, w *types.WithdrawSubmission
 	case asset.IsBuiltinAsset():
 		return app.banking.WithdrawBuiltinAsset(ctx, id, party, w.Asset, w.Amount)
 	case asset.IsERC20():
+		if w.Ext == nil {
+			return ErrMissingWithdrawERC20Ext
+		}
 		ext := w.Ext.GetErc20()
 		if ext == nil {
 			return ErrMissingWithdrawERC20Ext


### PR DESCRIPTION
A withdrawal submitted with a bad format caused a panic with 0.68.0:

```
   "withdrawSubmission": {
       "asset": "fc7fd956078fb1fc9db5c19b88f0874c4299b2a7639ad05a47a28c0aef291b55",
       "amount": "1000000000000000000",
       "erc20": {
          "receiverAddress": "0xFccb160E74DB212Be37c95F8BE61EEeE4E5b38a3"
       }
```

`panic.go:884 +0x212\[ncode.vegaprotocol.io/vega/core/types.(*WithdrawExt).GetErc20(...)](http://ncode.vegaprotocol.io/vega/core/types.(*WithdrawExt).GetErc20(...))\n\t/home/runner/work/vega/vega/core/types/chain_events.go:53\[ncode.vegaprotocol.io/vega/core/processor.(*App).processWithdraw(0xc00194b080](http://ncode.vegaprotocol.io/vega/core/processor.(*App).processWithdraw(0xc00194b080), {0x3b69818, 0xc0075447e0}, 0xc00d2e0440, {0xc009874700, 0x40}, {0xc00f9c0200, 0x40})\n\t/home/runner/work/vega/vega/core/processor/process_withdraw.go:39 +0x4df\[ncode.vegaprotocol.io/vega/core/processor.(*App).DeliverWithdraw(0xc00194b080](http://ncode.vegaprotocol.io/vega/core/processor.(*App).DeliverWithdraw(0xc00194b080), {0x3b69818, 0xc0075447e0}, {0x3b8a948, 0xc00cc22e00}`