### PR TITLE
Use mark price for all margin calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - [7950](https://github.com/vegaprotocol/vega/issues/7950) - Fix the restore of deposits from checkpoint
 - [7933](https://github.com/vegaprotocol/vega/issues/7933) - Ensure the wallet store is closed to avoid "too many opened files" error
 - [7956](https://github.com/vegaprotocol/vega/issues/7956) - Floor negative slippage per unit at 0
+- [7964](https://github.com/vegaprotocol/vega/issues/7964) - Use mark price for all margin calculations
+
 
 ## 0.70.0
 

--- a/core/execution/liquidity_provision.go
+++ b/core/execution/liquidity_provision.go
@@ -723,12 +723,7 @@ func (m *Market) amendLiquidityProvision(
 func (m *Market) amendLiquidityProvisionAuction(
 	ctx context.Context, sub *types.LiquidityProvisionAmendment, party string,
 ) error {
-	// first try to get the indicative uncrossing price from the book
-	price := m.matching.GetIndicativePrice()
-	if price.IsZero() {
-		// here it is 0 so we will use the mark price
-		price = m.getLastTradedPrice()
-	}
+	price := m.getMarketObservable(num.UintZero())
 
 	// now let's check if we are still at 0, if yes, it means we are in the
 	// third condition from before, no price available, we just accept the

--- a/core/execution/margin.go
+++ b/core/execution/margin.go
@@ -98,7 +98,8 @@ func (m *Market) calcMargins(ctx context.Context, pos *positions.MarketPosition,
 }
 
 func (m *Market) updateMargin(ctx context.Context, pos []events.MarketPosition) []events.Risk {
-	price := m.getCurrentMarkPrice()
+	// price := m.getCurrentMarkPrice()
+	price := m.getLastTradedPrice()
 	asset, _ := m.mkt.GetAsset()
 	mID := m.GetID()
 	margins := make([]events.Margin, 0, len(pos))
@@ -129,7 +130,7 @@ func (m *Market) marginsAuction(ctx context.Context, order *types.Order) ([]even
 	if err != nil {
 		return nil, nil, err
 	}
-	risk, closed := m.risk.UpdateMarginAuction(ctx, []events.Margin{e}, m.getMarketObservable(order.Price))
+	risk, closed := m.risk.UpdateMarginAuction(ctx, []events.Margin{e}, m.getMarketObservable(order.Price.Clone()))
 	if len(closed) > 0 {
 		// this order would take party below maintenance -> stop here
 		return nil, nil, ErrMarginCheckInsufficient
@@ -138,7 +139,7 @@ func (m *Market) marginsAuction(ctx context.Context, order *types.Order) ([]even
 }
 
 func (m *Market) margins(ctx context.Context, mpos *positions.MarketPosition, order *types.Order) ([]events.Risk, []events.MarketPosition, error) {
-	price := m.getMarketObservable(order.Price)
+	price := m.getMarketObservable(order.Price.Clone())
 	asset, _ := m.mkt.GetAsset()
 	mID := m.GetID()
 	pos, err := m.collateral.GetPartyMargin(mpos, asset, mID)

--- a/core/execution/margin.go
+++ b/core/execution/margin.go
@@ -35,7 +35,7 @@ func (m *Market) calcMarginsLiquidityProvisionAmendContinuous(
 		return err
 	}
 
-	_, evt, err := m.risk.UpdateMarginOnNewOrder(ctx, e, m.getLastTradedPrice())
+	_, evt, err := m.risk.UpdateMarginOnNewOrder(ctx, e, m.getCurrentMarkPrice())
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (m *Market) calcMargins(ctx context.Context, pos *positions.MarketPosition,
 }
 
 func (m *Market) updateMargin(ctx context.Context, pos []events.MarketPosition) []events.Risk {
-	price := m.getLastTradedPrice()
+	price := m.getCurrentMarkPrice()
 	asset, _ := m.mkt.GetAsset()
 	mID := m.GetID()
 	margins := make([]events.Margin, 0, len(pos))
@@ -129,7 +129,7 @@ func (m *Market) marginsAuction(ctx context.Context, order *types.Order) ([]even
 	if err != nil {
 		return nil, nil, err
 	}
-	risk, closed := m.risk.UpdateMarginAuction(ctx, []events.Margin{e}, m.getMarketObservable(order).Clone())
+	risk, closed := m.risk.UpdateMarginAuction(ctx, []events.Margin{e}, m.getMarketObservable(order.Price))
 	if len(closed) > 0 {
 		// this order would take party below maintenance -> stop here
 		return nil, nil, ErrMarginCheckInsufficient
@@ -138,7 +138,7 @@ func (m *Market) marginsAuction(ctx context.Context, order *types.Order) ([]even
 }
 
 func (m *Market) margins(ctx context.Context, mpos *positions.MarketPosition, order *types.Order) ([]events.Risk, []events.MarketPosition, error) {
-	price := m.getMarketObservable(order)
+	price := m.getMarketObservable(order.Price)
 	asset, _ := m.mkt.GetAsset()
 	mID := m.GetID()
 	pos, err := m.collateral.GetPartyMargin(mpos, asset, mID)
@@ -159,33 +159,4 @@ func (m *Market) margins(ctx context.Context, mpos *positions.MarketPosition, or
 		return []events.Risk{risk}, []events.MarketPosition{evt}, nil
 	}
 	return []events.Risk{risk}, nil, nil
-}
-
-func (m *Market) getMarketObservable(o *types.Order) *num.Uint {
-	// during opening auction we don't have a last traded price, so we use the indicative price instead
-	if m.as.IsOpeningAuction() {
-		if ip := m.matching.GetIndicativePrice(); !ip.IsZero() {
-			return ip
-		}
-		// we don't have an indicative price yet so we use the order price
-		return o.Price.Clone()
-	}
-	if m.lastTradedPrice == nil {
-		return num.UintZero()
-	}
-	return m.lastTradedPrice.Clone()
-}
-
-func (m *Market) getLastTradedPrice() *num.Uint {
-	if m.lastTradedPrice == nil {
-		return num.UintZero()
-	}
-	return m.lastTradedPrice.Clone()
-}
-
-func (m *Market) getCurrentMarkPrice() *num.Uint {
-	if m.markPrice == nil {
-		return num.UintZero()
-	}
-	return m.markPrice.Clone()
 }

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -762,7 +762,7 @@ func (m *Market) blockEnd(ctx context.Context) {
 	}
 	t := m.timeService.GetTimeNow()
 	if mp != nil && !mp.IsZero() && !m.as.InAuction() && (m.nextMTM.IsZero() || !m.nextMTM.After(t)) {
-		m.markPrice = mp.Clone()
+		m.markPrice = mp
 		m.nextMTM = t.Add(m.mtmDelta) // add delta here
 		if hasTraded {
 			// only MTM if we have traded
@@ -783,7 +783,7 @@ func (m *Market) blockEnd(ctx context.Context) {
 			m.releaseExcessMargin(ctx, closedWithoutLP...)
 		}
 		// last traded price should not reflect the closeout trades
-		m.lastTradedPrice = mp.Clone()
+		m.lastTradedPrice = m.getCurrentMarkPrice()
 	}
 	m.releaseExcessMargin(ctx, m.position.Positions()...)
 	// send position events
@@ -1129,7 +1129,7 @@ func (m *Market) leaveAuction(ctx context.Context, now time.Time) {
 		// now that we've left the auction and all the orders have been unparked,
 		// we can mark all positions using the margin calculation method appropriate
 		// for non-auction mode and carry out any closeouts if need be
-		m.markPrice = m.getLastTradedPrice().Clone()
+		m.markPrice = m.getLastTradedPrice()
 		m.confirmMTM(ctx, false)
 		// set next MTM
 		m.nextMTM = m.timeService.GetTimeNow().Add(m.mtmDelta)
@@ -1710,7 +1710,7 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 		return orderUpdates
 	}
 	// Calculate and set current mark price
-	m.setMarkPrice(conf.Trades[len(conf.Trades)-1])
+	m.setLastTradedPrice(conf.Trades[len(conf.Trades)-1])
 
 	// Insert all trades resulted from the executed order
 	tradeEvts := make([]events.Event, 0, len(conf.Trades))
@@ -1749,9 +1749,8 @@ func (m *Market) confirmMTM(
 	ctx context.Context, skipMargin bool,
 ) {
 	// now let's get the transfers for MTM settlement
-	markPrice := m.getLastTradedPrice()
-	evts := m.position.UpdateMarkPrice(markPrice)
-	settle := m.settlement.SettleMTM(ctx, markPrice, evts)
+	evts := m.position.UpdateMarkPrice(m.getCurrentMarkPrice())
+	settle := m.settlement.SettleMTM(ctx, m.getCurrentMarkPrice(), evts)
 	orderUpdates := []*types.Order{}
 
 	// Only process collateral and risk once per order, not for every trade
@@ -2283,10 +2282,7 @@ func (m *Market) checkMarginForAmendOrder(ctx context.Context, existingOrder *ty
 	return err
 }
 
-func (m *Market) setMarkPrice(trade *types.Trade) {
-	// The current mark price calculation is simply the last trade
-	// in the future this will use varying logic based on market config
-	// the responsibility for calculation could be elsewhere for testability
+func (m *Market) setLastTradedPrice(trade *types.Trade) {
 	m.lastTradedPrice = trade.Price.Clone()
 }
 
@@ -2311,7 +2307,7 @@ func (m *Market) collateralAndRisk(ctx context.Context, settle []events.Transfer
 
 	// let risk engine do its thing here - it returns a slice of money that needs
 	// to be moved to and from margin accounts
-	riskUpdates := m.risk.UpdateMarginsOnSettlement(ctx, evts, m.getLastTradedPrice())
+	riskUpdates := m.risk.UpdateMarginsOnSettlement(ctx, evts, m.getCurrentMarkPrice())
 	if len(riskUpdates) == 0 {
 		return nil
 	}
@@ -3195,7 +3191,7 @@ func (m *Market) getTheoreticalTargetStake() *num.Uint {
 }
 
 func (m *Market) getTargetStake() *num.Uint {
-	return m.tsCalc.GetTargetStake(*m.risk.GetRiskFactors(), m.timeService.GetTimeNow(), m.getLastTradedPrice())
+	return m.tsCalc.GetTargetStake(*m.risk.GetRiskFactors(), m.timeService.GetTimeNow(), m.getCurrentMarkPrice())
 }
 
 func (m *Market) getSuppliedStake() *num.Uint {
@@ -3269,7 +3265,7 @@ func (m *Market) tradingTerminated(ctx context.Context, tt bool) {
 			}()
 			// we have trades, and the market has been closed. Perform MTM sequence now so the final settlement
 			// works as expected.
-			m.markPrice = mp.Clone()
+			m.markPrice = mp
 			m.confirmMTM(ctx, true)
 		}
 		m.mkt.State = types.MarketStateTradingTerminated
@@ -3461,18 +3457,6 @@ func (m *Market) distributeLiquidityFees(ctx context.Context) error {
 	return nil
 }
 
-// Mark price gets returned when market is not in auction, otherwise indicative uncrossing price gets returned.
-func (m *Market) getReferencePrice() *num.Uint {
-	if !m.as.InAuction() {
-		return m.getLastTradedPrice()
-	}
-	ip := m.matching.GetIndicativePrice() // can be zero
-	if ip.IsZero() {
-		return m.getLastTradedPrice()
-	}
-	return ip
-}
-
 // GetTotalOrderBookLevelCount returns the total number of levels in the order book.
 func (m *Market) GetTotalOrderBookLevelCount() uint64 {
 	return m.matching.GetOrderBookLevelCount()
@@ -3496,4 +3480,43 @@ func (m *Market) GetTotalLPShapeCount() uint64 {
 // we use this in a banch of places so let's inform it from here in case we want to modify it in the future.
 func (m *Market) minValidPrice() *num.Uint {
 	return m.priceFactor
+}
+
+// getMarketObservable returns current mark price once market is out of opening auction, during opening auction the indicative uncrossing price is returned.
+func (m *Market) getMarketObservable(fallbackPrice *num.Uint) *num.Uint {
+	// during opening auction we don't have a last traded price, so we use the indicative price instead
+	if m.as.IsOpeningAuction() {
+		if ip := m.matching.GetIndicativePrice(); !ip.IsZero() {
+			return ip
+		}
+		// we don't have an indicative price yet so we use the supplied price
+		return fallbackPrice.Clone()
+	}
+	return m.getCurrentMarkPrice()
+}
+
+// Mark price gets returned when market is not in auction, otherwise indicative uncrossing price gets returned.
+func (m *Market) getReferencePrice() *num.Uint {
+	if !m.as.InAuction() {
+		return m.getCurrentMarkPrice()
+	}
+	ip := m.matching.GetIndicativePrice() // can be zero
+	if ip.IsZero() {
+		return m.getCurrentMarkPrice()
+	}
+	return ip
+}
+
+func (m *Market) getCurrentMarkPrice() *num.Uint {
+	if m.markPrice == nil {
+		return num.UintZero()
+	}
+	return m.markPrice.Clone()
+}
+
+func (m *Market) getLastTradedPrice() *num.Uint {
+	if m.lastTradedPrice == nil {
+		return num.UintZero()
+	}
+	return m.lastTradedPrice.Clone()
 }

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -783,7 +783,7 @@ func (m *Market) blockEnd(ctx context.Context) {
 			m.releaseExcessMargin(ctx, closedWithoutLP...)
 		}
 		// last traded price should not reflect the closeout trades
-		m.lastTradedPrice = m.getCurrentMarkPrice()
+		m.lastTradedPrice = mp.Clone()
 	}
 	m.releaseExcessMargin(ctx, m.position.Positions()...)
 	// send position events
@@ -1749,8 +1749,9 @@ func (m *Market) confirmMTM(
 	ctx context.Context, skipMargin bool,
 ) {
 	// now let's get the transfers for MTM settlement
-	evts := m.position.UpdateMarkPrice(m.getCurrentMarkPrice())
-	settle := m.settlement.SettleMTM(ctx, m.getCurrentMarkPrice(), evts)
+	mp := m.getCurrentMarkPrice()
+	evts := m.position.UpdateMarkPrice(mp)
+	settle := m.settlement.SettleMTM(ctx, mp, evts)
 	orderUpdates := []*types.Order{}
 
 	// Only process collateral and risk once per order, not for every trade
@@ -3490,7 +3491,7 @@ func (m *Market) getMarketObservable(fallbackPrice *num.Uint) *num.Uint {
 			return ip
 		}
 		// we don't have an indicative price yet so we use the supplied price
-		return fallbackPrice.Clone()
+		return fallbackPrice
 	}
 	return m.getCurrentMarkPrice()
 }

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -1709,7 +1709,6 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 	if len(conf.Trades) == 0 {
 		return orderUpdates
 	}
-	// Calculate and set current mark price
 	m.setLastTradedPrice(conf.Trades[len(conf.Trades)-1])
 
 	// Insert all trades resulted from the executed order

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -1815,8 +1815,6 @@ func (m *Market) confirmMTM(
 		// release excess margin for all positions
 		m.recheckMargin(ctx, m.position.Positions())
 	}
-	// release any excess if needed
-	// m.releaseExcessMargin(ctx, pos...)
 }
 
 // updateLiquidityFee computes the current LiquidityProvision fee and updates
@@ -2088,7 +2086,6 @@ func (m *Market) resolveClosedOutParties(ctx context.Context, distressedMarginEv
 	m.finalizePartiesCloseOut(ctx, closed, closedMPs)
 
 	m.confirmMTM(ctx, false)
-	m.recheckMargin(ctx, m.position.Positions())
 
 	return orderUpdates, nil
 }

--- a/core/execution/order_test.go
+++ b/core/execution/order_test.go
@@ -3056,10 +3056,11 @@ func TestPeggedOrderCancelledWhenPartyCannotAffordTheMarginOnceDeployed(t *testi
 	assert.Equal(t, 2, tm.market.GetParkedOrderCount())
 
 	bestBid := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux2", types.SideBuy, auxParty2, 1, 10)
+	matchingPrice := uint64(2000)
 	auxOrders := []*types.Order{
 		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux1", types.SideSell, auxParty1, 1, 10000),
-		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux2", types.SideBuy, auxParty2, 1, 2000),
-		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux2", types.SideSell, auxParty1, 1, 2000),
+		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux2", types.SideBuy, auxParty2, 1, matchingPrice),
+		getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "aux2", types.SideSell, auxParty1, 1, matchingPrice),
 	}
 	bestBidConf, err := tm.market.SubmitOrder(ctx, bestBid)
 	require.NoError(t, err)
@@ -3090,6 +3091,7 @@ func TestPeggedOrderCancelledWhenPartyCannotAffordTheMarginOnceDeployed(t *testi
 	md := tm.market.GetMarketData()
 	require.NotNil(t, md)
 	require.Equal(t, types.MarketTradingModeContinuous, md.MarketTradingMode)
+	require.Equal(t, num.NewUint(matchingPrice), md.MarkPrice)
 
 	assert.Equal(t, confirmationPeggedBuy.Order.Status, types.OrderStatusCancelled)
 	assert.Equal(t, confirmationPeggedSell.Order.Status, types.OrderStatusCancelled)

--- a/core/integration/features/auctions/5460-market-order-cannot-trade-due-to-auction.feature
+++ b/core/integration/features/auctions/5460-market-order-cannot-trade-due-to-auction.feature
@@ -133,4 +133,4 @@ Feature: Test for issue 5460
 
     And the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 8075         | 200000000      | 500000        |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 8187         | 200000000      | 500000        |

--- a/core/integration/features/fees/trading-fees-pdp.feature
+++ b/core/integration/features/fees/trading-fees-pdp.feature
@@ -410,11 +410,6 @@ Feature: Fees calculations
       | 1000       | 1002              | TRADING_MODE_CONTINUOUS |
 
     Then the following trades should be executed:
-
-
-      # | buyer   | price | size | seller  | maker   | taker   |
-      # | trader3 | 1002  | 3    | trader4 | trader3 | trader4 |
-      # TODO to be implemented by Core Team
       | buyer    | price | size | seller  |
       | trader3a | 1002  | 200  | trader4 |
       | trader3b | 1002  | 100  | trader4 |
@@ -451,6 +446,11 @@ Feature: Fees calculations
       | trader3b | ETH   | ETH/DEC21 | 240    | 9766    |
       | trader4  | ETH   | ETH/DEC21 | 480    | 743     |
 
+    Then the network moves ahead "1" blocks
+    And the market data for the market "ETH/DEC21" should be:
+      | mark price | last traded price | trading mode            |
+      | 1002       | 1002              | TRADING_MODE_CONTINUOUS |
+
     # Placing second set of orders
     When the parties place the following orders:
       | party    | market id | side | volume | price | resulting trades | type       | tif     | reference      |
@@ -469,16 +469,13 @@ Feature: Fees calculations
 
     # matching the order now
     Then the following trades should be executed:
-      # | buyer   | price | size | seller  | maker   | taker   |
-      # | trader3 | 1002  | 3    | trader4 | trader3 | trader4 |
-      # TODO to be implemented by Core Team
       | buyer    | price | size | seller  |
       | trader3a | 1002  | 200  | trader4 |
 
-    # checking if continuous mode still exists
+     # checking if continuous mode still exists
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            |
-      | 1000       | 1002              | TRADING_MODE_CONTINUOUS |
+      | 1002       | 1002              | TRADING_MODE_CONTINUOUS |
 
     Then the parties should have the following account balances:
       | party    | asset | market id | margin | general |
@@ -1058,7 +1055,6 @@ Feature: Fees calculations
       | lp1 | aux1  | ETH/DEC21 | 10000             | 0.001 | buy  | BID              | 1          | 10     | amendment |
       | lp1 | aux1  | ETH/DEC21 | 10000             | 0.001 | sell | ASK              | 1          | 10     | amendment |
 
-    #TODO: Raise a bug: mark price is not being checked, any value results in a pass.
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
       | 1002       | TRADING_MODE_CONTINUOUS | 1       | 903       | 1101      | 200          | 10000          | 100           |
@@ -1374,7 +1370,6 @@ Feature: Fees calculations
       | lp1 | aux1  | ETH/DEC21 | 10000             | 0.001 | buy  | BID              | 1          | 10     | amendment |
       | lp1 | aux1  | ETH/DEC21 | 10000             | 0.001 | sell | ASK              | 1          | 10     | amendment |
 
-    #TODO: Raise a bug: mark price is not being checked, any value results in a pass.
     And the market data for the market "ETH/DEC21" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
       | 1002       | TRADING_MODE_CONTINUOUS | 1       | 903       | 1101      | 200          | 10000          | 100           |

--- a/core/integration/features/price_monitoring/5206-price-bound-rounding.feature
+++ b/core/integration/features/price_monitoring/5206-price-bound-rounding.feature
@@ -60,7 +60,7 @@ Feature: Ensure price bounds are triggered as and when they should be, consideri
 
     And the market data for the market "ETH/DEC20" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake           | supplied stake          | open interest |
-      | 977142640  | TRADING_MODE_CONTINUOUS | 5       | 975999651 | 978286619 | 1080524332417800000000 | 39050000000000000000000 | 2             |
+      | 977142640  | TRADING_MODE_CONTINUOUS | 5       | 975999651 | 978286619 | 1080524331312000000000 | 39050000000000000000000 | 2             |
 
     When the parties place the following orders:
       | party  | market id | side | volume | price     | resulting trades | type       | tif     |
@@ -109,7 +109,7 @@ Feature: Ensure price bounds are triggered as and when they should be, consideri
 
     And the market data for the market "ETH/DEC20" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake           | supplied stake          | open interest |
-      | 977142640  | 977142641         | TRADING_MODE_CONTINUOUS | 5       | 975999651 | 978286619 | 1080524332417800000000 | 39050000000000000000000 | 2             |
+      | 977142640  | 977142641         | TRADING_MODE_CONTINUOUS | 5       | 975999651 | 978286619 | 1080524331312000000000 | 39050000000000000000000 | 2             |
 
     When the parties place the following orders:
       | party  | market id | side | volume | price     | resulting trades | type       | tif     |

--- a/core/integration/features/settlement/settlement_with_different_order_types.feature
+++ b/core/integration/features/settlement/settlement_with_different_order_types.feature
@@ -154,22 +154,37 @@ Feature: Test mark to market settlement with periodicity, takes the first scenar
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party3 | ETH/DEC19 | sell | 1      | 2000  | 0                | TYPE_LIMIT | TIF_IOC |
-    When the parties place the following orders:
+    And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party3 | ETH/DEC19 | sell | 1      | 2000  | 0                | TYPE_LIMIT | TIF_FOK |
+    Then the market data for the market "ETH/DEC19" should be:
+      | mark price | last traded price | trading mode            | 
+      | 1000       | 2000              | TRADING_MODE_CONTINUOUS |
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | initial |
+      | party3 | ETH/DEC19 | 1061000     | 1273200 |
 
     When the network moves ahead "6" blocks
     ## Now mark to market, the mark price should be 2,000 at this point, dramatically changing the balances
     ## The interval is set to 5s, so 6 blocks should do the trick
 
+    Then the market data for the market "ETH/DEC19" should be:
+      | mark price | last traded price | trading mode            | 
+      | 2000       | 2000              | TRADING_MODE_CONTINUOUS |
     And the following transfers should happen:
       | from   | to     | from account            | to account              | market id | amount  | asset |
       | party3 | party3 | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 360000  | ETH   |
-      | party3 | party3 | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 2245200 | ETH   |
+      | party3 | party3 | ACCOUNT_TYPE_GENERAL    | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 1332000 | ETH   |
       | aux    | market | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC19 | 1000000 | ETH   |
       | party1 | market | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC19 | 1000000 | ETH   |
       | market | aux2   | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 1000000 | ETH   |
       | market | party2 | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 1000000 | ETH   |
+    And the parties should have the following margin levels:
+      | party  | market id | maintenance | initial |
+      | party3 | ETH/DEC19 | 2171000     | 2605200 |
+    And the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party3 | ETH   | ETH/DEC19 | 2605200 | 7392800 |
 
     And the cumulated balance for all accounts should be worth "330000000"
     And the settlement account should have a balance of "0" for the market "ETH/DEC19"

--- a/core/integration/features/verified/0026-AUCT-auction_interaction.feature
+++ b/core/integration/features/verified/0026-AUCT-auction_interaction.feature
@@ -260,7 +260,7 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
     # verify that we don't enter liquidity auction immediately, but at the end of block as per 0035-LIQM-003
     And the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 3030         | 1000           | 30            |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 3000         | 1000           | 30            |
 
     # move to the next block to perform liquidity check
     Then the network moves ahead "1" blocks
@@ -343,7 +343,7 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
 
     And the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1414         | 1000           | 14            |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1400         | 1000           | 14            |
     When the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:
       | trading mode                    | auction trigger                          | target stake | supplied stake | open interest |
@@ -406,7 +406,7 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
 
     And the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | 1009              | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 403          | 2000           | 4             |
+      | 1000       | 1009              | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 400          | 2000           | 4             |
 
     When the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:
@@ -459,7 +459,7 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | party1 | 1      | 0              | 0            |
     And the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | 1010              | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 505          | 2000           | 5             |
+      | 1000       | 1010              | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 500          | 2000           | 5             |
     And the order book should have the following volumes for market "ETH/DEC21":
       | side | price | volume |
       | sell | 1010  | 0      |
@@ -586,7 +586,7 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | party1 | ETH/DEC21 | buy  | 4      | 1010  | 3                | TYPE_LIMIT | TIF_FOK |
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | 1010              | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 1414         | 1000           | 14            |
+      | 1000       | 1010              | TRADING_MODE_CONTINUOUS | 100     | 990       | 1010      | 1400         | 1000           | 14            |
 
     When the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:
@@ -679,7 +679,7 @@ Feature: Test interactions between different auction types (0035-LIQM-001)
       | party1 | ETH/DEC21 | buy  | 10     | 1010  | 3                | TYPE_LIMIT | TIF_GTC | trigger-liq |
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            | target stake | supplied stake | open interest |
-      | 1000       | 1010              | TRADING_MODE_CONTINUOUS | 1414         | 1000           | 14            |
+      | 1000       | 1010              | TRADING_MODE_CONTINUOUS | 1400         | 1000           | 14            |
 
     When the network moves ahead "1" blocks
     Then the market data for the market "ETH/DEC21" should be:

--- a/core/integration/features/verified/0035-LIQM-liquidity_monitoring.feature
+++ b/core/integration/features/verified/0035-LIQM-liquidity_monitoring.feature
@@ -80,7 +80,7 @@ Feature: Test liquidity monitoring
     # verify that we don't enter liquidity auction immediately despite liquidity being undersuplied
     And the market data for the market "ETH/DEC21" should be:
       | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 3030         | 1000           | 30            |
+      | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 3000         | 1000           | 30            |
 
     Then the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type   |

--- a/core/integration/features/verified/0041-TSK-target_stake.feature
+++ b/core/integration/features/verified/0041-TSK-target_stake.feature
@@ -175,13 +175,13 @@ Feature: Target stake
       | 90         | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 135          | 2000           | 10            |
     And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
 
-    When the parties place the following orders:
+    When the parties place the following orders with ticks:
       | party | market id | side | volume | price | resulting trades | type        | tif     |
       | tt_2  | ETH/DEC21 | buy  | 10     | 0     | 1                | TYPE_MARKET | TIF_FOK |
 
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | 90         | 110               | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 165          | 2000           | 0             |
+      | 110        | 110               | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 165          | 2000           | 0             |
     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
 
     # O is now the last recorded open interest so target stake should drop to 0
@@ -237,7 +237,7 @@ Feature: Target stake
     Then the network moves ahead "1" blocks
 
     # Trader 3 closes out 20
-    When the parties place the following orders:
+    When the parties place the following orders with ticks:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | tt_3  | ETH/DEC21 | sell | 20     | 90    | 1                | TYPE_LIMIT | TIF_GTC | tt_2_1    |
 
@@ -245,7 +245,7 @@ Feature: Target stake
     # target_stake = 90 x 60 x 1.5 x 0.1 = 810
     Then the market data for the market "ETH/DEC21" should be:
       | mark price | last traded price | trading mode            | auction trigger             | target stake | supplied stake | open interest |
-      | 110        | 90                | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 810          | 2000           | 40            |
+      | 90         | 90                | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 810          | 2000           | 40            |
 
     # T0 + 10s
     Then the network moves ahead "10" blocks
@@ -257,10 +257,10 @@ Feature: Target stake
     # target_stake = 90 x 40 x 1.5 x 0.1 = 540
     And the target stake should be "540" for the market "ETH/DEC21"
 
-    When the parties place the following orders:
+    When the parties place the following orders with ticks:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | tt_1  | ETH/DEC21 | buy  | 100    | 110   | 1                | TYPE_LIMIT | TIF_GTC | lp_1_0    |
-    Then the mark price should be "90" for the market "ETH/DEC21"
+    Then the mark price should be "110" for the market "ETH/DEC21"
 
     # max_io=10+20+30-20+100=140
     # target_stake = 110 x 140 x 1.5 x 0.1=2310
@@ -276,7 +276,7 @@ Feature: Target stake
     # target_stake = 110 x 140 x 1 x 0.1 =1540
     And the target stake should be "1540" for the market "ETH/DEC21"
 
-    When the parties place the following orders:
+    When the parties place the following orders with ticks:
       | party | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | tt_1  | ETH/DEC21 | buy  | 30     | 110   | 1                | TYPE_LIMIT | TIF_GTC | tt_1_0    |
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
@@ -327,7 +327,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | 1001              | TRADING_MODE_CONTINUOUS | 1       | 500       | 1500      | 5205         | 9000           | 52            |
+      | 1000       | 1001              | TRADING_MODE_CONTINUOUS | 1       | 500       | 1500      | 5200         | 9000           | 52            |
 
     # Trigger next liquidity fee distribution without triggering next period
     When the network moves ahead "1" blocks:

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
@@ -145,7 +145,7 @@ Feature:
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | 1001              | TRADING_MODE_CONTINUOUS | 1       | 500       | 1500      | 10260        | 49000          | 41            |
+      | 1000       | 1001              | TRADING_MODE_CONTINUOUS | 1       | 500       | 1500      | 10250        | 49000          | 41            |
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -645,7 +645,7 @@ Feature:
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000       | 1001              | TRADING_MODE_CONTINUOUS | 1       | 500       | 1500      | 7507         | 50000          | 30            |
+      | 1000       | 1001              | TRADING_MODE_CONTINUOUS | 1       | 500       | 1500      | 7500         | 50000          | 30            |
 
     # -------------------------------------------------------------------------------------------------------------------
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_with_decimal.feature
@@ -322,7 +322,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     And the accumulated liquidity fees should be "6" for the market "USD/DEC20"
     # liquidity fee = 5 * 100100000 * 0.001 which means actual number without decimal is 0.00005*1001*0.001 = 0.00005005, and translate back into asset decimal 5.005 (given fee is rounded up in vega, so it should be 6) given asset decimal 5, market decimal 5, position decimal 5
 
-    Then the parties place the following orders:
+    Then the parties place the following orders with ticks:
       | party  | market id | side | volume | price     | resulting trades | type       | tif     |
       | party1 | USD/DEC21 | buy  | 1      | 100100000 | 1                | TYPE_LIMIT | TIF_GTC |
     And the accumulated liquidity fees should be "101" for the market "USD/DEC21"
@@ -331,7 +331,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
     #check MTM settlement with correct PDP
     And the market data for the market "USD/DEC21" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 100000000  | 100100000         | TRADING_MODE_CONTINUOUS | 100000  | 86365368  | 115420826 | 3560812945   | 5001000000     | 10001         |
+      | 100100000  | 100100000         | TRADING_MODE_CONTINUOUS | 100000  | 86365368  | 115420826 | 3560812945   | 5001000000     | 10001         |
     # target_stake = mark_price x max_oi x target_stake_scaling_factor x rf = 1001 x 10.001 x 1 x 3.5569=35608.1294569, which is 3560812945 in asset decimal (which is 5)
 
     And the parties should have the following account balances:
@@ -347,7 +347,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
 
     And the market data for the market "USD/DEC19" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000000    | 1001000           | TRADING_MODE_CONTINUOUS | 100000  | 863654    | 1154208   | 3562237128   | 5002000000     | 10005         |
+      | 1001000    | 1001000           | TRADING_MODE_CONTINUOUS | 100000  | 863654    | 1154208   | 3562237128   | 5002000000     | 10005         |
 
     And the parties submit the following liquidity provision:
       | id  | party  | market id | commitment amount | fee   | side | pegged reference | proportion | offset | lp type   |
@@ -358,7 +358,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
 
     And the market data for the market "USD/DEC19" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000000    | 1001000           | TRADING_MODE_CONTINUOUS | 100000  | 863654    | 1154208   | 3562237128   | 5000000000     | 10005         |
+      | 1001000    | 1001000           | TRADING_MODE_CONTINUOUS | 100000  | 863654    | 1154208   | 3562237128   | 5000000000     | 10005         |
 
     #reduce LP commitment amount
     And the parties submit the following liquidity provision:
@@ -368,7 +368,7 @@ Feature: Test decimal places in LP order, liquidity provider reward distribution
 
     And the market data for the market "USD/DEC19" should be:
       | mark price | last traded price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1000000    | 1001000           | TRADING_MODE_CONTINUOUS | 100000  | 863654    | 1154208   | 3562237128   | 4600000000     | 10005         |
+      | 1001000    | 1001000           | TRADING_MODE_CONTINUOUS | 100000  | 863654    | 1154208   | 3562237128   | 4600000000     | 10005         |
 
     # 0038-OLIQ-006 assure that submission bringing supplied stake < target stake gets rejected
     And the parties submit the following liquidity provision:

--- a/core/integration/features/verified/Issue-6004-ProbOfTrading_Refactoring.feature
+++ b/core/integration/features/verified/Issue-6004-ProbOfTrading_Refactoring.feature
@@ -71,7 +71,7 @@ Feature: test probability of trading used in LP vol when best bid/ask is changin
 
     Then the market data for the market "ETH/MAR22" should be:
       | trading mode            | supplied stake | target stake |
-      | TRADING_MODE_CONTINUOUS | 50000          | 186562       |
+      | TRADING_MODE_CONTINUOUS | 50000          | 188871       |
 
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference    |
@@ -79,7 +79,7 @@ Feature: test probability of trading used in LP vol when best bid/ask is changin
 
     Then the market data for the market "ETH/MAR22" should be:
       | trading mode            | supplied stake | target stake |
-      | TRADING_MODE_CONTINUOUS | 50000          | 196049       |
+      | TRADING_MODE_CONTINUOUS | 50000          | 198475       |
 
   Scenario: 002, market starts with a low best bid price 1 (ProbTrading is large), and then best bid goes to 899; test of the new ProbTrading is reasonable, and LP is not distressed; 0038-OLIQ-002
 


### PR DESCRIPTION
We used to have a mix of last traded price and mark price used in margin-related calculations.

Closes https://github.com/vegaprotocol/vega/issues/7964
