### PR TITLE
feat: set sensible default values for the IPFS resource manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🛠 Improvements
 - [7834](https://github.com/vegaprotocol/vega/issues/7834) - Support TLS connection for gRPC endpoints in wallet when prefixed with `tls://`
 - [7851](https://github.com/vegaprotocol/vega/issues/7851) - Implement post only and reduce only orders
+- [7768](https://github.com/vegaprotocol/vega/issues/7768) - Set sensible defaults for the IPFS resource manager 
 - [7863](https://github.com/vegaprotocol/vega/issues/7863) - Rework positions indexes so that snapshot creation does not slow down
 - [7670](https://github.com/vegaprotocol/vega/issues/7670) - Removes the need for the buffered event source to hold a large buffer of sequence numbers 
 

--- a/cmd/data-node/commands/networkhistory/latest_history_segment.go
+++ b/cmd/data-node/commands/networkhistory/latest_history_segment.go
@@ -72,7 +72,8 @@ func (cmd *latestHistorySegment) Execute(_ []string) error {
 
 		latestSegment = response.Segments[0]
 	} else {
-		networkHistoryStore, err := store.New(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome), false)
+		networkHistoryStore, err := store.New(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory.Store,
+			vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome), false, cmd.Config.MaxMemoryPercent)
 		if err != nil {
 			handleErr(log, cmd.Output.IsJSON(), "failed to create network history store", err)
 			os.Exit(1)

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -107,7 +107,8 @@ func (cmd *loadCmd) Execute(args []string) error {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	networkHistoryStore, err := store.New(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome), false)
+	networkHistoryStore, err := store.New(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
+		false, cmd.Config.MaxMemoryPercent)
 	if err != nil {
 		return fmt.Errorf("failed to create network history store:%w", err)
 	}

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -343,7 +343,7 @@ func (l *NodeCommand) initialiseNetworkHistory(preLog *logging.Logger, connConfi
 	l.networkHistoryService, err = networkhistory.New(l.ctx, networkHistoryServiceLog, l.conf.NetworkHistory, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
 		networkHistoryPool,
 		l.conf.ChainID, l.snapshotService, l.conf.API.Port, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
-		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo))
+		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), l.conf.MaxMemoryPercent)
 
 	if err != nil {
 		return fmt.Errorf("failed to create networkHistory service:%w", err)

--- a/datanode/networkhistory/service.go
+++ b/datanode/networkhistory/service.go
@@ -52,12 +52,13 @@ type Service struct {
 func New(ctx context.Context, log *logging.Logger, cfg Config, networkHistoryHome string, connPool *pgxpool.Pool,
 	chainID string,
 	snapshotService *snapshot.Service, datanodeGrpcAPIPort int,
-	snapshotsCopyFromDir, snapshotsCopyToDir string,
+	snapshotsCopyFromDir, snapshotsCopyToDir string, maxMemoryPercent uint8,
 ) (*Service, error) {
 	storeLog := log.Named("store")
 	storeLog.SetLevel(cfg.Level.Get())
 
-	networkHistoryStore, err := store.New(ctx, storeLog, chainID, cfg.Store, networkHistoryHome, bool(cfg.WipeOnStartup))
+	networkHistoryStore, err := store.New(ctx, storeLog, chainID, cfg.Store, networkHistoryHome,
+		bool(cfg.WipeOnStartup), maxMemoryPercent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network history store:%w", err)
 	}

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -319,7 +319,7 @@ func TestMain(t *testing.M) {
 
 		storeLog := logging.NewTestLogger()
 		storeLog.SetLevel(logging.InfoLevel)
-		networkHistoryStore, err = store.New(outerCtx, storeLog, chainID, storeCfg, networkHistoryHome, false)
+		networkHistoryStore, err = store.New(outerCtx, storeLog, chainID, storeCfg, networkHistoryHome, false, 33)
 		if err != nil {
 			panic(err)
 		}

--- a/datanode/networkhistory/store/store_test.go
+++ b/datanode/networkhistory/store/store_test.go
@@ -118,7 +118,7 @@ func createStore(t *testing.T, historyRetentionBlockSpan int64, chainID string, 
 	cfg.HistoryRetentionBlockSpan = historyRetentionBlockSpan
 	snapshotsDir := t.TempDir()
 
-	s, err := store.New(context.Background(), log, chainID, cfg, networkhistoryHome, false)
+	s, err := store.New(context.Background(), log, chainID, cfg, networkhistoryHome, false, 33)
 	require.NoError(t, err)
 	return s, snapshotsDir
 }


### PR DESCRIPTION
closes #7768 
The Resource Manager is designed to protect the IPFS node from malicious and non-malicious attacks, it uses max memory and max file descriptor configuration properties to determine how to setup this protection.   By default the max memory and max file descriptors used as the basis of the resource managers calculations are set to half of the available memory and half of the available file descriptors respectively, which in the context of a data-node running with multiple processes on one box is probably excessive.   This change set the max file descriptors to a quarter of the total available and the max memory to a quarter of that allocated to the datanode by the `MaxMemoryPercent` configuration parameter  (ie so if that is set to 33%, the resource manager max memory limit will be 33%/4  -> 8.25% of total system memory )


(Additional note, as mentioned in the issue ticket, the IPFS resource manager currently logs out the defaults using fmt.Printf, so no way to silence this logging withoug disabling the resource manager)
