### PR TITLE
fix: ensure users cannot specify both a before and after cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [7964](https://github.com/vegaprotocol/vega/issues/7964) - Use mark price for all margin calculations
 - [8001](https://github.com/vegaprotocol/vega/issues/8001) - Fix issues with order subscriptions
 - [7980](https://github.com/vegaprotocol/vega/issues/7980) - Visor - prevent panic when auto install configuration is missing assets
+- [8012](https://github.com/vegaprotocol/vega/issues/8012) - Ensure client do not specify both a before and after cursor
 
 
 ## 0.70.0

--- a/datanode/entities/pagination.go
+++ b/datanode/entities/pagination.go
@@ -113,6 +113,10 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 	var err error
 	var forwardOffset, backwardOffset *offset
 
+	if cp.Before != nil && cp.After != nil {
+		return CursorPagination{}, errors.New("cannot set both a before and after cursor")
+	}
+
 	if cp.First != nil {
 		forwardOffset = &offset{
 			Limit: cp.First,


### PR DESCRIPTION
close #8012  