### PR TITLE
feat: network history stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🛠 Improvements
+- [7862](https://github.com/vegaprotocol/vega/issues/7862) - Add per table statistics for network history segment creation 
 - [7834](https://github.com/vegaprotocol/vega/issues/7834) - Support TLS connection for gRPC endpoints in wallet when prefixed with `tls://`
 - [7851](https://github.com/vegaprotocol/vega/issues/7851) - Implement post only and reduce only orders
 - [7768](https://github.com/vegaprotocol/vega/issues/7768) - Set sensible defaults for the IPFS resource manager 

--- a/datanode/metrics/prometheus.go
+++ b/datanode/metrics/prometheus.go
@@ -80,6 +80,10 @@ var (
 	networkHistoryIpfsStoreBytes prometheus.Gauge
 	// Data Node HTTP bindings that we will check against when updating HTTP metrics.
 	httpBindings *protos.Bindings
+
+	// Per table segment creation time.
+	networkHistoryCopiedRowsCounter *prometheus.CounterVec
+	networkHistoryCopyTimeCounter   *prometheus.CounterVec
 )
 
 // abstract prometheus types.
@@ -452,6 +456,36 @@ func setupMetrics() error {
 		return err
 	}
 	eventCounter = ec
+
+	h, err = addInstrument(
+		Counter,
+		"network_history_copied_rows_total",
+		Namespace("datanode"),
+		Vectors("table"),
+	)
+	if err != nil {
+		return err
+	}
+	cr, err := h.CounterVec()
+	if err != nil {
+		return err
+	}
+	networkHistoryCopiedRowsCounter = cr
+
+	h, err = addInstrument(
+		Counter,
+		"network_history_copy_time_total",
+		Namespace("datanode"),
+		Vectors("table"),
+	)
+	if err != nil {
+		return err
+	}
+	ct, err := h.CounterVec()
+	if err != nil {
+		return err
+	}
+	networkHistoryCopyTimeCounter = ct
 
 	// sqlQueryTime
 	h, err = addInstrument(
@@ -875,6 +909,24 @@ func StartAPIRequestAndTimeGRPC(request string) func() {
 		apiRequestCallCounter.WithLabelValues("GRPC", request).Inc()
 		duration := time.Since(startTime).Seconds()
 		apiRequestTimeCounter.WithLabelValues("GRPC", request).Add(duration)
+	}
+}
+
+func NetworkHistoryRowsCopied(table string, rowsCopied int64) {
+	if networkHistoryCopiedRowsCounter == nil {
+		return
+	}
+	networkHistoryCopiedRowsCounter.WithLabelValues(table).Add(float64(rowsCopied))
+}
+
+func StartNetworkHistoryCopy(table string) func() {
+	startTime := time.Now()
+	return func() {
+		if networkHistoryCopyTimeCounter == nil {
+			return
+		}
+		duration := time.Since(startTime).Seconds()
+		networkHistoryCopyTimeCounter.WithLabelValues(table).Add(duration)
 	}
 }
 

--- a/datanode/networkhistory/snapshot/current.go
+++ b/datanode/networkhistory/snapshot/current.go
@@ -15,6 +15,11 @@ type CurrentState struct {
 	Height  int64
 }
 
+type TableCopySql struct {
+	metaData TableMetadata
+	copySql  string
+}
+
 const currentStateSnapshotIdentifier = "currentstatesnapshot"
 
 func NewCurrentSnapshot(chainID string, height int64) CurrentState {
@@ -36,14 +41,14 @@ func (s CurrentState) String() string {
 	return fmt.Sprintf("{Current State Snapshot Chain ID:%s Height:%d}", s.ChainID, s.Height)
 }
 
-func (s CurrentState) GetCopySQL(dbMetaData DatabaseMetadata, databaseSnapshotsPath string) []string {
-	var copySQL []string
+func (s CurrentState) GetCopySQL(dbMetaData DatabaseMetadata, databaseSnapshotsPath string) []TableCopySql {
+	var copySQL []TableCopySql
 	for tableName, meta := range dbMetaData.TableNameToMetaData {
 		if !dbMetaData.TableNameToMetaData[tableName].Hypertable {
 			snapshotFile := filepath.Join(databaseSnapshotsPath, s.UncompressedDataDir(), tableName)
 			tableCopySQL := fmt.Sprintf(`copy (select * from %s order by %s) to '%s'`, tableName,
 				meta.SortOrder, snapshotFile)
-			copySQL = append(copySQL, tableCopySQL)
+			copySQL = append(copySQL, TableCopySql{meta, tableCopySQL})
 		}
 	}
 

--- a/datanode/networkhistory/snapshot/history.go
+++ b/datanode/networkhistory/snapshot/history.go
@@ -38,8 +38,8 @@ func (h History) CompressedFileName() string {
 	return fmt.Sprintf("%s-%d-%d-%s.tar.gz", h.ChainID, h.HeightFrom, h.HeightTo, historySnapshotTypeIdentifier)
 }
 
-func (h History) GetCopySQL(dbMetaData DatabaseMetadata, databaseSnapshotsPath string) []string {
-	var copySQL []string
+func (h History) GetCopySQL(dbMetaData DatabaseMetadata, databaseSnapshotsPath string) []TableCopySql {
+	var copySQL []TableCopySql
 	for tableName, meta := range dbMetaData.TableNameToMetaData {
 		if dbMetaData.TableNameToMetaData[tableName].Hypertable {
 			partitionColumn := dbMetaData.TableNameToMetaData[tableName].PartitionColumn
@@ -49,7 +49,7 @@ func (h History) GetCopySQL(dbMetaData DatabaseMetadata, databaseSnapshotsPath s
 				partitionColumn,
 				h.HeightFrom,
 				meta.SortOrder, snapshotFile)
-			copySQL = append(copySQL, hyperTableCopySQL)
+			copySQL = append(copySQL, TableCopySql{meta, hyperTableCopySQL})
 		}
 	}
 


### PR DESCRIPTION
closes #7862  Adds per table stats for network history creation so we can pre-empt any issues similar to that seen for the positions table.