### PR TITLE
Datanode buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [7834](https://github.com/vegaprotocol/vega/issues/7834) - Support TLS connection for gRPC endpoints in wallet when prefixed with `tls://`
 - [7851](https://github.com/vegaprotocol/vega/issues/7851) - Implement post only and reduce only orders
 - [7863](https://github.com/vegaprotocol/vega/issues/7863) - Rework positions indexes so that snapshot creation does not slow down
+- [7670](https://github.com/vegaprotocol/vega/issues/7670) - Removes the need for the buffered event source to hold a large buffer of sequence numbers 
 
 ### 🐛 Fixes
 - [7835](https://github.com/vegaprotocol/vega/issues/7835) - Ensure the command errors have the same format on arrays

--- a/datanode/broker/buffered_event_source.go
+++ b/datanode/broker/buffered_event_source.go
@@ -76,13 +76,13 @@ func NewBufferedEventSource(ctx context.Context, log *logging.Logger, config Buf
 		log:                log.Named("buffered-event-source"),
 		source:             source,
 		config:             config,
-		lastBufferedSeqNum: make(chan uint64, config.MaxBufferedEvents),
+		lastBufferedSeqNum: make(chan uint64, 100),
 		bufferFilePath:     bufferFilesDir,
 		archiveFilesPath:   archiveFilesDir,
 	}
 
 	fb.log.Infof("Starting buffered event source with a max buffered event count of %d, and events per buffer file size %d",
-		config.MaxBufferedEvents, config.EventsPerFile)
+		config.EventsPerFile)
 
 	return fb, nil
 }
@@ -152,21 +152,17 @@ func (m *FileBufferedEventSource) writeEventsToBuffer(ctx context.Context, sourc
 				sinkErrorCh <- fmt.Errorf("failed to write events to buffer:%w", err)
 			}
 
-			select {
-			case m.lastBufferedSeqNum <- bufferSeqNum:
-			default:
-			loop:
-				for {
-					select {
-					case <-m.lastBufferedSeqNum:
-					case <-ctx.Done():
-						return
-					default:
-						break loop
-					}
+		loop:
+			for {
+				select {
+				case <-m.lastBufferedSeqNum:
+				case <-ctx.Done():
+					return
+				default:
+					break loop
 				}
-				m.lastBufferedSeqNum <- bufferSeqNum
 			}
+			m.lastBufferedSeqNum <- bufferSeqNum
 
 		case srcErr, ok := <-sourceErrCh:
 			if !ok {

--- a/datanode/broker/buffered_event_source_test.go
+++ b/datanode/broker/buffered_event_source_test.go
@@ -166,7 +166,6 @@ func Test_FileBufferedEventSource_BufferingDisabledWhenEventsPerFileIsZero(t *te
 	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         0,
 		SendChannelBufferSize: 1000,
-		MaxBufferedEvents:     10000,
 	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
@@ -200,7 +199,6 @@ func Test_FileBufferedEventSource_ErrorSentOnPathError(t *testing.T) {
 	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         10,
 		SendChannelBufferSize: 0,
-		MaxBufferedEvents:     10000,
 	}, eventSource, "thepaththatdoesntexist", "")
 
 	assert.NoError(t, err)
@@ -227,7 +225,6 @@ func Test_FileBufferedEventSource_ErrorsArePassedThrough(t *testing.T) {
 	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         10,
 		SendChannelBufferSize: 0,
-		MaxBufferedEvents:     10000,
 	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
@@ -254,7 +251,6 @@ func Test_FileBufferedEventSource_EventsAreBufferedAndPassedThrough(t *testing.T
 	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         10,
 		SendChannelBufferSize: 0,
-		MaxBufferedEvents:     10000,
 	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)
@@ -290,7 +286,6 @@ func Test_FileBufferedEventSource_RollsBufferFiles(t *testing.T) {
 	fb, err := NewBufferedEventSource(ctx, logging.NewTestLogger(), BufferedEventSourceConfig{
 		EventsPerFile:         eventsPerFile,
 		SendChannelBufferSize: 0,
-		MaxBufferedEvents:     10000,
 	}, eventSource, path, archivePath)
 
 	assert.NoError(t, err)

--- a/datanode/broker/config.go
+++ b/datanode/broker/config.go
@@ -58,7 +58,6 @@ func NewDefaultConfig() Config {
 		BufferedEventSourceConfig: BufferedEventSourceConfig{
 			EventsPerFile:           10_000_000,
 			SendChannelBufferSize:   10_000,
-			MaxBufferedEvents:       100_000_000,
 			Archive:                 true,
 			ArchiveMaximumSizeBytes: 10_000_000_000,
 		},
@@ -82,7 +81,6 @@ type SocketConfig struct {
 type BufferedEventSourceConfig struct {
 	EventsPerFile           int   `long:"events-per-file" description:"the number of events to store in a file buffer, set to 0 to disable the buffer"`
 	SendChannelBufferSize   int   `long:"send-buffer-size" description:"sink event channel buffer size"`
-	MaxBufferedEvents       int   `long:"max-buffered-events" description:"max number of events that can be buffered, after this point events will no longer be buffered"`
 	Archive                 bool  `long:"archive" description:"archives event buffer files after they have been read, default false"`
 	ArchiveMaximumSizeBytes int64 `long:"archive-maximum-size" description:"the maximum size of the archive directory"`
 }


### PR DESCRIPTION
closes #7670  Removed the need for the channel that signals available data to have a large buffer, confirmed with local testing that there is no impact on performance.   @peterbarrow is going to run a test to confirm this before this PR is merged.  

@peterbarrow  Testing confirms performance is broadly similar.