### PR TITLE
chore: Update CODEOWNERS for API docs reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,5 @@
 * @vegaprotocol/core
 core/integration/features/verified/ @vegaprotocol/research
 core/netparams/defaults.go @vegaprotocol/research
-datanode/gateway/graphql/schema.graphql @vegaprotocol/frontend
+datanode/gateway/graphql/schema.graphql @vegaprotocol/frontend @candida-d
+protos/**/*.proto @candida-d


### PR DESCRIPTION
In order to make sure that the comments that feed into the API docs are reviewed in the context of the docs site this PR adds Candida as a reviewer

If we add this it could be temporary until we get a style guide for this type of information