### PR TITLE
Support parallel request on different party on the wallet API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - [8402](https://github.com/vegaprotocol/vega/issues/8402) - Avoid division by 0 in market activity tracker
 - [8347](https://github.com/vegaprotocol/vega/issues/8347) - Market state (`ELS`) to be included in checkpoint data.
 - [8303](https://github.com/vegaprotocol/vega/issues/8303) - Add support for successor markets in datanode.
-
+- [7701](https://github.com/vegaprotocol/vega/issues/7701) - Support parallel request on different party on the wallet API
 
 ### 🐛 Fixes
 - [8208](https://github.com/vegaprotocol/vega/issues/8208) - Fix block explorer API documentation

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/machinebox/graphql v0.2.2
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/muesli/cancelreader v0.2.2
 	github.com/muesli/termenv v0.11.0
 	github.com/multiformats/go-multiaddr v0.9.0
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220317090546-adb2f9614b17

--- a/go.sum
+++ b/go.sum
@@ -1095,6 +1095,8 @@ github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjW
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
+github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
+github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.11.0 h1:fwNUbu2mfWlgicwG7qYzs06aOI8Z/zKPAv8J4uKbT+o=
 github.com/muesli/termenv v0.11.0/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL8NSQj0zQ5Nz/AA=

--- a/wallet/api/api.go
+++ b/wallet/api/api.go
@@ -222,14 +222,15 @@ func (a *ClientAPI) SendTransaction(ctx context.Context, rawParams jsonrpc.Param
 }
 
 func BuildClientAPI(walletStore WalletStore, interactor Interactor, nodeSelector node.Selector, spam SpamHandler) (*ClientAPI, error) {
-	clientAPI := &ClientAPI{}
+	requestController := DefaultRequestController()
 
-	clientAPI.checkTransaction = NewClientCheckTransaction(walletStore, interactor, nodeSelector, spam)
+	clientAPI := &ClientAPI{}
 	clientAPI.connectWallet = NewConnectWallet(walletStore, interactor)
 	clientAPI.getChainID = NewGetChainID(nodeSelector)
 	clientAPI.listKeys = NewListKeys(walletStore, interactor)
-	clientAPI.signTransaction = NewClientSignTransaction(walletStore, interactor, nodeSelector, spam)
-	clientAPI.sendTransaction = NewClientSendTransaction(walletStore, interactor, nodeSelector, spam)
+	clientAPI.checkTransaction = NewClientCheckTransaction(walletStore, interactor, nodeSelector, spam, requestController)
+	clientAPI.signTransaction = NewClientSignTransaction(walletStore, interactor, nodeSelector, spam, requestController)
+	clientAPI.sendTransaction = NewClientSendTransaction(walletStore, interactor, nodeSelector, spam, requestController)
 
 	return clientAPI, nil
 }

--- a/wallet/api/client_send_transaction.go
+++ b/wallet/api/client_send_transaction.go
@@ -40,10 +40,11 @@ type ClientSendTransactionResult struct {
 }
 
 type ClientSendTransaction struct {
-	walletStore  WalletStore
-	interactor   Interactor
-	nodeSelector node.Selector
-	spam         SpamHandler
+	walletStore       WalletStore
+	interactor        Interactor
+	nodeSelector      node.Selector
+	spam              SpamHandler
+	requestController *RequestController
 }
 
 func (h *ClientSendTransaction) Handle(ctx context.Context, rawParams jsonrpc.Params, connectedWallet ConnectedWallet) (jsonrpc.Result, *jsonrpc.ErrorDetails) {
@@ -79,6 +80,12 @@ func (h *ClientSendTransaction) Handle(ctx context.Context, rawParams jsonrpc.Pa
 		return nil, InvalidParams(errs)
 	}
 
+	iAmDone, err := h.requestController.IsPublicKeyAlreadyInUse(params.PublicKey)
+	if err != nil {
+		return nil, RequestNotPermittedError(err)
+	}
+	defer iAmDone()
+
 	if err := h.interactor.NotifyInteractionSessionBegan(ctx, traceID, TransactionReviewWorkflow, 2); err != nil {
 		return nil, RequestNotPermittedError(err)
 	}
@@ -97,6 +104,8 @@ func (h *ClientSendTransaction) Handle(ctx context.Context, rawParams jsonrpc.Pa
 		if !approved {
 			return nil, UserRejectionError(ErrUserRejectedSendingOfTransaction)
 		}
+	} else {
+		h.interactor.Log(ctx, traceID, InfoLog, fmt.Sprintf("Trying to send the transaction: %v", request.String()))
 	}
 
 	h.interactor.Log(ctx, traceID, InfoLog, "Looking for a healthy node...")
@@ -254,11 +263,12 @@ func validateSendTransactionParams(rawParams jsonrpc.Params) (ClientParsedSendTr
 	}, nil
 }
 
-func NewClientSendTransaction(walletStore WalletStore, interactor Interactor, nodeSelector node.Selector, pow SpamHandler) *ClientSendTransaction {
+func NewClientSendTransaction(walletStore WalletStore, interactor Interactor, nodeSelector node.Selector, pow SpamHandler, requestController *RequestController) *ClientSendTransaction {
 	return &ClientSendTransaction{
-		walletStore:  walletStore,
-		interactor:   interactor,
-		nodeSelector: nodeSelector,
-		spam:         pow,
+		walletStore:       walletStore,
+		interactor:        interactor,
+		nodeSelector:      nodeSelector,
+		spam:              pow,
+		requestController: requestController,
 	}
 }

--- a/wallet/api/client_send_transaction_test.go
+++ b/wallet/api/client_send_transaction_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"code.vegaprotocol.io/vega/libs/jsonrpc"
 	vgrand "code.vegaprotocol.io/vega/libs/rand"
@@ -24,6 +26,7 @@ func TestSendTransaction(t *testing.T) {
 	t.Run("Documentation matches the code", testClientSendTransactionSchemaCorrect)
 	t.Run("Sending a transaction with invalid params fails", testSendingTransactionWithInvalidParamsFails)
 	t.Run("Sending a transaction with valid params succeeds", testSendingTransactionWithValidParamsSucceeds)
+	t.Run("Sending a transaction in parallel blocks on same party but not on different parties", testSendingTransactionInParallelBlocksOnSamePartyButNotOnDifferentParties)
 	t.Run("Sending a transaction without the needed permissions send the transaction", testSendingTransactionWithoutNeededPermissionsDoesNotSendTransaction)
 	t.Run("Refusing the sending of a transaction does not send the transaction", testRefusingSendingOfTransactionDoesNotSendTransaction)
 	t.Run("Cancelling the review does not send the transaction", testCancellingTheReviewDoesNotSendTransaction)
@@ -207,6 +210,213 @@ func testSendingTransactionWithValidParamsSucceeds(t *testing.T) {
 	require.NotEmpty(t, result)
 	assert.Equal(t, txHash, result.TransactionHash)
 	assert.NotEmpty(t, result.Transaction)
+}
+
+func testSendingTransactionInParallelBlocksOnSamePartyButNotOnDifferentParties(t *testing.T) {
+	// setup
+
+	// Use channels to orchestrate requests.
+	sendSecondRequests := make(chan interface{})
+	sendThirdRequests := make(chan interface{})
+	waitForSecondRequestToExit := make(chan interface{})
+	waitForThirdRequestToExit := make(chan interface{})
+
+	hostname := vgrand.RandomStr(5)
+	nodeHost := vgrand.RandomStr(5)
+
+	// One context for each request.
+	r1Ctx, r1TraceID := clientContextForTest()
+	r2Ctx, _ := clientContextForTest()
+	r3Ctx, r3TraceID := clientContextForTest()
+
+	// A wallet with 2 keys to have 2 different parties.
+	wallet1 := walletWithPerms(t, hostname, wallet.Permissions{
+		PublicKeys: wallet.PublicKeysPermission{
+			Access:      wallet.ReadAccess,
+			AllowedKeys: nil,
+		},
+	})
+	kp1, err := wallet1.GenerateKeyPair(nil)
+	require.NoError(t, err)
+	kp2, err := wallet1.GenerateKeyPair(nil)
+	require.NoError(t, err)
+
+	// We can have a single connection as the implementation only cares about the
+	// party.
+	connectedWallet, err := api.NewConnectedWallet(hostname, wallet1)
+	require.NoError(t, err)
+
+	// Some mock data. Their value is irrelevant to test parallelism, so we recycle
+	// them.
+	txHash := vgrand.RandomStr(64)
+	spamStats := types.SpamStatistics{
+		ChainID:           vgrand.RandomStr(5),
+		LastBlockHeight:   100,
+		Proposals:         &types.SpamStatistic{MaxForEpoch: 1},
+		NodeAnnouncements: &types.SpamStatistic{MaxForEpoch: 1},
+		Delegations:       &types.SpamStatistic{MaxForEpoch: 1},
+		Transfers:         &types.SpamStatistic{MaxForEpoch: 1},
+		Votes:             &types.VoteSpamStatistics{MaxForEpoch: 1},
+		PoW: &types.PoWStatistics{
+			PowBlockStates: []types.PoWBlockState{{}},
+		},
+	}
+	pow := &commandspb.ProofOfWork{
+		Tid:   vgrand.RandomStr(5),
+		Nonce: 12345678,
+	}
+
+	// Setting up the mocked calls. The second request shouldn't trigger any of
+	// them, since it should be rejected because it uses the same party as the
+	// first request, which only unblock at the end.
+	handler := newSendTransactionHandler(t)
+
+	gomock.InOrder(
+		// First request.
+		handler.spam.EXPECT().GenerateProofOfWork(kp1.PublicKey(), &spamStats).Times(1).Return(pow, nil),
+		// Third request.
+		handler.spam.EXPECT().GenerateProofOfWork(kp2.PublicKey(), &spamStats).Times(1).Return(pow, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().NotifyInteractionSessionBegan(r1Ctx, r1TraceID, api.TransactionReviewWorkflow, uint8(2)).Times(1).Return(nil),
+		// Third request.
+		handler.interactor.EXPECT().NotifyInteractionSessionBegan(r3Ctx, r3TraceID, api.TransactionReviewWorkflow, uint8(2)).Times(1).Return(nil),
+	)
+	gomock.InOrder(
+		// Third request is expected before because the first request get unblocked
+		// when the third request finishes.
+		handler.interactor.EXPECT().NotifyInteractionSessionEnded(r3Ctx, r3TraceID).Times(1),
+		// First request.
+		handler.interactor.EXPECT().NotifyInteractionSessionEnded(r1Ctx, r1TraceID).Times(1),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().RequestTransactionReviewForSending(r1Ctx, r1TraceID, uint8(1), hostname, wallet1.Name(), kp1.PublicKey(), fakeTransaction, gomock.Any()).Times(1).Return(true, nil),
+		// Third request.
+		handler.interactor.EXPECT().RequestTransactionReviewForSending(r3Ctx, r3TraceID, uint8(1), hostname, wallet1.Name(), kp2.PublicKey(), fakeTransaction, gomock.Any()).Times(1).Return(true, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.nodeSelector.EXPECT().Node(r1Ctx, gomock.Any()).Times(1).Return(handler.node, nil),
+		// Third request.
+		handler.nodeSelector.EXPECT().Node(r3Ctx, gomock.Any()).Times(1).Return(handler.node, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.node.EXPECT().SendTransaction(r1Ctx, gomock.Any(), apipb.SubmitTransactionRequest_TYPE_SYNC).Times(1).Return(txHash, nil),
+		// Third request.
+		handler.node.EXPECT().SendTransaction(r3Ctx, gomock.Any(), apipb.SubmitTransactionRequest_TYPE_SYNC).Times(1).Return(txHash, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.walletStore.EXPECT().GetWallet(r1Ctx, wallet1.Name()).Times(1).Return(wallet1, nil),
+		// Second request.
+		handler.walletStore.EXPECT().GetWallet(r2Ctx, wallet1.Name()).Times(1).DoAndReturn(func(_ context.Context, _ string) (wallet.Wallet, error) {
+			close(sendThirdRequests)
+			return wallet1, nil
+		}),
+		// Third request.
+		handler.walletStore.EXPECT().GetWallet(r3Ctx, wallet1.Name()).Times(1).Return(wallet1, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.node.EXPECT().SpamStatistics(r1Ctx, kp1.PublicKey()).Times(1).Return(spamStats, nil),
+		// Third request.
+		handler.node.EXPECT().SpamStatistics(r3Ctx, kp2.PublicKey()).Times(1).Return(spamStats, nil),
+	)
+
+	// First request and third request,
+	handler.node.EXPECT().Host().Times(2).Return(nodeHost)
+
+	gomock.InOrder(
+		// First request.
+		handler.spam.EXPECT().CheckSubmission(gomock.Any(), &spamStats).Times(1).Return(nil),
+		// Third request.
+		handler.spam.EXPECT().CheckSubmission(gomock.Any(), &spamStats).Times(1).Return(nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().NotifySuccessfulTransaction(r1Ctx, r1TraceID, uint8(2), txHash, gomock.Any(), gomock.Any(), gomock.Any(), nodeHost).Times(1).Do(func(_ context.Context, _ string, _ uint8, _, _, _ string, _ time.Time, _ string) {
+			// Unblock the second and third requests, and trigger the signing.
+			close(sendSecondRequests)
+			<-waitForSecondRequestToExit
+		}),
+		// Third request.
+		handler.interactor.EXPECT().NotifySuccessfulTransaction(r3Ctx, r3TraceID, uint8(2), txHash, gomock.Any(), gomock.Any(), gomock.Any(), nodeHost).Times(1),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().Log(r1Ctx, r1TraceID, gomock.Any(), gomock.Any()).AnyTimes(),
+		// Third request.
+		handler.interactor.EXPECT().Log(r3Ctx, r3TraceID, gomock.Any(), gomock.Any()).AnyTimes(),
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		// when
+		result, errorDetails := handler.handle(t, r1Ctx, api.ClientSendTransactionParams{
+			PublicKey:   kp1.PublicKey(),
+			SendingMode: "TYPE_SYNC",
+			Transaction: testTransaction(t),
+		}, connectedWallet)
+
+		<-waitForSecondRequestToExit
+		<-waitForThirdRequestToExit
+
+		// then
+		assert.Nil(t, errorDetails)
+		require.NotEmpty(t, result)
+		assert.NotEmpty(t, result.Transaction)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Closing this resume, unblock the first request.
+		defer close(waitForSecondRequestToExit)
+
+		// Ensure the first request acquire the "lock" on the public key.
+		<-sendSecondRequests
+
+		// when
+		result, errorDetails := handler.handle(t, r2Ctx, api.ClientSendTransactionParams{
+			PublicKey:   kp1.PublicKey(),
+			SendingMode: "TYPE_SYNC",
+			Transaction: testTransaction(t),
+		}, connectedWallet)
+
+		// then
+		assert.NotNil(t, errorDetails)
+		assertRequestNotPermittedError(t, errorDetails, fmt.Errorf("this public key %q is already in use, retry later", kp1.PublicKey()))
+		require.Empty(t, result)
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer close(waitForThirdRequestToExit)
+
+		// Ensure the first request acquire the "lock" on the public key, and
+		// we second request calls `GetWallet()` before the third request.
+		<-sendThirdRequests
+
+		// then
+		result, errorDetails := handler.handle(t, r3Ctx, api.ClientSendTransactionParams{
+			PublicKey:   kp2.PublicKey(),
+			SendingMode: "TYPE_SYNC",
+			Transaction: testTransaction(t),
+		}, connectedWallet)
+
+		// then
+		assert.Nil(t, errorDetails)
+		require.NotEmpty(t, result)
+		assert.NotEmpty(t, result.Transaction)
+	}()
+
+	wg.Wait()
 }
 
 func testSendingTransactionWithoutNeededPermissionsDoesNotSendTransaction(t *testing.T) {
@@ -640,8 +850,13 @@ func newSendTransactionHandler(t *testing.T) *sendTransactionHandler {
 	walletStore := mocks.NewMockWalletStore(ctrl)
 	node := nodemocks.NewMockNode(ctrl)
 
+	requestController := api.NewRequestController(
+		api.WithMaximumAttempt(1),
+		api.WithIntervalDelayBetweenRetries(1*time.Second),
+	)
+
 	return &sendTransactionHandler{
-		ClientSendTransaction: api.NewClientSendTransaction(walletStore, interactor, nodeSelector, proofOfWork),
+		ClientSendTransaction: api.NewClientSendTransaction(walletStore, interactor, nodeSelector, proofOfWork, requestController),
 		ctrl:                  ctrl,
 		nodeSelector:          nodeSelector,
 		interactor:            interactor,

--- a/wallet/api/client_sign_transaction_test.go
+++ b/wallet/api/client_sign_transaction_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"code.vegaprotocol.io/vega/libs/jsonrpc"
 	vgrand "code.vegaprotocol.io/vega/libs/rand"
@@ -23,7 +25,8 @@ func TestClientSignTransaction(t *testing.T) {
 	t.Run("Documentation matches the code", testClientSignTransactionSchemaCorrect)
 	t.Run("Signing a transaction with invalid params fails", testSigningTransactionWithInvalidParamsFails)
 	t.Run("Signing a transaction with valid params succeeds", testSigningTransactionWithValidParamsSucceeds)
-	t.Run("Signing a transaction without the needed permissions sign the transaction", testSigningTransactionWithoutNeededPermissionsDoesNotSignTransaction)
+	t.Run("Signing a transaction in parallel blocks on same party but not on different parties", testSigningTransactionInParallelBlocksOnSamePartyButNotOnDifferentParties)
+	t.Run("Signing a transaction without the needed permissions does not sign the transaction", testSigningTransactionWithoutNeededPermissionsDoesNotSignTransaction)
 	t.Run("Refusing the signing of a transaction does not sign the transaction", testRefusingSigningOfTransactionDoesNotSignTransaction)
 	t.Run("Cancelling the review does not sign the transaction", testCancellingTheReviewDoesNotSignTransaction)
 	t.Run("Interrupting the request does not sign the transaction", testInterruptingTheRequestDoesNotSignTransaction)
@@ -160,6 +163,198 @@ func testSigningTransactionWithValidParamsSucceeds(t *testing.T) {
 	assert.Nil(t, errorDetails)
 	require.NotEmpty(t, result)
 	assert.NotEmpty(t, result.Transaction)
+}
+
+func testSigningTransactionInParallelBlocksOnSamePartyButNotOnDifferentParties(t *testing.T) {
+	// setup
+
+	// Use channels to orchestrate requests.
+	sendSecondRequests := make(chan interface{})
+	sendThirdRequests := make(chan interface{})
+	waitForSecondRequestToExit := make(chan interface{})
+	waitForThirdRequestToExit := make(chan interface{})
+
+	hostname := vgrand.RandomStr(5)
+
+	// One context for each request.
+	r1Ctx, r1TraceID := clientContextForTest()
+	r2Ctx, _ := clientContextForTest()
+	r3Ctx, r3TraceID := clientContextForTest()
+
+	// A wallet with 2 keys to have 2 different parties.
+	wallet1 := walletWithPerms(t, hostname, wallet.Permissions{
+		PublicKeys: wallet.PublicKeysPermission{
+			Access:      wallet.ReadAccess,
+			AllowedKeys: nil,
+		},
+	})
+	kp1, err := wallet1.GenerateKeyPair(nil)
+	require.NoError(t, err)
+	kp2, err := wallet1.GenerateKeyPair(nil)
+	require.NoError(t, err)
+
+	// We can have a single connection as the implementation only cares about the
+	// party.
+	connectedWallet, err := api.NewConnectedWallet(hostname, wallet1)
+	require.NoError(t, err)
+
+	// Some mock data. Their value is irrelevant to test parallelism, so we recycle
+	// them.
+	spamStats := types.SpamStatistics{
+		ChainID:           vgrand.RandomStr(5),
+		LastBlockHeight:   100,
+		Proposals:         &types.SpamStatistic{MaxForEpoch: 1},
+		NodeAnnouncements: &types.SpamStatistic{MaxForEpoch: 1},
+		Delegations:       &types.SpamStatistic{MaxForEpoch: 1},
+		Transfers:         &types.SpamStatistic{MaxForEpoch: 1},
+		Votes:             &types.VoteSpamStatistics{MaxForEpoch: 1},
+		PoW: &types.PoWStatistics{
+			PowBlockStates: []types.PoWBlockState{{}},
+		},
+	}
+	pow := &commandspb.ProofOfWork{
+		Tid:   vgrand.RandomStr(5),
+		Nonce: 12345678,
+	}
+
+	// Setting up the mocked calls. The second request shouldn't trigger any of
+	// them, since it should be rejected because it uses the same party as the
+	// first request, which only unblock at the end.
+	handler := newSignTransactionHandler(t)
+
+	gomock.InOrder(
+		// First request.
+		handler.spam.EXPECT().GenerateProofOfWork(kp1.PublicKey(), &spamStats).Times(1).Return(pow, nil),
+		// Third request.
+		handler.spam.EXPECT().GenerateProofOfWork(kp2.PublicKey(), &spamStats).Times(1).Return(pow, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().NotifyInteractionSessionBegan(r1Ctx, r1TraceID, api.TransactionReviewWorkflow, uint8(2)).Times(1).Return(nil),
+		// Third request.
+		handler.interactor.EXPECT().NotifyInteractionSessionBegan(r3Ctx, r3TraceID, api.TransactionReviewWorkflow, uint8(2)).Times(1).Return(nil),
+	)
+	gomock.InOrder(
+		// Third request is expected before because the first request get unblocked
+		// when the third request finishes.
+		handler.interactor.EXPECT().NotifyInteractionSessionEnded(r3Ctx, r3TraceID).Times(1),
+		// First request.
+		handler.interactor.EXPECT().NotifyInteractionSessionEnded(r1Ctx, r1TraceID).Times(1),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().RequestTransactionReviewForSigning(r1Ctx, r1TraceID, uint8(1), hostname, wallet1.Name(), kp1.PublicKey(), fakeTransaction, gomock.Any()).Times(1).Return(true, nil),
+		// Third request.
+		handler.interactor.EXPECT().RequestTransactionReviewForSigning(r3Ctx, r3TraceID, uint8(1), hostname, wallet1.Name(), kp2.PublicKey(), fakeTransaction, gomock.Any()).Times(1).Return(true, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.nodeSelector.EXPECT().Node(r1Ctx, gomock.Any()).Times(1).Return(handler.node, nil),
+		// Third request.
+		handler.nodeSelector.EXPECT().Node(r3Ctx, gomock.Any()).Times(1).Return(handler.node, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.walletStore.EXPECT().GetWallet(r1Ctx, wallet1.Name()).Times(1).Return(wallet1, nil),
+		// Second request.
+		handler.walletStore.EXPECT().GetWallet(r2Ctx, wallet1.Name()).Times(1).DoAndReturn(func(_ context.Context, _ string) (wallet.Wallet, error) {
+			close(sendThirdRequests)
+			return wallet1, nil
+		}),
+		// Third request.
+		handler.walletStore.EXPECT().GetWallet(r3Ctx, wallet1.Name()).Times(1).Return(wallet1, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.node.EXPECT().SpamStatistics(r1Ctx, kp1.PublicKey()).Times(1).Return(spamStats, nil),
+		// Third request.
+		handler.node.EXPECT().SpamStatistics(r3Ctx, kp2.PublicKey()).Times(1).Return(spamStats, nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.spam.EXPECT().CheckSubmission(gomock.Any(), &spamStats).Times(1).Return(nil),
+		// Third request.
+		handler.spam.EXPECT().CheckSubmission(gomock.Any(), &spamStats).Times(1).Return(nil),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().NotifySuccessfulRequest(r1Ctx, r1TraceID, uint8(2), api.TransactionSuccessfullySigned).Times(1).Do(func(_ context.Context, _ string, _ uint8, _ string) {
+			// Unblock the second and third requests, and trigger the signing.
+			close(sendSecondRequests)
+			<-waitForSecondRequestToExit
+		}),
+		// Third request.
+		handler.interactor.EXPECT().NotifySuccessfulRequest(r3Ctx, r3TraceID, uint8(2), api.TransactionSuccessfullySigned).Times(1),
+	)
+	gomock.InOrder(
+		// First request.
+		handler.interactor.EXPECT().Log(r1Ctx, r1TraceID, gomock.Any(), gomock.Any()).AnyTimes(),
+		// Third request.
+		handler.interactor.EXPECT().Log(r3Ctx, r3TraceID, gomock.Any(), gomock.Any()).AnyTimes(),
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		// when
+		result, errorDetails := handler.handle(t, r1Ctx, api.ClientSignTransactionParams{
+			PublicKey:   kp1.PublicKey(),
+			Transaction: testTransaction(t),
+		}, connectedWallet)
+
+		<-waitForSecondRequestToExit
+		<-waitForThirdRequestToExit
+
+		// then
+		assert.Nil(t, errorDetails)
+		require.NotEmpty(t, result)
+		assert.NotEmpty(t, result.Transaction)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Closing this resume, unblock the first request.
+		defer close(waitForSecondRequestToExit)
+
+		// Ensure the first request acquire the "lock" on the public key.
+		<-sendSecondRequests
+
+		// when
+		result, errorDetails := handler.handle(t, r2Ctx, api.ClientSignTransactionParams{
+			PublicKey:   kp1.PublicKey(),
+			Transaction: testTransaction(t),
+		}, connectedWallet)
+
+		// then
+		assert.NotNil(t, errorDetails)
+		assertRequestNotPermittedError(t, errorDetails, fmt.Errorf("this public key %q is already in use, retry later", kp1.PublicKey()))
+		require.Empty(t, result)
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer close(waitForThirdRequestToExit)
+
+		// Ensure the first request acquire the "lock" on the public key, and
+		// we second request calls `GetWallet()` before the third request.
+		<-sendThirdRequests
+
+		// then
+		result, errorDetails := handler.handle(t, r3Ctx, api.ClientSignTransactionParams{
+			PublicKey:   kp2.PublicKey(),
+			Transaction: testTransaction(t),
+		}, connectedWallet)
+
+		// then
+		assert.Nil(t, errorDetails)
+		require.NotEmpty(t, result)
+		assert.NotEmpty(t, result.Transaction)
+	}()
+
+	wg.Wait()
 }
 
 func testSigningTransactionWithoutNeededPermissionsDoesNotSignTransaction(t *testing.T) {
@@ -522,16 +717,21 @@ func newSignTransactionHandler(t *testing.T) *signTransactionHandler {
 
 	ctrl := gomock.NewController(t)
 	walletStore := mocks.NewMockWalletStore(ctrl)
-	interactor := mocks.NewMockInteractor(ctrl)
+	interact := mocks.NewMockInteractor(ctrl)
 	nodeSelector := nodemock.NewMockSelector(ctrl)
 	node := nodemock.NewMockNode(ctrl)
 	proofOfWork := mocks.NewMockSpamHandler(ctrl)
 
+	requestController := api.NewRequestController(
+		api.WithMaximumAttempt(1),
+		api.WithIntervalDelayBetweenRetries(1*time.Second),
+	)
+
 	return &signTransactionHandler{
-		ClientSignTransaction: api.NewClientSignTransaction(walletStore, interactor, nodeSelector, proofOfWork),
+		ClientSignTransaction: api.NewClientSignTransaction(walletStore, interact, nodeSelector, proofOfWork, requestController),
 		ctrl:                  ctrl,
 		nodeSelector:          nodeSelector,
-		interactor:            interactor,
+		interactor:            interact,
 		node:                  node,
 		walletStore:           walletStore,
 		spam:                  proofOfWork,

--- a/wallet/api/interactor/interaction.go
+++ b/wallet/api/interactor/interaction.go
@@ -183,16 +183,21 @@ func (f *Interaction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// CancelRequest cancels a request that is waiting for user inputs.
-// It can't cancel a request when there is no response awaited.
-type CancelRequest struct{}
-
 // RequestWalletConnectionReview is a request emitted when a third-party
 // application wants to connect to a wallet.
 type RequestWalletConnectionReview struct {
 	Hostname string `json:"hostname"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh <-chan error `json:"-"`
 }
 
 // RequestWalletSelection is a request emitted when the service requires the user
@@ -204,6 +209,15 @@ type RequestWalletSelection struct {
 	AvailableWallets []string `json:"availableWallets"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh chan error `json:"-"`
 }
 
 // RequestPassphrase is a request emitted when the service wants to confirm
@@ -214,6 +228,15 @@ type RequestPassphrase struct {
 	Reason string `json:"reason"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh chan error `json:"-"`
 }
 
 // RequestPermissionsReview is a review request emitted when a third-party
@@ -224,6 +247,15 @@ type RequestPermissionsReview struct {
 	Permissions map[string]string `json:"permissions"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh chan error `json:"-"`
 }
 
 // RequestTransactionReviewForSending is a review request emitted when a third-party
@@ -236,6 +268,15 @@ type RequestTransactionReviewForSending struct {
 	ReceivedAt  time.Time `json:"receivedAt"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh chan error `json:"-"`
 }
 
 // RequestTransactionReviewForChecking is a review request when a third-party
@@ -248,6 +289,15 @@ type RequestTransactionReviewForChecking struct {
 	ReceivedAt  time.Time `json:"receivedAt"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh chan error `json:"-"`
 }
 
 // RequestTransactionReviewForSigning is a review request when a third-party
@@ -260,6 +310,15 @@ type RequestTransactionReviewForSigning struct {
 	ReceivedAt  time.Time `json:"receivedAt"`
 
 	StepNumber uint8 `json:"stepNumber"`
+
+	// ResponseCh is the channel in which the response to that request is expected.
+	ResponseCh chan<- Interaction `json:"-"`
+
+	// ControlCh is the channel we use to communicate state of the request to
+	// the UI. If the request gets canceled on the third-party application side,
+	// we close this channel and the UI, that is listening to it, has to react
+	// accordingly.
+	ControlCh chan error `json:"-"`
 }
 
 // WalletConnectionDecision is a specific response for interactor.RequestWalletConnectionReview.
@@ -290,6 +349,10 @@ type EnteredPassphrase struct {
 type SelectedWallet struct {
 	Wallet string `json:"wallet"`
 }
+
+// CancelRequest cancels a request that is waiting for user inputs.
+// It can't cancel a request when there is no response awaited.
+type CancelRequest struct{}
 
 // InteractionSessionBegan is a notification that is emitted when the interaction
 // session begin. It only carries informational value on a request lifecycle. This

--- a/wallet/api/interactor/parallel_test.go
+++ b/wallet/api/interactor/parallel_test.go
@@ -1,0 +1,356 @@
+package interactor_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	vgrand "code.vegaprotocol.io/vega/libs/rand"
+	"code.vegaprotocol.io/vega/wallet/api/interactor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelInteractor(t *testing.T) {
+	t.Run("Request wallet connection review succeeds", testRequestWalletConnectionReviewSucceeds)
+	t.Run("Request wallet selection review succeeds", testRequestWalletSelectionSucceeds)
+	t.Run("Request passphrase succeeds", testRequestPassphraseSucceeds)
+	t.Run("Request permissions review succeeds", testRequestPermissionsReviewSucceeds)
+	t.Run("Request transaction review for sending succeeds", testRequestTransactionReviewForSendingSucceeds)
+	t.Run("Request transaction review for signing succeeds", testRequestTransactionReviewForSigningSucceeds)
+	t.Run("Request transaction review for checking succeeds", testRequestTransactionReviewForCheckingSucceeds)
+}
+
+func testRequestWalletConnectionReviewSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	approval := vgrand.RandomStr(5)
+	traceID := vgrand.RandomStr(4)
+	hostname := vgrand.RandomStr(4)
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestWalletConnectionReviewName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestWalletConnectionReview)
+		require.True(t, ok)
+		assert.Equal(t, hostname, request.Hostname)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.WalletConnectionDecisionName,
+			Data: interactor.WalletConnectionDecision{
+				ConnectionApproval: approval,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestWalletConnectionReview(interactionCtx, traceID, 1, hostname)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.Equal(t, approval, result)
+}
+
+func testRequestWalletSelectionSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	selectedWallet := vgrand.RandomStr(5)
+	traceID := vgrand.RandomStr(4)
+	hostname := vgrand.RandomStr(4)
+	availableWallets := []string{
+		vgrand.RandomStr(4),
+		vgrand.RandomStr(4),
+	}
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestWalletSelectionName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestWalletSelection)
+		require.True(t, ok)
+		assert.Equal(t, hostname, request.Hostname)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.SelectedWalletName,
+			Data: interactor.SelectedWallet{
+				Wallet: selectedWallet,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestWalletSelection(interactionCtx, traceID, 1, hostname, availableWallets)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.Equal(t, selectedWallet, result)
+}
+
+func testRequestPassphraseSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	passphrase := vgrand.RandomStr(5)
+	traceID := vgrand.RandomStr(4)
+	wallet := vgrand.RandomStr(4)
+	reason := vgrand.RandomStr(4)
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestPassphraseName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestPassphrase)
+		require.True(t, ok)
+		assert.Equal(t, wallet, request.Wallet)
+		assert.Equal(t, reason, request.Reason)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.EnteredPassphraseName,
+			Data: interactor.EnteredPassphrase{
+				Passphrase: passphrase,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestPassphrase(interactionCtx, traceID, 1, wallet, reason)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.Equal(t, passphrase, result)
+}
+
+func testRequestPermissionsReviewSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	traceID := vgrand.RandomStr(4)
+	wallet := vgrand.RandomStr(4)
+	hostname := vgrand.RandomStr(4)
+	perms := map[string]string{
+		vgrand.RandomStr(4): vgrand.RandomStr(4),
+	}
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestPermissionsReviewName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestPermissionsReview)
+		require.True(t, ok)
+		assert.Equal(t, wallet, request.Wallet)
+		assert.Equal(t, hostname, request.Hostname)
+		assert.Equal(t, perms, request.Permissions)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.DecisionName,
+			Data: interactor.Decision{
+				Approved: true,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestPermissionsReview(interactionCtx, traceID, 1, hostname, wallet, perms)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func testRequestTransactionReviewForSendingSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	traceID := vgrand.RandomStr(4)
+	hostname := vgrand.RandomStr(4)
+	wallet := vgrand.RandomStr(4)
+	publicKey := vgrand.RandomStr(4)
+	receivedAt := time.Now()
+	transaction := vgrand.RandomStr(4)
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestTransactionReviewForSendingName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestTransactionReviewForSending)
+		require.True(t, ok)
+		assert.Equal(t, hostname, request.Hostname)
+		assert.Equal(t, wallet, request.Wallet)
+		assert.Equal(t, publicKey, request.PublicKey)
+		assert.Equal(t, transaction, request.Transaction)
+		assert.Equal(t, receivedAt, request.ReceivedAt)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.DecisionName,
+			Data: interactor.Decision{
+				Approved: true,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestTransactionReviewForSending(interactionCtx, traceID, 1, hostname, wallet, publicKey, transaction, receivedAt)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func testRequestTransactionReviewForSigningSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	traceID := vgrand.RandomStr(4)
+	hostname := vgrand.RandomStr(4)
+	wallet := vgrand.RandomStr(4)
+	publicKey := vgrand.RandomStr(4)
+	receivedAt := time.Now()
+	transaction := vgrand.RandomStr(4)
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestTransactionReviewForSigningName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestTransactionReviewForSigning)
+		require.True(t, ok)
+		assert.Equal(t, hostname, request.Hostname)
+		assert.Equal(t, wallet, request.Wallet)
+		assert.Equal(t, publicKey, request.PublicKey)
+		assert.Equal(t, transaction, request.Transaction)
+		assert.Equal(t, receivedAt, request.ReceivedAt)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.DecisionName,
+			Data: interactor.Decision{
+				Approved: true,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestTransactionReviewForSigning(interactionCtx, traceID, 1, hostname, wallet, publicKey, transaction, receivedAt)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func testRequestTransactionReviewForCheckingSucceeds(t *testing.T) {
+	interactorCtx := context.Background()
+	interactionCtx := context.Background()
+	traceID := vgrand.RandomStr(4)
+	hostname := vgrand.RandomStr(4)
+	wallet := vgrand.RandomStr(4)
+	publicKey := vgrand.RandomStr(4)
+	receivedAt := time.Now()
+	transaction := vgrand.RandomStr(4)
+
+	outboundCh := make(chan interactor.Interaction)
+	defer close(outboundCh)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		receivedInteraction := <-outboundCh
+
+		assert.Equal(t, traceID, receivedInteraction.TraceID)
+		assert.Equal(t, interactor.RequestTransactionReviewForCheckingName, receivedInteraction.Name)
+		request, ok := receivedInteraction.Data.(interactor.RequestTransactionReviewForChecking)
+		require.True(t, ok)
+		assert.Equal(t, hostname, request.Hostname)
+		assert.Equal(t, wallet, request.Wallet)
+		assert.Equal(t, publicKey, request.PublicKey)
+		assert.Equal(t, transaction, request.Transaction)
+		assert.Equal(t, receivedAt, request.ReceivedAt)
+		assert.Equal(t, uint8(1), request.StepNumber)
+
+		request.ResponseCh <- interactor.Interaction{
+			TraceID: traceID,
+			Name:    interactor.DecisionName,
+			Data: interactor.Decision{
+				Approved: true,
+			},
+		}
+
+		wg.Done()
+	}()
+
+	pInteractor := interactor.NewParallelInteractor(interactorCtx, outboundCh)
+	result, err := pInteractor.RequestTransactionReviewForChecking(interactionCtx, traceID, 1, hostname, wallet, publicKey, transaction, receivedAt)
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	assert.True(t, result)
+}

--- a/wallet/api/request_controller.go
+++ b/wallet/api/request_controller.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type RequestController struct {
+	publicKeysInUse sync.Map
+
+	maximumAttempt              uint
+	intervalDelayBetweenRetries time.Duration
+}
+
+func (c *RequestController) IsPublicKeyAlreadyInUse(publicKey string) (func(), error) {
+	doneCh, err := c.impatientWait(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-doneCh
+		c.publicKeysInUse.Delete(publicKey)
+	}()
+
+	return func() {
+		close(doneCh)
+	}, nil
+}
+
+func (c *RequestController) impatientWait(publicKey string) (chan interface{}, error) {
+	tick := time.NewTicker(c.intervalDelayBetweenRetries)
+	defer tick.Stop()
+
+	doneCh := make(chan interface{})
+
+	attemptsLeft := c.maximumAttempt
+	for attemptsLeft > 0 {
+		if _, alreadyInUse := c.publicKeysInUse.LoadOrStore(publicKey, doneCh); !alreadyInUse {
+			return doneCh, nil
+		}
+		<-tick.C
+		attemptsLeft--
+	}
+
+	close(doneCh)
+	return nil, fmt.Errorf("this public key %q is already in use, retry later", publicKey)
+}
+
+func DefaultRequestController() *RequestController {
+	return NewRequestController(
+		WithMaximumAttempt(10),
+		WithIntervalDelayBetweenRetries(2*time.Second),
+	)
+}
+
+func NewRequestController(opts ...RequestControllerOptionFn) *RequestController {
+	rq := &RequestController{
+		publicKeysInUse: sync.Map{},
+	}
+
+	for _, opt := range opts {
+		opt(rq)
+	}
+
+	return rq
+}
+
+type RequestControllerOptionFn func(rq *RequestController)
+
+func WithMaximumAttempt(max uint) RequestControllerOptionFn {
+	return func(rq *RequestController) {
+		rq.maximumAttempt = max
+	}
+}
+
+func WithIntervalDelayBetweenRetries(duration time.Duration) RequestControllerOptionFn {
+	return func(rq *RequestController) {
+		rq.intervalDelayBetweenRetries = duration
+	}
+}

--- a/wallet/api/spam/spam.go
+++ b/wallet/api/spam/spam.go
@@ -9,11 +9,7 @@ import (
 	nodetypes "code.vegaprotocol.io/vega/wallet/api/node/types"
 )
 
-var (
-	ErrPartyBanned       = errors.New("the network's spam rules has banned this key from submitting the transaction")
-	ErrPartyBannedPoW    = errors.New("the network's spam rules has banned this key from submitting all transaction")
-	ErrPartyWillBeBanned = errors.New("submitting this transaction will cause this key to be temporarily banned by the the network")
-)
+var ErrPartyWillBeBanned = errors.New("submitting this transaction will cause this key to be temporarily banned by the the network")
 
 type Handler struct {
 	// chainID to the counter for transactions sent.


### PR DESCRIPTION
Close #7701 

## Test protocol

1. Initiate a wallet connection, keep the token. Use a wallet that can send a transaction (with right permissions)
2. Initiate another wallet connection **but don't complete it**
3. In parallel, try to send a transaction with the first token. **the request should be completed despite the UI being blocked on the second request (This is expected because of the nature of the terminal).**
4. Try yet another wallet connection, let it hang.
5. Complete the hanging wallet connect from step 2. You can accept or reject.
6. Witness the logs of the transaction from step 3 appear, then the log of step 5 appear and block again. 

That's it!