### PR TITLE
fix: command validation for heartbeat and announce node signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [8020](https://github.com/vegaprotocol/vega/issues/8020) - Update default `tendermint` home path to `cometbft`
 - [7919](https://github.com/vegaprotocol/vega/issues/7919) - Avoid sending empty ledger movements
 - [8053](https://github.com/vegaprotocol/vega/issues/8053) - Fix notary vote count
+- [8004](https://github.com/vegaprotocol/vega/issues/8004) - Validate signatures exist in announce node command
 - [8046](https://github.com/vegaprotocol/vega/issues/8046) - Update GraphQL schema with new order rejection reason
 - [6659](https://github.com/vegaprotocol/vega/issues/6659) - Wallet application configuration is correctly reported on default location
 - [8074](https://github.com/vegaprotocol/vega/issues/8074) - Add missing order rejection reason to `graphql` schema

--- a/commands/announce_node.go
+++ b/commands/announce_node.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"encoding/hex"
+
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 )
 
@@ -33,6 +35,24 @@ func checkAnnounceNode(cmd *commandspb.AnnounceNode) Errors {
 
 	if len(cmd.ChainPubKey) == 0 {
 		errs.AddForProperty("announce_node.chain_pub_key", ErrIsRequired)
+	}
+
+	if cmd.EthereumSignature == nil || len(cmd.EthereumSignature.Value) == 0 {
+		errs.AddForProperty("announce_node.ethereum_signature", ErrIsRequired)
+	} else {
+		_, err := hex.DecodeString(cmd.EthereumSignature.Value)
+		if err != nil {
+			errs.AddForProperty("announce_node.ethereum_signature.value", ErrShouldBeHexEncoded)
+		}
+	}
+
+	if cmd.VegaSignature == nil || len(cmd.VegaSignature.Value) == 0 {
+		errs.AddForProperty("announce_node.vega_signature", ErrIsRequired)
+	} else {
+		_, err := hex.DecodeString(cmd.VegaSignature.Value)
+		if err != nil {
+			errs.AddForProperty("announce_node.vega_signature.value", ErrShouldBeHexEncoded)
+		}
 	}
 
 	return errs

--- a/commands/validator_heartbeat.go
+++ b/commands/validator_heartbeat.go
@@ -18,15 +18,14 @@ func checkValidatorHeartbeat(cmd *commandspb.ValidatorHeartbeat) Errors {
 	}
 
 	if len(cmd.NodeId) == 0 {
-		errs.AddForProperty("validator_heartbeat.vega_pub_key", ErrIsRequired)
+		errs.AddForProperty("validator_heartbeat.node_id", ErrIsRequired)
 	} else {
-		_, err := hex.DecodeString(cmd.NodeId)
-		if err != nil {
-			errs.AddForProperty("validator_heartbeat.vega_pub_key", ErrShouldBeHexEncoded)
+		if !IsVegaPubkey(cmd.NodeId) {
+			errs.AddForProperty("validator_heartbeat.node_id", ErrShouldBeAValidVegaPubkey)
 		}
 	}
 
-	if cmd.VegaSignature == nil || len(cmd.EthereumSignature.Value) == 0 {
+	if cmd.EthereumSignature == nil || len(cmd.EthereumSignature.Value) == 0 {
 		errs.AddForProperty("validator_heartbeat.ethereum_signature.value", ErrIsRequired)
 	} else {
 		_, err := hex.DecodeString(cmd.EthereumSignature.Value)

--- a/commands/validator_heartbeat_test.go
+++ b/commands/validator_heartbeat_test.go
@@ -76,7 +76,17 @@ func TestValidatorHeartbeat(t *testing.T) {
 					Algo:  "some/algo",
 				},
 			},
-			errString: "validator_heartbeat.vega_pub_key (is required)",
+			errString: "validator_heartbeat.node_id (is required)",
+		},
+		{
+			vh: commandspb.ValidatorHeartbeat{
+				NodeId: "84e2b15102a8d6c1c6b4bdf40af8a0dc21b040eaaa1c94cd10d17604b75fdc35",
+				VegaSignature: &commandspb.Signature{
+					Value: "84e2b15102a8d6c1c6b4bdf40af8a0dc21b040eaaa1c94cd10d17604b75fdc35",
+					Algo:  "some/algo",
+				},
+			},
+			errString: "validator_heartbeat.ethereum_signature.value (is required)",
 		},
 	}
 


### PR DESCRIPTION
Its possible to cause core to panic because we were missing `nil` checks on the signatures in the announce-node command. Also there is a bug in the validation on heartbeat signature that would also cause a panic if the ethereum signature was `nil`.

This improves the validation in those commands.

