### PR TITLE
feat: new command line

### DIFF
--- a/cmd/vegaone/config/config.go
+++ b/cmd/vegaone/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+)
+
+const configFileName = "config.json"
+
+type Config struct {
+	WithDatanode bool
+}
+
+func Load(home string) (*Config, error) {
+	buf, err := ioutil.ReadFile(filepath.Join(home, configFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Config{}
+	return c, json.Unmarshal(buf, c)
+}
+
+func Save(home string, c *Config) (string, error) {
+	buf, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(home, configFileName)
+	return path, ioutil.WriteFile(path, buf, 0644)
+}

--- a/cmd/vegaone/config/config.go
+++ b/cmd/vegaone/config/config.go
@@ -29,5 +29,5 @@ func Save(home string, c *Config) (string, error) {
 	}
 
 	path := filepath.Join(home, configFileName)
-	return path, ioutil.WriteFile(path, buf, 0644)
+	return path, ioutil.WriteFile(path, buf, 0o644)
 }

--- a/cmd/vegaone/flags/flags.go
+++ b/cmd/vegaone/flags/flags.go
@@ -1,0 +1,145 @@
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	vgos "code.vegaprotocol.io/vega/libs/os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Empty is used when a command or sub-command receives no argument and has no execution.
+type Empty struct{}
+
+var (
+	ErrPassphraseDoNotMatch = errors.New("passphrase do not match")
+
+	supportedOutputs = []string{
+		"json",
+		"human",
+	}
+)
+
+type OutputFlag struct {
+	Output Output `long:"output" description:"Specify the output format: json,human" default:"human" required:"true"`
+}
+
+func (f OutputFlag) GetOutput() (Output, error) {
+	outputStr := string(f.Output)
+	if !isSupportedOutput(outputStr) {
+		return "", fmt.Errorf("unsupported output \"%s\"", outputStr)
+	}
+	if f.Output == "human" && vgos.HasNoTTY() {
+		return "", errors.New("output \"human\" is not script-friendly, use \"json\" instead")
+	}
+	return f.Output, nil
+}
+
+func isSupportedOutput(output string) bool {
+	for _, o := range supportedOutputs {
+		if output == o {
+			return true
+		}
+	}
+	return false
+}
+
+type Output string
+
+func (o Output) IsHuman() bool {
+	return string(o) == "human"
+}
+
+func (o Output) IsJSON() bool {
+	return string(o) == "json"
+}
+
+type VegaHomeFlag struct {
+	VegaHome string `long:"home" description:"Path to the custom home for vega"`
+}
+
+type PassphraseFlag struct {
+	PassphraseFile Passphrase `short:"p" long:"passphrase-file" description:"A file containing the passphrase for the wallet, if empty will prompt for input"`
+}
+
+type Passphrase string
+
+func (p Passphrase) Get(prompt string, withConfirmation bool) (string, error) {
+	if len(p) == 0 {
+		if vgos.HasNoTTY() {
+			return "", errors.New("passphrase-file flag required without TTY")
+		}
+		return p.getFromUser(prompt, withConfirmation)
+	}
+
+	return p.getFromFile(string(p))
+}
+
+func (p Passphrase) getFromUser(prompt string, withConfirmation bool) (string, error) {
+	passphrase, err := promptForPassphrase(fmt.Sprintf("Enter %s passphrase:", prompt))
+	if err != nil {
+		return "", err
+	}
+
+	if withConfirmation {
+		passphraseConfirmation, err := promptForPassphrase(fmt.Sprintf("Confirm %s passphrase:", prompt))
+		if err != nil {
+			return "", err
+		}
+
+		if passphrase != passphraseConfirmation {
+			return "", ErrPassphraseDoNotMatch
+		}
+	}
+
+	return passphrase, nil
+}
+
+func promptForPassphrase(msg string) (string, error) {
+	fmt.Print(msg)
+	password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", fmt.Errorf("failed to read passphrase input: %w", err)
+	}
+	fmt.Println()
+
+	return string(password), nil
+}
+
+func (p Passphrase) getFromFile(path string) (string, error) {
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimRight(string(buf), "\n"), nil
+}
+
+type PromptString string
+
+// Get returns a string if set or prompts user otherwise.
+func (p PromptString) Get(prompt, name string) (string, error) {
+	if len(p) == 0 {
+		if vgos.HasNoTTY() {
+			return "", fmt.Errorf("%s flag required without TTY", name)
+		}
+		return p.getFromUser(prompt)
+	}
+
+	return string(p), nil
+}
+
+func (p PromptString) getFromUser(prompt string) (string, error) {
+	var s string
+	fmt.Printf("Enter %s:", prompt)
+	defer func() { fmt.Printf("\n") }()
+	if _, err := fmt.Scanf("%s", &s); err != nil {
+		return "", fmt.Errorf("failed read the input: %w", err)
+	}
+
+	return s, nil
+}

--- a/cmd/vegaone/init.go
+++ b/cmd/vegaone/init.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"code.vegaprotocol.io/vega/cmd/vegaone/config"
+	"code.vegaprotocol.io/vega/cmd/vegaone/flags"
+	cconfig "code.vegaprotocol.io/vega/core/config"
+	encoding "code.vegaprotocol.io/vega/core/config/encoding"
+	"code.vegaprotocol.io/vega/core/nodewallets/registry"
+	dnconfig "code.vegaprotocol.io/vega/datanode/config"
+
+	"code.vegaprotocol.io/vega/datanode/sqlstore"
+	lencoding "code.vegaprotocol.io/vega/libs/config/encoding"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	tmcfg "github.com/tendermint/tendermint/config"
+	tmos "github.com/tendermint/tendermint/libs/os"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/privval"
+	"github.com/tendermint/tendermint/types"
+)
+
+type initFlags struct {
+	globalFlags
+
+	Force         bool
+	Passphrase    string
+	Mode          string
+	WithDatanode  bool
+	ChainID       string
+	RetentionMode string
+	EmbedPostgres bool
+}
+
+func (g *initFlags) Register(fset *flag.FlagSet) {
+	g.globalFlags.Register(fset)
+	fset.BoolVar(&g.EmbedPostgres, "embed-postgres", false, "use the embeded postgres instance")
+	fset.BoolVar(&g.Force, "force", false, "should the command erase existing configuration")
+	fset.StringVar(&g.Passphrase, "nodewallet-passphrase-file", "", "an optional file containing the passphrase for the node wallet")
+	fset.StringVar(&g.ChainID, "chainid", "", "the id of the chain this node with be joining (required only when setting up the datanode)")
+	fset.StringVar(&g.Mode, "mode", "validator", "the mode of the vega node [validator|full]")
+	fset.StringVar(&g.RetentionMode, "retention-mode", "standard", "the retention mode of the data node state [standard|archive|lite]")
+	fset.BoolVar(&g.WithDatanode, "with-datanode", false, "initialise the datanode as well as the core node")
+}
+
+type initCommand struct {
+	flags initFlags
+	fset  *flag.FlagSet
+}
+
+func newInit() (i *initCommand) {
+	defer func() { i.flags.Register(i.fset) }()
+	return &initCommand{
+		flags: initFlags{},
+		fset:  flag.NewFlagSet("init", flag.ExitOnError),
+	}
+}
+
+func (i *initCommand) Parse(args []string) error {
+	return i.fset.Parse(args)
+}
+
+func (i *initCommand) Execute() error {
+	logger := configureLogger()
+	defer logger.AtExit()
+
+	home := os.ExpandEnv(i.flags.Home)
+	tendermintHome := filepath.Join(home, "tendermint")
+	vegaPaths := paths.New(home)
+
+	// first check datanode specific error handling
+	if i.flags.WithDatanode && len(i.flags.ChainID) <= 0 {
+		return errors.New("chain-id is required when setting up a datanode")
+	}
+
+	// always init vega
+	if err := i.initVega(logger, vegaPaths, i.flags.WithDatanode); err != nil {
+		return fmt.Errorf("couldn't initialise vega %w", err)
+	}
+
+	// always init tendermint
+	if err := i.initTendermint(logger, tendermintHome); err != nil {
+		return fmt.Errorf("couldn't initialise tendermint %w", err)
+	}
+
+	// init datanode if users want's it
+	if i.flags.WithDatanode {
+		if err := i.initDatanode(logger, vegaPaths, i.flags.EmbedPostgres); err != nil {
+			return fmt.Errorf("couldn't initialise data node %w", err)
+		}
+	}
+
+	// then final the vegaone config
+	c := config.Config{
+		WithDatanode: i.flags.WithDatanode,
+	}
+
+	path, err := config.Save(home, &c)
+	if err != nil {
+		return fmt.Errorf("couldn't save vegaone configuration file: %w", err)
+	}
+
+	logger.Info("vegone configuration generated successfully", logging.String("path", path))
+
+	return nil
+}
+
+func (i *initCommand) initDatanode(
+	logger *logging.Logger, vegaPaths paths.Paths, embedPostgres bool,
+) error {
+	opts := i.flags
+
+	cfgLoader, err := dnconfig.InitialiseLoader(vegaPaths)
+	if err != nil {
+		return fmt.Errorf("couldn't initialise configuration loader: %w", err)
+	}
+
+	configExists, err := cfgLoader.ConfigExists()
+	if err != nil {
+		return fmt.Errorf("couldn't verify configuration presence: %w", err)
+	}
+
+	if configExists && !opts.Force {
+		return fmt.Errorf("configuration already exists at `%s` please remove it first or re-run using -f", cfgLoader.ConfigFilePath())
+	}
+
+	if configExists && opts.Force {
+		cfgLoader.Remove()
+	}
+
+	cfg := dnconfig.NewDefaultConfig()
+
+	cfg.SQLStore.UseEmbedded = true
+
+	cfg.Broker.SocketConfig.IP = "vega_datanode"
+	cfg.Broker.SocketConfig.TransportType = "inproc"
+	cfg.Broker.SocketConfig.Port = 1789
+
+	mode, err := encoding.DataNodeRetentionModeFromString(opts.RetentionMode)
+	if err != nil {
+		return err
+	}
+
+	switch mode {
+	case encoding.DataNodeRetentionModeArchive:
+		cfg.NetworkHistory.Store.HistoryRetentionBlockSpan = math.MaxInt64
+		cfg.SQLStore.RetentionPeriod = sqlstore.RetentionPeriodArchive
+	case encoding.DataNodeRetentionModeLite:
+		cfg.SQLStore.RetentionPeriod = sqlstore.RetentionPeriodLite
+	}
+
+	cfg.ChainID = opts.ChainID
+
+	if err := cfgLoader.Save(&cfg); err != nil {
+		return fmt.Errorf("couldn't save configuration file: %w", err)
+	}
+
+	logger.Info("datanode configuration generated successfully", logging.String("path", cfgLoader.ConfigFilePath()))
+
+	return nil
+
+}
+
+func (i *initCommand) initVega(
+	logger *logging.Logger,
+	vegaPaths paths.Paths,
+	withDatanode bool,
+) error {
+	opts := i.flags
+	if len(opts.Mode) <= 0 {
+		return errors.New("missing node mode")
+	}
+
+	mode, err := encoding.NodeModeFromString(opts.Mode)
+	if err != nil {
+		return err
+	}
+
+	// a nodewallet will be required only for a validator node
+	if mode == encoding.NodeModeValidator {
+		pass, err := flags.Passphrase(i.flags.Passphrase).Get("nodewallet passphrase", true)
+		if err != nil {
+			return err
+		}
+
+		_, err = registry.NewLoader(vegaPaths, pass)
+		if err != nil {
+			return err
+		}
+	}
+
+	cfgLoader, err := cconfig.InitialiseLoader(vegaPaths)
+	if err != nil {
+		return fmt.Errorf("couldn't initialise configuration loader: %w", err)
+	}
+
+	configExists, err := cfgLoader.ConfigExists()
+	if err != nil {
+		return fmt.Errorf("couldn't verify configuration presence: %w", err)
+	}
+
+	if configExists && !opts.Force {
+		return fmt.Errorf("configuration already exists at `%s` please remove it first or re-run using -f", cfgLoader.ConfigFilePath())
+	}
+
+	if configExists && opts.Force {
+		logger.Info("removing existing configuration", logging.String("path", cfgLoader.ConfigFilePath()))
+		cfgLoader.Remove()
+	}
+
+	cfg := cconfig.NewDefaultConfig()
+	cfg.NodeMode = mode
+	cfg.Broker.Socket.Address = "vega_datanode"
+	cfg.Broker.Socket.Transport = "inproc"
+	cfg.Broker.Socket.Port = 1789
+	cfg.Broker.Socket.Enabled = lencoding.Bool(withDatanode)
+	cfg.SetDefaultMaxMemoryPercent()
+
+	if err := cfgLoader.Save(&cfg); err != nil {
+		return fmt.Errorf("couldn't save configuration file: %w", err)
+	}
+
+	logger.Info("core configuration generated successfully",
+		logging.String("path", cfgLoader.ConfigFilePath()))
+
+	return nil
+}
+
+func (i *initCommand) initTendermint(logger *logging.Logger, tendermintHome string) error {
+	config := tmcfg.DefaultConfig()
+	config.SetRoot(tendermintHome)
+	tmcfg.EnsureRoot(config.RootDir)
+
+	config.Consensus.TimeoutCommit = 0
+	config.Consensus.CreateEmptyBlocks = true
+	// enforce using priority mempool
+	config.Mempool.Version = "v1"
+	// enforce compatibility
+	config.P2P.MaxPacketMsgPayloadSize = 16384
+
+	// private validator
+	privValKeyFile := config.PrivValidatorKeyFile()
+	privValStateFile := config.PrivValidatorStateFile()
+	var pv *privval.FilePV
+	if tmos.FileExists(privValKeyFile) {
+		pv = privval.LoadFilePV(privValKeyFile, privValStateFile)
+		logger.Info("found private validator",
+			logging.String("keyFile", privValKeyFile),
+			logging.String("stateFile", privValStateFile),
+		)
+	} else {
+		pv = privval.GenFilePV(privValKeyFile, privValStateFile)
+		pv.Save()
+		logger.Info("generated private validator",
+			logging.String("keyFile", privValKeyFile),
+			logging.String("stateFile", privValStateFile),
+		)
+	}
+
+	nodeKeyFile := config.NodeKeyFile()
+	if tmos.FileExists(nodeKeyFile) {
+		logger.Info("found node key", logging.String("path", nodeKeyFile))
+	} else {
+		if _, err := p2p.LoadOrGenNodeKey(nodeKeyFile); err != nil {
+			return err
+		}
+		logger.Info("generated node key", logging.String("path", nodeKeyFile))
+	}
+
+	// genesis file
+	genFile := config.GenesisFile()
+	if tmos.FileExists(genFile) {
+		logger.Info("found genesis file", logging.String("path", genFile))
+	} else {
+		genDoc := types.GenesisDoc{
+			ChainID:         fmt.Sprintf("test-chain-%v", tmrand.Str(6)),
+			GenesisTime:     time.Now().Round(0).UTC(),
+			ConsensusParams: types.DefaultConsensusParams(),
+		}
+		pubKey, err := pv.GetPubKey()
+		if err != nil {
+			return fmt.Errorf("can't get pubkey: %w", err)
+		}
+		genDoc.Validators = []types.GenesisValidator{{
+			Address: pubKey.Address(),
+			PubKey:  pubKey,
+			Power:   10,
+		}}
+
+		if err := genDoc.SaveAs(genFile); err != nil {
+			return err
+		}
+		logger.Info("generated genesis file", logging.String("path", genFile))
+	}
+
+	return nil
+}
+
+func configureLogger() *logging.Logger {
+	cfg := zap.Config{
+		Encoding:         "json",
+		Level:            zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:  "message",
+			LevelKey:    "level",
+			EncodeLevel: zapcore.CapitalLevelEncoder,
+			TimeKey:     "time",
+			EncodeTime:  zapcore.RFC3339TimeEncoder,
+
+			CallerKey:    "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+	return logging.NewLoggerFromZapConfig(cfg)
+}

--- a/cmd/vegaone/init.go
+++ b/cmd/vegaone/init.go
@@ -15,6 +15,7 @@ import (
 	encoding "code.vegaprotocol.io/vega/core/config/encoding"
 	"code.vegaprotocol.io/vega/core/nodewallets/registry"
 	dnconfig "code.vegaprotocol.io/vega/datanode/config"
+	dencoding "code.vegaprotocol.io/vega/datanode/config/encoding"
 
 	"code.vegaprotocol.io/vega/datanode/sqlstore"
 	lencoding "code.vegaprotocol.io/vega/libs/config/encoding"
@@ -45,7 +46,7 @@ type initFlags struct {
 
 func (g *initFlags) Register(fset *flag.FlagSet) {
 	g.globalFlags.Register(fset)
-	fset.BoolVar(&g.EmbedPostgres, "embed-postgres", false, "use the embeded postgres instance")
+	fset.BoolVar(&g.EmbedPostgres, "embed-postgres", false, "use the embedded postgres instance")
 	fset.BoolVar(&g.Force, "force", false, "should the command erase existing configuration")
 	fset.StringVar(&g.Passphrase, "nodewallet-passphrase-file", "", "an optional file containing the passphrase for the node wallet")
 	fset.StringVar(&g.ChainID, "chainid", "", "the id of the chain this node with be joining (required only when setting up the datanode)")
@@ -141,7 +142,7 @@ func (i *initCommand) initDatanode(
 
 	cfg := dnconfig.NewDefaultConfig()
 
-	cfg.SQLStore.UseEmbedded = true
+	cfg.SQLStore.UseEmbedded = dencoding.Bool(embedPostgres)
 
 	cfg.Broker.SocketConfig.IP = "vega_datanode"
 	cfg.Broker.SocketConfig.TransportType = "inproc"
@@ -169,7 +170,6 @@ func (i *initCommand) initDatanode(
 	logger.Info("datanode configuration generated successfully", logging.String("path", cfgLoader.ConfigFilePath()))
 
 	return nil
-
 }
 
 func (i *initCommand) initVega(

--- a/cmd/vegaone/main.go
+++ b/cmd/vegaone/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+type globalFlags struct {
+	Home string
+}
+
+func (g *globalFlags) Register(fset *flag.FlagSet) {
+	fset.StringVar(&g.Home, "home", "$HOME/.vegaone", "the root home for all vega configurations and state")
+}
+
+type Command interface {
+	Execute() error
+	Parse([]string) error
+}
+
+func main() {
+	if len(os.Args) <= 1 {
+		printUsage()
+	}
+
+	cmdName := os.Args[1]
+	os.Args = os.Args[1:]
+	var cmd Command
+	switch cmdName {
+	case "init":
+		cmd = newInit()
+	case "start":
+		cmd = newStart()
+	case "wallet":
+		cmd = newWallet(os.Args)
+	case "tendermint":
+		cmd = newTendermint(os.Args)
+	case "version":
+		cmd = newVersion()
+	case "help", "-h", "--help":
+		printUsage()
+	default:
+		printUnknownCommand(cmdName)
+	}
+
+	if err := cmd.Parse(os.Args[1:]); err != nil {
+		printError(err)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		printError(err)
+	}
+}
+
+func printUnknownCommand(cmdName string) {
+	fmt.Printf(`vegaone %s: unknown command
+Run 'vegaone help' for usage.
+`, cmdName)
+	os.Exit(2)
+}
+
+func printUsage() {
+	fmt.Printf("%v\n", help)
+	os.Exit(0)
+}
+
+func printError(err error) {
+	fmt.Printf("error: %v\n", err)
+	os.Exit(1)
+}
+
+const help = `Vegaone is a tool for operating a Vega node.
+
+Usage:
+
+	vegaone <command> [arguments]
+
+The commands are:
+
+	init         initialise a new vega node
+	start        start a vega node
+	tendermint   manage the tendermint state
+	version      show the protocol version
+	wallet       use the vega wallet
+`

--- a/cmd/vegaone/start.go
+++ b/cmd/vegaone/start.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"code.vegaprotocol.io/vega/cmd/vegaone/config"
+	"code.vegaprotocol.io/vega/cmd/vegaone/start"
+	"code.vegaprotocol.io/vega/paths"
+)
+
+type startFlags struct {
+	globalFlags
+
+	Passphrase string
+	NetworkURL string
+	Network    string
+}
+
+func (g *startFlags) Register(fset *flag.FlagSet) {
+	g.globalFlags.Register(fset)
+	fset.StringVar(&g.Passphrase, "nodewallet-passphrase-file", "", "an optional file containing the passphrase for the node wallet")
+	fset.StringVar(&g.Network, "network", "", "a vega network name to be started")
+	fset.StringVar(&g.NetworkURL, "network-url", "", "the url from which to retrieve the genesis file of a network")
+
+}
+
+type startCommand struct {
+	flags startFlags
+	fset  *flag.FlagSet
+}
+
+func newStart() (i *startCommand) {
+	defer func() { i.flags.Register(i.fset) }()
+	return &startCommand{
+		flags: startFlags{},
+		fset:  flag.NewFlagSet("start", flag.ExitOnError),
+	}
+}
+
+func (s *startCommand) Parse(args []string) error {
+	return s.fset.Parse(args)
+}
+
+func (s *startCommand) Execute() error {
+	if len(s.flags.Network) > 0 && len(s.flags.NetworkURL) > 0 {
+		return errors.New("cannot set both -network and -network-url flags")
+	}
+
+	home := os.ExpandEnv(s.flags.Home)
+	tendermintHome := filepath.Join(home, "tendermint")
+	vegaPaths := paths.New(home)
+
+	c, err := config.Load(home)
+	if err != nil {
+		return fmt.Errorf("couldn't load vegaone configuration: %w", err)
+	}
+
+	return start.Run(vegaPaths, tendermintHome, s.flags.NetworkURL, s.flags.Network, s.flags.Passphrase, c)
+}

--- a/cmd/vegaone/start.go
+++ b/cmd/vegaone/start.go
@@ -25,7 +25,6 @@ func (g *startFlags) Register(fset *flag.FlagSet) {
 	fset.StringVar(&g.Passphrase, "nodewallet-passphrase-file", "", "an optional file containing the passphrase for the node wallet")
 	fset.StringVar(&g.Network, "network", "", "a vega network name to be started")
 	fset.StringVar(&g.NetworkURL, "network-url", "", "the url from which to retrieve the genesis file of a network")
-
 }
 
 type startCommand struct {

--- a/cmd/vegaone/start/app_wrapper.go
+++ b/cmd/vegaone/start/app_wrapper.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package start
+
+import "github.com/tendermint/tendermint/abci/types"
+
+type appW struct {
+	// this is the application currently in use
+	impl types.Application
+	// this is the application that'll need to be swap if expected by
+	// the application, will be call on commit and needs to be swap atomically
+	// before returning from Commit
+	update types.Application
+}
+
+func newAppW(app types.Application) *appW {
+	return &appW{
+		impl: app,
+	}
+}
+
+func (app *appW) Info(req types.RequestInfo) types.ResponseInfo {
+	return app.impl.Info(req)
+}
+
+func (app *appW) DeliverTx(req types.RequestDeliverTx) types.ResponseDeliverTx {
+	return app.impl.DeliverTx(req)
+}
+
+func (app *appW) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
+	return app.impl.CheckTx(req)
+}
+
+func (app *appW) Commit() types.ResponseCommit {
+	resp := app.impl.Commit()
+	// if we are scheduled for an upgrade of the protocol
+	// let's do it now.
+	if app.update != nil {
+		app.impl = app.update
+		app.update = nil
+	}
+	return resp
+}
+
+func (app *appW) Query(req types.RequestQuery) types.ResponseQuery {
+	return app.impl.Query(req)
+}
+
+func (app *appW) InitChain(req types.RequestInitChain) types.ResponseInitChain {
+	return app.impl.InitChain(req)
+}
+
+func (app *appW) BeginBlock(req types.RequestBeginBlock) types.ResponseBeginBlock {
+	return app.impl.BeginBlock(req)
+}
+
+func (app *appW) EndBlock(req types.RequestEndBlock) types.ResponseEndBlock {
+	return app.impl.EndBlock(req)
+}
+
+func (app *appW) ListSnapshots(
+	req types.RequestListSnapshots,
+) types.ResponseListSnapshots {
+	return app.impl.ListSnapshots(req)
+}
+
+func (app *appW) OfferSnapshot(
+	req types.RequestOfferSnapshot,
+) types.ResponseOfferSnapshot {
+	return app.impl.OfferSnapshot(req)
+}
+
+func (app *appW) LoadSnapshotChunk(
+	req types.RequestLoadSnapshotChunk,
+) types.ResponseLoadSnapshotChunk {
+	return app.impl.LoadSnapshotChunk(req)
+}
+
+func (app *appW) ApplySnapshotChunk(
+	req types.RequestApplySnapshotChunk,
+) types.ResponseApplySnapshotChunk {
+	return app.impl.ApplySnapshotChunk(req)
+}
+
+func (app *appW) SetOption(
+	req types.RequestSetOption,
+) types.ResponseSetOption {
+	return app.impl.SetOption(req)
+}

--- a/cmd/vegaone/start/core.go
+++ b/cmd/vegaone/start/core.go
@@ -1,0 +1,469 @@
+package start
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"code.vegaprotocol.io/vega/cmd/vegaone/flags"
+	"code.vegaprotocol.io/vega/core/admin"
+	"code.vegaprotocol.io/vega/core/api"
+	"code.vegaprotocol.io/vega/core/api/rest"
+	"code.vegaprotocol.io/vega/core/blockchain"
+	"code.vegaprotocol.io/vega/core/blockchain/abci"
+	"code.vegaprotocol.io/vega/core/blockchain/nullchain"
+	ethclient "code.vegaprotocol.io/vega/core/client/eth"
+	"code.vegaprotocol.io/vega/core/config"
+	"code.vegaprotocol.io/vega/core/coreapi"
+	"code.vegaprotocol.io/vega/core/metrics"
+	"code.vegaprotocol.io/vega/core/nodewallets"
+	"code.vegaprotocol.io/vega/core/protocol"
+	"code.vegaprotocol.io/vega/core/stats"
+	"code.vegaprotocol.io/vega/libs/pprof"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+	apipb "code.vegaprotocol.io/vega/protos/vega/api/v1"
+	"code.vegaprotocol.io/vega/version"
+
+	"github.com/tendermint/tendermint/abci/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+	"google.golang.org/grpc"
+)
+
+const namedLogger = "core"
+
+type Core struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	Log *logging.Logger
+
+	pproffhandlr *pprof.Pprofhandler
+	stats        *stats.Stats
+
+	conf        config.Config
+	confWatcher *config.Watcher
+
+	nullBlockchain   *nullchain.NullBlockchain
+	blockchainServer *blockchain.Server
+	blockchainClient *blockchain.Client
+
+	nodeWallets          *nodewallets.NodeWallets
+	nodeWalletPassphrase string
+
+	vegaPaths      paths.Paths
+	tendermintHome string
+
+	ethClient        *ethclient.Client
+	ethConfirmations *ethclient.EthereumConfirmations
+
+	abciApp  *appW
+	protocol *protocol.Protocol
+
+	// APIs
+	grpcServer  *api.GRPC
+	proxyServer *rest.ProxyServer
+	adminServer *admin.Server
+	coreService *coreapi.Service
+
+	genesisDoc *tmtypes.GenesisDoc
+	tmNode     *abci.TmNode
+
+	errCh chan error
+}
+
+func newCore(
+	log *logging.Logger,
+	vegaPaths paths.Paths,
+	tendermintHome string,
+	networkURL, network string,
+	passphraseFile string,
+) (*Core, error) {
+	log = log.Named(namedLogger)
+
+	confWatcher, err := config.NewWatcher(context.Background(), log, vegaPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	// only try to get the passphrase if the node is started
+	// as a validator
+	var pass string
+	if confWatcher.Get().IsValidator() {
+		pass, err = flags.Passphrase(passphraseFile).Get("nodewallet passphrase", true)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	genesisDoc, err := pullGenesis(log, networkURL, network)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Core{
+		Log:                  log,
+		conf:                 confWatcher.Get(),
+		confWatcher:          confWatcher,
+		vegaPaths:            vegaPaths,
+		tendermintHome:       tendermintHome,
+		genesisDoc:           genesisDoc,
+		nodeWalletPassphrase: pass,
+	}
+
+	if err := c.setupCommon(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func pullGenesis(log *logging.Logger, networkURL, network string) (*tmtypes.GenesisDoc, error) {
+	genesisURL := networkURL
+	if len(genesisURL) <= 0 && len(network) > 0 {
+		genesisURL = httpGenesisDocURLFromNetwork(network)
+	}
+
+	var (
+		genesisDoc *tmtypes.GenesisDoc
+		err        error
+	)
+	if len(genesisURL) > 0 {
+		log.Info("retrieving genesis file from", logging.String("url", genesisURL))
+		if genesisDoc, err = genesisDocHTTPFromURL(genesisURL); err != nil {
+			return nil, err
+		}
+		log.Info("genesis file loaded successfully", logging.String("url", genesisURL))
+	}
+
+	return genesisDoc, nil
+}
+
+var ErrUnknownChainProvider = errors.New("unknown chain provider")
+
+func (c *Core) Start() error {
+	c.Log.Info("starting vega",
+		logging.String("version", version.Get()),
+		logging.String("commit-hash", version.GetCommitHash()),
+	)
+
+	if err := c.loadNodeWallets(); err != nil {
+		return err
+	}
+
+	if err := c.startBlockchainClients(); err != nil {
+		return err
+	}
+
+	// TODO(): later we will want to select what version of the protocol
+	// to run, most likely via configuration, so we can use legacy or current
+	var err error
+	c.protocol, err = protocol.New(
+		c.ctx, c.confWatcher, c.Log, c.cancel, c.stopBlockchain, c.nodeWallets, c.ethClient, c.ethConfirmations, c.blockchainClient, c.vegaPaths, c.stats)
+	if err != nil {
+		return err
+	}
+
+	if err := c.startAPIs(); err != nil {
+		return err
+	}
+
+	// if a chain is being replayed tendermint does this during the initial handshake with the
+	// app and does so synchronously. We to need to set this off in a goroutine so we can catch any
+	// SIGTERM during that replay and shutdown properly
+	c.errCh = make(chan error)
+	go func() {
+		defer func() {
+			// if a consensus failure happens during replay tendermint panics
+			// we need to catch it so we can call shutdown and then re-panic
+			if r := recover(); r != nil {
+				c.Stop()
+				panic(r)
+			}
+		}()
+		if err := c.startBlockchain(); err != nil {
+			c.errCh <- err
+		}
+		// start the nullblockchain if we are in that mode, it *needs* to be after we've started the gRPC server
+		// otherwise it'll start calling init-chain and all the way before we're ready.
+		if c.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
+			if err := c.nullBlockchain.StartServer(); err != nil {
+				c.errCh <- err
+			}
+		}
+	}()
+
+	// at this point all is good, and we should be started, we can
+	// just wait for signals or whatever
+	c.Log.Info("Vega startup complete",
+		logging.String("node-mode", string(c.conf.NodeMode)))
+
+	return nil
+}
+
+func (c *Core) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+func (c *Core) Err() <-chan error {
+	return c.errCh
+}
+
+func (c *Core) stopBlockchain() error {
+	if c.blockchainServer == nil {
+		return nil
+	}
+	return c.blockchainServer.Stop()
+}
+
+func (c *Core) Stop() error {
+	upStatus := c.protocol.GetProtocolUpgradeService().GetUpgradeStatus()
+
+	// Blockchain server has been already stopped by the app during the upgrade.
+	// Calling stop again would block forever.
+	if c.blockchainServer != nil && !upStatus.ReadyToUpgrade {
+		c.blockchainServer.Stop()
+	}
+	if c.protocol != nil {
+		c.protocol.Stop()
+	}
+	if c.grpcServer != nil {
+		c.grpcServer.Stop()
+	}
+	if c.proxyServer != nil {
+		c.proxyServer.Stop()
+	}
+	if c.adminServer != nil {
+		c.adminServer.Stop()
+	}
+
+	if c.conf.IsValidator() {
+		if err := c.nodeWallets.Ethereum.Cleanup(); err != nil {
+			c.Log.Error("couldn't clean up Ethereum node wallet", logging.Error(err))
+		}
+	}
+
+	var err error
+	if c.pproffhandlr != nil {
+		err = c.pproffhandlr.Stop()
+	}
+
+	c.Log.Info("Vega shutdown complete",
+		logging.String("version", version.Get()),
+		logging.String("version-hash", version.GetCommitHash()))
+
+	c.Log.Sync()
+	c.cancel()
+
+	// Blockchain server need to be killed as it is stuck in BeginBlock function.
+	if upStatus.ReadyToUpgrade {
+		return kill()
+	}
+
+	return err
+}
+
+func (c *Core) startAPIs() error {
+	c.grpcServer = api.NewGRPC(
+		c.Log,
+		c.conf.API,
+		c.stats,
+		c.blockchainClient,
+		c.protocol.GetEventForwarder(),
+		c.protocol.GetTimeService(),
+		c.protocol.GetEventService(),
+		c.protocol.GetPoW(),
+		c.protocol.GetSpamEngine(),
+		c.protocol.GetPowEngine(),
+	)
+
+	c.coreService = coreapi.NewService(c.ctx, c.Log, c.conf.CoreAPI, c.protocol.GetBroker())
+	c.grpcServer.RegisterService(func(server *grpc.Server) {
+		apipb.RegisterCoreStateServiceServer(server, c.coreService)
+	})
+
+	// watch configs
+	c.confWatcher.OnConfigUpdate(
+		func(cfg config.Config) { c.grpcServer.ReloadConf(cfg.API) },
+	)
+
+	c.proxyServer = rest.NewProxyServer(c.Log, c.conf.API)
+
+	if c.conf.IsValidator() {
+		adminServer, err := admin.NewValidatorServer(c.Log, c.conf.Admin, c.vegaPaths, c.nodeWalletPassphrase, c.nodeWallets, c.protocol.GetProtocolUpgradeService())
+		if err != nil {
+			return err
+		}
+		c.adminServer = adminServer
+	} else {
+		adminServer, err := admin.NewNonValidatorServer(c.Log, c.conf.Admin, c.protocol.GetProtocolUpgradeService())
+		if err != nil {
+			return err
+		}
+		c.adminServer = adminServer
+	}
+
+	go c.grpcServer.Start()
+	go c.proxyServer.Start()
+
+	if c.adminServer != nil {
+		go c.adminServer.Start()
+	}
+
+	return nil
+}
+
+func (c *Core) startBlockchain() error {
+	// make sure any env variable is resolved
+	tmHome := os.ExpandEnv(c.tendermintHome)
+	c.abciApp = newAppW(c.protocol.Abci())
+
+	switch c.conf.Blockchain.ChainProvider {
+	case blockchain.ProviderTendermint:
+		var err error
+		// initialise the node
+		c.tmNode, err = c.startABCI(c.Log, c.abciApp, tmHome)
+		if err != nil {
+			return err
+		}
+		c.blockchainServer = blockchain.NewServer(c.Log, c.tmNode)
+		// initialise the client
+		client, err := c.tmNode.GetClient()
+		if err != nil {
+			return err
+		}
+		// n.blockchainClient = blockchain.NewClient(client)
+		c.blockchainClient.Set(client)
+	case blockchain.ProviderNullChain:
+		// nullchain acts as both the client and the server because its does everything
+		c.nullBlockchain = nullchain.NewClient(
+			c.Log,
+			c.conf.Blockchain.Null,
+			c.protocol.GetTimeService(), // if we've loaded from a snapshot we need to be able to ask the protocol what time its at
+		)
+		c.nullBlockchain.SetABCIApp(c.abciApp)
+		c.blockchainServer = blockchain.NewServer(c.Log, c.nullBlockchain)
+		// n.blockchainClient = blockchain.NewClient(n.nullBlockchain)
+		c.blockchainClient.Set(c.nullBlockchain)
+
+	default:
+		return ErrUnknownChainProvider
+	}
+
+	c.confWatcher.OnConfigUpdate(
+		func(cfg config.Config) { c.blockchainServer.ReloadConf(cfg.Blockchain) },
+	)
+
+	if err := c.blockchainServer.Start(); err != nil {
+		return err
+	}
+
+	if err := c.blockchainClient.Start(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *Core) setupCommon() (err error) {
+	// this shouldn't happen, the context is initialized in here
+	if n.cancel != nil {
+		n.cancel()
+	}
+
+	// ensure we cancel the context on error
+	defer func() {
+		if err != nil {
+			n.cancel()
+		}
+	}()
+
+	// initialize the application context
+	n.ctx, n.cancel = context.WithCancel(context.Background())
+
+	// get the configuration, this have been loaded by the root
+	conf := n.confWatcher.Get()
+
+	// reload logger with the setup from configuration
+	// n.Log = logging.NewLoggerFromConfig(conf.Logging).Named(n.Log.GetName())
+
+	// enable pprof if necessary
+	if conf.Pprof.Enabled {
+		n.Log.Info("vega is starting with pprof profile, this is not a recommended setting for production")
+		n.pproffhandlr, err = pprof.New(n.Log, conf.Pprof)
+		if err != nil {
+			return err
+		}
+		n.confWatcher.OnConfigUpdate(
+			func(cfg config.Config) { n.pproffhandlr.ReloadConf(cfg.Pprof) },
+		)
+	}
+
+	n.stats = stats.New(n.Log, n.conf.Stats)
+
+	// start prometheus stuff
+	metrics.Start(n.conf.Metrics)
+
+	return err
+}
+
+func (n *Core) loadNodeWallets() (err error) {
+	// if we are a non-validator, nothing needs to be done here
+	if !n.conf.IsValidator() {
+		return nil
+	}
+
+	n.nodeWallets, err = nodewallets.GetNodeWallets(n.conf.NodeWallet, n.vegaPaths, n.nodeWalletPassphrase)
+	if err != nil {
+		return fmt.Errorf("couldn't get node wallets: %w", err)
+	}
+
+	return n.nodeWallets.Verify()
+}
+
+func (c *Core) startABCI(
+	log *logging.Logger,
+	app types.Application,
+	tmHome string,
+) (*abci.TmNode, error) {
+	return abci.NewTmNode(
+		c.conf.Blockchain,
+		log,
+		tmHome,
+		app,
+		c.genesisDoc,
+	)
+}
+
+func (c *Core) startBlockchainClients() error {
+	// just intantiate the client here, we'll setup the actual impl later on
+	// when the null blockchain or tendermint is started.
+	c.blockchainClient = blockchain.NewClient()
+
+	// if we are a non-validator, nothing needs to be done here
+	if !c.conf.IsValidator() {
+		return nil
+	}
+
+	if c.conf.Blockchain.ChainProvider != blockchain.ProviderNullChain {
+		var err error
+		c.ethClient, err = ethclient.Dial(c.ctx, c.conf.Ethereum)
+		if err != nil {
+			return fmt.Errorf("could not instantiate ethereum client: %w", err)
+		}
+		c.ethConfirmations = ethclient.NewEthereumConfirmations(c.conf.Ethereum, c.ethClient, nil)
+	}
+
+	return nil
+}
+
+// kill the running process by signaling itself with SIGKILL.
+func kill() error {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+	return p.Signal(syscall.SIGKILL)
+}

--- a/cmd/vegaone/start/core.go
+++ b/cmd/vegaone/start/core.go
@@ -367,60 +367,60 @@ func (c *Core) startBlockchain() error {
 	return nil
 }
 
-func (n *Core) setupCommon() (err error) {
+func (c *Core) setupCommon() (err error) {
 	// this shouldn't happen, the context is initialized in here
-	if n.cancel != nil {
-		n.cancel()
+	if c.cancel != nil {
+		c.cancel()
 	}
 
 	// ensure we cancel the context on error
 	defer func() {
 		if err != nil {
-			n.cancel()
+			c.cancel()
 		}
 	}()
 
 	// initialize the application context
-	n.ctx, n.cancel = context.WithCancel(context.Background())
+	c.ctx, c.cancel = context.WithCancel(context.Background())
 
 	// get the configuration, this have been loaded by the root
-	conf := n.confWatcher.Get()
+	conf := c.confWatcher.Get()
 
 	// reload logger with the setup from configuration
 	// n.Log = logging.NewLoggerFromConfig(conf.Logging).Named(n.Log.GetName())
 
 	// enable pprof if necessary
 	if conf.Pprof.Enabled {
-		n.Log.Info("vega is starting with pprof profile, this is not a recommended setting for production")
-		n.pproffhandlr, err = pprof.New(n.Log, conf.Pprof)
+		c.Log.Info("vega is starting with pprof profile, this is not a recommended setting for production")
+		c.pproffhandlr, err = pprof.New(c.Log, conf.Pprof)
 		if err != nil {
 			return err
 		}
-		n.confWatcher.OnConfigUpdate(
-			func(cfg config.Config) { n.pproffhandlr.ReloadConf(cfg.Pprof) },
+		c.confWatcher.OnConfigUpdate(
+			func(cfg config.Config) { c.pproffhandlr.ReloadConf(cfg.Pprof) },
 		)
 	}
 
-	n.stats = stats.New(n.Log, n.conf.Stats)
+	c.stats = stats.New(c.Log, c.conf.Stats)
 
 	// start prometheus stuff
-	metrics.Start(n.conf.Metrics)
+	metrics.Start(c.conf.Metrics)
 
 	return err
 }
 
-func (n *Core) loadNodeWallets() (err error) {
+func (c *Core) loadNodeWallets() (err error) {
 	// if we are a non-validator, nothing needs to be done here
-	if !n.conf.IsValidator() {
+	if !c.conf.IsValidator() {
 		return nil
 	}
 
-	n.nodeWallets, err = nodewallets.GetNodeWallets(n.conf.NodeWallet, n.vegaPaths, n.nodeWalletPassphrase)
+	c.nodeWallets, err = nodewallets.GetNodeWallets(c.conf.NodeWallet, c.vegaPaths, c.nodeWalletPassphrase)
 	if err != nil {
 		return fmt.Errorf("couldn't get node wallets: %w", err)
 	}
 
-	return n.nodeWallets.Verify()
+	return c.nodeWallets.Verify()
 }
 
 func (c *Core) startABCI(

--- a/cmd/vegaone/start/dnode/node.go
+++ b/cmd/vegaone/start/dnode/node.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package dnode
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"code.vegaprotocol.io/vega/datanode/admin"
+	"code.vegaprotocol.io/vega/datanode/api"
+	"code.vegaprotocol.io/vega/datanode/broker"
+	"code.vegaprotocol.io/vega/datanode/config"
+	"code.vegaprotocol.io/vega/datanode/gateway/server"
+	"code.vegaprotocol.io/vega/datanode/metrics"
+	"code.vegaprotocol.io/vega/datanode/networkhistory"
+	"code.vegaprotocol.io/vega/datanode/networkhistory/snapshot"
+	"code.vegaprotocol.io/vega/datanode/sqlstore"
+	"code.vegaprotocol.io/vega/libs/pprof"
+	"code.vegaprotocol.io/vega/libs/subscribers"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"golang.org/x/sync/errgroup"
+)
+
+// DN use to implement 'node' command.
+type DN struct {
+	SQLSubscribers
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	embeddedPostgres              *embeddedpostgres.EmbeddedPostgres
+	transactionalConnectionSource *sqlstore.ConnectionSource
+
+	networkHistoryService *networkhistory.Service
+	snapshotService       *snapshot.Service
+
+	vegaCoreServiceClient api.CoreServiceClient
+
+	broker    *broker.Broker
+	sqlBroker broker.SQLStoreEventBroker
+
+	eventService *subscribers.Service
+
+	pproffhandlr  *pprof.Pprofhandler
+	Log           *logging.Logger
+	vegaPaths     paths.Paths
+	configWatcher *config.Watcher
+	conf          config.Config
+
+	Version     string
+	VersionHash string
+
+	eg *errgroup.Group
+}
+
+const namedLogger = "datanode"
+
+func New(
+	log *logging.Logger,
+	vegaPaths paths.Paths,
+) (*DN, error) {
+	log = log.Named(namedLogger)
+
+	confWatcher, err := config.NewWatcher(context.Background(), log, vegaPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	eg, ctx := errgroup.WithContext(ctx)
+
+	dn := &DN{
+		Log:           log,
+		configWatcher: confWatcher,
+		conf:          confWatcher.Get(),
+		eg:            eg,
+		ctx:           ctx,
+		cancel:        cancel,
+		vegaPaths:     vegaPaths,
+	}
+
+	if err := dn.persistentPre(nil); err != nil {
+		return nil, err
+	}
+
+	if err := dn.preRun(nil); err != nil {
+		return nil, err
+	}
+
+	return dn, nil
+}
+
+func (d *DN) Start() error {
+
+	err := d.runNode(nil)
+	if err != nil {
+		d.cancel()
+	}
+
+	return nil
+}
+
+func (d *DN) Done() <-chan struct{} {
+	return d.ctx.Done()
+}
+
+// Stop is for graceful shutdown.
+func (d *DN) Stop() {
+	d.cancel()
+	err := d.eg.Wait()
+	if !errors.Is(err, context.Canceled) {
+		d.Log.Error("error with datanode shutdown", logging.Error(err))
+	}
+
+	if err := d.postRun([]string{}); err != nil {
+		d.Log.Error("error with datanode shutdown", logging.Error(err))
+	}
+
+	if err := d.persistentPost([]string{}); err != nil {
+		d.Log.Error("error with datanode shutdown", logging.Error(err))
+	}
+}
+
+// runNode is the entry of node command.
+func (l *DN) runNode([]string) error {
+	nodeLog := l.Log.Named("start.runNode")
+
+	// gRPC server
+	grpcServer := l.createGRPCServer(l.conf.API)
+
+	// Admin server
+	adminServer := admin.NewServer(l.Log, l.conf.Admin, l.vegaPaths, admin.NewNetworkHistoryAdminService(l.networkHistoryService))
+
+	// watch configs
+	l.configWatcher.OnConfigUpdate(
+		func(cfg config.Config) {
+			grpcServer.ReloadConf(cfg.API)
+			adminServer.ReloadConf(cfg.Admin)
+		},
+	)
+
+	// start the grpc server
+	l.eg.Go(func() error { return grpcServer.Start(l.ctx, nil) })
+
+	// start the admin server
+	l.eg.Go(func() error {
+		if err := adminServer.Start(l.ctx); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+
+	// start gateway
+	if l.conf.GatewayEnabled {
+		gty := server.New(l.conf.Gateway, l.Log, l.vegaPaths)
+		l.eg.Go(func() error { return gty.Start(l.ctx) })
+	}
+
+	l.eg.Go(func() error {
+		return l.broker.Receive(l.ctx)
+	})
+
+	l.eg.Go(func() error {
+		defer func() {
+			if l.conf.NetworkHistory.Enabled {
+				l.networkHistoryService.Stop()
+			}
+		}()
+
+		return l.sqlBroker.Receive(l.ctx)
+	})
+
+	metrics.Start(l.conf.Metrics)
+
+	nodeLog.Info("Vega data node startup complete")
+
+	return nil
+}
+
+func (l *DN) createGRPCServer(config api.Config) *api.GRPCServer {
+	grpcServer := api.NewGRPCServer(
+		l.Log,
+		config,
+		l.vegaCoreServiceClient,
+		l.eventService,
+		l.orderService,
+		l.networkLimitsService,
+		l.marketDataService,
+		l.tradeService,
+		l.assetService,
+		l.accountService,
+		l.rewardService,
+		l.marketsService,
+		l.delegationService,
+		l.epochService,
+		l.depositService,
+		l.withdrawalService,
+		l.governanceService,
+		l.riskFactorService,
+		l.riskService,
+		l.networkParameterService,
+		l.blockService,
+		l.checkpointService,
+		l.partyService,
+		l.candleService,
+		l.oracleSpecService,
+		l.oracleDataService,
+		l.liquidityProvisionService,
+		l.positionService,
+		l.transferService,
+		l.stakeLinkingService,
+		l.notaryService,
+		l.multiSigService,
+		l.keyRotationsService,
+		l.ethereumKeyRotationsService,
+		l.nodeService,
+		l.marketDepthService,
+		l.ledgerService,
+		l.protocolUpgradeService,
+		l.networkHistoryService,
+		l.coreSnapshotService,
+	)
+	return grpcServer
+}

--- a/cmd/vegaone/start/dnode/node_post.go
+++ b/cmd/vegaone/start/dnode/node_post.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package dnode
+
+import (
+	"strings"
+
+	"code.vegaprotocol.io/vega/logging"
+
+	"github.com/pkg/errors"
+)
+
+type errStack []error
+
+func (l *DN) postRun(_ []string) error {
+	var werr errStack
+
+	postLog := l.Log.Named("postRun")
+
+	if l.embeddedPostgres != nil {
+		if err := l.embeddedPostgres.Stop(); err != nil {
+			werr = append(werr, errors.Wrap(err, "error closing embedded postgres in command"))
+		}
+	}
+	if l.pproffhandlr != nil {
+		if err := l.pproffhandlr.Stop(); err != nil {
+			werr = append(werr, errors.Wrap(err, "error stopping pprof"))
+		}
+	}
+
+	postLog.Info("Vega datanode shutdown complete",
+		logging.String("version", l.Version),
+		logging.String("version-hash", l.VersionHash))
+
+	postLog.Sync()
+
+	if len(werr) == 0 {
+		// Prevent printing of empty error and exiting with non-zero code.
+		return nil
+	}
+	return werr
+}
+
+func (l *DN) persistentPost(_ []string) error {
+	l.cancel()
+	return nil
+}
+
+// Error - implement the error interface on the errStack type.
+func (e errStack) Error() string {
+	s := make([]string, 0, len(e))
+	for _, err := range e {
+		s = append(s, err.Error())
+	}
+	return strings.Join(s, "\n")
+}

--- a/cmd/vegaone/start/dnode/node_post.go
+++ b/cmd/vegaone/start/dnode/node_post.go
@@ -22,25 +22,25 @@ import (
 
 type errStack []error
 
-func (l *DN) postRun(_ []string) error {
+func (d *DN) postRun(_ []string) error {
 	var werr errStack
 
-	postLog := l.Log.Named("postRun")
+	postLog := d.Log.Named("postRun")
 
-	if l.embeddedPostgres != nil {
-		if err := l.embeddedPostgres.Stop(); err != nil {
+	if d.embeddedPostgres != nil {
+		if err := d.embeddedPostgres.Stop(); err != nil {
 			werr = append(werr, errors.Wrap(err, "error closing embedded postgres in command"))
 		}
 	}
-	if l.pproffhandlr != nil {
-		if err := l.pproffhandlr.Stop(); err != nil {
+	if d.pproffhandlr != nil {
+		if err := d.pproffhandlr.Stop(); err != nil {
 			werr = append(werr, errors.Wrap(err, "error stopping pprof"))
 		}
 	}
 
 	postLog.Info("Vega datanode shutdown complete",
-		logging.String("version", l.Version),
-		logging.String("version-hash", l.VersionHash))
+		logging.String("version", d.Version),
+		logging.String("version-hash", d.VersionHash))
 
 	postLog.Sync()
 
@@ -51,8 +51,8 @@ func (l *DN) postRun(_ []string) error {
 	return werr
 }
 
-func (l *DN) persistentPost(_ []string) error {
-	l.cancel()
+func (d *DN) persistentPost(_ []string) error { //nolint:unparam
+	d.cancel()
 	return nil
 }
 

--- a/cmd/vegaone/start/dnode/node_pre.go
+++ b/cmd/vegaone/start/dnode/node_pre.go
@@ -1,0 +1,350 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package dnode
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"code.vegaprotocol.io/vega/libs/subscribers"
+
+	"github.com/cenkalti/backoff"
+	"google.golang.org/grpc"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"code.vegaprotocol.io/vega/datanode/broker"
+	"code.vegaprotocol.io/vega/datanode/config"
+	"code.vegaprotocol.io/vega/datanode/networkhistory"
+	"code.vegaprotocol.io/vega/datanode/networkhistory/snapshot"
+	"code.vegaprotocol.io/vega/datanode/sqlstore"
+	"code.vegaprotocol.io/vega/libs/pprof"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+	vegaprotoapi "code.vegaprotocol.io/vega/protos/vega/api/v1"
+)
+
+func (l *DN) persistentPre([]string) (err error) {
+	// this shouldn't happen...
+	if l.cancel != nil {
+		l.cancel()
+	}
+	// ensure we cancel the context on error
+	defer func() {
+		if err != nil {
+			l.cancel()
+		}
+	}()
+	l.ctx, l.cancel = context.WithCancel(context.Background())
+
+	conf := l.configWatcher.Get()
+
+	preLog := l.Log.Named("start.persistentPre")
+
+	if conf.Pprof.Enabled {
+		preLog.Info("vega is starting with pprof profile, this is not a recommended setting for production")
+		l.pproffhandlr, err = pprof.New(l.Log, conf.Pprof)
+		if err != nil {
+			return
+		}
+		l.configWatcher.OnConfigUpdate(
+			func(cfg config.Config) { l.pproffhandlr.ReloadConf(cfg.Pprof) },
+		)
+	}
+
+	preLog.Info("Starting Vega Datanode",
+		logging.String("version", l.Version),
+		logging.String("version-hash", l.VersionHash))
+
+	if l.conf.SQLStore.UseEmbedded {
+		logDir := l.vegaPaths.StatePathFor(paths.DataNodeLogsHome)
+		postgresLogger := &lumberjack.Logger{
+			Filename: filepath.Join(logDir, "embedded-postgres.log"),
+			MaxSize:  l.conf.SQLStore.LogRotationConfig.MaxSize,
+			MaxAge:   l.conf.SQLStore.LogRotationConfig.MaxAge,
+			Compress: true,
+		}
+
+		runtimeDir := l.vegaPaths.StatePathFor(paths.DataNodeEmbeddedPostgresRuntimeDir)
+		l.embeddedPostgres, err = sqlstore.StartEmbeddedPostgres(l.Log, l.conf.SQLStore,
+			runtimeDir, postgresLogger)
+
+		if err != nil {
+			return fmt.Errorf("failed to start embedded postgres: %w", err)
+		}
+
+		go func() {
+			for range l.ctx.Done() {
+				l.embeddedPostgres.Stop()
+			}
+		}()
+	}
+
+	if l.conf.SQLStore.WipeOnStartup {
+		if err = sqlstore.WipeDatabaseAndMigrateSchemaToLatestVersion(preLog, l.conf.SQLStore.ConnectionConfig, sqlstore.EmbedMigrations,
+			bool(l.conf.SQLStore.VerboseMigration)); err != nil {
+			return fmt.Errorf("failed to wiped database:%w", err)
+		}
+		preLog.Info("Wiped all existing data from the datanode")
+	}
+
+	initialisedFromNetworkHistory := false
+	if l.conf.NetworkHistory.Enabled {
+		preLog.Info("Initializing Network History")
+
+		if l.conf.AutoInitialiseFromNetworkHistory {
+			if err := networkhistory.KillAllConnectionsToDatabase(context.Background(), l.conf.SQLStore.ConnectionConfig); err != nil {
+				return fmt.Errorf("failed to kill all connections to database: %w", err)
+			}
+		}
+
+		err = l.initialiseNetworkHistory(preLog, l.conf.SQLStore.ConnectionConfig)
+		if err != nil {
+			return fmt.Errorf("failed to initialise network history:%w", err)
+		}
+
+		if l.conf.AutoInitialiseFromNetworkHistory {
+			preLog.Info("Auto Initialising Datanode From Network History")
+			apiPorts := []int{l.conf.API.Port}
+			apiPorts = append(apiPorts, l.conf.NetworkHistory.Initialise.GrpcAPIPorts...)
+
+			if err = networkhistory.InitialiseDatanodeFromNetworkHistory(l.ctx, l.conf.NetworkHistory.Initialise,
+				preLog, l.conf.SQLStore.ConnectionConfig, l.networkHistoryService, apiPorts,
+				bool(l.conf.SQLStore.VerboseMigration)); err != nil {
+				return fmt.Errorf("failed to initialize datanode from network history: %w", err)
+			}
+
+			initialisedFromNetworkHistory = true
+			preLog.Info("Initialized from network history")
+		}
+	}
+
+	if !initialisedFromNetworkHistory {
+		operation := func() (opErr error) {
+			preLog.Info("Attempting to initialise database...")
+			opErr = l.initialiseDatabase(preLog)
+			if opErr != nil {
+				preLog.Error("Failed to initialise database, retrying...", logging.Error(opErr))
+			}
+			preLog.Info("Database initialised")
+			return opErr
+		}
+
+		retryConfig := l.conf.SQLStore.ConnectionRetryConfig
+
+		expBackoff := backoff.NewExponentialBackOff()
+		expBackoff.InitialInterval = retryConfig.InitialInterval
+		expBackoff.MaxInterval = retryConfig.MaxInterval
+		expBackoff.MaxElapsedTime = retryConfig.MaxElapsedTime
+
+		err = backoff.Retry(operation, backoff.WithMaxRetries(expBackoff, retryConfig.MaxRetries))
+		if err != nil {
+			return fmt.Errorf("failed to connect to database: %w", err)
+		}
+	}
+
+	preLog.Info("Applying Data Retention Policies")
+
+	err = sqlstore.ApplyDataRetentionPolicies(l.conf.SQLStore, preLog)
+	if err != nil {
+		return fmt.Errorf("failed to apply data retention policies:%w", err)
+	}
+
+	preLog.Info("Enabling SQL stores")
+
+	l.transactionalConnectionSource, err = sqlstore.NewTransactionalConnectionSource(preLog, l.conf.SQLStore.ConnectionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create transactional connection source: %w", err)
+	}
+
+	logSqlstore := l.Log.Named("sqlstore")
+	l.CreateAllStores(l.ctx, logSqlstore, l.transactionalConnectionSource, l.conf.CandlesV2.CandleStore)
+
+	logService := l.Log.Named("service")
+	logService.SetLevel(l.conf.Service.Level.Get())
+	if err := l.SetupServices(l.ctx, logService, l.conf.CandlesV2); err != nil {
+		return err
+	}
+
+	err = networkhistory.VerifyChainID(l.conf.ChainID, l.chainService)
+	if err != nil {
+		return fmt.Errorf("failed to verify chain id:%w", err)
+	}
+
+	l.SetupSQLSubscribers()
+
+	return nil
+}
+
+func (l *DN) initialiseDatabase(preLog *logging.Logger) error {
+	var err error
+	conf := l.conf.SQLStore.ConnectionConfig
+	conf.MaxConnPoolSize = 1
+	pool, err := sqlstore.CreateConnectionPool(conf)
+	if err != nil {
+		return fmt.Errorf("failed to create connection pool: %w", err)
+	}
+	defer pool.Close()
+
+	hasVegaSchema, err := sqlstore.HasVegaSchema(l.ctx, pool)
+	if err != nil {
+		return fmt.Errorf("failed to check if database has schema: %w", err)
+	}
+
+	// If it's an empty database, recreate it with correct locale settings
+	if !hasVegaSchema {
+		err = sqlstore.RecreateVegaDatabase(l.ctx, preLog, l.conf.SQLStore.ConnectionConfig)
+		if err != nil {
+			return fmt.Errorf("failed to recreate vega schema: %w", err)
+		}
+	}
+
+	err = sqlstore.MigrateToLatestSchema(preLog, l.conf.SQLStore)
+	if err != nil {
+		return fmt.Errorf("failed to migrate to latest schema:%w", err)
+	}
+
+	return nil
+}
+
+// we've already set everything up WRT arguments etc... just bootstrap the node.
+func (l *DN) preRun([]string) (err error) {
+	// ensure that context is cancelled if we return an error here
+	defer func() {
+		if err != nil {
+			l.cancel()
+		}
+	}()
+
+	preLog := l.Log.Named("start.preRun")
+	brokerLog := l.Log.Named("broker")
+	eventSourceLog := brokerLog.Named("eventsource")
+
+	eventReceiverSender, err := broker.NewEventReceiverSender(l.conf.Broker, eventSourceLog, l.conf.ChainID)
+	if err != nil {
+		preLog.Error("unable to initialise event source", logging.Error(err))
+		return err
+	}
+
+	var rawEventSource broker.RawEventReceiver = eventReceiverSender
+
+	if l.conf.Broker.UseBufferedEventSource {
+		bufferFilePath, err := l.vegaPaths.CreateStatePathFor(paths.DataNodeEventBufferHome)
+		if err != nil {
+			preLog.Error("failed to create path for buffered event source", logging.Error(err))
+			return err
+		}
+
+		archiveFilesPath, err := l.vegaPaths.CreateStatePathFor(paths.DataNodeArchivedEventBufferHome)
+		if err != nil {
+			l.Log.Error("failed to create archive path for buffered event source", logging.Error(err))
+			return err
+		}
+
+		rawEventSource, err = broker.NewBufferedEventSource(l.ctx, l.Log, l.conf.Broker.BufferedEventSourceConfig, eventReceiverSender,
+			bufferFilePath, archiveFilesPath)
+		if err != nil {
+			preLog.Error("unable to initialise file buffered event source", logging.Error(err))
+			return err
+		}
+	}
+
+	var eventSource broker.EventReceiver
+	eventSource = broker.NewDeserializer(rawEventSource)
+	eventSource = broker.NewFanOutEventSource(eventSource, l.conf.SQLStore.FanOutBufferSize, 2)
+
+	var onBlockCommittedHandler func(ctx context.Context, chainId string, lastCommittedBlockHeight int64, snapshotTaken bool)
+	var protocolUpgradeHandler broker.ProtocolUpgradeHandler
+
+	if l.conf.NetworkHistory.Enabled {
+		blockCommitHandler := networkhistory.NewBlockCommitHandler(l.Log, l.conf.NetworkHistory, l.snapshotService.SnapshotData,
+			bool(l.conf.Broker.UseEventFile), l.conf.Broker.FileEventSourceConfig.TimeBetweenBlocks.Duration,
+			5*time.Second, 6)
+		onBlockCommittedHandler = blockCommitHandler.OnBlockCommitted
+		protocolUpgradeHandler = networkhistory.NewProtocolUpgradeHandler(l.Log, l.protocolUpgradeService, eventReceiverSender,
+			l.networkHistoryService.CreateAndPublishSegment)
+	} else {
+		onBlockCommittedHandler = func(ctx context.Context, chainId string, lastCommittedBlockHeight int64, snapshotTaken bool) {}
+		protocolUpgradeHandler = networkhistory.NewProtocolUpgradeHandler(l.Log, l.protocolUpgradeService, eventReceiverSender,
+			func(ctx context.Context, chainID string, toHeight int64) error { return nil })
+	}
+
+	l.sqlBroker = broker.NewSQLStoreBroker(l.Log, l.conf.Broker, l.conf.ChainID, eventSource,
+		l.transactionalConnectionSource,
+		l.blockStore,
+		onBlockCommittedHandler,
+		protocolUpgradeHandler,
+		l.GetSQLSubscribers(),
+	)
+
+	l.broker, err = broker.New(l.ctx, brokerLog, l.conf.Broker, l.conf.ChainID, eventSource)
+	if err != nil {
+		preLog.Error("unable to initialise broker", logging.Error(err))
+		return err
+	}
+
+	// Event service as used by old and new world
+	l.eventService = subscribers.NewService(preLog, l.broker, l.conf.Broker.EventBusClientBufferSize)
+
+	nodeAddr := fmt.Sprintf("%v:%v", l.conf.API.CoreNodeIP, l.conf.API.CoreNodeGRPCPort)
+	conn, err := grpc.Dial(nodeAddr, grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+
+	l.vegaCoreServiceClient = vegaprotoapi.NewCoreServiceClient(conn)
+	return nil
+}
+
+func (l *DN) initialiseNetworkHistory(preLog *logging.Logger, connConfig sqlstore.ConnectionConfig) error {
+	// Want to pre-allocate some connections to ensure a connection is always available,
+	// 3 is chosen to allow for the fact that pool size can temporarily drop below the min pool size.
+	connConfig.MaxConnPoolSize = 3
+	connConfig.MinConnPoolSize = 3
+
+	networkHistoryPool, err := sqlstore.CreateConnectionPool(connConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create network history connection pool: %w", err)
+	}
+
+	preNetworkHistoryLog := preLog.Named("networkHistory")
+	networkHistoryLog := l.Log.Named("networkHistory")
+	networkHistoryLog.SetLevel(l.conf.NetworkHistory.Level.Get())
+
+	snapshotServiceLog := networkHistoryLog.Named("snapshot")
+	networkHistoryServiceLog := networkHistoryLog.Named("service")
+
+	l.snapshotService, err = snapshot.NewSnapshotService(snapshotServiceLog, l.conf.NetworkHistory.Snapshot,
+		networkHistoryPool, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
+		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
+			if err = sqlstore.MigrateToSchemaVersion(preNetworkHistoryLog, l.conf.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
+				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
+			}
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("failed to create snapshot service:%w", err)
+	}
+
+	l.networkHistoryService, err = networkhistory.New(l.ctx, networkHistoryServiceLog, l.conf.NetworkHistory, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
+		networkHistoryPool,
+		l.conf.ChainID, l.snapshotService, l.conf.API.Port, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
+		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), l.conf.MaxMemoryPercent)
+
+	if err != nil {
+		return fmt.Errorf("failed to create networkHistory service:%w", err)
+	}
+
+	return nil
+}

--- a/cmd/vegaone/start/dnode/sqlsubscribers.go
+++ b/cmd/vegaone/start/dnode/sqlsubscribers.go
@@ -1,0 +1,301 @@
+package dnode
+
+import (
+	"context"
+
+	"code.vegaprotocol.io/vega/datanode/broker"
+	"code.vegaprotocol.io/vega/datanode/candlesv2"
+	"code.vegaprotocol.io/vega/datanode/service"
+	"code.vegaprotocol.io/vega/datanode/sqlstore"
+	"code.vegaprotocol.io/vega/datanode/sqlsubscribers"
+	"code.vegaprotocol.io/vega/logging"
+)
+
+type SQLSubscribers struct {
+	// Stores
+	assetStore                *sqlstore.Assets
+	blockStore                *sqlstore.Blocks
+	accountStore              *sqlstore.Accounts
+	balanceStore              *sqlstore.Balances
+	ledger                    *sqlstore.Ledger
+	partyStore                *sqlstore.Parties
+	orderStore                *sqlstore.Orders
+	tradeStore                *sqlstore.Trades
+	networkLimitsStore        *sqlstore.NetworkLimits
+	marketDataStore           *sqlstore.MarketData
+	rewardStore               *sqlstore.Rewards
+	delegationStore           *sqlstore.Delegations
+	marketsStore              *sqlstore.Markets
+	epochStore                *sqlstore.Epochs
+	depositStore              *sqlstore.Deposits
+	withdrawalsStore          *sqlstore.Withdrawals
+	proposalStore             *sqlstore.Proposals
+	voteStore                 *sqlstore.Votes
+	marginLevelsStore         *sqlstore.MarginLevels
+	riskFactorStore           *sqlstore.RiskFactors
+	netParamStore             *sqlstore.NetworkParameters
+	checkpointStore           *sqlstore.Checkpoints
+	oracleSpecStore           *sqlstore.OracleSpec
+	oracleDataStore           *sqlstore.OracleData
+	liquidityProvisionStore   *sqlstore.LiquidityProvision
+	positionStore             *sqlstore.Positions
+	transfersStore            *sqlstore.Transfers
+	stakeLinkingStore         *sqlstore.StakeLinking
+	notaryStore               *sqlstore.Notary
+	multiSigSignerAddedStore  *sqlstore.ERC20MultiSigSignerEvent
+	keyRotationsStore         *sqlstore.KeyRotations
+	ethereumKeyRotationsStore *sqlstore.EthereumKeyRotations
+	nodeStore                 *sqlstore.Node
+	candleStore               *sqlstore.Candles
+	chainStore                *sqlstore.Chain
+	pupStore                  *sqlstore.ProtocolUpgradeProposals
+	snapStore                 *sqlstore.CoreSnapshotData
+
+	// Services
+	candleService               *candlesv2.Svc
+	marketDepthService          *service.MarketDepth
+	riskService                 *service.Risk
+	marketDataService           *service.MarketData
+	positionService             *service.Position
+	tradeService                *service.Trade
+	ledgerService               *service.Ledger
+	rewardService               *service.Reward
+	delegationService           *service.Delegation
+	assetService                *service.Asset
+	blockService                *service.Block
+	partyService                *service.Party
+	accountService              *service.Account
+	orderService                *service.Order
+	networkLimitsService        *service.NetworkLimits
+	marketsService              *service.Markets
+	epochService                *service.Epoch
+	depositService              *service.Deposit
+	withdrawalService           *service.Withdrawal
+	governanceService           *service.Governance
+	riskFactorService           *service.RiskFactor
+	networkParameterService     *service.NetworkParameter
+	checkpointService           *service.Checkpoint
+	oracleSpecService           *service.OracleSpec
+	oracleDataService           *service.OracleData
+	liquidityProvisionService   *service.LiquidityProvision
+	transferService             *service.Transfer
+	stakeLinkingService         *service.StakeLinking
+	notaryService               *service.Notary
+	multiSigService             *service.MultiSig
+	keyRotationsService         *service.KeyRotations
+	ethereumKeyRotationsService *service.EthereumKeyRotation
+	nodeService                 *service.Node
+	chainService                *service.Chain
+	protocolUpgradeService      *service.ProtocolUpgrade
+	coreSnapshotService         *service.SnapshotData
+
+	// Subscribers
+	accountSub              *sqlsubscribers.Account
+	assetSub                *sqlsubscribers.Asset
+	partySub                *sqlsubscribers.Party
+	transferResponseSub     *sqlsubscribers.TransferResponse
+	orderSub                *sqlsubscribers.Order
+	networkLimitsSub        *sqlsubscribers.NetworkLimits
+	marketDataSub           *sqlsubscribers.MarketData
+	tradesSub               *sqlsubscribers.TradeSubscriber
+	rewardsSub              *sqlsubscribers.Reward
+	delegationsSub          *sqlsubscribers.Delegation
+	marketCreatedSub        *sqlsubscribers.MarketCreated
+	marketUpdatedSub        *sqlsubscribers.MarketUpdated
+	epochSub                *sqlsubscribers.Epoch
+	depositSub              *sqlsubscribers.Deposit
+	withdrawalSub           *sqlsubscribers.Withdrawal
+	proposalsSub            *sqlsubscribers.Proposal
+	votesSub                *sqlsubscribers.Vote
+	marginLevelsSub         *sqlsubscribers.MarginLevels
+	riskFactorSub           *sqlsubscribers.RiskFactor
+	netParamSub             *sqlsubscribers.NetworkParameter
+	checkpointSub           *sqlsubscribers.Checkpoint
+	oracleSpecSub           *sqlsubscribers.OracleSpec
+	oracleDataSub           *sqlsubscribers.OracleData
+	liquidityProvisionSub   *sqlsubscribers.LiquidityProvision
+	positionsSub            *sqlsubscribers.Position
+	transferSub             *sqlsubscribers.Transfer
+	stakeLinkingSub         *sqlsubscribers.StakeLinking
+	notarySub               *sqlsubscribers.Notary
+	multiSigSignerEventSub  *sqlsubscribers.ERC20MultiSigSignerEvent
+	keyRotationsSub         *sqlsubscribers.KeyRotation
+	ethereumKeyRotationsSub *sqlsubscribers.EthereumKeyRotation
+	nodeSub                 *sqlsubscribers.Node
+	pupSub                  *sqlsubscribers.ProtocolUpgrade
+	snapSub                 *sqlsubscribers.SnapshotData
+}
+
+func (s *SQLSubscribers) GetSQLSubscribers() []broker.SQLBrokerSubscriber {
+	return []broker.SQLBrokerSubscriber{
+		s.accountSub,
+		s.assetSub,
+		s.partySub,
+		s.transferResponseSub,
+		s.orderSub,
+		s.networkLimitsSub,
+		s.marketDataSub,
+		s.tradesSub,
+		s.rewardsSub,
+		s.delegationsSub,
+		s.marketCreatedSub,
+		s.marketUpdatedSub,
+		s.epochSub,
+		s.marketUpdatedSub,
+		s.depositSub,
+		s.withdrawalSub,
+		s.proposalsSub,
+		s.votesSub,
+		s.depositSub,
+		s.marginLevelsSub,
+		s.riskFactorSub,
+		s.netParamSub,
+		s.checkpointSub,
+		s.positionsSub,
+		s.oracleSpecSub,
+		s.oracleDataSub,
+		s.liquidityProvisionSub,
+		s.transferSub,
+		s.stakeLinkingSub,
+		s.notarySub,
+		s.multiSigSignerEventSub,
+		s.keyRotationsSub,
+		s.nodeSub,
+		s.ethereumKeyRotationsSub,
+		s.pupSub,
+		s.snapSub,
+	}
+}
+
+func (s *SQLSubscribers) CreateAllStores(ctx context.Context, Log *logging.Logger, transactionalConnectionSource *sqlstore.ConnectionSource,
+	candleV2Config candlesv2.CandleStoreConfig,
+) {
+	s.assetStore = sqlstore.NewAssets(transactionalConnectionSource)
+	s.blockStore = sqlstore.NewBlocks(transactionalConnectionSource)
+	s.partyStore = sqlstore.NewParties(transactionalConnectionSource)
+	s.partyStore.Initialise(ctx)
+	s.accountStore = sqlstore.NewAccounts(transactionalConnectionSource)
+	s.balanceStore = sqlstore.NewBalances(transactionalConnectionSource)
+	s.ledger = sqlstore.NewLedger(transactionalConnectionSource)
+	s.orderStore = sqlstore.NewOrders(transactionalConnectionSource)
+	s.tradeStore = sqlstore.NewTrades(transactionalConnectionSource)
+	s.networkLimitsStore = sqlstore.NewNetworkLimits(transactionalConnectionSource)
+	s.marketDataStore = sqlstore.NewMarketData(transactionalConnectionSource)
+	s.rewardStore = sqlstore.NewRewards(transactionalConnectionSource)
+	s.marketsStore = sqlstore.NewMarkets(transactionalConnectionSource)
+	s.delegationStore = sqlstore.NewDelegations(transactionalConnectionSource)
+	s.epochStore = sqlstore.NewEpochs(transactionalConnectionSource)
+	s.depositStore = sqlstore.NewDeposits(transactionalConnectionSource)
+	s.withdrawalsStore = sqlstore.NewWithdrawals(transactionalConnectionSource)
+	s.proposalStore = sqlstore.NewProposals(transactionalConnectionSource)
+	s.voteStore = sqlstore.NewVotes(transactionalConnectionSource)
+	s.marginLevelsStore = sqlstore.NewMarginLevels(transactionalConnectionSource)
+	s.riskFactorStore = sqlstore.NewRiskFactors(transactionalConnectionSource)
+	s.netParamStore = sqlstore.NewNetworkParameters(transactionalConnectionSource)
+	s.checkpointStore = sqlstore.NewCheckpoints(transactionalConnectionSource)
+	s.positionStore = sqlstore.NewPositions(transactionalConnectionSource)
+	s.oracleSpecStore = sqlstore.NewOracleSpec(transactionalConnectionSource)
+	s.oracleDataStore = sqlstore.NewOracleData(transactionalConnectionSource)
+	s.liquidityProvisionStore = sqlstore.NewLiquidityProvision(transactionalConnectionSource, Log)
+	s.transfersStore = sqlstore.NewTransfers(transactionalConnectionSource)
+	s.stakeLinkingStore = sqlstore.NewStakeLinking(transactionalConnectionSource)
+	s.notaryStore = sqlstore.NewNotary(transactionalConnectionSource)
+	s.multiSigSignerAddedStore = sqlstore.NewERC20MultiSigSignerEvent(transactionalConnectionSource)
+	s.keyRotationsStore = sqlstore.NewKeyRotations(transactionalConnectionSource)
+	s.ethereumKeyRotationsStore = sqlstore.NewEthereumKeyRotations(transactionalConnectionSource)
+	s.nodeStore = sqlstore.NewNode(transactionalConnectionSource)
+	s.candleStore = sqlstore.NewCandles(ctx, transactionalConnectionSource, candleV2Config)
+	s.chainStore = sqlstore.NewChain(transactionalConnectionSource)
+	s.pupStore = sqlstore.NewProtocolUpgradeProposals(transactionalConnectionSource)
+	s.snapStore = sqlstore.NewCoreSnapshotData(transactionalConnectionSource)
+}
+
+func (s *SQLSubscribers) SetupServices(ctx context.Context, log *logging.Logger, candlesConfig candlesv2.Config) error {
+	s.accountService = service.NewAccount(s.accountStore, s.balanceStore, log)
+	s.assetService = service.NewAsset(s.assetStore)
+	s.blockService = service.NewBlock(s.blockStore)
+	s.candleService = candlesv2.NewService(ctx, log, candlesConfig, s.candleStore)
+	s.checkpointService = service.NewCheckpoint(s.checkpointStore)
+	s.delegationService = service.NewDelegation(s.delegationStore, log)
+	s.depositService = service.NewDeposit(s.depositStore)
+	s.epochService = service.NewEpoch(s.epochStore)
+	s.governanceService = service.NewGovernance(s.proposalStore, s.voteStore, log)
+	s.keyRotationsService = service.NewKeyRotations(s.keyRotationsStore)
+	s.ethereumKeyRotationsService = service.NewEthereumKeyRotation(s.ethereumKeyRotationsStore, log)
+	s.ledgerService = service.NewLedger(s.ledger, log)
+	s.liquidityProvisionService = service.NewLiquidityProvision(s.liquidityProvisionStore)
+	s.marketDataService = service.NewMarketData(s.marketDataStore, log)
+	s.marketDepthService = service.NewMarketDepth(s.orderStore, log)
+	s.marketsService = service.NewMarkets(s.marketsStore)
+	s.multiSigService = service.NewMultiSig(s.multiSigSignerAddedStore)
+	s.networkLimitsService = service.NewNetworkLimits(s.networkLimitsStore)
+	s.networkParameterService = service.NewNetworkParameter(s.netParamStore)
+	s.nodeService = service.NewNode(s.nodeStore)
+	s.notaryService = service.NewNotary(s.notaryStore)
+	s.oracleDataService = service.NewOracleData(s.oracleDataStore)
+	s.oracleSpecService = service.NewOracleSpec(s.oracleSpecStore)
+	s.orderService = service.NewOrder(s.orderStore, log)
+	s.partyService = service.NewParty(s.partyStore)
+	s.positionService = service.NewPosition(s.positionStore, log)
+	s.rewardService = service.NewReward(s.rewardStore, log)
+	s.riskFactorService = service.NewRiskFactor(s.riskFactorStore)
+	s.riskService = service.NewRisk(s.marginLevelsStore, s.accountStore, log)
+	s.stakeLinkingService = service.NewStakeLinking(s.stakeLinkingStore)
+	s.tradeService = service.NewTrade(s.tradeStore, log)
+	s.transferService = service.NewTransfer(s.transfersStore)
+	s.withdrawalService = service.NewWithdrawal(s.withdrawalsStore)
+	s.chainService = service.NewChain(s.chainStore)
+	s.protocolUpgradeService = service.NewProtocolUpgrade(s.pupStore, log)
+	s.coreSnapshotService = service.NewSnapshotData(s.snapStore)
+
+	toInit := []interface{ Initialise(context.Context) error }{
+		s.marketDepthService,
+		s.marketDataService,
+		s.marketsService,
+	}
+
+	for _, svc := range toInit {
+		if err := svc.Initialise(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *SQLSubscribers) SetupSQLSubscribers() {
+	s.accountSub = sqlsubscribers.NewAccount(s.accountService)
+	s.assetSub = sqlsubscribers.NewAsset(s.assetService)
+	s.partySub = sqlsubscribers.NewParty(s.partyService)
+	s.transferResponseSub = sqlsubscribers.NewTransferResponse(s.ledgerService, s.accountService)
+	s.orderSub = sqlsubscribers.NewOrder(s.orderService, s.marketDepthService)
+	s.networkLimitsSub = sqlsubscribers.NewNetworkLimitSub(s.networkLimitsService)
+	s.marketDataSub = sqlsubscribers.NewMarketData(s.marketDataService)
+	s.tradesSub = sqlsubscribers.NewTradesSubscriber(s.tradeService)
+	s.rewardsSub = sqlsubscribers.NewReward(s.rewardService)
+	s.marketCreatedSub = sqlsubscribers.NewMarketCreated(s.marketsService)
+	s.marketUpdatedSub = sqlsubscribers.NewMarketUpdated(s.marketsService)
+	s.delegationsSub = sqlsubscribers.NewDelegation(s.delegationService)
+	s.epochSub = sqlsubscribers.NewEpoch(s.epochService)
+	s.depositSub = sqlsubscribers.NewDeposit(s.depositService)
+	s.withdrawalSub = sqlsubscribers.NewWithdrawal(s.withdrawalService)
+	s.proposalsSub = sqlsubscribers.NewProposal(s.governanceService)
+	s.votesSub = sqlsubscribers.NewVote(s.governanceService)
+	s.marginLevelsSub = sqlsubscribers.NewMarginLevels(s.riskService, s.accountStore)
+	s.riskFactorSub = sqlsubscribers.NewRiskFactor(s.riskFactorService)
+	s.netParamSub = sqlsubscribers.NewNetworkParameter(s.networkParameterService)
+	s.checkpointSub = sqlsubscribers.NewCheckpoint(s.checkpointService)
+	s.positionsSub = sqlsubscribers.NewPosition(s.positionService, s.marketsService)
+	s.oracleSpecSub = sqlsubscribers.NewOracleSpec(s.oracleSpecService)
+	s.oracleDataSub = sqlsubscribers.NewOracleData(s.oracleDataService)
+	s.liquidityProvisionSub = sqlsubscribers.NewLiquidityProvision(s.liquidityProvisionService)
+	s.transferSub = sqlsubscribers.NewTransfer(s.transfersStore, s.accountService)
+	s.stakeLinkingSub = sqlsubscribers.NewStakeLinking(s.stakeLinkingService)
+	s.notarySub = sqlsubscribers.NewNotary(s.notaryService)
+	s.multiSigSignerEventSub = sqlsubscribers.NewERC20MultiSigSignerEvent(s.multiSigService)
+	s.keyRotationsSub = sqlsubscribers.NewKeyRotation(s.keyRotationsService)
+	s.ethereumKeyRotationsSub = sqlsubscribers.NewEthereumKeyRotation(s.ethereumKeyRotationsService)
+	s.nodeSub = sqlsubscribers.NewNode(s.nodeService)
+	s.pupSub = sqlsubscribers.NewProtocolUpgrade(s.protocolUpgradeService)
+	s.snapSub = sqlsubscribers.NewSnapshotData(s.coreSnapshotService)
+}

--- a/cmd/vegaone/start/start.go
+++ b/cmd/vegaone/start/start.go
@@ -1,0 +1,153 @@
+package start
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"code.vegaprotocol.io/vega/cmd/vegaone/config"
+	"code.vegaprotocol.io/vega/cmd/vegaone/start/dnode"
+	"code.vegaprotocol.io/vega/core/genesis"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+
+	tmtypes "github.com/tendermint/tendermint/types"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func Run(
+	vegaPaths paths.Paths,
+	tendermintHome string,
+	networkURL, network string,
+	passphraseFile string,
+	c *config.Config,
+) error {
+	log := configureLogger()
+	defer func() {
+		log.AtExit()
+	}()
+
+	core, err := newCore(log, vegaPaths, tendermintHome, networkURL, network, passphraseFile)
+	if err != nil {
+		return err
+	}
+
+	var dn *dnode.DN
+
+	// datanode is enabled, so start it up
+	if c.WithDatanode {
+		dn, err = dnode.New(log, vegaPaths)
+		if err != nil {
+			return fmt.Errorf("could not start datanode: %w", err)
+		}
+	}
+
+	go dn.Start()
+	go core.Start()
+
+	// wait for an error or user input to exit
+	wait(log, core, dn)
+
+	core.Stop()
+	if dn != nil {
+		dn.Stop()
+	}
+
+	return nil
+}
+
+func wait(log *logging.Logger, core *Core, dn *dnode.DN) error {
+	gracefulStop := make(chan os.Signal, 1)
+	signal.Notify(gracefulStop, syscall.SIGTERM, syscall.SIGINT)
+	if dn != nil {
+		for {
+			select {
+			case sig := <-gracefulStop:
+				log.Info("caught signal", logging.String("name", fmt.Sprintf("%+v", sig)))
+				return nil
+			case e := <-core.Err():
+				log.Error("problem starting blockchain", logging.Error(e))
+				return e
+			case <-core.Done():
+				// nothing to do
+				return nil
+			case <-dn.Done():
+				// nothing to do
+				return nil
+			}
+		}
+	}
+
+	for {
+		select {
+		case sig := <-gracefulStop:
+			log.Info("caught signal", logging.String("name", fmt.Sprintf("%+v", sig)))
+			return nil
+		case e := <-core.Err():
+			log.Error("problem starting blockchain", logging.Error(e))
+			return e
+		case <-core.ctx.Done():
+			// nothing to do
+			return nil
+		}
+	}
+}
+
+func configureLogger() *logging.Logger {
+	cfg := zap.Config{
+		Encoding:         "json",
+		Level:            zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:  "message",
+			LevelKey:    "level",
+			NameKey:     "scope",
+			EncodeLevel: zapcore.CapitalLevelEncoder,
+			TimeKey:     "time",
+			EncodeTime:  zapcore.RFC3339TimeEncoder,
+
+			CallerKey:    "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+	return logging.NewLoggerFromZapConfig(cfg)
+}
+
+func genesisDocHTTPFromURL(genesisFilePath string) (*tmtypes.GenesisDoc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, genesisFilePath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load genesis file from %s: %w", genesisFilePath, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load genesis file from %s: %w", genesisFilePath, err)
+	}
+	defer resp.Body.Close()
+	jsonGenesis, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, _, err := genesis.FromJSON(jsonGenesis)
+	if err != nil {
+		return nil, fmt.Errorf("invalid genesis file from %s: %w", genesisFilePath, err)
+	}
+
+	return doc, nil
+}
+
+func httpGenesisDocURLFromNetwork(networkSelect string) string {
+	return fmt.Sprintf(
+		"https://raw.githubusercontent.com/vegaprotocol/networks/master/%s",
+		networkSelect,
+	)
+}

--- a/cmd/vegaone/tendermint.go
+++ b/cmd/vegaone/tendermint.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+
+	tmcmd "github.com/tendermint/tendermint/cmd/cometbft/commands"
+	tmdebug "github.com/tendermint/tendermint/cmd/cometbft/commands/debug"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+)
+
+type tendermintCommand struct {
+	args []string
+}
+
+func newTendermint(args []string) *tendermintCommand {
+	return &tendermintCommand{args: args}
+}
+
+func (*tendermintCommand) Parse(args []string) error { return nil }
+
+func (i *tendermintCommand) Execute() error {
+	os.Args = i.args
+	rootCmd := tmcmd.RootCmd
+	rootCmd.AddCommand(
+		tmcmd.GenValidatorCmd,
+		tmcmd.InitFilesCmd,
+		tmcmd.ProbeUpnpCmd,
+		tmcmd.LightCmd,
+		tmcmd.ReplayCmd,
+		tmcmd.ReplayConsoleCmd,
+		tmcmd.ResetAllCmd,
+		tmcmd.ResetPrivValidatorCmd,
+		tmcmd.ResetStateCmd,
+		tmcmd.ShowValidatorCmd,
+		tmcmd.TestnetFilesCmd,
+		tmcmd.ShowNodeIDCmd,
+		tmcmd.GenNodeKeyCmd,
+		tmcmd.VersionCmd,
+		tmcmd.RollbackStateCmd,
+		tmcmd.CompactGoLevelDBCmd,
+		tmdebug.DebugCmd,
+		tmcli.NewCompletionCmd(rootCmd, true),
+	)
+
+	baseCmd := tmcli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv("$HOME/.vegaone/tendermint"))
+	if err := baseCmd.Execute(); err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/cmd/vegaone/tendermint.go
+++ b/cmd/vegaone/tendermint.go
@@ -48,5 +48,4 @@ func (i *tendermintCommand) Execute() error {
 	}
 
 	return nil
-
 }

--- a/cmd/vegaone/version.go
+++ b/cmd/vegaone/version.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"code.vegaprotocol.io/vega/version"
+)
+
+type versionCommand struct{}
+
+func newVersion() *versionCommand {
+	return &versionCommand{}
+}
+
+func (*versionCommand) Parse(_ []string) error {
+	return nil
+}
+
+func (*versionCommand) Execute() error {
+	fmt.Printf("Vega CLI %s (%s)\n", version.Get(), version.GetCommitHash())
+	return nil
+}

--- a/cmd/vegaone/wallet.go
+++ b/cmd/vegaone/wallet.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+
+	cmd "code.vegaprotocol.io/vega/cmd/vegawallet/commands"
+)
+
+type walletCommand struct {
+	args []string
+}
+
+func newWallet(args []string) *walletCommand {
+	return &walletCommand{args: args}
+}
+
+func (*walletCommand) Parse(args []string) error { return nil }
+
+func (i *walletCommand) Execute() error {
+	writer := &cmd.Writer{
+		Out: os.Stdout,
+		Err: os.Stderr,
+	}
+	cmd.Execute(writer)
+
+	return nil
+}

--- a/core/collateral/engine.go
+++ b/core/collateral/engine.go
@@ -1082,7 +1082,6 @@ func (e *Engine) GetPartyMargin(pos events.MarketPosition, asset, marketID strin
 		MarketPosition:  pos,
 		margin:          marAcc,
 		general:         genAcc,
-		lock:            nil,
 		bond:            bondAcc,
 		asset:           asset,
 		marketID:        marketID,

--- a/core/collateral/margins.go
+++ b/core/collateral/margins.go
@@ -23,7 +23,6 @@ type marginUpdate struct {
 	events.MarketPosition
 	margin          *types.Account
 	general         *types.Account
-	lock            *types.Account
 	bond            *types.Account
 	asset           string
 	marketID        string

--- a/core/config/encoding/encoding.go
+++ b/core/config/encoding/encoding.go
@@ -140,3 +140,25 @@ func (n *NodeMode) UnmarshalText(text []byte) error {
 func (n NodeMode) MarshalText() ([]byte, error) {
 	return []byte(n), nil
 }
+
+type DataNodeRetentionMode string
+
+const (
+	DataNodeRetentionModeStd         DataNodeRetentionMode = "standard"
+	DataNodeRetentionModeArchive     DataNodeRetentionMode = "archive"
+	DataNodeRetentionModeLite        DataNodeRetentionMode = "lite"
+	DataNodeRetentionModeUnsupported DataNodeRetentionMode = "unsupported"
+)
+
+func DataNodeRetentionModeFromString(s string) (DataNodeRetentionMode, error) {
+	switch DataNodeRetentionMode(s) {
+	case DataNodeRetentionModeStd:
+		return DataNodeRetentionModeStd, nil
+	case DataNodeRetentionModeArchive:
+		return DataNodeRetentionModeArchive, nil
+	case DataNodeRetentionModeLite:
+		return DataNodeRetentionModeLite, nil
+	default:
+		return DataNodeRetentionModeUnsupported, fmt.Errorf("%s is not a valid data node retention mode, expected [standard, archive, lite]", s)
+	}
+}

--- a/datanode/broker/socket_server.go
+++ b/datanode/broker/socket_server.go
@@ -72,7 +72,8 @@ func (s socketServer) Listen() error {
 		net.JoinHostPort(s.config.SocketConfig.IP, fmt.Sprintf("%d", s.config.SocketConfig.Port)),
 	)
 
-	listenOptions := map[string]interface{}{mangos.OptionMaxRecvSize: 0}
+	// listenOptions := map[string]interface{}{mangos.OptionMaxRecvSize: 0}
+	listenOptions := map[string]interface{}{}
 
 	listener, err := s.sock.NewListener(addr, listenOptions)
 	if err != nil {

--- a/datanode/broker/sqlstore_broker.go
+++ b/datanode/broker/sqlstore_broker.go
@@ -110,7 +110,10 @@ func NewSQLStoreBroker(
 	return b
 }
 
-func (b *SQLStoreBroker) Receive(ctx context.Context) error {
+func (b *SQLStoreBroker) Receive(ctx context.Context) (errr error) {
+	defer func() {
+		panic(fmt.Sprintf("%v", errr))
+	}()
 	if err := b.eventSource.Listen(); err != nil {
 		return err
 	}

--- a/datanode/networkhistory/snapshot/service.go
+++ b/datanode/networkhistory/snapshot/service.go
@@ -24,7 +24,10 @@ type Service struct {
 	migrateSchemaDownToVersion func(version int64) error
 }
 
-func NewSnapshotService(log *logging.Logger, config Config, connPool *pgxpool.Pool,
+func NewSnapshotService(
+	log *logging.Logger,
+	config Config,
+	connPool *pgxpool.Pool,
 	snapshotsCopyToPath string,
 	migrateDatabaseToVersion func(version int64) error,
 	migrateSchemaDownToVersion func(version int64) error,

--- a/logging/log.go
+++ b/logging/log.go
@@ -247,6 +247,16 @@ func newLoggerFromConfig(config Config) *Logger {
 	return New(zaplogger, &zapconfig, config.Environment, "root")
 }
 
+func NewLoggerFromZapConfig(cfg zap.Config) *Logger {
+	zaplogger, err := cfg.Build()
+	if err != nil {
+		panic(err)
+	}
+	zaplogger = zaplogger.Named("root")
+	return New(zaplogger, &cfg, "production", "root")
+
+}
+
 // NewDevLogger creates a new logger suitable for development environments.
 func NewDevLogger() *Logger {
 	config := Config{

--- a/logging/log.go
+++ b/logging/log.go
@@ -254,7 +254,6 @@ func NewLoggerFromZapConfig(cfg zap.Config) *Logger {
 	}
 	zaplogger = zaplogger.Named("root")
 	return New(zaplogger, &cfg, "production", "root")
-
 }
 
 // NewDevLogger creates a new logger suitable for development environments.


### PR DESCRIPTION
I've been playing with the idea of a simpler command line for the node in general a few months ago, and decided to play with it tonight too. Opened a PR  just to show things around, nothing crazy, but basically it's another command line, which is meant to be simpler. basically less option, less commands, less configuration to handle, both the core and the datanode running in the same binary etc.
Connecting to an existing network is pretty much as easy as this:
```
$ vegaone init -embed-postgres -with-datanode -chainid="vega-stagnet1-202303281617" -mode=full
$ vegaone start -network-url="https://raw.githubusercontent.com/vegaprotocol/networks-internal/main/stagnet1/genesis.json"
```

Now obviously you need to add the seeds node in the tendermint config in between, But I can imagine that could be passed in the init too.
Also I think having easy access to tendermint statesync from the command line could be useful, we could also query all the information we need from the peers, I can imagine the init / start command to be extended with these parameters:
```
$ vegaone init -embed-postgres -with-datanode -chainid="vega-stagnet1-202303281617" -seeds="6a473fa0c9571deb3c494c9ac64d4dda41adde3f@n01.stagnet1.vega.xyz:26656,ca6e178a32324e07893049f1090077b520912803@n02.stagnet1.vega.xyz:26656" -use-comet-statesync -mode=full
```
Any thoughts? there's nothing to be done about it really, just wondering if it's worth exploring to make things a bit simpler