### PR TITLE
Network History Fetch command should retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [7990](https://github.com/vegaprotocol/vega/issues/7990) - Remove reference to `postgres` in the `protobuf` documentation comments
 - [7992](https://github.com/vegaprotocol/vega/issues/7992) - Improve Candles related `APIs`
 - [7986](https://github.com/vegaprotocol/vega/issues/7986) - Remove cross `protobuf` files documentation references
+- [8146](https://github.com/vegaprotocol/vega/issues/8146) - Add fetch retry behaviour to network history fetch command  
 - [7982](https://github.com/vegaprotocol/vega/issues/7982) - Fix behaviour of endpoints with `marketIds` and `partyIds` filters
 - [7846](https://github.com/vegaprotocol/vega/issues/7846) - Add event indicating distressed parties that are still holding an active position.
 - [7985](https://github.com/vegaprotocol/vega/issues/7985) - Add full stop on all fields documentation to get it properly generated

--- a/datanode/networkhistory/config.go
+++ b/datanode/networkhistory/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	Store    store.Config    `group:"Store" namespace:"store"`
 	Snapshot snapshot.Config `group:"Snapshot" namespace:"snapshot"`
 
+	FetchRetryMax int               `long:"fetch-retry-max" description:"maximum number of times to retry fetching segments - default 10"`
+	RetryTimeout  encoding.Duration `long:"retry-timeout" description:"time to wait between retries, increases with each retry - default 5s"`
+
 	Initialise InitializationConfig `group:"Initialise" namespace:"initialise"`
 }
 
@@ -32,6 +35,8 @@ func NewDefaultConfig() Config {
 		Publish:       true,
 		Store:         store.NewDefaultConfig(),
 		Snapshot:      snapshot.NewDefaultConfig(),
+		FetchRetryMax: 10,
+		RetryTimeout:  encoding.Duration{Duration: 5 * time.Second},
 		Initialise:    NewDefaultInitializationConfig(),
 	}
 }
@@ -42,8 +47,6 @@ func NewDefaultInitializationConfig() InitializationConfig {
 		TimeOut:           encoding.Duration{Duration: 1 * time.Minute},
 		GrpcAPIPorts:      []int{},
 		ToSegment:         "",
-		FetchRetryMax:     5,
-		RetryTimeout:      encoding.Duration{Duration: time.Second},
 	}
 }
 
@@ -52,6 +55,4 @@ type InitializationConfig struct {
 	MinimumBlockCount int64             `long:"block-count" description:"the minimum number of blocks to fetch"`
 	TimeOut           encoding.Duration `long:"timeout" description:"maximum time allowed to auto-initialise the node"`
 	GrpcAPIPorts      []int             `long:"grpc-api-ports" description:"list of additional ports to check to for api connection when getting latest segment"`
-	FetchRetryMax     uint64            `long:"fetch-retry-max" description:"maximum number of times to retry fetching segments - default 5"`
-	RetryTimeout      encoding.Duration `long:"retry-timeout" description:"time to wait between retries - default 1 second"`
 }

--- a/datanode/networkhistory/store/store.go
+++ b/datanode/networkhistory/store/store.go
@@ -661,6 +661,11 @@ func (p *Store) FetchHistorySegment(ctx context.Context, historySegmentID string
 		HistorySegmentID: historySegmentID,
 	}
 
+	err = p.ipfsAPI.Pin().Add(ctx, path.IpfsPath(contentID))
+	if err != nil {
+		return segment.Full{}, fmt.Errorf("failed to pin fetched segment: %w", err)
+	}
+
 	if err = p.index.Add(indexEntry); err != nil {
 		return segment.Full{}, fmt.Errorf("failed to add index entry:%w", err)
 	}


### PR DESCRIPTION
closes #8146 closes #8137 closes #8145

Network History Fetch command should retry and consolidate the retry behaviour in node initialisation into one place.