### PR TITLE
fix: continuous aggregate time period after network history load and load history and current state in one transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - [7956](https://github.com/vegaprotocol/vega/issues/7956) - Floor negative slippage per unit at 0
 - [7964](https://github.com/vegaprotocol/vega/issues/7964) - Use mark price for all margin calculations
 - [8003](https://github.com/vegaprotocol/vega/issues/8003) - Fix `ListGovernanceData` does not honour `TYPE_ALL`
+- [8057](https://github.com/vegaprotocol/vega/issues/8057) - Load history and current state in one transaction   
+- [8058](https://github.com/vegaprotocol/vega/issues/8058) - Continuous aggregates should be updated according to the watermark and span of history loaded   
 - [8001](https://github.com/vegaprotocol/vega/issues/8001) - Fix issues with order subscriptions
 - [7980](https://github.com/vegaprotocol/vega/issues/7980) - Visor - prevent panic when auto install configuration is missing assets
 - [7995](https://github.com/vegaprotocol/vega/issues/7995) - Validate order price input to `estimateFee` and `estimateMargin`

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -95,7 +95,7 @@ func (cmd *loadCmd) Execute(args []string) error {
 	snapshotService, err := snapshot.NewSnapshotService(log, cmd.Config.NetworkHistory.Snapshot, connPool,
 		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
 		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
-			if err = sqlstore.MigrateToSchemaVersion(log, cmd.Config.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
+			if err = sqlstore.MigrateUpToSchemaVersion(log, cmd.Config.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
 				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
 			}
 			return nil

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -331,7 +331,7 @@ func (l *NodeCommand) initialiseNetworkHistory(preLog *logging.Logger, connConfi
 	l.snapshotService, err = snapshot.NewSnapshotService(snapshotServiceLog, l.conf.NetworkHistory.Snapshot,
 		networkHistoryPool, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
 		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
-			if err = sqlstore.MigrateToSchemaVersion(preNetworkHistoryLog, l.conf.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
+			if err = sqlstore.MigrateUpToSchemaVersion(preNetworkHistoryLog, l.conf.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
 				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
 			}
 			return nil

--- a/datanode/entities/block.go
+++ b/datanode/entities/block.go
@@ -13,10 +13,7 @@
 package entities
 
 import (
-	"encoding/hex"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"code.vegaprotocol.io/vega/core/events"
 )
@@ -30,19 +27,4 @@ type Block struct {
 	VegaTime time.Time
 	Height   int64
 	Hash     []byte
-}
-
-func BlockFromTimeUpdate(te TimeUpdateEvent) (*Block, error) {
-	hash, err := hex.DecodeString(te.TraceID())
-	if err != nil {
-		return nil, errors.Wrapf(err, "Trace ID is not valid hex string, trace ID:%s", te.TraceID())
-	}
-
-	// Postgres only stores timestamps in microsecond resolution
-	block := Block{
-		VegaTime: te.Time().Truncate(time.Microsecond),
-		Hash:     hash,
-		Height:   te.BlockNr(),
-	}
-	return &block, err
 }

--- a/datanode/networkhistory/snapshot/database_meta_data_test.go
+++ b/datanode/networkhistory/snapshot/database_meta_data_test.go
@@ -1,0 +1,34 @@
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractIntervalFromViewDefinition(t *testing.T) {
+	viewDefinition := ` SELECT balances.account_id,
+	time_bucket('01:00:00'::interval, balances.vega_time) AS bucket,
+		last(balances.balance, balances.vega_time) AS balance,
+		last(balances.tx_hash, balances.vega_time) AS tx_hash,
+		last(balances.vega_time, balances.vega_time) AS vega_time
+	FROM balances
+	GROUP BY balances.account_id, (time_bucket('01:00:00'::interval, balances.vega_time));`
+
+	interval, err := extractIntervalFromViewDefinition(viewDefinition)
+	require.NoError(t, err)
+	assert.Equal(t, "01:00:00", interval)
+
+	viewDefinition = ` SELECT balances.account_id,
+	time_bucket('1 day'::interval, balances.vega_time) AS bucket,
+		last(balances.balance, balances.vega_time) AS balance,
+		last(balances.tx_hash, balances.vega_time) AS tx_hash,
+		last(balances.vega_time, balances.vega_time) AS vega_time
+	FROM balances
+	GROUP BY balances.account_id, (time_bucket('1 day'::interval, balances.vega_time));`
+
+	interval, err = extractIntervalFromViewDefinition(viewDefinition)
+	require.NoError(t, err)
+	assert.Equal(t, "1 day", interval)
+}

--- a/datanode/sqlstore/connection_source.go
+++ b/datanode/sqlstore/connection_source.go
@@ -176,6 +176,10 @@ func (s *ConnectionSource) Close() {
 }
 
 func (s *ConnectionSource) wrapE(err error) error {
+	return wrapE(err)
+}
+
+func wrapE(err error) error {
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return entities.ErrNotFound

--- a/datanode/sqlstore/sqlstore.go
+++ b/datanode/sqlstore/sqlstore.go
@@ -108,7 +108,7 @@ func MigrateToLatestSchema(log *logging.Logger, config Config) error {
 	return nil
 }
 
-func MigrateToSchemaVersion(log *logging.Logger, config Config, version int64, fs fs.FS) error {
+func MigrateUpToSchemaVersion(log *logging.Logger, config Config, version int64, fs fs.FS) error {
 	goose.SetBaseFS(fs)
 	goose.SetLogger(log.Named("db migration").GooseLogger())
 	goose.SetVerbose(bool(config.VerboseMigration))

--- a/datanode/sqlstore/sqlstore_test.go
+++ b/datanode/sqlstore/sqlstore_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 var (
+	config           sqlstore.Config
 	connectionSource *sqlstore.ConnectionSource
 	testDBPort       int
 	testDBSocketDir  string
@@ -52,11 +53,8 @@ func TestMain(m *testing.M) {
 		testDBPort = cfg.ConnectionConfig.Port
 		testDBSocketDir = cfg.ConnectionConfig.SocketDir
 		connectionSource = source
+		config = cfg
 	}, postgresRuntimePath, sqlstore.EmbedMigrations)
-}
-
-func NewTestConfig() sqlstore.Config {
-	return databasetest.NewTestConfig(testDBPort, "", testDBSocketDir)
 }
 
 func generateTxHash() entities.TxHash {


### PR DESCRIPTION
closes #8057
closes #8058 

After network history load, caggs are updated based on the highwater mark of the cagg and the most recent to time that contains a full buckets worth of data.

History data and current state data for a given schema version is now loaded in one transaction to prevent database being left in an inconsistent state should the load fail. 