### PR TITLE
Fix auction margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [7829](https://github.com/vegaprotocol/vega/issues/7829) - Get precision for reference price from price monitoring bounds when getting market data
 - [7670](https://github.com/vegaprotocol/vega/issues/7670) - Removes the need for the buffered event source to hold a large buffer of sequence numbers
 - [7904](https://github.com/vegaprotocol/vega/issues/7904) - Add a default system test template for integration tests
+- [7894](https://github.com/vegaprotocol/vega/issues/7894) - Use slippage cap when market is in auction mode
 
 ### 🐛 Fixes
 - [7835](https://github.com/vegaprotocol/vega/issues/7835) - Ensure the command errors have the same format on arrays
@@ -25,6 +26,7 @@
 - [7880](https://github.com/vegaprotocol/vega/issues/7880) - Update volume-weighted average price party's of open orders after a trade
 - [7883](https://github.com/vegaprotocol/vega/issues/7883) - Fix snapshot issue with witness on accounting
 - [7921](https://github.com/vegaprotocol/vega/issues/7921) - Fix streams batches
+- [7895](https://github.com/vegaprotocol/vega/issues/7895) - Fix margin calculation during auction
 
 
 ## 0.69.0

--- a/core/integration/features/auctions/3528-indefinite-auction-extension.feature
+++ b/core/integration/features/auctions/3528-indefinite-auction-extension.feature
@@ -21,7 +21,7 @@ Feature: Replicate issue 3528, where price monitoring continuously extended liqu
       | 100     | 0.99        | 300               |
     And the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.01                   | 0                         |
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount     |
       | party0 | ETH   | 1000000000 |

--- a/core/integration/features/auctions/enter-leave-liquidity-auction.feature
+++ b/core/integration/features/auctions/enter-leave-liquidity-auction.feature
@@ -8,7 +8,7 @@ Feature: Ensure we can enter and leave liquidity auction
       | limits.markets.maxPeggedOrders    | 1500  |
     And the markets:
       | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 0.01                   | 0                         |
 
 
 

--- a/core/integration/features/auctions/leave-price-enter-liquidity-auction.feature
+++ b/core/integration/features/auctions/leave-price-enter-liquidity-auction.feature
@@ -4,7 +4,7 @@ Feature: Leave a monitoring auction, enter a liquidity auction
 
     And the markets:
       | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-basic    | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-basic    | default-eth-for-future | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 1     |

--- a/core/integration/features/auctions/liquidity-uncross.feature
+++ b/core/integration/features/auctions/liquidity-uncross.feature
@@ -6,7 +6,7 @@ Feature: Ensure we don't uncross when leaving liquidity auction
       | ETH | 5              |
     And the markets:
       | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config     | decimal places | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 2              | 1e6                    | 1e6                       |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 2              | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 1     |

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout-pdp.feature
@@ -26,7 +26,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
   Scenario: LP gets distressed during continuous trading (0042-LIQF-014)
     Given the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | position decimal places | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.01           | 2                       | 1e6                    | 1e6                       |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.01           | 2                       | 0.5                    | 0                         |
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount     |
       | party0 | ETH   | 5721       |
@@ -132,7 +132,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | 0.1  | 0.1   | 30          | 30            | 0.2                    |
     And the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | position decimal places | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-2 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.5            | 2                       | 1e6                    | 1e6                       |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-2 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.5            | 2                       | 0.5                    | 0                         |
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount     |
       | party0 | ETH   | 5721       |

--- a/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
+++ b/core/integration/features/liquidity-provision/lp-distressed-closeout.feature
@@ -185,7 +185,7 @@ Feature: Replicate LP getting distressed during continuous trading, and after le
       | 0.1  | 0.1   | 30          | 30            | 0.2                    |
     And the markets:
       | id        | quote name | asset | risk model          | margin calculator         | auction duration | fees          | price monitoring   | data source config     | lp price range | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-2 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.5            | 1e6                    | 1e6                       |
+      | ETH/DEC21 | ETH        | ETH   | simple-risk-model-2 | default-margin-calculator | 1                | fees-config-1 | price-monitoring-1 | default-eth-for-future | 0.5            | 0.5                    | 0                         |
     And the parties deposit on asset's general account the following amount:
       | party  | asset | amount     |
       | party0 | ETH   | 5721       |

--- a/core/integration/features/liquidity-provision/verify-CcySiska.feature
+++ b/core/integration/features/liquidity-provision/verify-CcySiska.feature
@@ -88,8 +88,8 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
     Then the parties should have the following account balances:
       | party  | asset | market id | margin   | general   |
       | party0 | USD   | ETH/MAR22 | 42093820 | 452906180 |
-      | party1 | USD   | ETH/MAR22 | 49815    | 99950185  |
-      | party2 | USD   | ETH/MAR22 | 222394   | 99777606  |
+      | party1 | USD   | ETH/MAR22 | 49860    | 99950140  |
+      | party2 | USD   | ETH/MAR22 | 222421   | 99777579  |
 
     When the parties place the following orders with ticks:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
@@ -145,8 +145,8 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
     Then the parties should have the following account balances:
       | party  | asset | market id | margin   | general   |
       | party0 | USD   | ETH/MAR22 | 10525590 | 484474410 |
-      | party1 | USD   | ETH/MAR22 | 49815    | 99950185  |
-      | party2 | USD   | ETH/MAR22 | 222394   | 99777606  |
+      | party1 | USD   | ETH/MAR22 | 49860    | 99950140  |
+      | party2 | USD   | ETH/MAR22 | 222421   | 99777579  |
 
     When the parties place the following orders with ticks:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |

--- a/core/integration/features/liquidity-provision/verify-CcySiska.feature
+++ b/core/integration/features/liquidity-provision/verify-CcySiska.feature
@@ -53,9 +53,15 @@ Feature: check the impact from change of market parameter: market.liquidity.stak
       | lp1 | party0 | ETH/MAR22 | 5000000           | 0   | sell | ASK              | 500        | 20     | submission |
       | lp1 | party0 | ETH/MAR22 | 5000000           | 0   | buy  | BID              | 500        | 20     | amendment  |
 
+    # party1 :=  buy order volume * vwap * rf_long  = (900  + 990  + 50 * 1000) * 0.8007282079844139 =  41549.786712311237271
+    # party2 := sell order volume * vwap * rf_short = (1100 + 1010 + 50 * 1000) * 3.556903591579342  = 185350.246157199511620
+    Then the parties should have the following margin levels:
+      | party  | market id | maintenance | initial  |
+      | party1 | ETH/MAR22 | 41550       | 49860    |
+      | party2 | ETH/MAR22 | 185351      | 222421   |
+
     When the opening auction period ends for market "ETH/MAR22"
     Then the auction ends with a traded volume of "50" at a price of "1000"
-    # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1000 x 10 x 1 x 0.1
     And the insurance pool balance should be "0" for the market "ETH/MAR22"
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |

--- a/core/integration/features/position_tracking/wrong-position-tracking.feature
+++ b/core/integration/features/position_tracking/wrong-position-tracking.feature
@@ -3,7 +3,7 @@ Feature: Test position tracking with auctions
   Background:
     Given the markets:
       | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-basic    | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-basic    | default-eth-for-future | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 1     |

--- a/core/integration/features/price_monitoring/3362-failing-system-tests-trigger-close-out.feature
+++ b/core/integration/features/price_monitoring/3362-failing-system-tests-trigger-close-out.feature
@@ -11,7 +11,7 @@ Feature: Replicate failing system tests after changes to price monitoring (not t
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
       | id        | quote name | asset | risk model               | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | my-log-normal-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 1     |

--- a/core/integration/features/price_monitoring/price-monitoring-lognormal-decimals.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-lognormal-decimals.feature
@@ -14,7 +14,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
       | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring    | data source config     | decimal places | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring | default-eth-for-future | 2              | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring | default-eth-for-future | 2              | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 60    |

--- a/core/integration/features/price_monitoring/price-monitoring-lognormal.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-lognormal.feature
@@ -15,8 +15,8 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
       | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring      | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring   | default-eth-for-future | 1e6                    | 1e6                       |
-      | ETH/DEC21 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring-2 | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring   | default-eth-for-future | 0.01                   | 0                         |
+      | ETH/DEC21 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring-2 | default-eth-for-future | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                           | value |
       | market.auction.minimumDuration | 60    |

--- a/core/integration/features/price_monitoring/price-monitoring-simple.feature
+++ b/core/integration/features/price_monitoring/price-monitoring-simple.feature
@@ -11,7 +11,7 @@ Feature: Price monitoring test using simple risk model
       | 0.11 | 0.1   | 10          | 11            | 0.1                    |
     And the markets:
       | id        | quote name | asset | auction duration | risk model           | margin calculator         | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | 240              | my-simple-risk-model | default-margin-calculator | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | 240              | my-simple-risk-model | default-margin-calculator | default-none | my-price-monitoring | default-eth-for-future | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 240   |

--- a/core/integration/features/verified/0029-FEES-trading_fees.feature
+++ b/core/integration/features/verified/0029-FEES-trading_fees.feature
@@ -891,7 +891,7 @@ Feature: Fees calculations
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 5772   | 4238    |
+      | trader3a | ETH   | ETH/DEC21 | 6494   | 3516    |
       | trader4  | ETH   | ETH/DEC21 | 9259   | 708     |
 
     And the market data for the market "ETH/DEC21" should be:
@@ -929,7 +929,7 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader4  | ETH   | ETH/DEC21 | 10093  | 586     |
-      | trader3a | ETH   | ETH/DEC21 | 5503   | 3791    |
+      | trader3a | ETH   | ETH/DEC21 | 5780   | 3514    |
 
     Then the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             |
@@ -1179,10 +1179,10 @@ Feature: Fees calculations
       | party    | asset | amount    |
       | aux1     | ETH   | 100000000 |
       | aux2     | ETH   | 100000000 |
-      | trader3a | ETH   | 5000      |
-      | trader4  | ETH   | 5261      |
-      | tradera3 | ETH   | 100000000 |
-      | tradera4 | ETH   | 100000000 |
+      | trader3a | ETH   | 5173      |
+      | trader4  | ETH   | 5432      |
+      | trader5  | ETH   | 100000000 |
+      | trader6  | ETH   | 100000000 |
 
     Then the parties place the following orders:
       | party    | market id | side | volume | price | resulting trades | type       | tif     |
@@ -1202,11 +1202,11 @@ Feature: Fees calculations
 
     Then the parties place the following orders:
       | party    | market id | side | volume | price | resulting trades | type       | tif     |
-      | tradera3 | ETH/DEC21 | buy  | 3      | 1002  | 0                | TYPE_LIMIT | TIF_GTC |
-      | tradera4 | ETH/DEC21 | sell | 3      | 1002  | 1                | TYPE_LIMIT | TIF_GTC |
+      | trader5 | ETH/DEC21 | buy  | 3      | 1002  | 0                | TYPE_LIMIT | TIF_GTC |
+      | trader6 | ETH/DEC21 | sell | 3      | 1002  | 1                | TYPE_LIMIT | TIF_GTC |
     And the following trades should be executed:
-      | buyer    | price | size | seller   |
-      | tradera3 | 1002  | 3    | tradera4 |
+      | buyer   | price | size | seller   |
+      | trader5 | 1002  | 3    | trader6 |
 
     When the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:

--- a/core/integration/features/verified/0029-FEES-trading_fees.feature
+++ b/core/integration/features/verified/0029-FEES-trading_fees.feature
@@ -891,7 +891,7 @@ Feature: Fees calculations
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
-      | trader3a | ETH   | ETH/DEC21 | 6494   | 3516    |
+      | trader3a | ETH   | ETH/DEC21 | 6493   | 3517    |
       | trader4  | ETH   | ETH/DEC21 | 9259   | 708     |
 
     And the market data for the market "ETH/DEC21" should be:
@@ -929,7 +929,7 @@ Feature: Fees calculations
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
       | trader4  | ETH   | ETH/DEC21 | 10093  | 586     |
-      | trader3a | ETH   | ETH/DEC21 | 5780   | 3514    |
+      | trader3a | ETH   | ETH/DEC21 | 5779   | 3515    |
 
     Then the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             |

--- a/core/integration/features/verified/0032-PRIM-price_monitoring_lognormal.feature
+++ b/core/integration/features/verified/0032-PRIM-price_monitoring_lognormal.feature
@@ -11,7 +11,7 @@ Feature: Price monitoring test using forward risk model (bounds for the valid pr
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
     And the markets:
       | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring | default-eth-for-future | 1e6                    | 1e6                       |
+      | ETH/DEC20 | ETH        | ETH   | default-log-normal-risk-model | default-margin-calculator | 60               | default-none | my-price-monitoring | default-eth-for-future | 0.01                   | 0                         |
     And the following network parameters are set:
       | name                                    | value |
       | market.auction.minimumDuration          | 60    |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -148,9 +148,9 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
       | lp1    | USD   |           |            | 100000000000   |            |
       | lp1    | ETH   | USD/DEC21 | 4134260182 | 99984597723110 | 1000000000 |
       | lp1    | USD   |           |            | 100000000000   |            |
-      | party1 | ETH   | USD/DEC19 | 1047352495 | 9996857942515  |            |
+      | party1 | ETH   | USD/DEC19 | 1047352496 | 9996857942512  |            |
       | party1 | USD   |           |            | 10000000000    |            |
-      | party2 | ETH   | USD/DEC19 | 4737795542 | 9985786613374  |            |
+      | party2 | ETH   | USD/DEC19 | 4737795584 | 9985786613248  |            |
       | party2 | USD   |           |            | 10000000000    |            |
 
   Scenario: 002: 0070-MKTD-007, 0042-LIQF-001, 0038-OLIQ-002; 0038-OLIQ-006; 0019-MCAL-008, check updated version of dpd feature in 0038-OLIQ-liquidity_provision_order_type.md
@@ -306,7 +306,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
       | lp1    | USD   |           |            | 100000000000   |         |
       | party1 | ETH   | USD/DEC19 | 1179036394 | 9996462886930  |         |
       | party1 | USD   |           |            | 10000000000    |         |
-      | party2 | ETH   | USD/DEC19 | 4737795542 | 9985786613374  |         |
+      | party2 | ETH   | USD/DEC19 | 4737795584 | 9985786613248  |         |
       | party2 | USD   |           |            | 10000000000    |         |
 
     Then the parties place the following orders:
@@ -457,8 +457,8 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general   | bond  |
       | lp1    | USD   | ETH/MAR22 | 170732 | 999789268 | 40000 |
-      | party1 | USD   | ETH/MAR22 | 10464  | 99989536  |       |
-      | party2 | USD   | ETH/MAR22 | 47374  | 99952626  |       |
+      | party1 | USD   | ETH/MAR22 | 10473  | 99989527  |       |
+      | party2 | USD   | ETH/MAR22 | 47378  | 99952622  |       |
 
     Then the network moves ahead "1" blocks
 

--- a/core/integration/features/verified/Negative-Position-Decimal-Places.feature
+++ b/core/integration/features/verified/Negative-Position-Decimal-Places.feature
@@ -108,7 +108,7 @@ Feature: test negative PDP (position decimal places)
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1778   | 99998222 |      |
-            | party2 | ETH   | USD/DEC22 | 6830   | 99993170 |      |
+            | party2 | ETH   | USD/DEC22 | 7042   | 99992958 |      |
 
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |
@@ -167,7 +167,7 @@ Feature: test negative PDP (position decimal places)
             | party  | asset | market id | margin | general  | bond  |
             | party0 | ETH   | USD/DEC22 | 632133 | 4332298  | 35569 |
             | party1 | ETH   | USD/DEC22 | 1678   | 99998223 |       |
-            | party2 | ETH   | USD/DEC22 | 6930   | 99993170 |       |
+            | party2 | ETH   | USD/DEC22 | 7142   | 99992958 |       |
         # Margin_maintenance_party0 = max(1481*10*3.5569036*9,1206*10*0.801225765*9)=474100
         And the parties should have the following margin levels:
             | party  | market id | maintenance | search | initial | release |

--- a/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account-dp.feature
@@ -80,7 +80,7 @@ Feature: Check that bond slashing works with non-default asset decimals, market 
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 240854   | 50000 |
       | party1 | USD   | ETH/MAR22 | 11425  | 99988575 |       |
-      | party2 | USD   | ETH/MAR22 | 51688  | 99948312 |       |
+      | party2 | USD   | ETH/MAR22 | 51690  | 99948310 |       |
     #check the margin levels
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | initial |

--- a/core/integration/features/verified/liquidity-provision-bond-account.feature
+++ b/core/integration/features/verified/liquidity-provision-bond-account.feature
@@ -82,8 +82,8 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 253354   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11415  | 99988585 |       |
-      | party2 | USD   | ETH/MAR22 | 51680  | 99948320 |       |
+      | party1 | USD   | ETH/MAR22 | 11425  | 99988575 |       |
+      | party2 | USD   | ETH/MAR22 | 51690  | 99948310 |       |
     #check the margin levels
     Then the parties should have the following margin levels:
       | party  | market id | maintenance | initial |
@@ -115,7 +115,7 @@ Feature: Replicate LP getting distressed during continuous trading, check if pen
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general  | bond  |
       | party0 | USD   | ETH/MAR22 | 209146 | 253354   | 50000 |
-      | party1 | USD   | ETH/MAR22 | 11415  | 99988585 |       |
+      | party1 | USD   | ETH/MAR22 | 11425  | 99988575 |       |
       | party2 | USD   | ETH/MAR22 | 264970 | 99734850 |       |
     #check the margin levels
     Then the parties should have the following margin levels:

--- a/core/integration/features/verified/risk-parameters-ranges-test.feature
+++ b/core/integration/features/verified/risk-parameters-ranges-test.feature
@@ -373,69 +373,69 @@ Feature: test risk model parameter ranges
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR0  | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR0  | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR0  | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR0  | 47378  | 49999999589597 |       |
     # intial margin level for LP = 92*1000*1.2*3.5569036=392682
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR11 | 265987 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR11 | 12595  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR11 | 65605  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR11 | 65611  | 49999999589597 |       |
     # intial margin level for LP = 92*1000*1.2*4.9256840 =543796
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR12 | 36284  | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR12 | 7350   | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR12 | 10286  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR12 | 10286  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR21 | 34     | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR21 | 1423   | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR21 | 1423   | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR21 | 1423   | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR22 | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR22 | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR22 | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR22 | 47378  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR31 | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR31 | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR31 | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR31 | 47378  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR32 | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR32 | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR32 | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR32 | 47378  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR41 | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR41 | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR41 | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR41 | 47378  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR42 | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR42 | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR42 | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR42 | 47378  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR43 | 192073 | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR43 | 11986  | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR43 | 47374  | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR43 | 47378  | 49999999589597 |       |
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general        | bond  |
       | party0 | USD   | ETH/MAR51 | 108    | 49999997803076 | 50000 |
       | party1 | USD   | ETH/MAR51 | 1437   | 49999999893293 |       |
-      | party2 | USD   | ETH/MAR51 | 1437   | 49999999589631 |       |
+      | party2 | USD   | ETH/MAR51 | 1437   | 49999999589597 |       |
 
   @Now
   Scenario: 002, test market ETH/MAR23 (tau=1)
@@ -496,7 +496,7 @@ Feature: test risk model parameter ranges
       | party  | asset | market id | margin    | general        | bond    |
       | party0 | USD   | ETH/MAR23 | 461953956 | 49999533046044 | 5000000 |
       | party1 | USD   | ETH/MAR23 | 14558     | 49999999985442 |         |
-      | party2 | USD   | ETH/MAR23 | 1148316   | 49999998851684 |         |
+      | party2 | USD   | ETH/MAR23 | 1148419   | 49999998851581 |         |
 
   # initial margin level for LP = 1000*9092*86.2176101*1.2=9.4e8
 
@@ -559,7 +559,7 @@ Feature: test risk model parameter ranges
       | party  | asset | market id | margin      | general        | bond   |
       | party0 | USD   | ETH/MAR52 | 20083423736 | 49979915976264 | 600000 |
       | party1 | USD   | ETH/MAR52 | 133         | 49999999999867 |        |
-      | party2 | USD   | ETH/MAR52 | 7363922     | 49999992636078 |        |
+      | party2 | USD   | ETH/MAR52 | 8033370     | 49999991966630 |        |
 
 # initial margin level for LP = 10*114559*55787.2881561700*1.2=7.66e10
 

--- a/core/integration/features/verified/risk-parameters-sigma-test.feature
+++ b/core/integration/features/verified/risk-parameters-sigma-test.feature
@@ -86,8 +86,8 @@ Feature: test risk model parameter sigma
     And the parties should have the following account balances:
       | party  | asset | market id | margin         | general                     | bond      |
       | party0 | USD   | ETH/MAR53 | 74999925000000 | 499999999999924999975000000 | 100000000 |
-      | party1 | USD   | ETH/MAR53 | 148            | 4999999852                  |           |
-      | party2 | USD   | ETH/MAR53 | 164999835      | 4835000165                  |           |
+      | party1 | USD   | ETH/MAR53 | 150            | 4999999850                  |           |
+      | party2 | USD   | ETH/MAR53 | 179999820      | 4820000180                  |           |
 
     # mentainance margin level for LP: 10*22580646*999999=2.258e14
     # initial  margin level for LP: 10*22580646*999999 *1.5=3.38e14
@@ -141,8 +141,8 @@ Feature: test risk model parameter sigma
     And the parties should have the following account balances:
       | party  | asset | market id | margin   | general                     | bond     |
       | party0 | USD   | ETH/MAR0  | 41041689 | 499999999999999999948958311 | 10000000 |
-      | party1 | USD   | ETH/MAR0  | 1189     | 4999998811                  |          |
-      | party2 | USD   | ETH/MAR0  | 6397     | 4999993603                  |          |
+      | party1 | USD   | ETH/MAR0  | 1201     | 4999998799                  |          |
+      | party2 | USD   | ETH/MAR0  | 6403     | 4999993597                  |          |
 
     # mentainance margin level for LP: 181819*100*3.5569036=6.47e7
     # initial  margin level for LP: 181819*100*3.5569036 *1.2=9.7e7

--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -244,7 +244,7 @@ func (e *Engine) UpdateMarginAuction(ctx context.Context, evts []events.Margin, 
 	// for now, we can assume a single asset for all events
 	rFactors := *e.factors
 	for _, evt := range evts {
-		levels := e.calculateAuctionMargins(evt, price, rFactors)
+		levels := e.calculateMargins(evt, price, rFactors, true, true)
 		if levels == nil {
 			continue
 		}
@@ -300,7 +300,7 @@ func (e *Engine) UpdateMarginOnNewOrder(ctx context.Context, evt events.Margin, 
 	if !e.as.InAuction() || e.as.CanLeave() {
 		margins = e.calculateMargins(evt, markPrice, *e.factors, true, false)
 	} else {
-		margins = e.calculateAuctionMargins(evt, markPrice, *e.factors)
+		margins = e.calculateMargins(evt, markPrice, *e.factors, true, true)
 	}
 	// no margins updates, nothing to do then
 	if margins == nil {
@@ -421,7 +421,7 @@ func (e *Engine) UpdateMarginsOnSettlement(
 		if !e.as.InAuction() || e.as.CanLeave() {
 			margins = e.calculateMargins(evt, markPrice, *e.factors, true, false)
 		} else {
-			margins = e.calculateAuctionMargins(evt, markPrice, *e.factors)
+			margins = e.calculateMargins(evt, markPrice, *e.factors, true, true)
 		}
 		// no margins updates, nothing to do then
 		if margins == nil {
@@ -514,7 +514,7 @@ func (e *Engine) ExpectMargins(
 		if !e.as.InAuction() || e.as.CanLeave() {
 			margins = e.calculateMargins(evt, markPrice, *e.factors, false, false)
 		} else {
-			margins = e.calculateAuctionMargins(evt, markPrice, *e.factors)
+			margins = e.calculateMargins(evt, markPrice, *e.factors, true, true)
 		}
 		// no margins updates, nothing to do then
 		if margins == nil {

--- a/core/risk/engine.go
+++ b/core/risk/engine.go
@@ -295,13 +295,9 @@ func (e *Engine) UpdateMarginOnNewOrder(ctx context.Context, evt events.Margin, 
 	if evt == nil {
 		return nil, nil, nil
 	}
+	auction := e.as.InAuction() && !e.as.CanLeave()
+	margins := e.calculateMargins(evt, markPrice, *e.factors, true, auction)
 
-	var margins *types.MarginLevels
-	if !e.as.InAuction() || e.as.CanLeave() {
-		margins = e.calculateMargins(evt, markPrice, *e.factors, true, false)
-	} else {
-		margins = e.calculateMargins(evt, markPrice, *e.factors, true, true)
-	}
 	// no margins updates, nothing to do then
 	if margins == nil {
 		return nil, nil, nil
@@ -417,12 +413,9 @@ func (e *Engine) UpdateMarginsOnSettlement(
 			continue
 		}
 		// channel is closed, and we've got a nil interface
-		var margins *types.MarginLevels
-		if !e.as.InAuction() || e.as.CanLeave() {
-			margins = e.calculateMargins(evt, markPrice, *e.factors, true, false)
-		} else {
-			margins = e.calculateMargins(evt, markPrice, *e.factors, true, true)
-		}
+		auction := e.as.InAuction() && !e.as.CanLeave()
+		margins := e.calculateMargins(evt, markPrice, *e.factors, true, auction)
+
 		// no margins updates, nothing to do then
 		if margins == nil {
 			continue
@@ -509,13 +502,9 @@ func (e *Engine) ExpectMargins(
 ) (okMargins []events.Margin, distressedPositions []events.Margin) {
 	okMargins = make([]events.Margin, 0, len(evts)/2)
 	distressedPositions = make([]events.Margin, 0, len(evts)/2)
+	auction := e.as.InAuction() && !e.as.CanLeave()
 	for _, evt := range evts {
-		var margins *types.MarginLevels
-		if !e.as.InAuction() || e.as.CanLeave() {
-			margins = e.calculateMargins(evt, markPrice, *e.factors, false, false)
-		} else {
-			margins = e.calculateMargins(evt, markPrice, *e.factors, true, true)
-		}
+		margins := e.calculateMargins(evt, markPrice, *e.factors, false, auction)
 		// no margins updates, nothing to do then
 		if margins == nil {
 			okMargins = append(okMargins, evt)

--- a/core/risk/engine_test.go
+++ b/core/risk/engine_test.go
@@ -15,6 +15,7 @@ package risk_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -193,7 +194,6 @@ func testMarginNotReleasedInAuction(t *testing.T) {
 	eng.broker.EXPECT().SendBatch(gomock.Any()).AnyTimes()
 	eng.as.EXPECT().InAuction().AnyTimes().Return(true)
 	eng.as.EXPECT().CanLeave().AnyTimes().Return(false)
-	eng.orderbook.EXPECT().GetIndicativePrice().Times(1).Return(markPrice.Clone())
 	evts := []events.Margin{evt}
 	resp := eng.UpdateMarginsOnSettlement(ctx, evts, markPrice)
 	assert.Equal(t, 0, len(resp))
@@ -695,13 +695,13 @@ func testInitialMarginRequirement(t *testing.T) {
 		general: initialMargin - 1,
 		market:  "ETH/DEC19",
 	}
-	eng.tsvc.EXPECT().GetTimeNow().Times(4)
+	eng.tsvc.EXPECT().GetTimeNow().Times(6)
 	eng.as.EXPECT().InAuction().Times(2).Return(false)
 	eng.orderbook.EXPECT().GetCloseoutPrice(gomock.Any(), gomock.Any()).Times(2).
 		DoAndReturn(func(volume uint64, side types.Side) (*num.Uint, error) {
 			return markPrice.Clone(), nil
 		})
-	eng.broker.EXPECT().SendBatch(gomock.Any()).Times(2)
+	eng.broker.EXPECT().SendBatch(gomock.Any()).Times(3)
 	riskevt, _, err := eng.UpdateMarginOnNewOrder(context.Background(), evt, markPrice)
 	assert.Error(t, err, risk.ErrInsufficientFundsForInitialMargin.Error())
 	assert.Nil(t, riskevt)
@@ -712,20 +712,42 @@ func testInitialMarginRequirement(t *testing.T) {
 	assert.NotNil(t, riskevt)
 	assert.True(t, riskevt.MarginLevels().InitialMargin.EQ(num.NewUint(initialMargin)))
 
-	eng.as.EXPECT().InAuction().Times(2).Return(true)
-	eng.as.EXPECT().CanLeave().Times(2).Return(false)
-	eng.orderbook.EXPECT().GetIndicativePrice().Times(2).Return(markPrice.Clone())
+	eng.as.EXPECT().InAuction().Times(4).Return(true)
+	eng.as.EXPECT().CanLeave().Times(4).Return(false)
 
-	evt.general = initialMargin - 1
+	slippageFactor := DefaultSlippageFactor.InexactFloat64()
+	size := math.Abs(float64(evt.size))
+	rf := eng.GetRiskFactors()
+	initialMarginScalingFactor := 1.2
+	initialMarginAuction := math.Ceil(initialMarginScalingFactor * (size*slippageFactor + size*size*slippageFactor + size*rf.Short.InexactFloat64()) * markPrice.ToDecimal().InexactFloat64())
+
+	evt.general = uint64(initialMarginAuction) - 1
 	riskevt, _, err = eng.UpdateMarginOnNewOrder(context.Background(), evt, markPrice)
 	assert.Error(t, err, risk.ErrInsufficientFundsForInitialMargin.Error())
 	assert.Nil(t, riskevt)
 
-	evt.general = initialMargin
+	evt.general = uint64(initialMarginAuction)
 	riskevt, _, err = eng.UpdateMarginOnNewOrder(context.Background(), evt, markPrice)
 	assert.NoError(t, err)
 	assert.NotNil(t, riskevt)
-	assert.True(t, riskevt.MarginLevels().InitialMargin.EQ(num.NewUint(initialMargin)))
+	assert.True(t, riskevt.MarginLevels().InitialMargin.EQ(num.NewUint(uint64(initialMarginAuction))))
+
+	evt.sell = 7
+	evt.sellSumProduct = 123
+
+	ordersBit := evt.SellSumProduct().Float64() * rf.Short.InexactFloat64()
+	initialMarginAuction = math.Ceil(initialMarginAuction + initialMarginScalingFactor*ordersBit)
+
+	evt.general = uint64(initialMarginAuction) - 1
+	riskevt, _, err = eng.UpdateMarginOnNewOrder(context.Background(), evt, markPrice)
+	assert.Error(t, err, risk.ErrInsufficientFundsForInitialMargin.Error())
+	assert.Nil(t, riskevt)
+
+	evt.general = uint64(math.Ceil(initialMarginAuction))
+	riskevt, _, err = eng.UpdateMarginOnNewOrder(context.Background(), evt, markPrice)
+	assert.NoError(t, err)
+	assert.NotNil(t, riskevt)
+	assert.True(t, riskevt.MarginLevels().InitialMargin.EQ(num.NewUint(uint64(initialMarginAuction))))
 }
 
 func getTestEngine(t *testing.T) *testEngine {

--- a/core/risk/margins_calculation.go
+++ b/core/risk/margins_calculation.go
@@ -52,14 +52,6 @@ func newMarginLevels(maintenance num.Decimal, scalingFactors *scalingFactorsUint
 	}
 }
 
-func addMarginLevels(ml *types.MarginLevels, maintenance num.Decimal, scalingFactors *scalingFactorsUint) {
-	mtl, _ := num.UintFromDecimal(maintenance.Ceil())
-	ml.MaintenanceMargin.AddSum(mtl)
-	ml.SearchLevel.AddSum(num.UintZero().Div(num.UintZero().Mul(scalingFactors.search, mtl), exp))
-	ml.InitialMargin.AddSum(num.UintZero().Div(num.UintZero().Mul(scalingFactors.initial, mtl), exp))
-	ml.CollateralReleaseLevel.AddSum(num.UintZero().Div(num.UintZero().Mul(scalingFactors.release, mtl), exp))
-}
-
 // Implementation of the margin calculator per specs:
 // https://github.com/vegaprotocol/product/blob/master/specs/0019-margin-calculator.md
 func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types.RiskFactor, withPotentialBuyAndSell, auction bool) *types.MarginLevels {

--- a/core/risk/margins_calculation.go
+++ b/core/risk/margins_calculation.go
@@ -131,11 +131,11 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 			}
 		}
 
-		bDec := num.DecimalFromInt64(m.Buy()).Div(e.positionFactor)
 		minV := mPriceDec.Mul(e.linearSlippageFactor.Mul(slippageVolume).Add(e.quadraticSlippageFactor.Mul(slippageVolume.Mul(slippageVolume))))
 		if auction {
 			marginMaintenanceLng = minV.Add(slippageVolume.Mul(mPriceDec.Mul(rf.Long)))
 			if withPotentialBuyAndSell {
+				bDec := num.DecimalFromInt64(m.Buy()).Div(e.positionFactor)
 				marginMaintenanceLng = marginMaintenanceLng.Add(bDec.Mul(rf.Long).Mul(mPriceDec))
 			}
 		} else {
@@ -174,6 +174,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 				num.DecimalZero(),
 				minV,
 			).Add(slippageVolume.Mul(rf.Long).Mul(mPriceDec))
+			bDec := num.DecimalFromInt64(m.Buy()).Div(e.positionFactor)
 			maintenanceMarginLongOpenOrders := bDec.Mul(rf.Long).Mul(mPriceDec)
 			marginMaintenanceLng = maintenanceMarginLongOpenPosition.Add(maintenanceMarginLongOpenOrders)
 		}
@@ -210,7 +211,6 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 				// slippagePerUnit = -1 * (markPrice - int64(exitPrice))
 			}
 		}
-		sDec := num.DecimalFromInt64(m.Sell()).Div(e.positionFactor)
 		absSlippageVolume := slippageVolume.Abs()
 		linearSlippage := absSlippageVolume.Mul(e.linearSlippageFactor)
 		quadraticSlipage := absSlippageVolume.Mul(absSlippageVolume).Mul(e.quadraticSlippageFactor)
@@ -218,6 +218,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 		if auction {
 			marginMaintenanceSht = minV.Add(absSlippageVolume.Mul(mPriceDec.Mul(rf.Short)))
 			if withPotentialBuyAndSell {
+				sDec := num.DecimalFromInt64(m.Sell()).Div(e.positionFactor)
 				marginMaintenanceSht = marginMaintenanceSht.Add(sDec.Mul(rf.Short).Mul(mPriceDec))
 			}
 		} else {
@@ -250,6 +251,7 @@ func (e *Engine) calculateMargins(m events.Margin, markPrice *num.Uint, rf types
 				num.DecimalZero(),
 				minV,
 			).Add(absSlippageVolume.Mul(mPriceDec).Mul(rf.Short))
+			sDec := num.DecimalFromInt64(m.Sell()).Div(e.positionFactor)
 			maintenanceMarginShortOpenOrders := sDec.Abs().Mul(mPriceDec).Mul(rf.Short)
 			marginMaintenanceSht = maintenanceMarginShortOpenPosition.Add(maintenanceMarginShortOpenOrders)
 		}


### PR DESCRIPTION
* Apply slippage cap in auction (no orders on the book)
* Don't double count orders part of margin during auction (used to calculated with mark price once and then again with vwap, should only be vwap)

Closes https://github.com/vegaprotocol/vega/issues/7894 
Closes https://github.com/vegaprotocol/vega/issues/7895