### PR TITLE
feat: rolling back data node to previous block height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🛠 Improvements
 - [8030](https://github.com/vegaprotocol/vega/issues/8030) - Add `API` for fetching `CSV` data from network history.
 - [7943](https://github.com/vegaprotocol/vega/issues/7943) - Add version to network file to be future-proof.
+- [7759](https://github.com/vegaprotocol/vega/issues/7759) - Support for rolling back data node to a previous network history segment 
 - [7505](https://github.com/vegaprotocol/vega/issues/7505) - `Datanode` batcher statistics
 - [8045](https://github.com/vegaprotocol/vega/issues/8045) - Fix bug in handling internal sources data.
 - [7843](https://github.com/vegaprotocol/vega/issues/7843) - Report partial batch market instruction processing failure

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
 
 	vgterm "code.vegaprotocol.io/vega/libs/term"
 
@@ -27,9 +30,9 @@ type loadCmd struct {
 	config.VegaHomeFlag
 	config.Config
 
-	Force                       bool   `short:"f" long:"force" description:"do not prompt for confirmation"`
-	WipeExistingData            bool   `short:"w" long:"wipe-existing-data" description:"Erase all data from the node before loading from network history"`
-	WithIndexesAndOrderTriggers string `short:"i" long:"with-indexes-and-order-triggers" required:"false" description:"if true the load will not drop indexes and order triggers when loading data, this is usually the best option when appending new segments onto existing datanode data" choice:"default" choice:"true" choice:"false" default:"default"`
+	Force             bool   `short:"f" long:"force" description:"do not prompt for confirmation"`
+	WipeExistingData  bool   `short:"w" long:"wipe-existing-data" description:"Erase all data from the node before loading from network history"`
+	OptimiseForAppend string `short:"a" long:"optimise-for-append" required:"false" description:"if true the load will be optimised for appending new segments onto existing datanode data, this is the default if the node already contains data" choice:"default" choice:"true" choice:"false" default:"default"`
 }
 
 func (cmd *loadCmd) Execute(args []string) error {
@@ -92,37 +95,19 @@ func (cmd *loadCmd) Execute(args []string) error {
 		}
 	}
 
-	snapshotService, err := snapshot.NewSnapshotService(log, cmd.Config.NetworkHistory.Snapshot, connPool,
-		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
-		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
-			if err = sqlstore.MigrateUpToSchemaVersion(log, cmd.Config.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
-				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
-			}
-			return nil
-		})
-	if err != nil {
-		return fmt.Errorf("failed to create snapshot service: %w", err)
-	}
-
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
-
-	networkHistoryStore, err := store.New(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
-		false, cmd.Config.MaxMemoryPercent)
+	networkHistoryService, err := createNetworkHistoryService(ctx, log, cmd.Config, connPool, vegaPaths)
 	if err != nil {
-		return fmt.Errorf("failed to create network history store:%w", err)
+		return fmt.Errorf("failed to created network history service: %w", err)
 	}
-	defer networkHistoryStore.Stop()
-
-	networkHistoryService, err := networkhistory.NewWithStore(ctx, log, cmd.Config.ChainID, cmd.Config.NetworkHistory,
-		connPool, snapshotService, networkHistoryStore, cmd.Config.API.Port,
-		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
-		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo))
-	if err != nil {
-		return fmt.Errorf("failed new networkhistory service:%w", err)
-	}
+	defer networkHistoryService.Stop()
 
 	segments, err := networkHistoryService.ListAllHistorySegments()
+	if err != nil {
+		return fmt.Errorf("failed to list history segments: %w", err)
+	}
+
 	mostRecentContiguousHistory := networkhistory.GetMostRecentContiguousHistory(segments)
 
 	if mostRecentContiguousHistory == nil {
@@ -194,24 +179,26 @@ func (cmd *loadCmd) Execute(args []string) error {
 		}
 	}
 
-	withIndexesAndOrderTriggers := false
-	switch cmd.WithIndexesAndOrderTriggers {
+	optimiseForAppend := false
+	switch strings.ToLower(cmd.OptimiseForAppend) {
 	case "true":
-		withIndexesAndOrderTriggers = true
-	case "default":
-		withIndexesAndOrderTriggers = span.HasData
+		optimiseForAppend = true
+	case "false":
+		optimiseForAppend = false
+	default:
+		optimiseForAppend = span.HasData
 	}
 
-	if withIndexesAndOrderTriggers {
-		fmt.Println("Loading history with indexes and order triggers...")
+	if optimiseForAppend {
+		fmt.Println("Loading history, optimising for append")
 	} else {
-		fmt.Println("Loading history...")
+		fmt.Println("Loading history, optimising for bulk load")
 	}
 
 	loadLog := newLoadLog()
 	defer loadLog.AtExit()
 	loaded, err := networkHistoryService.LoadNetworkHistoryIntoDatanodeWithLog(context.Background(), loadLog, *contiguousHistory,
-		cmd.Config.SQLStore.ConnectionConfig, withIndexesAndOrderTriggers, bool(cmd.Config.SQLStore.VerboseMigration))
+		cmd.Config.SQLStore.ConnectionConfig, optimiseForAppend, bool(cmd.Config.SQLStore.VerboseMigration))
 	if err != nil {
 		return fmt.Errorf("failed to load all available history:%w", err)
 	}
@@ -219,6 +206,41 @@ func (cmd *loadCmd) Execute(args []string) error {
 	fmt.Printf("Loaded history from height %d to %d into the datanode\n", loaded.LoadedFromHeight, loaded.LoadedToHeight)
 
 	return nil
+}
+
+func createNetworkHistoryService(ctx context.Context, log *logging.Logger, vegaConfig config.Config, connPool *pgxpool.Pool, vegaPaths paths.Paths) (*networkhistory.Service, error) {
+	snapshotService, err := snapshot.NewSnapshotService(log, vegaConfig.NetworkHistory.Snapshot, connPool,
+		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
+		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
+			if err := sqlstore.MigrateUpToSchemaVersion(log, vegaConfig.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
+				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
+			}
+			return nil
+		},
+		func(version int64) error {
+			if err := sqlstore.MigrateDownToSchemaVersion(log, vegaConfig.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
+				return fmt.Errorf("failed to migrate down to schema version %d: %w", version, err)
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create snapshot service: %w", err)
+	}
+
+	networkHistoryStore, err := store.New(ctx, log, vegaConfig.ChainID, vegaConfig.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
+		false, vegaConfig.MaxMemoryPercent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create network history store:%w", err)
+	}
+
+	networkHistoryService, err := networkhistory.NewWithStore(ctx, log, vegaConfig.ChainID, vegaConfig.NetworkHistory,
+		connPool, snapshotService, networkHistoryStore, vegaConfig.API.Port,
+		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
+		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo))
+	if err != nil {
+		return nil, fmt.Errorf("failed new networkhistory service:%w", err)
+	}
+	return networkHistoryService, nil
 }
 
 type loadLog struct {

--- a/cmd/data-node/commands/networkhistory/networkhistory.go
+++ b/cmd/data-node/commands/networkhistory/networkhistory.go
@@ -23,6 +23,7 @@ type Cmd struct {
 	// Subcommands
 	Show                          showCmd                       `command:"show" description:"shows network history segments currently stored by the node"`
 	Load                          loadCmd                       `command:"load" description:"load [from height] [to height], loads the given span of network history into the datanode, if no span is specified the latest contiguous network history will be loaded"`
+	Rollback                      rollbackCmd                   `command:"rollback" description:"rollback [to height], rolls back the datanode to the given height, the rollback height must match the to height of a network history segment"`
 	Fetch                         fetchCmd                      `command:"fetch" description:"fetch <history segment id> <blocks to fetch>, fetches the given segment and all previous segments until <blocks to fetch> blocks have been retrieved"`
 	LatestHistorySegmentFromPeers latestHistorySegmentFromPeers `command:"latest-history-segment-from-peers" description:"latest-history-segment-from-peers returns the id of the networks latest history segment"`
 	LatestHistorySegment          latestHistorySegment          `command:"latest-history-segment" description:"latest-history-segment returns the id of the node's latest history segment"`

--- a/cmd/data-node/commands/networkhistory/rollback.go
+++ b/cmd/data-node/commands/networkhistory/rollback.go
@@ -1,0 +1,89 @@
+package networkhistory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	vgterm "code.vegaprotocol.io/vega/libs/term"
+
+	"code.vegaprotocol.io/vega/cmd/vegawallet/commands/flags"
+	"code.vegaprotocol.io/vega/datanode/networkhistory"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+
+	"code.vegaprotocol.io/vega/datanode/config"
+)
+
+type rollbackCmd struct {
+	config.VegaHomeFlag
+	config.Config
+
+	Force bool `short:"f" long:"force" description:"do not prompt for confirmation"`
+}
+
+func (cmd *rollbackCmd) Execute(args []string) error {
+	cfg := logging.NewDefaultConfig()
+	cfg.Custom.Zap.Level = logging.WarnLevel
+	cfg.Environment = "custom"
+	log := logging.NewLoggerFromConfig(
+		cfg,
+	)
+	defer log.AtExit()
+
+	if len(args) != 1 {
+		return errors.New("expected <rollback-to-height>")
+	}
+
+	rollbackToHeight, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse rollback to height: %w", err)
+	}
+
+	vegaPaths := paths.New(cmd.VegaHome)
+	err = fixConfig(&cmd.Config, vegaPaths)
+	if err != nil {
+		return fmt.Errorf("failed to fix config:%w", err)
+	}
+
+	if datanodeLive(cmd.Config) {
+		return fmt.Errorf("datanode must be shutdown before it can be rolled back")
+	}
+
+	if !cmd.Force && vgterm.HasTTY() {
+		if !flags.YesOrNo("Running this command will kill all existing database connections, do you want to continue?") {
+			return nil
+		}
+	}
+
+	if err := networkhistory.KillAllConnectionsToDatabase(context.Background(), cmd.SQLStore.ConnectionConfig); err != nil {
+		return fmt.Errorf("failed to kill all connections to database: %w", err)
+	}
+
+	connPool, err := getCommandConnPool(cmd.Config.SQLStore.ConnectionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get command connection pool: %w", err)
+	}
+	defer connPool.Close()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	networkHistoryService, err := createNetworkHistoryService(ctx, log, cmd.Config, connPool, vegaPaths)
+	if err != nil {
+		return fmt.Errorf("failed to created network history service: %w", err)
+	}
+	defer networkHistoryService.Stop()
+
+	loadLog := newLoadLog()
+	defer loadLog.AtExit()
+	err = networkHistoryService.RollbackToHeight(context.Background(), loadLog, rollbackToHeight)
+	if err != nil {
+		return fmt.Errorf("failed to rollback datanode: %w", err)
+	}
+
+	fmt.Printf("Rolled back datanode to height %d\n", rollbackToHeight)
+
+	return nil
+}

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -332,7 +332,13 @@ func (l *NodeCommand) initialiseNetworkHistory(preLog *logging.Logger, connConfi
 		networkHistoryPool, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
 		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
 			if err = sqlstore.MigrateUpToSchemaVersion(preNetworkHistoryLog, l.conf.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
-				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
+				return fmt.Errorf("failed to migrate up to schema version %d: %w", version, err)
+			}
+			return nil
+		},
+		func(version int64) error {
+			if err = sqlstore.MigrateDownToSchemaVersion(preNetworkHistoryLog, l.conf.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
+				return fmt.Errorf("failed to migrate down to schema version %d: %w", version, err)
 			}
 			return nil
 		})
@@ -340,7 +346,8 @@ func (l *NodeCommand) initialiseNetworkHistory(preLog *logging.Logger, connConfi
 		return fmt.Errorf("failed to create snapshot service:%w", err)
 	}
 
-	l.networkHistoryService, err = networkhistory.New(l.ctx, networkHistoryServiceLog, l.conf.NetworkHistory, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
+	l.networkHistoryService, err = networkhistory.New(l.ctx, networkHistoryServiceLog, l.conf.NetworkHistory,
+		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
 		networkHistoryPool,
 		l.conf.ChainID, l.snapshotService, l.conf.API.Port, l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyFrom),
 		l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), l.conf.MaxMemoryPercent)

--- a/datanode/networkhistory/snapshot/service.go
+++ b/datanode/networkhistory/snapshot/service.go
@@ -18,16 +18,18 @@ type Service struct {
 	config   Config
 	connPool *pgxpool.Pool
 
-	createSnapshotLock       mutex.CtxMutex
-	absSnapshotsCopyFromPath string
-	absSnapshotsCopyToPath   string
-	migrateSchemaToVersion   func(version int64) error
+	createSnapshotLock         mutex.CtxMutex
+	absSnapshotsCopyFromPath   string
+	absSnapshotsCopyToPath     string
+	migrateSchemaUpToVersion   func(version int64) error
+	migrateSchemaDownToVersion func(version int64) error
 }
 
 func NewSnapshotService(log *logging.Logger, config Config, connPool *pgxpool.Pool,
 	snapshotsCopyFromPath string,
 	snapshotsCopyToPath string,
 	migrateDatabaseToVersion func(version int64) error,
+	migrateSchemaDownToVersion func(version int64) error,
 ) (*Service, error) {
 	var err error
 	// As these paths are passed to postgres, they need to be absolute as it will likely have
@@ -43,13 +45,14 @@ func NewSnapshotService(log *logging.Logger, config Config, connPool *pgxpool.Po
 	}
 
 	s := &Service{
-		log:                      log,
-		config:                   config,
-		connPool:                 connPool,
-		createSnapshotLock:       mutex.New(),
-		absSnapshotsCopyFromPath: snapshotsCopyFromPath,
-		absSnapshotsCopyToPath:   snapshotsCopyToPath,
-		migrateSchemaToVersion:   migrateDatabaseToVersion,
+		log:                        log,
+		config:                     config,
+		connPool:                   connPool,
+		createSnapshotLock:         mutex.New(),
+		absSnapshotsCopyFromPath:   snapshotsCopyFromPath,
+		absSnapshotsCopyToPath:     snapshotsCopyToPath,
+		migrateSchemaUpToVersion:   migrateDatabaseToVersion,
+		migrateSchemaDownToVersion: migrateSchemaDownToVersion,
 	}
 
 	err = os.MkdirAll(s.absSnapshotsCopyToPath, fs.ModePerm)

--- a/datanode/networkhistory/store/store.go
+++ b/datanode/networkhistory/store/store.go
@@ -609,6 +609,10 @@ func (p *Store) extractHistorySegmentToStagingArea(ctx context.Context, toHeight
 	return nil
 }
 
+func (p *Store) GetSegmentIndexEntryForHeight(toHeight int64) (SegmentIndexEntry, error) {
+	return p.index.Get(toHeight)
+}
+
 func (p *Store) getHistorySegmentForHeight(ctx context.Context, toHeight int64, toDir string) (pathToSegment string, err error) {
 	indexEntry, err := p.index.Get(toHeight)
 	if err != nil {


### PR DESCRIPTION
closes #7759  -  Adds the functionality to support rolling back the data node to a previous block height, where a network history segment for that height exists.