### PR TITLE
fix: nil pointer protection on state-var bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - [7919](https://github.com/vegaprotocol/vega/issues/7919) - Avoid sending empty ledger movements
 - [8053](https://github.com/vegaprotocol/vega/issues/8053) - Fix notary vote count
 - [8004](https://github.com/vegaprotocol/vega/issues/8004) - Validate signatures exist in announce node command
+- [8004](https://github.com/vegaprotocol/vega/issues/8004) - Validate value in state variable bundles
 - [8046](https://github.com/vegaprotocol/vega/issues/8046) - Update GraphQL schema with new order rejection reason
 - [6659](https://github.com/vegaprotocol/vega/issues/6659) - Wallet application configuration is correctly reported on default location
 - [8074](https://github.com/vegaprotocol/vega/issues/8074) - Add missing order rejection reason to `graphql` schema

--- a/commands/state_var_proposal_submission.go
+++ b/commands/state_var_proposal_submission.go
@@ -23,6 +23,9 @@ func checkStateVariableProposal(cmd *commandspb.StateVariableProposal) Errors {
 	if len(cmd.Proposal.EventId) == 0 {
 		errs.AddForProperty("state_variable_proposal.event_id", ErrIsRequired)
 	}
+	if len(cmd.Proposal.StateVarId) == 0 {
+		errs.AddForProperty("state_variable_proposal.state_var_id", ErrIsRequired)
+	}
 	if len(cmd.Proposal.Kvb) == 0 {
 		errs.AddForProperty("state_variable_proposal.key_value_bundle", ErrIsRequired)
 	}
@@ -30,6 +33,10 @@ func checkStateVariableProposal(cmd *commandspb.StateVariableProposal) Errors {
 	for i, kvb := range cmd.Proposal.Kvb {
 		if len(kvb.Key) == 0 {
 			errs.AddForProperty("state_variable_proposal.key_value_bundle."+strconv.Itoa(i)+".key", ErrIsRequired)
+		}
+
+		if kvb.Value == nil {
+			errs.AddForProperty("state_variable_proposal.key_value_bundle."+strconv.Itoa(i)+".value", ErrIsRequired)
 		}
 	}
 	return errs

--- a/core/statevar/snapshot.go
+++ b/core/statevar/snapshot.go
@@ -167,7 +167,10 @@ func (e *Engine) postRestore(stateVariablesInternalState []*snapshot.StateVarInt
 			sv.validatorResults = make(map[string]*statevar.KeyValueBundle, len(svis.ValidatorsResults))
 		}
 		for _, fpvr := range svis.ValidatorsResults {
-			kvb, _ := statevar.KeyValueBundleFromProto(fpvr.Bundle)
+			kvb, err := statevar.KeyValueBundleFromProto(fpvr.Bundle)
+			if err != nil {
+				e.log.Panic("restoring malformed statevar kvb", logging.String("id", fpvr.Id), logging.Error(err))
+			}
 			sv.validatorResults[fpvr.Id] = kvb
 		}
 	}

--- a/core/types/statevar/key_value_state_vars.go
+++ b/core/types/statevar/key_value_state_vars.go
@@ -13,6 +13,8 @@
 package statevar
 
 import (
+	"fmt"
+
 	"code.vegaprotocol.io/vega/libs/num"
 	"code.vegaprotocol.io/vega/protos/vega"
 )
@@ -68,6 +70,9 @@ func KeyValueBundleFromProto(protoKVT []*vega.KeyValueBundle) (*KeyValueBundle, 
 
 // ValueFromProto converts the proto into a value.
 func ValueFromProto(val *vega.StateVarValue) (value, error) {
+	if val == nil {
+		return nil, fmt.Errorf("missing state-var value")
+	}
 	switch v := val.Value.(type) {
 	case *vega.StateVarValue_ScalarVal:
 		val, err := num.DecimalFromString(v.ScalarVal.Value)


### PR DESCRIPTION
Add `nil` check on `.Value` in state-var KVB validation. Very unlikely unless some validator was intentionally being naughty.