### PR TITLE
fix: increase default validation timestamps for the erc20 events

### DIFF
--- a/core/banking/engine.go
+++ b/core/banking/engine.go
@@ -115,7 +115,7 @@ const (
 	rejectedState
 )
 
-var defaultValidationDuration = 2 * time.Hour
+var defaultValidationDuration = 30 * 24 * time.Hour
 
 type Engine struct {
 	cfg            Config


### PR DESCRIPTION
Increase the default validation for the witness calls for erc20 events to be on par with other uses of the witness.