### PR TITLE
Keep remainder in fee account + small bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [8144](https://github.com/vegaprotocol/vega/issues/8144) - Visor - remove data node asset option from the config. Use only one asset.
 - [7969](https://github.com/vegaprotocol/vega/issues/7969) - Add `GoodForBlocks` field to transaction input data.
 - [8155](https://github.com/vegaprotocol/vega/issues/8155) - Visor - allow restart without snapshot.
+- [8129](https://github.com/vegaprotocol/vega/issues/8129) - Keep liquidity fee remainder in fee account.
 
 ### 🐛 Fixes
 

--- a/core/collateral/engine.go
+++ b/core/collateral/engine.go
@@ -2118,7 +2118,7 @@ func (e *Engine) ClearMarket(ctx context.Context, mktID, asset string, parties [
 	}
 
 	// redistribute the remaining funds in the market insurance account between other markets insurance accounts and global insurance account
-	if marketInsuranceAcc.Balance.EQ(num.UintZero()) {
+	if marketInsuranceAcc.Balance.IsZero() {
 		// if there's no market insurance account or it has no balance, nothing to do here
 		e.removeAccount(marketInsuranceID)
 		return resps, nil

--- a/core/collateral/engine_test.go
+++ b/core/collateral/engine_test.go
@@ -781,7 +781,7 @@ func testTransferLoss(t *testing.T) {
 	eng := getTestEngine(t)
 	defer eng.Finish()
 
-	eng.broker.EXPECT().Send(gomock.Any()).Times(10)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(9)
 
 	insurancePool, err := eng.GetMarketInsurancePoolAccount(testMarketID, testMarketAsset)
 	assert.Nil(t, err)
@@ -2332,7 +2332,7 @@ func TestClearMarket(t *testing.T) {
 	party := "okparty"
 
 	// create parties
-	eng.broker.EXPECT().Send(gomock.Any()).Times(9)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(10)
 
 	eng.IncrementBalance(context.Background(), eng.marketInsuranceID, num.NewUint(1000))
 
@@ -2346,7 +2346,7 @@ func TestClearMarket(t *testing.T) {
 	responses, err := eng.ClearMarket(context.Background(), testMarketID, testMarketAsset, parties)
 
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(responses))
+	assert.Equal(t, 3, len(responses))
 
 	assert.Equal(t, 1, len(responses[0].Entries))
 	assert.Equal(t, num.NewUint(500), responses[0].Entries[0].ToAccountBalance)
@@ -2363,7 +2363,7 @@ func TestClearMarketNoMargin(t *testing.T) {
 	party := "okparty"
 
 	// create parties
-	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(4)
 	acc, _ := eng.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
 	eng.IncrementBalance(context.Background(), acc, num.NewUint(500))
 
@@ -2372,7 +2372,7 @@ func TestClearMarketNoMargin(t *testing.T) {
 	responses, err := eng.ClearMarket(context.Background(), testMarketID, testMarketAsset, parties)
 
 	assert.NoError(t, err)
-	assert.Equal(t, len(responses), 0)
+	assert.Equal(t, len(responses), 1)
 }
 
 func TestRewardDepositOK(t *testing.T) {

--- a/core/execution/equity_shares_test.go
+++ b/core/execution/equity_shares_test.go
@@ -437,12 +437,13 @@ func testWithinMarket(t *testing.T) {
 	fmt.Printf("Target stake: %s\nSupplied: %s\n\n", md.TargetStake, md.SuppliedStake)
 	require.Equal(t, types.MarketTradingModeContinuous, md.MarketTradingMode)
 
-	assert.True(t, esm.LiquidityFeeAccount().Balance.IsZero(),
-		"LiquidityFeeAccount should be empty after a fee distribution")
+	oneU := num.NewUint(1)
+	assert.True(t, esm.LiquidityFeeAccount().Balance.EQ(oneU),
+		"LiquidityFeeAccount should have a balance of 1 (remainder)")
 
 	// exp = originalBalance*(2/3)
-	exp := num.UintZero().Mul(num.NewUint(2), originalBalance)
-	exp = exp.Div(exp, num.NewUint(3))
+	exp := num.UintZero().Mul(num.Sum(oneU, oneU), originalBalance)
+	exp = exp.Div(exp, num.Sum(oneU, oneU, oneU))
 	actual := num.UintZero().Sub(esm.PartyGeneralAccount("party1").Balance, party1Balance)
 	assert.True(t,
 		exp.EQ(actual),
@@ -450,7 +451,9 @@ func testWithinMarket(t *testing.T) {
 	)
 
 	// exp = originalBalance*(1/3)
-	exp = num.UintZero().Div(originalBalance, num.NewUint(3))
+	exp = num.UintZero().Div(originalBalance, num.Sum(oneU, oneU, oneU))
+	// minus the remainder
+	exp.Sub(exp, oneU)
 	actual = num.UintZero().Sub(esm.PartyGeneralAccount("party2").Balance, party2Balance)
 	assert.True(t,
 		exp.EQ(actual),

--- a/core/integration/features/accounts/2943-distressed-trader-has-general-balance.feature
+++ b/core/integration/features/accounts/2943-distressed-trader-has-general-balance.feature
@@ -89,7 +89,7 @@ Feature: Distressed parties should not have general balance left
 
     And the parties should have the following account balances:
       | party  | asset | market id | margin | general       |
-      | party3 | ETH   | ETH/DEC20 | 3152   | 924           |
+      | party3 | ETH   | ETH/DEC20 | 3152   | 923           |
       | party4 | ETH   | ETH/DEC20 | 160    | 9999999999640 |
 
     ## Now let's increase the mark price so party3 gets distressed

--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -232,6 +232,7 @@ Feature: Test liquidity provider reward distribution
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 8      | ETH   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 8      | ETH   |
 
+  @FeeRound
   Scenario: 003, 2 LPs joining at start, equal commitments, unequal offsets
     Given the following network parameters are set:
       | name                                                | value |
@@ -288,7 +289,7 @@ Feature: Test liquidity provider reward distribution
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 26     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 14     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 13     | ETH   |
 
     # modify lp2 orders so that they fall outside the price monitoring bounds
     When clear all events
@@ -303,20 +304,20 @@ Feature: Test liquidity provider reward distribution
     And the market data for the market "ETH/DEC22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | best static bid price | static mid price | best static offer price |
       | 1000       | TRADING_MODE_CONTINUOUS | 10000   | 893       | 1120      | 995                   | 1000             | 1005                    |
-    And the accumulated liquidity fees should be "0" for the market "ETH/DEC22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/DEC22"
 
     When the network moves ahead "6" blocks
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
-    Then the accumulated liquidity fees should be "40" for the market "ETH/DEC22"
+    Then the accumulated liquidity fees should be "41" for the market "ETH/DEC22"
 
     When the network moves ahead "6" blocks
     # all the fees go to lp2
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 40     | ETH   |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 41     | ETH   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 0      | ETH   |
 
     # lp2 manually adds some limit orders within PM range, observe automatically deployed orders go down and fee share go up
@@ -348,7 +349,7 @@ Feature: Test liquidity provider reward distribution
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 29     | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 11     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 10     | ETH   |
 
     # lp2 manually adds some pegged orders within PM range, liquidity obligation is now fullfiled by limit and pegged orders so no automatic order deployment takes place
     When clear all events
@@ -363,7 +364,7 @@ Feature: Test liquidity provider reward distribution
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
-    Then the accumulated liquidity fees should be "40" for the market "ETH/DEC22"
+    Then the accumulated liquidity fees should be "41" for the market "ETH/DEC22"
 
     When the network moves ahead "6" blocks
     # lp2 has increased their liquidity score by placing pegged orders closer to the mid (and within price monitoring bounds),
@@ -373,6 +374,7 @@ Feature: Test liquidity provider reward distribution
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 19     | ETH   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC22 | 21     | ETH   |
 
+  @FeeRound
   Scenario: 004, 2 LPs joining at start, unequal commitments
 
     Given the parties deposit on asset's general account the following amount:
@@ -472,10 +474,11 @@ Feature: Test liquidity provider reward distribution
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 6      | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 2      | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 1      | ETH   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "1" for the market "ETH/DEC21"
 
+  @FeeRound
   Scenario: 005, 2 LPs joining at start, unequal commitments, 1 LP lp3 joining later, and 4 LPs lp4/5/6/7 with large commitment and low/high fee joins later
 
     Given the parties deposit on asset's general account the following amount:
@@ -610,8 +613,8 @@ Feature: Test liquidity provider reward distribution
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 6      | ETH   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 1      | ETH   |
-      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 9      | ETH   |
-    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 8      | ETH   |
+    And the accumulated liquidity fees should be "1" for the market "ETH/DEC21"
     And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
     And the target stake should be "7608" for the market "ETH/DEC21"
     And the supplied stake should be "20000" for the market "ETH/DEC21"
@@ -640,7 +643,7 @@ Feature: Test liquidity provider reward distribution
     When time is updated to "2019-11-30T00:43:08Z"
     And the liquidity fee factor should be "0.0005" for the market "ETH/DEC21"
 
-  @Panic
+  @FeeRound
   Scenario: 006, 2 LPs joining at start, unequal commitments, market settles (0042-LIQF-014)
 
     Given the parties deposit on asset's general account the following amount:
@@ -722,11 +725,11 @@ Feature: Test liquidity provider reward distribution
       | name             | value |
       | prices.ETH.value | 42    |
     Then the market state should be "STATE_SETTLED" for the market "ETH/DEC21"
-    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "1" for the market "ETH/DEC21"
     And the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 6      | ETH   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 2      | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 1      | ETH   |
 
   Scenario: 007, 2 LPs joining at start, unequal commitments, 1 leaves later (0042-LIQF-012)
 

--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -725,7 +725,7 @@ Feature: Test liquidity provider reward distribution
       | name             | value |
       | prices.ETH.value | 42    |
     Then the market state should be "STATE_SETTLED" for the market "ETH/DEC21"
-    And the accumulated liquidity fees should be "1" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
     And the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/DEC21 | 6      | ETH   |

--- a/core/integration/features/rewards/multi_asset_multi_market_fees_rewards.feature
+++ b/core/integration/features/rewards/multi_asset_multi_market_fees_rewards.feature
@@ -68,6 +68,7 @@ Feature: Fees rewards with multiple markets and assets
     #complete the epoch to advance to a meaningful epoch (can't setup transfer to start at epoch 0)
     Then the network moves ahead "7" blocks
 
+  @FeeRound
   Scenario: all sort of fees with multiple assets and multiple markets pay rewards on epoch end
 
     Given the parties submit the following recurring transfers:
@@ -253,5 +254,5 @@ Feature: Fees rewards with multiple markets and assets
     Then "party1" should have general account balance of "1567" for asset "USDT"
     Then "party2" should have general account balance of "20431" for asset "USDT"
 
-    Then "lp1" should have general account balance of "3061" for asset "USDC"
-    Then "lp2" should have general account balance of "760" for asset "USDC"
+    Then "lp1" should have general account balance of "3184" for asset "USDC"
+    Then "lp2" should have general account balance of "693" for asset "USDC"

--- a/core/integration/features/verified/0034-PROB-liquidity_TauScaling.feature
+++ b/core/integration/features/verified/0034-PROB-liquidity_TauScaling.feature
@@ -114,7 +114,7 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 295    | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1607   | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1606   | USD   |
 
   Scenario: 002: set tau.scaling to 10
   Background:
@@ -213,7 +213,7 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 291    | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1611   | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1610   | USD   |
 
   Scenario: 003: set tau.scaling to 1000
   Background:
@@ -313,7 +313,7 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 289    | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1613   | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1612   | USD   |
 
   Scenario: 004: set tau.scaling to 1, smaller lp offset
   Background:
@@ -415,7 +415,7 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 815    | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1087   | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1086   | USD   |
 
   Scenario: 005: set tau.scaling to 10, smaller lp offset
   Background:
@@ -516,7 +516,7 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 910    | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 992    | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 991    | USD   |
 
   Scenario: 006: set tau.scaling to 1000, smaller lp offset
   Background:
@@ -616,5 +616,5 @@ Feature: Tests impact from change of tau.scaling parameter on probability of tra
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 946    | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 956    | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 955    | USD   |
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards.feature
@@ -336,10 +336,11 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 6      | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 2      | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
+  @FeeRound
   Scenario: 004 2 LPs joining at start, unequal commitments, lp2's equity like share is very small, check the rounding of equity like share (round to 16 decimal places in this case)(0042-LIQF-004, 0042-LIQF-015)
 
     Given the parties deposit on asset's general account the following amount:
@@ -410,8 +411,9 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 19     | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1      | USD   |
-  @STTest
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 0      | USD   |
+
+  @FeeRound
   Scenario: 005: 2 LP distribution at settlement
 
     Given the parties deposit on asset's general account the following amount:
@@ -486,12 +488,12 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
 
     # check lp fee distribution at s
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 19     | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1      | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 0      | USD   |
 
   Scenario: 006 Cut the market value window short with a parameter change (0042-LIQF-022)
     Given the parties deposit on asset's general account the following amount:

--- a/core/integration/features/verified/0042-LIQF-fees_rewards.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards.feature
@@ -488,7 +488,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
 
     # check lp fee distribution at s
 
-    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
 
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_VirtualStake.feature
@@ -222,7 +222,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 8      | USD   |
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
 
-  @VirtStake
+  @FeeRound
   Scenario: 003 2 LPs joining at start, unequal commitments. Checking calculation of equity-like-shares and liquidity-fee-distribution in a shrinking market. (0042-LIQF-008 0042-LIQF-011)
 
     # Scenario has 6 market periods:
@@ -340,9 +340,9 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     And the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1      | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 4      | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
 
     # 2nd period: 1 LPs increase commitment, some trades occur
@@ -369,7 +369,8 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 5      | USD   |
 
-    And the accumulated liquidity fees should be "5" for the market "ETH/MAR22"
+    # 5 + 1 remainder
+    And the accumulated liquidity fees should be "6" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -388,7 +389,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 2      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
 
     # 3rd period: 2 LPs decrease commitment, some trades occur
@@ -421,7 +422,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 7      | USD   |
 
-    And the accumulated liquidity fees should be "7" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "8" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -440,7 +441,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 2      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 5      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
 
     # 4nd period: 2 LPs increase commitment, some trades occur
@@ -474,7 +475,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 10     | USD   |
 
-    And the accumulated liquidity fees should be "10" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "11" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -493,7 +494,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 4      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 6      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
 
     # 5th period: 1 LPs decrease commitment 1 LPs increase commitment, some trades occur
@@ -527,7 +528,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 12     | USD   |
 
-    And the accumulated liquidity fees should be "12" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "13" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -546,9 +547,9 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 9      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
-  @VirtStake
+  @FeeRound
   Scenario: 004 2 LPs joining at start, 1 LP forcibly closed out (0042-LIQF-008)
 
     Given the average block duration is "601"
@@ -619,9 +620,9 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 6      | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 63     | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 62     | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
 
     # 2nd set of trades: market moves against LP1s position, margin-insufficient, margin topped up from general and bond
@@ -643,7 +644,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
 
     # liquidity_fee = ceil(volume * price * liquidity_fee_factor) =  ceil(1300 * 30 * 0.002) = ceil(78) = 78
 
-    And the accumulated liquidity fees should be "78" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "79" for the market "ETH/MAR22"
 
     Then the parties should have the following account balances:
       | party | asset | market id | margin | general | bond |
@@ -658,7 +659,7 @@ Feature: Test liquidity provider reward distribution; Should also cover liquidit
 
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 78     | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 79     | USD   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_growing_market.feature
@@ -24,7 +24,7 @@ Feature:
       | ETH/MAR22 | USD        | USD   | simple-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring | default-eth-for-future | 0.5                    | 0                         |
 
 
-  @VirtStake
+  @FeeRound
   Scenario: 001 2 LPs joining at start, unequal commitments. Checking calculation of equity-like-shares and liquidity-fee-distribution in a market with small growth (0042-LIQF-008)
 
     # Scenario has 6 market periods:
@@ -167,9 +167,9 @@ Feature:
     And the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 2      | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 41     | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -229,7 +229,7 @@ Feature:
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 45     | USD   |
 
-    And the accumulated liquidity fees should be "45" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "46" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -257,7 +257,7 @@ Feature:
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 42     | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -322,7 +322,7 @@ Feature:
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 48     | USD   |
 
-    Then the accumulated liquidity fees should be "48" for the market "ETH/MAR22"
+    Then the accumulated liquidity fees should be "49" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -347,10 +347,10 @@ Feature:
 
     And the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 2      | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 46     | USD   |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 45     | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -415,7 +415,7 @@ Feature:
       | from   | to     | from account         | to account                  | market id | amount | asset |
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 50     | USD   |
 
-    Then the accumulated liquidity fees should be "50" for the market "ETH/MAR22"
+    Then the accumulated liquidity fees should be "51" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -440,10 +440,10 @@ Feature:
 
     And the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount | asset |
-      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 47     | USD   |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 4      | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 46     | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -512,7 +512,7 @@ Feature:
       | party1 | market | ACCOUNT_TYPE_GENERAL | ACCOUNT_TYPE_FEES_LIQUIDITY | ETH/MAR22 | 52     | USD   |
 
     # CALCULATION:
-    Then the accumulated liquidity fees should be "52" for the market "ETH/MAR22"
+    Then the accumulated liquidity fees should be "53" for the market "ETH/MAR22"
 
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
@@ -540,7 +540,7 @@ Feature:
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 49     | USD   |
 
-    Then the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    Then the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -562,7 +562,7 @@ Feature:
   # -------------------------------------------------------------------------------------------------------------------
   # -------------------------------------------------------------------------------------------------------------------
 
-  @VirtStake
+  @FeeRound
   Scenario: 002  Checks ELS calculations for a market which grows and then shrinks.
 
     Given the average block duration is "1801"
@@ -737,7 +737,7 @@ Feature:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 16     | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 16     | USD   |
-      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 0      | USD   |
+      #| market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 0      | USD   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
 
@@ -796,9 +796,9 @@ Feature:
       | from   | to  | from account                | to account           | market id | amount | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 4      | USD   |
       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 4      | USD   |
-      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 3      | USD   |
+      | market | lp3 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 2      | USD   |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -828,7 +828,7 @@ Feature:
       | lp2   | 0.3750624687656172 | 50000                   |
       | lp3   | 0.2498750624687656 | 100050                  |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -858,7 +858,7 @@ Feature:
       | lp2   | 0.3685041026719966 | 50000                   |
       | lp3   | 0.2629917946560067 | 100050                  |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -888,7 +888,7 @@ Feature:
       | lp2   | 0.3500899460323806 | 50000                   |
       | lp3   | 0.2998201079352388 | 100050                  |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 
@@ -918,7 +918,7 @@ Feature:
       | lp2   | 0.3334285170378831 | 50000                   |
       | lp3   | 0.3331429659242338 | 100050                  |
 
-    And the accumulated liquidity fees should be "0" for the market "ETH/MAR22"
+    And the accumulated liquidity fees should be "1" for the market "ETH/MAR22"
 
     # -------------------------------------------------------------------------------------------------------------------
 

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_multi_lps.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_multi_lps.feature
@@ -126,7 +126,7 @@ Feature: Test liquidity provider reward distribution when there are multiple liq
       | market | party1 | ACCOUNT_TYPE_FEES_MAKER     | ACCOUNT_TYPE_GENERAL             | ETH/MAR22 | 80000  | USD   |
       | market | lp1    | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL             | ETH/MAR22 | 5      | USD   |
       | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL             | ETH/MAR22 | 599    | USD   |
-      | market | lp3    | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL             | ETH/MAR22 | 599396 | USD   |
+      | market | lp3    | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL             | ETH/MAR22 | 599394 | USD   |
 
 # liquidity fee lp1 = 600000 * 0.0000099899101907 = 5
 # liquidity fee lp2 = 600000 * 0.0009989910190707 = 599

--- a/core/integration/features/verified/0042-LIQF-fees_rewards_rounding.feature
+++ b/core/integration/features/verified/0042-LIQF-fees_rewards_rounding.feature
@@ -95,4 +95,4 @@ Feature: All liquidity providers with `average fraction of liquidity provided by
     Then the following transfers should happen:
       | from   | to  | from account                | to account           | market id | amount  | asset |
       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1901999 | USD   |
-      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 1       | USD   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 0       | USD   |


### PR DESCRIPTION
Closes #8129 

In the process, noticed a small bug where an empty insurance pool wasn't properly removed (and thus would be part of insurance funds distribution when another market terminated).