### PR TITLE
fix: client.check_transactionCLI client interaction

### DIFF
--- a/cmd/vegawallet/commands/service_run.go
+++ b/cmd/vegawallet/commands/service_run.go
@@ -576,7 +576,7 @@ func handleAPIv2Request(interaction interactor.Interaction, responseChan chan<- 
 			},
 		}
 	case interactor.RequestTransactionReviewForChecking:
-		str := p.String().BlueArrow().Text("The application \"").InfoText(data.Hostname).Text("\" wants to send the following transaction to be checked:").NextLine()
+		str := p.String().BlueArrow().Text("The application \"").InfoText(data.Hostname).Text("\" wants to check the following transaction:").NextLine()
 		str.Pad().Text("Using the key: ").InfoText(data.PublicKey).NextLine()
 		str.Pad().Text("From the wallet: ").InfoText(data.Wallet).NextLine()
 		fmtCmd := strings.Replace("  "+data.Transaction, "\n", "\n  ", -1)
@@ -584,12 +584,12 @@ func handleAPIv2Request(interaction interactor.Interaction, responseChan chan<- 
 		p.Print(str)
 		approved := true
 		if !enableAutomaticConsent {
-			approved = yesOrNo(p.String().QuestionMark().Text("Do you want to sign this transaction?"), p)
+			approved = yesOrNo(p.String().QuestionMark().Text("Do you allow the network to check this transaction?"), p)
 		}
 		if approved {
-			p.Print(p.String().CheckMark().Text("Signing approved.").NextLine())
+			p.Print(p.String().CheckMark().Text("Checking approved.").NextLine())
 		} else {
-			p.Print(p.String().CrossMark().Text("Signing rejected.").NextLine())
+			p.Print(p.String().CrossMark().Text("Checking rejected.").NextLine())
 		}
 		responseChan <- interactor.Interaction{
 			TraceID: interaction.TraceID,

--- a/cmd/vegawallet/commands/service_run.go
+++ b/cmd/vegawallet/commands/service_run.go
@@ -575,6 +575,29 @@ func handleAPIv2Request(interaction interactor.Interaction, responseChan chan<- 
 				Approved: approved,
 			},
 		}
+	case interactor.RequestTransactionReviewForChecking:
+		str := p.String().BlueArrow().Text("The application \"").InfoText(data.Hostname).Text("\" wants to send the following transaction to be checked:").NextLine()
+		str.Pad().Text("Using the key: ").InfoText(data.PublicKey).NextLine()
+		str.Pad().Text("From the wallet: ").InfoText(data.Wallet).NextLine()
+		fmtCmd := strings.Replace("  "+data.Transaction, "\n", "\n  ", -1)
+		str.InfoText(fmtCmd).NextLine()
+		p.Print(str)
+		approved := true
+		if !enableAutomaticConsent {
+			approved = yesOrNo(p.String().QuestionMark().Text("Do you want to sign this transaction?"), p)
+		}
+		if approved {
+			p.Print(p.String().CheckMark().Text("Signing approved.").NextLine())
+		} else {
+			p.Print(p.String().CrossMark().Text("Signing rejected.").NextLine())
+		}
+		responseChan <- interactor.Interaction{
+			TraceID: interaction.TraceID,
+			Name:    interactor.DecisionName,
+			Data: interactor.Decision{
+				Approved: approved,
+			},
+		}
 	case interactor.TransactionFailed:
 		str := p.String()
 		str.DangerBangMark().DangerText("The transaction failed.").NextLine()


### PR DESCRIPTION
Noticed that the `client.check_transaction` wallet-service endpoint wasn't working when using the client interaction through the CLI.

Before:
```
panic: unhandled interaction: "REQUEST_TRANSACTION_REVIEW_FOR_CHECKING"

goroutine 178 [running]:
code.vegaprotocol.io/vega/cmd/vegawallet/commands.handleAPIv2Request({{0xc0033d6050, 0x40}, {0x40d0753, 0x27}, {0x3cdd900, 0xc00154f260}}, 0xc00046f9e0?, 0x0?, 0xc0011a7180?)
	/Users/wwestgarth/work/vega/cmd/vegawallet/commands/service_run.go:591 +0x3cb4
code.vegaprotocol.io/vega/cmd/vegawallet/commands.RunService.func5({0x476b9d8, 0xc001b3fb40})
	/Users/wwestgarth/work/vega/cmd/vegawallet/commands/service_run.go:299 +0x1ef
code.vegaprotocol.io/vega/libs/job.(*Runner).Go.func1()
	/Users/wwestgarth/work/vega/libs/job/runner.go:31 +0x66
created by code.vegaprotocol.io/vega/libs/job.(*Runner).Go
	/Users/wwestgarth/work/vega/libs/job/runner.go:29 +0x8a
```

now:
```
➜ The application "hello-hello" wants to send the following transaction to be checked:
  Using the key: 4dbb7733b4381d79ce372ef838e1651e028b19553d8ae2de14dc2dd37bdf17b2
  From the wallet: sandbox
  {"orderSubmission":{"marketId":"eb2d3902fdda9c3eb6e369f2235689b871c7322cf3ab284dde3e9dfc13863a17","price":"1000000","side":"SIDE_SELL","size":10,"timeInForce":"TIME_IN_FORCE_FOK","type":"TYPE_LIMIT"}}
? Do you want to sign this transaction? (yes/no)
```