### PR TITLE
fix: paths fix

### DIFF
--- a/datanode/networkhistory/snapshot/service.go
+++ b/datanode/networkhistory/snapshot/service.go
@@ -18,10 +18,10 @@ type Service struct {
 	config   Config
 	connPool *pgxpool.Pool
 
-	createSnapshotLock     mutex.CtxMutex
-	snapshotsCopyFromPath  string
-	snapshotsCopyToPath    string
-	migrateSchemaToVersion func(version int64) error
+	createSnapshotLock       mutex.CtxMutex
+	absSnapshotsCopyFromPath string
+	absSnapshotsCopyToPath   string
+	migrateSchemaToVersion   func(version int64) error
 }
 
 func NewSnapshotService(log *logging.Logger, config Config, connPool *pgxpool.Pool,
@@ -43,18 +43,18 @@ func NewSnapshotService(log *logging.Logger, config Config, connPool *pgxpool.Po
 	}
 
 	s := &Service{
-		log:                    log,
-		config:                 config,
-		connPool:               connPool,
-		createSnapshotLock:     mutex.New(),
-		snapshotsCopyFromPath:  snapshotsCopyFromPath,
-		snapshotsCopyToPath:    snapshotsCopyToPath,
-		migrateSchemaToVersion: migrateDatabaseToVersion,
+		log:                      log,
+		config:                   config,
+		connPool:                 connPool,
+		createSnapshotLock:       mutex.New(),
+		absSnapshotsCopyFromPath: snapshotsCopyFromPath,
+		absSnapshotsCopyToPath:   snapshotsCopyToPath,
+		migrateSchemaToVersion:   migrateDatabaseToVersion,
 	}
 
-	err = os.MkdirAll(s.snapshotsCopyToPath, fs.ModePerm)
+	err = os.MkdirAll(s.absSnapshotsCopyToPath, fs.ModePerm)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the snapshots dir %s: %w", s.snapshotsCopyToPath, err)
+		return nil, fmt.Errorf("failed to create the snapshots dir %s: %w", s.absSnapshotsCopyToPath, err)
 	}
 
 	return s, nil

--- a/datanode/networkhistory/snapshot/service_create_snapshot.go
+++ b/datanode/networkhistory/snapshot/service_create_snapshot.go
@@ -84,7 +84,7 @@ func (b *Service) createNewSnapshot(ctx context.Context, chainID string, toHeigh
 		return MetaData{}, fmt.Errorf("failed to set transaction isolation level to serilizable: %w", err)
 	}
 
-	snapshotInProgressFile := filepath.Join(b.snapshotsCopyToPath, InProgressFileName(chainID, toHeight))
+	snapshotInProgressFile := filepath.Join(b.absSnapshotsCopyToPath, InProgressFileName(chainID, toHeight))
 	if _, err = os.Create(snapshotInProgressFile); err != nil {
 		runAllInReverseOrder(cleanUp)
 		return MetaData{}, fmt.Errorf("failed to create write lock file:%w", err)
@@ -129,8 +129,8 @@ func (b *Service) createNewSnapshot(ctx context.Context, chainID string, toHeigh
 	return MetaData{
 		CurrentStateSnapshot:     currentSnapshot,
 		HistorySnapshot:          historySnapshot,
-		CurrentStateSnapshotPath: filepath.Join(b.snapshotsCopyToPath, currentSnapshot.CompressedFileName()),
-		HistorySnapshotPath:      filepath.Join(b.snapshotsCopyToPath, historySnapshot.CompressedFileName()),
+		CurrentStateSnapshotPath: filepath.Join(b.absSnapshotsCopyToPath, currentSnapshot.CompressedFileName()),
+		HistorySnapshotPath:      filepath.Join(b.absSnapshotsCopyToPath, historySnapshot.CompressedFileName()),
 		DatabaseVersion:          dbMetaData.DatabaseVersion,
 	}, nil
 }
@@ -210,8 +210,8 @@ func (b *Service) snapshotData(ctx context.Context, copyDataTx pgx.Tx, dbMetaDat
 	currentSnapshot CurrentState,
 	historySnapshot History,
 ) (err error) {
-	uncompressedCurrentDataDir := filepath.Join(b.snapshotsCopyToPath, currentSnapshot.UncompressedDataDir())
-	uncompressedHistoryDataDir := filepath.Join(b.snapshotsCopyToPath, historySnapshot.UncompressedDataDir())
+	uncompressedCurrentDataDir := filepath.Join(b.absSnapshotsCopyToPath, currentSnapshot.UncompressedDataDir())
+	uncompressedHistoryDataDir := filepath.Join(b.absSnapshotsCopyToPath, historySnapshot.UncompressedDataDir())
 
 	defer func() {
 		// Calling rollback on a committed transaction has no effect, hence we can rollback in defer to ensure
@@ -235,8 +235,8 @@ func (b *Service) snapshotData(ctx context.Context, copyDataTx pgx.Tx, dbMetaDat
 
 	start := time.Now()
 	b.log.Infof("copying all table data....")
-	allCopySQL := append(currentSnapshot.GetCopySQL(dbMetaData, b.snapshotsCopyToPath),
-		historySnapshot.GetCopySQL(dbMetaData, b.snapshotsCopyToPath)...)
+	allCopySQL := append(currentSnapshot.GetCopySQL(dbMetaData, b.absSnapshotsCopyToPath),
+		historySnapshot.GetCopySQL(dbMetaData, b.absSnapshotsCopyToPath)...)
 	rowsCopied, err := copyTableData(ctx, copyDataTx, allCopySQL)
 	if err != nil {
 		return fmt.Errorf("failed to copy table data:%w", err)
@@ -249,7 +249,7 @@ func (b *Service) snapshotData(ctx context.Context, copyDataTx pgx.Tx, dbMetaDat
 
 	b.log.Infof("compressing current state snapshot data")
 
-	compressedCurrentStateFile := filepath.Join(b.snapshotsCopyToPath, currentSnapshot.CompressedFileName())
+	compressedCurrentStateFile := filepath.Join(b.absSnapshotsCopyToPath, currentSnapshot.CompressedFileName())
 	compressedCurrentStateByteCount, err := fsutil.TarAndCompressDirWithDeterministicHeader(uncompressedCurrentDataDir, compressedCurrentStateFile, dbMetaData.DatabaseVersion)
 	if err != nil {
 		return fmt.Errorf("failed to compress snapshot:%w", err)
@@ -257,7 +257,7 @@ func (b *Service) snapshotData(ctx context.Context, copyDataTx pgx.Tx, dbMetaDat
 	b.log.Infof("compressed current state snapshot data size: %dB", compressedCurrentStateByteCount)
 
 	b.log.Infof("compressing history data")
-	compressedHistoryStateFile := filepath.Join(b.snapshotsCopyToPath, historySnapshot.CompressedFileName())
+	compressedHistoryStateFile := filepath.Join(b.absSnapshotsCopyToPath, historySnapshot.CompressedFileName())
 	compressedHistoryByteCount, err := fsutil.TarAndCompressDirWithDeterministicHeader(uncompressedHistoryDataDir, compressedHistoryStateFile, dbMetaData.DatabaseVersion)
 	if err != nil {
 		return fmt.Errorf("failed to compress history snapshot:%w", err)


### PR DESCRIPTION
closes #7848 Refactor in the load data in a transaction PR incorrectly substituted relative snapshots path for an absolute snapshots path.  This change corrects that.