### PR TITLE
Expose margin and liquidation price calculations for new API endpoint

### DIFF
--- a/core/risk/engine_test.go
+++ b/core/risk/engine_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"testing"
 	"time"
 
@@ -748,6 +749,586 @@ func testInitialMarginRequirement(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, riskevt)
 	assert.True(t, riskevt.MarginLevels().InitialMargin.EQ(num.NewUint(uint64(initialMarginAuction))))
+}
+
+func TestMaintenanceMarign(t *testing.T) {
+	relativeTolerance := num.DecimalFromFloat(0.000001)
+
+	testCases := []struct {
+		markPrice               float64
+		positionFactor          float64
+		positionSize            int64
+		buyOrders               []*risk.OrderInfo
+		sellOrders              []*risk.OrderInfo
+		linearSlippageFactor    float64
+		quadraticSlippageFactor float64
+		riskFactorLong          float64
+		riskFactorShort         float64
+		auction                 bool
+	}{
+		{
+			markPrice:      123.4,
+			positionFactor: 1,
+			positionSize:   40000,
+			buyOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(0), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(0), false},
+			},
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.1,
+			auction:                 false,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 10,
+			positionSize:   40000,
+			buyOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(111.1), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(133.3), false},
+			},
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.1,
+			auction:                 true,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 10,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(111.1), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(133.3), false},
+			},
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.1,
+			auction:                 true,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 10,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{10000, num.NewDecimalFromFloat(111.1), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{30000, num.NewDecimalFromFloat(133.3), false},
+			},
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.2,
+			auction:                 false,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 100,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{40000, num.NewDecimalFromFloat(111.1), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{30000, num.NewDecimalFromFloat(133.3), false},
+			},
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.1,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.2,
+			auction:                 false,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 100,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{10000, num.NewDecimalFromFloat(111.4), false},
+				{30000, num.NewDecimalFromFloat(111), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{10000, num.NewDecimalFromFloat(133.9), false},
+				{20000, num.NewDecimalFromFloat(133.0), false},
+			},
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.1,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.2,
+			auction:                 false,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 100,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{10000, num.NewDecimalFromFloat(111.4), false},
+				{30000, num.NewDecimalFromFloat(111), false},
+				{20000, num.NewDecimalFromFloat(0), true},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{10000, num.NewDecimalFromFloat(133.9), false},
+				{20000, num.NewDecimalFromFloat(133.0), false},
+				{30000, num.NewDecimalFromFloat(0), true},
+			},
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.1,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.2,
+			auction:                 false,
+		},
+	}
+
+	for i, tc := range testCases {
+		markPrice := num.DecimalFromFloat(tc.markPrice)
+		positionFactor := num.DecimalFromFloat(tc.positionFactor)
+		buySumProduct := num.DecimalZero()
+		sellSumProduct := num.DecimalZero()
+		buySize := int64(0)
+		sellSize := int64(0)
+
+		linearSlippageFactor := num.DecimalFromFloat(tc.linearSlippageFactor)
+		quadraticSlippageFactor := num.DecimalFromFloat(tc.quadraticSlippageFactor)
+		riskFactorLong := num.DecimalFromFloat(tc.riskFactorLong)
+		riskFactorShort := num.DecimalFromFloat(tc.riskFactorShort)
+
+		positionSize := tc.positionSize
+		for _, o := range tc.buyOrders {
+			s := int64(o.Size)
+			if o.IsMarketOrder {
+				positionSize += s
+			} else {
+				buySize += s
+				buySumProduct = buySumProduct.Add(num.DecimalFromInt64(s).Mul(o.Price))
+			}
+		}
+
+		for _, o := range tc.sellOrders {
+			s := int64(o.Size)
+			if o.IsMarketOrder {
+				positionSize -= s
+			} else {
+				sellSize += s
+				sellSumProduct = sellSumProduct.Add(num.DecimalFromInt64(s).Mul(o.Price))
+			}
+		}
+
+		openVolume := num.DecimalFromInt64(positionSize).Div(positionFactor).Abs()
+		expectedMarginShort, expectedMarginLong := num.DecimalZero(), num.DecimalZero()
+		slippage := markPrice.Mul(openVolume.Mul(linearSlippageFactor).Add(openVolume.Mul(openVolume).Mul(quadraticSlippageFactor)))
+
+		if positionSize-sellSize < 0 {
+			expectedMarginShort = slippage.Add(openVolume.Mul(markPrice).Mul(riskFactorShort))
+			orders := num.DecimalFromInt64(sellSize).Div(positionFactor).Abs().Mul(riskFactorShort)
+			if tc.auction {
+				expectedMarginShort = expectedMarginShort.Add(orders.Mul(sellSumProduct))
+			} else {
+				expectedMarginShort = expectedMarginShort.Add(orders.Mul(markPrice))
+			}
+		}
+		if positionSize+buySize > 0 {
+			expectedMarginLong = slippage.Add(openVolume.Mul(markPrice).Mul(riskFactorLong))
+			orders := num.DecimalFromInt64(buySize).Div(positionFactor).Abs().Mul(riskFactorLong)
+			if tc.auction {
+				expectedMarginLong = expectedMarginLong.Add(orders.Mul(buySumProduct))
+			} else {
+				expectedMarginLong = expectedMarginLong.Add(orders.Mul(markPrice))
+			}
+		}
+		expectedMargin := num.MaxD(expectedMarginShort, expectedMarginLong)
+
+		actualMargin := risk.CalculateMaintenanceMarginWithSlippageFactors(tc.positionSize, tc.buyOrders, tc.sellOrders, markPrice, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort, tc.auction)
+
+		require.True(t, expectedMargin.Div(actualMargin).Sub(num.DecimalOne()).Abs().LessThan(relativeTolerance), fmt.Sprintf("Test case %v: expectedMargin=%s, actualMargin:=%s", i+1, expectedMargin, actualMargin))
+	}
+}
+
+func TestLiquidationPriceWithNoOrders(t *testing.T) {
+	relativeTolerance := num.DecimalFromFloat(0.000001)
+
+	testCases := []struct {
+		markPrice               float64
+		positionFactor          float64
+		positionSize            int64
+		linearSlippageFactor    float64
+		quadraticSlippageFactor float64
+		riskFactorLong          float64
+		riskFactorShort         float64
+		collateralFactor        float64
+		expectError             bool
+	}{
+		{
+			markPrice:               123.4,
+			positionFactor:          1,
+			positionSize:            40000,
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralFactor:        1.7,
+		},
+		{
+			markPrice:               1234.5,
+			positionFactor:          10,
+			positionSize:            40000,
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralFactor:        1.1,
+		},
+		{
+			markPrice:               1234.5,
+			positionFactor:          100,
+			positionSize:            -40000,
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.01,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralFactor:        3,
+		},
+		{
+			markPrice:               1234.5,
+			positionFactor:          1000,
+			positionSize:            -40000,
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.1,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralFactor:        0.2,
+		},
+		{
+			markPrice:               1,
+			positionFactor:          1,
+			positionSize:            1,
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          1,
+			riskFactorShort:         1,
+			collateralFactor:        2.5,
+			expectError:             true,
+		},
+		{
+			markPrice:               110,
+			positionFactor:          1,
+			positionSize:            41,
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.01,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralFactor:        1000,
+		},
+	}
+
+	for i, tc := range testCases {
+		markPrice := num.DecimalFromFloat(tc.markPrice)
+		positionFactor := num.DecimalFromFloat(tc.positionFactor)
+
+		linearSlippageFactor := num.DecimalFromFloat(tc.linearSlippageFactor)
+		quadraticSlippageFactor := num.DecimalFromFloat(tc.quadraticSlippageFactor)
+		riskFactorLong := num.DecimalFromFloat(tc.riskFactorLong)
+		riskFactorShort := num.DecimalFromFloat(tc.riskFactorShort)
+
+		maintenanceMargin := risk.CalculateMaintenanceMarginWithSlippageFactors(tc.positionSize, nil, nil, markPrice, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort, false)
+
+		sMargi := maintenanceMargin.String()
+		fmt.Print(sMargi)
+
+		liquidationPrice, _, _, err := risk.CalculateLiquidationPriceWithSlippageFactors(tc.positionSize, nil, nil, markPrice, maintenanceMargin, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+		if tc.expectError {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+
+		liquidationPriceFp := liquidationPrice.InexactFloat64()
+		require.GreaterOrEqual(t, liquidationPriceFp, 0.0)
+
+		require.True(t, markPrice.Div(liquidationPrice).Sub(num.DecimalOne()).Abs().LessThan(relativeTolerance))
+
+		collateral := maintenanceMargin.Mul(num.DecimalFromFloat(tc.collateralFactor))
+
+		liquidationPrice, _, _, err = risk.CalculateLiquidationPriceWithSlippageFactors(tc.positionSize, nil, nil, markPrice, collateral, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+		require.NoError(t, err)
+		require.False(t, liquidationPrice.IsNegative())
+
+		marginAtLiquidationPrice := risk.CalculateMaintenanceMarginWithSlippageFactors(tc.positionSize, nil, nil, liquidationPrice, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort, false)
+		openVolume := num.DecimalFromInt64(tc.positionSize).Div(positionFactor)
+		mtmLoss := liquidationPrice.Sub(markPrice).Mul(openVolume)
+		collateralAfterLoss := collateral.Add(mtmLoss)
+
+		sLiquidationPrice := liquidationPrice.String()
+		sLoss := mtmLoss.String()
+		sCollat := collateral.String()
+		sMargin := marginAtLiquidationPrice.String()
+		sCollatAfterLoss := collateralAfterLoss.String()
+
+		fmt.Print(sLiquidationPrice)
+		fmt.Print(sLoss)
+		fmt.Print(sCollat)
+		fmt.Print(sMargin)
+		fmt.Print(sCollatAfterLoss)
+
+		relativeDifference := collateralAfterLoss.Div(marginAtLiquidationPrice).Sub(num.DecimalOne()).Abs().String()
+		fmt.Print(relativeDifference)
+
+		if !marginAtLiquidationPrice.IsZero() {
+			require.True(t, collateralAfterLoss.Div(marginAtLiquidationPrice).Sub(num.DecimalOne()).Abs().LessThan(relativeTolerance), fmt.Sprintf("Test case %v: collateralAfterLoss=%s, marginAtLiquidationPrice:=%s", i+1, collateralAfterLoss, marginAtLiquidationPrice))
+		} else {
+			require.True(t, liquidationPrice.IsZero(), fmt.Sprintf("Test case %v:", i+1))
+			require.True(t, collateralAfterLoss.IsNegative(), fmt.Sprintf("Test case %v:", i+1))
+		}
+	}
+}
+
+func TestLiquidationPriceWithOrders(t *testing.T) {
+	testCases := []struct {
+		markPrice               float64
+		positionFactor          float64
+		positionSize            int64
+		buyOrders               []*risk.OrderInfo
+		sellOrders              []*risk.OrderInfo
+		linearSlippageFactor    float64
+		quadraticSlippageFactor float64
+		riskFactorLong          float64
+		riskFactorShort         float64
+		collateralAvailable     float64
+	}{
+		{
+			markPrice:      123.4,
+			positionFactor: 1,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{1, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0,
+			quadraticSlippageFactor: 0,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     100,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 1,
+			positionSize:   0,
+			buyOrders: []*risk.OrderInfo{
+				{39, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{40, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0.5,
+			quadraticSlippageFactor: 0.01,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 1,
+			positionSize:   20,
+			buyOrders: []*risk.OrderInfo{
+				{39, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{40, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 100,
+			positionSize:   -2000,
+			buyOrders: []*risk.OrderInfo{
+				{3900, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{4000, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 0.1,
+			positionSize:   -2,
+			buyOrders: []*risk.OrderInfo{
+				{3, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{4, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      101.2,
+			positionFactor: 100,
+			positionSize:   -2000,
+			buyOrders: []*risk.OrderInfo{
+				{3900, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{4000, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      144.5,
+			positionFactor: 100,
+			positionSize:   -2000,
+			buyOrders: []*risk.OrderInfo{
+				{3900, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{4000, num.NewDecimalFromFloat(130), false},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 100,
+			positionSize:   -2000,
+			buyOrders: []*risk.OrderInfo{
+				{1800, num.NewDecimalFromFloat(100), false},
+				{1700, num.NewDecimalFromFloat(110), false},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{3000, num.NewDecimalFromFloat(120), false},
+				{2000, num.NewDecimalFromFloat(130), false},
+				{1000, num.NewDecimalFromFloat(140), false},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+		{
+			markPrice:      123.4,
+			positionFactor: 100,
+			positionSize:   -2000,
+			buyOrders: []*risk.OrderInfo{
+				{1800, num.NewDecimalFromFloat(100), false},
+				{1700, num.NewDecimalFromFloat(0), true},
+			},
+			sellOrders: []*risk.OrderInfo{
+				{3000, num.NewDecimalFromFloat(120), false},
+				{2000, num.NewDecimalFromFloat(130), false},
+				{1000, num.NewDecimalFromFloat(0), true},
+			},
+			linearSlippageFactor:    0.01,
+			quadraticSlippageFactor: 0.000001,
+			riskFactorLong:          0.1,
+			riskFactorShort:         0.11,
+			collateralAvailable:     50800,
+		},
+	}
+
+	for i, tc := range testCases {
+		markPrice := num.DecimalFromFloat(tc.markPrice)
+		positionFactor := num.DecimalFromFloat(tc.positionFactor)
+		collateral := num.DecimalFromFloat(tc.collateralAvailable)
+
+		linearSlippageFactor := num.DecimalFromFloat(tc.linearSlippageFactor)
+		quadraticSlippageFactor := num.DecimalFromFloat(tc.quadraticSlippageFactor)
+		riskFactorLong := num.DecimalFromFloat(tc.riskFactorLong)
+		riskFactorShort := num.DecimalFromFloat(tc.riskFactorShort)
+
+		positionOnly, withBuy, withSell, err := risk.CalculateLiquidationPriceWithSlippageFactors(tc.positionSize, tc.buyOrders, tc.sellOrders, markPrice, collateral, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+		require.NoError(t, err, fmt.Sprintf("Test case %v:", i+1))
+
+		sPositionOnly := positionOnly.String()
+		sWithBuy := withBuy.String()
+		sWithSell := withSell.String()
+
+		t.Logf("positionOnly=%s, withBuy=%s, withSell=%s", sPositionOnly, sWithBuy, sWithSell)
+
+		if tc.positionSize == 0 {
+			require.True(t, positionOnly.IsZero(), fmt.Sprintf("Test case %v:", i+1))
+		}
+		if tc.positionSize > 0 {
+			require.True(t, withBuy.GreaterThanOrEqual(positionOnly), fmt.Sprintf("Test case %v:", i+1))
+		}
+		if tc.positionSize < 0 {
+			require.True(t, withSell.LessThanOrEqual(positionOnly), fmt.Sprintf("Test case %v:", i+1))
+		}
+
+		sort.Slice(tc.buyOrders, func(i, j int) bool {
+			return tc.buyOrders[i].Price.GreaterThan(tc.buyOrders[j].Price)
+		})
+		sort.Slice(tc.sellOrders, func(i, j int) bool {
+			return tc.sellOrders[i].Price.LessThan(tc.sellOrders[j].Price)
+		})
+
+		newPositionSize := tc.positionSize
+		mtmDelta := num.DecimalZero()
+		lastMarkPrice := markPrice
+		for _, o := range tc.buyOrders {
+			if o.Price.LessThan(withBuy) {
+				break
+			}
+			mtmDelta = mtmDelta.Add(num.DecimalFromInt64(newPositionSize).Mul(o.Price.Sub(lastMarkPrice)))
+			newPositionSize += int64(o.Size)
+			lastMarkPrice = o.Price
+		}
+		collateralAfterMtm := collateral.Add(mtmDelta)
+		newPositionOnly, _, _, err := risk.CalculateLiquidationPriceWithSlippageFactors(newPositionSize, nil, nil, lastMarkPrice, collateralAfterMtm, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+		require.NoError(t, err, fmt.Sprintf("Test case %v:", i+1))
+		require.True(t, withBuy.Equal(newPositionOnly), fmt.Sprintf("Test case %v: withBuy=%s, newPositionOnly=%s", i+1, withBuy.String(), newPositionOnly.String()))
+
+		if tc.positionSize < 0 && newPositionSize > 0 {
+			require.True(t, withBuy.LessThan(positionOnly), fmt.Sprintf("Test case %v:", i+1))
+		}
+
+		newPositionSize = tc.positionSize
+		mtmDelta = num.DecimalZero()
+		lastMarkPrice = markPrice
+		for _, o := range tc.sellOrders {
+			if o.Price.GreaterThan(withSell) {
+				break
+			}
+			mtmDelta = mtmDelta.Add(num.DecimalFromInt64(newPositionSize).Div(positionFactor).Mul(o.Price.Sub(lastMarkPrice)))
+			newPositionSize -= int64(o.Size)
+			lastMarkPrice = o.Price
+		}
+		collateralAfterMtm = collateral.Add(mtmDelta)
+		newPositionOnly, _, _, err = risk.CalculateLiquidationPriceWithSlippageFactors(newPositionSize, nil, nil, lastMarkPrice, collateralAfterMtm, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+		require.NoError(t, err, fmt.Sprintf("Test case %v:", i+1))
+		require.True(t, withSell.Equal(newPositionOnly), fmt.Sprintf("Test case %v: withSell=%s, newPositionOnly=%s", i+1, withSell.String(), newPositionOnly.String()))
+
+		if tc.positionSize > 0 && newPositionSize < 0 {
+			require.True(t, withSell.GreaterThan(positionOnly), fmt.Sprintf("Test case %v:", i+1))
+		}
+	}
 }
 
 func getTestEngine(t *testing.T) *testEngine {

--- a/core/risk/liquidation_calculation.go
+++ b/core/risk/liquidation_calculation.go
@@ -1,0 +1,106 @@
+package risk
+
+import (
+	"fmt"
+	"sort"
+
+	"code.vegaprotocol.io/vega/libs/num"
+)
+
+type OrderInfo struct {
+	Size          uint64
+	Price         num.Decimal
+	IsMarketOrder bool
+}
+
+func CalculateLiquidationPriceWithSlippageFactors(sizePosition int64, buyOrders, sellOrders []*OrderInfo, currentPrice, collateralAvailable num.Decimal, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort num.Decimal) (liquidationPriceForOpenVolume, liquidationPriceWithSellOrders, liquidationPriceWithBuyOrders num.Decimal, err error) {
+	openVolume := num.DecimalFromInt64(sizePosition).Div(positionFactor)
+
+	if sizePosition != 0 {
+		liquidationPriceForOpenVolume, err = calculateLiquidationPrice(openVolume, currentPrice, collateralAvailable, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+	}
+
+	liquidationPriceWithSellOrders, liquidationPriceWithBuyOrders = liquidationPriceForOpenVolume, liquidationPriceForOpenVolume
+	if err != nil || len(buyOrders)+len(sellOrders) == 0 {
+		return
+	}
+
+	// assume market orders will trade immediately
+	for _, o := range buyOrders {
+		if o.IsMarketOrder {
+			o.Price = currentPrice
+		}
+	}
+
+	for _, o := range sellOrders {
+		if o.IsMarketOrder {
+			o.Price = currentPrice
+		}
+	}
+
+	sort.Slice(buyOrders, func(i, j int) bool {
+		return buyOrders[i].Price.GreaterThan(buyOrders[j].Price)
+	})
+	sort.Slice(sellOrders, func(i, j int) bool {
+		return sellOrders[i].Price.LessThan(sellOrders[j].Price)
+	})
+
+	liquidationPriceWithBuyOrders, err = calculateLiquidationPriceWithOrders(liquidationPriceForOpenVolume, buyOrders, true, openVolume, currentPrice, collateralAvailable, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+	if err != nil {
+		liquidationPriceWithBuyOrders = num.DecimalZero()
+		return
+	}
+	liquidationPriceWithSellOrders, err = calculateLiquidationPriceWithOrders(liquidationPriceForOpenVolume, sellOrders, false, openVolume, currentPrice, collateralAvailable, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+	if err != nil {
+		liquidationPriceWithSellOrders = num.DecimalZero()
+		return
+	}
+
+	return liquidationPriceForOpenVolume, liquidationPriceWithBuyOrders, liquidationPriceWithSellOrders, nil
+}
+
+func calculateLiquidationPrice(openVolume num.Decimal, currentPrice, collateralAvailable num.Decimal, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort num.Decimal) (num.Decimal, error) {
+	rf := riskFactorLong
+	if openVolume.IsNegative() {
+		rf = riskFactorShort
+	}
+
+	denominator := calculateSlippageFactor(openVolume, linearSlippageFactor, quadraticSlippageFactor).Add(openVolume.Abs().Mul(rf)).Sub(openVolume)
+	if denominator.IsZero() {
+		return num.DecimalZero(), fmt.Errorf("liquidation price not defined")
+	}
+
+	ret := collateralAvailable.Sub(openVolume.Mul(currentPrice)).Div(denominator)
+	if ret.IsNegative() {
+		return num.DecimalZero(), nil
+	}
+	return ret, nil
+}
+
+func calculateLiquidationPriceWithOrders(liquidationPriceOpenVolumeOnly num.Decimal, orders []*OrderInfo, buySide bool, openVolume num.Decimal, currentPrice, collateralAvailable num.Decimal, positionFactor, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort num.Decimal) (num.Decimal, error) {
+	var err error
+	liquidationPrice := liquidationPriceOpenVolumeOnly
+	exposureWithOrders := openVolume
+	collateralWithOrders := collateralAvailable
+	for _, o := range orders {
+		if !exposureWithOrders.IsZero() && ((buySide && exposureWithOrders.IsPositive() && o.Price.LessThan(liquidationPrice)) || (!buySide && exposureWithOrders.IsNegative() && o.Price.GreaterThan(liquidationPrice))) {
+			// party gets marked for closeout before this order gets a chance to fill
+			break
+		}
+		mtm := exposureWithOrders.Mul(o.Price.Sub(currentPrice))
+		currentPrice = o.Price
+
+		collateralWithOrders = collateralWithOrders.Add(mtm)
+		if buySide {
+			exposureWithOrders = exposureWithOrders.Add(num.DecimalFromInt64(int64(o.Size)).Div(positionFactor))
+		} else {
+			exposureWithOrders = exposureWithOrders.Sub(num.DecimalFromInt64(int64(o.Size)).Div(positionFactor))
+		}
+
+		liquidationPrice, err = calculateLiquidationPrice(exposureWithOrders, o.Price, collateralWithOrders, linearSlippageFactor, quadraticSlippageFactor, riskFactorLong, riskFactorShort)
+		if err != nil {
+			return num.DecimalZero(), err
+		}
+	}
+	return liquidationPrice, nil
+}


### PR DESCRIPTION
Expose margin and liquidation price calculations.

Margin calculations are duplicated for now to avoid risk of introducing unintentional changes prior to launch, will add a refactoring ticket once this gets merged.