### PR TITLE
fix: fix nil pointer handling in ds

### DIFF
--- a/core/oracles/oracle_spec.go
+++ b/core/oracles/oracle_spec.go
@@ -82,10 +82,14 @@ func NewOracleSpec(originalSpec types.ExternalDataSourceSpec) (*OracleSpec, erro
 	signersFromSpec := []*types.Signer{}
 
 	isExtType := false
+	var err error
 	if originalSpec.Spec != nil {
 		if originalSpec.Spec.Data != nil {
 			filtersFromSpec = originalSpec.Spec.Data.GetFilters()
-			isExtType = originalSpec.Spec.Data.IsExternal()
+			isExtType, err = originalSpec.Spec.Data.IsExternal()
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/core/types/data_source.go
+++ b/core/types/data_source.go
@@ -450,13 +450,17 @@ func (s *DataSourceDefinition) SetOracleConfig(oc *DataSourceSpecConfiguration) 
 	return s
 }
 
-func (s *DataSourceDefinition) IsExternal() bool {
-	switch s.SourceType.oneOfProto().(type) {
-	case *vegapb.DataSourceDefinition_External:
-		return true
+func (s *DataSourceDefinition) IsExternal() (bool, error) {
+	if s.SourceType != nil {
+		switch s.SourceType.oneOfProto().(type) {
+		case *vegapb.DataSourceDefinition_External:
+			return true, nil
+		}
+
+		return false, nil
 	}
 
-	return false
+	return false, errors.New("unknown type of data source provided")
 }
 
 func (s *DataSourceDefinition) GetDataSourceSpecConfigurationTime() *vegapb.DataSourceSpecConfigurationTime {


### PR DESCRIPTION
Fix panic in the core from system tests run:
```{"err": "runtime error: invalid memory address or nil pointer dereference", "stack": "goroutine 267 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x65\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine.func2()\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:732 +0x4c\npanic({0x4559e80, 0x6f19a40})\n\t/usr/local/go/src/runtime/panic.go:884 +0x212\ncode.vegaprotocol.io/vega/core/types.(*DataSourceDefinition).IsExternal(...)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/types/data_source.go:454\ncode.vegaprotocol.io/vega/core/oracles.NewOracleSpec({0xc00711e750})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/oracles/oracle_spec.go:88 +0xcc\ncode.vegaprotocol.io/vega/core/governance.validateFuture(0xc00813b860, 0xc001649d90?, {0x53dd1f0, 0xc00129e0c0}, 0xc001649e40?, 0x0?)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/market.go:290 +0x2f1\ncode.vegaprotocol.io/vega/core/governance.validateNewInstrument(0x7f8ea58511d8?, 0xc001649de8?, {0x53dd1f0?, 0xc00129e0c0?}, 0xedba4182d?, 0x80?)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/market.go:314 +0x4d\ncode.vegaprotocol.io/vega/core/governance.validateNewMarketChange(0xc0077f1f38, {0x53dd1f0?, 0xc00129e0c0?}, 0x0?, {0x53e0a98, 0xc001a30420}, 0x0?, 0x0?)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/market.go:398 +0x6b\ncode.vegaprotocol.io/vega/core/governance.(*Engine).validateChange(0xc001961290, 0xc00711e660)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/engine.go:833 +0x171\ncode.vegaprotocol.io/vega/core/governance.(*Engine).validateOpenProposal(0xc001961290, 0xc006da0c60)\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/engine.go:707 +0x22b0\ncode.vegaprotocol.io/vega/core/governance.(*Engine).SubmitProposal(0xc001961290, {0x53cd640, 0xc00711e420}, {{0xc0121c0780?, 0x73faea0?}, 0xc00711e660?, 0xc0049b0680?}, {0xc00983d040, 0x40}, {0xc00a2772c0, ...})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/governance/engine.go:453 +0x5ea\ncode.vegaprotocol.io/vega/core/processor.(*App).DeliverPropose(0xc00029e2c0, {0x53cd640, 0xc00711e420}, {0x53efb48, 0xc006117c40}, {0xc00983d040, 0x40})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/processor/abci.go:1407 +0x5de\ncode.vegaprotocol.io/vega/core/processor.addDeterministicID.func1({0x53cd640, 0xc00711e420}, {0x53efb48, 0xc006117c40})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/processor/abci.go:418 +0x103\ncode.vegaprotocol.io/vega/core/processor.(*App).CheckProposeW.func1({0x53cd640, 0xc00711e420}, {0x53efb48, 0xc006117c40})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/processor/abci.go:429 +0x76\ncode.vegaprotocol.io/vega/core/processor.(*App).SendTransactionResult.func1({0x53cd640, 0xc00711e420}, {0x53efb48, 0xc006117c40})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/processor/abci.go:470 +0x5c\ncode.vegaprotocol.io/vega/core/blockchain/abci.(*App).DeliverTx(0xc0019614a0, {{0xc00232f500, 0x35e, 0x35e}})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/blockchain/abci/abci.go:140 +0x762\ncode.vegaprotocol.io/vega/cmd/vega/node.(*appW).DeliverTx(0xc00a668640?, {{0xc00232f500?, 0x20?, 0xc00a668660?}})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/cmd/vega/node/app_wrapper.go:37 +0x6c\ngithub.com/tendermint/tendermint/abci/client.(*localClient).DeliverTxAsync(0xc0017f6060, {{0xc00232f500?, 0x0?, 0xc0017f6060?}})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/abci/client/local_client.go:93 +0x105\ngithub.com/tendermint/tendermint/proxy.(*appConnConsensus).DeliverTxAsync(0xc0075b9700?, {{0xc00232f500?, 0x20?, 0xb?}})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/proxy/app_conn.go:85 +0x26\ngithub.com/tendermint/tendermint/state.execBlockOnProxyApp({0x53cbc70?, 0xc0019ceb58}, {0x53dee60, 0xc00059fce0}, 0xc00a4192c0, {0x53f0430, 0xc000595170}, 0x1359?)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/state/execution.go:320 +0x847\ngithub.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x1}, {0xc001914bd0, 0x7}}, {0xc001914c00, 0xb}, 0x1, 0x1359, {{0xc005b81a60, ...}, ...}, ...}, ...)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/state/execution.go:140 +0x171\ngithub.com/tendermint/tendermint/consensus.(*State).finalizeCommit(0xc003500380, 0x135a)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1661 +0xafd\ngithub.com/tendermint/tendermint/consensus.(*State).tryFinalizeCommit(0xc003500380, 0x135a)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1570 +0x2ff\ngithub.com/tendermint/tendermint/consensus.(*State).enterCommit.func1()\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1505 +0xaa\ngithub.com/tendermint/tendermint/consensus.(*State).enterCommit(0xc003500380, 0x135a, 0x0)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1543 +0xccf\ngithub.com/tendermint/tendermint/consensus.(*State).addVote(0xc003500380, 0xc007cb2460, {0xc001853ce0, 0x28})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:2165 +0x18dc\ngithub.com/tendermint/tendermint/consensus.(*State).tryAddVote(0xc003500380, 0xc007cb2460, {0xc001853ce0?, 0xc0025cf200?})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:1963 +0x2c\ngithub.com/tendermint/tendermint/consensus.(*State).handleMsg(0xc003500380, {{0x53a9bc0?, 0xc0077f1ca8?}, {0xc001853ce0?, 0x0?}})\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:861 +0x170\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine(0xc003500380, 0x0)\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:768 +0x3f9\ncreated by github.com/tendermint/tendermint/consensus.(*State).OnStart\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.34.27/consensus/state.go:379 +0x12d\n"}```