### PR TITLE
fix: validate ethereum addresses and cap node vote reference length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - [8053](https://github.com/vegaprotocol/vega/issues/8053) - Fix notary vote count
 - [8004](https://github.com/vegaprotocol/vega/issues/8004) - Validate signatures exist in announce node command
 - [8004](https://github.com/vegaprotocol/vega/issues/8004) - Validate value in state variable bundles
+- [8004](https://github.com/vegaprotocol/vega/issues/8004) - Validate Ethereum addresses and add a cap on node vote reference length
 - [8046](https://github.com/vegaprotocol/vega/issues/8046) - Update GraphQL schema with new order rejection reason
 - [6659](https://github.com/vegaprotocol/vega/issues/6659) - Wallet application configuration is correctly reported on default location
 - [8074](https://github.com/vegaprotocol/vega/issues/8074) - Add missing order rejection reason to `graphql` schema

--- a/commands/announce_node.go
+++ b/commands/announce_node.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/hex"
 
+	"code.vegaprotocol.io/vega/libs/crypto"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 )
 
@@ -31,6 +32,8 @@ func checkAnnounceNode(cmd *commandspb.AnnounceNode) Errors {
 
 	if len(cmd.EthereumAddress) == 0 {
 		errs.AddForProperty("announce_node.ethereum_address", ErrIsRequired)
+	} else if !crypto.EthereumIsValidAddress(cmd.EthereumAddress) {
+		errs.AddForProperty("announce_node.ethereum_address", ErrIsNotValidEthereumAddress)
 	}
 
 	if len(cmd.ChainPubKey) == 0 {
@@ -53,6 +56,10 @@ func checkAnnounceNode(cmd *commandspb.AnnounceNode) Errors {
 		if err != nil {
 			errs.AddForProperty("announce_node.vega_signature.value", ErrShouldBeHexEncoded)
 		}
+	}
+
+	if len(cmd.SubmitterAddress) != 0 && !crypto.EthereumIsValidAddress(cmd.SubmitterAddress) {
+		errs.AddForProperty("announce_node.submitter_address", ErrIsNotValidEthereumAddress)
 	}
 
 	return errs

--- a/commands/ethereum_key_rotate_submission.go
+++ b/commands/ethereum_key_rotate_submission.go
@@ -1,6 +1,9 @@
 package commands
 
-import commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+import (
+	"code.vegaprotocol.io/vega/libs/crypto"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+)
 
 func CheckEthereumKeyRotateSubmission(cmd *commandspb.EthereumKeyRotateSubmission) error {
 	return checkEthereumKeyRotateSubmission(cmd).ErrorOrNil()
@@ -15,10 +18,14 @@ func checkEthereumKeyRotateSubmission(cmd *commandspb.EthereumKeyRotateSubmissio
 
 	if len(cmd.NewAddress) <= 0 {
 		errs.AddForProperty("ethereum_key_rotate_submission.new_address", ErrIsRequired)
+	} else if !crypto.EthereumIsValidAddress(cmd.NewAddress) {
+		errs.AddForProperty("ethereum_key_rotate_submission.new_address", ErrIsNotValidEthereumAddress)
 	}
 
 	if len(cmd.CurrentAddress) <= 0 {
 		errs.AddForProperty("ethereum_key_rotate_submission.current_address", ErrIsRequired)
+	} else if !crypto.EthereumIsValidAddress(cmd.CurrentAddress) {
+		errs.AddForProperty("ethereum_key_rotate_submission.current_address", ErrIsNotValidEthereumAddress)
 	}
 
 	if cmd.TargetBlock == 0 {
@@ -27,6 +34,10 @@ func checkEthereumKeyRotateSubmission(cmd *commandspb.EthereumKeyRotateSubmissio
 
 	if cmd.EthereumSignature == nil {
 		errs.AddForProperty("ethereum_key_rotate_submission.signature", ErrIsRequired)
+	}
+
+	if len(cmd.SubmitterAddress) != 0 && !crypto.EthereumIsValidAddress(cmd.SubmitterAddress) {
+		errs.AddForProperty("ethereum_key_rotate_submission.submitter_address", ErrIsNotValidEthereumAddress)
 	}
 
 	return errs

--- a/commands/ethereum_key_rotate_submission_test.go
+++ b/commands/ethereum_key_rotate_submission_test.go
@@ -76,6 +76,22 @@ func TestSubmittingNonEmptyEthereumKeyRotateSubmissionCommandSuccess(t *testing.
 	assert.True(t, err.Empty())
 }
 
+func TestEthereumKeyRotateSubmissionInvalidEthereumAddresses(t *testing.T) {
+	err := checkEthereumKeyRotateSubmission(&commandspb.EthereumKeyRotateSubmission{
+		NewAddress:       "0xE7d65d1A6CD6eCc",
+		CurrentAddress:   "0xED816fd7a6e",
+		SubmitterAddress: "0xED816fd7a6e",
+		EthereumSignature: &commandspb.Signature{
+			Value: "deadbeef",
+			Algo:  "vega/ed25519",
+		},
+	})
+
+	assert.Contains(t, err.Get("ethereum_key_rotate_submission.new_address"), commands.ErrIsNotValidEthereumAddress)
+	assert.Contains(t, err.Get("ethereum_key_rotate_submission.current_address"), commands.ErrIsNotValidEthereumAddress)
+	assert.Contains(t, err.Get("ethereum_key_rotate_submission.submitter_address"), commands.ErrIsNotValidEthereumAddress)
+}
+
 func TestSubmittingNonEmptyEthereumKeyRotateSubmissionWithoutSigFails(t *testing.T) {
 	err := checkEthereumKeyRotateSubmission(&commandspb.EthereumKeyRotateSubmission{
 		TargetBlock:    100,

--- a/commands/issue_signatures.go
+++ b/commands/issue_signatures.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"code.vegaprotocol.io/vega/libs/crypto"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 )
 
@@ -20,6 +21,8 @@ func checkIssueSignatures(cmd *commandspb.IssueSignatures) Errors {
 
 	if len(cmd.Submitter) == 0 {
 		errs.AddForProperty("issue_signatures.submitter", ErrIsRequired)
+	} else if !crypto.EthereumIsValidAddress(cmd.Submitter) {
+		errs.AddForProperty("issue_signatures.submitter", ErrIsNotValidEthereumAddress)
 	}
 
 	if cmd.Kind != commandspb.NodeSignatureKind_NODE_SIGNATURE_KIND_ERC20_MULTISIG_SIGNER_REMOVED &&

--- a/commands/node_vote.go
+++ b/commands/node_vote.go
@@ -15,6 +15,8 @@ func checkNodeVote(cmd *commandspb.NodeVote) Errors {
 
 	if len(cmd.Reference) == 0 {
 		errs.AddForProperty("node_vote.reference", ErrIsRequired)
+	} else if len(cmd.Reference) > 1000 {
+		errs.AddForProperty("node_vote.reference", ErrReferenceTooLong)
 	}
 
 	return errs

--- a/commands/proposal_submission.go
+++ b/commands/proposal_submission.go
@@ -15,7 +15,6 @@ import (
 	vegapb "code.vegaprotocol.io/vega/protos/vega"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 	datapb "code.vegaprotocol.io/vega/protos/vega/data/v1"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 const ReferenceMaxLen int = 100
@@ -686,7 +685,7 @@ func checkDataSourceSpec(spec *vegapb.DataSourceDefinition, name string, parentP
 				errs.AddForProperty(fmt.Sprintf("%s.%s.external.oracle.signers.%d", parentProperty, name, i), ErrIsNotValid)
 			} else if pubkey := signer.GetSignerPubKey(); pubkey != nil && !crypto.IsValidVegaPubKey(pubkey.Key) {
 				errs.AddForProperty(fmt.Sprintf("%s.%s.external.oracle.signers.%d", parentProperty, name, i), ErrIsNotValidVegaPubkey)
-			} else if address := signer.GetSignerETHAddress(); address != nil && !common.IsHexAddress(address.Address) {
+			} else if address := signer.GetSignerETHAddress(); address != nil && !crypto.EthereumIsValidAddress(address.Address) {
 				errs.AddForProperty(fmt.Sprintf("%s.%s.external.oracle.signers.%d", parentProperty, name, i), ErrIsNotValidEthereumAddress)
 			}
 		}

--- a/commands/state_var_proposal_submission_test.go
+++ b/commands/state_var_proposal_submission_test.go
@@ -1,0 +1,109 @@
+package commands_test
+
+import (
+	"testing"
+
+	"code.vegaprotocol.io/vega/commands"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNilStateVarProposalFundsFails(t *testing.T) {
+	err := checkStateVarProposal(nil)
+	assert.Contains(t, err.Get("state_variable_proposal"), commands.ErrIsRequired)
+}
+
+func TestStateVarProposals(t *testing.T) {
+	cases := []struct {
+		stateVar  commandspb.StateVariableProposal
+		errString string
+	}{
+		{
+			stateVar: commandspb.StateVariableProposal{
+				Proposal: &vega.StateValueProposal{
+					StateVarId: vgcrypto.RandomHash(),
+					EventId:    "",
+					Kvb: []*vega.KeyValueBundle{
+						{
+							Key:       vgcrypto.RandomHash(),
+							Tolerance: "11000",
+							Value:     &vega.StateVarValue{},
+						},
+					},
+				},
+			},
+			errString: "state_variable_proposal.event_id (is required)",
+		},
+		{
+			stateVar: commandspb.StateVariableProposal{
+				Proposal: &vega.StateValueProposal{
+					StateVarId: "",
+					EventId:    vgcrypto.RandomHash(),
+					Kvb: []*vega.KeyValueBundle{
+						{
+							Key:       vgcrypto.RandomHash(),
+							Tolerance: "11000",
+							Value:     &vega.StateVarValue{},
+						},
+					},
+				},
+			},
+			errString: "state_variable_proposal.state_var_id (is required)",
+		},
+		{
+			stateVar: commandspb.StateVariableProposal{
+				Proposal: &vega.StateValueProposal{
+					StateVarId: "",
+					EventId:    vgcrypto.RandomHash(),
+					Kvb: []*vega.KeyValueBundle{
+						{
+							Key:       vgcrypto.RandomHash(),
+							Tolerance: "11000",
+							Value:     nil,
+						},
+					},
+				},
+			},
+			errString: "state_variable_proposal.key_value_bundle.0.value (is required)",
+		},
+		{
+			stateVar: commandspb.StateVariableProposal{
+				Proposal: &vega.StateValueProposal{
+					StateVarId: vgcrypto.RandomHash(),
+					EventId:    vgcrypto.RandomHash(),
+					Kvb: []*vega.KeyValueBundle{
+						{
+							Key:       vgcrypto.RandomHash(),
+							Tolerance: "11000",
+							Value:     &vega.StateVarValue{},
+						},
+					},
+				},
+			},
+			errString: "",
+		},
+	}
+
+	for _, c := range cases {
+		err := commands.CheckStateVariableProposal(&c.stateVar)
+		if len(c.errString) <= 0 {
+			assert.NoError(t, err)
+			continue
+		}
+		assert.Contains(t, err.Error(), c.errString)
+	}
+}
+
+func checkStateVarProposal(cmd *commandspb.StateVariableProposal) commands.Errors {
+	err := commands.CheckStateVariableProposal(cmd)
+
+	e, ok := err.(commands.Errors)
+	if !ok {
+		return commands.NewErrors()
+	}
+
+	return e
+}

--- a/commands/withdraw_submission.go
+++ b/commands/withdraw_submission.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math/big"
 
+	"code.vegaprotocol.io/vega/libs/crypto"
 	types "code.vegaprotocol.io/vega/protos/vega"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 )
@@ -51,6 +52,8 @@ func checkWithdrawExt(wext *types.WithdrawExt) Errors {
 				"withdraw_ext.erc20.received_address",
 				ErrIsRequired,
 			)
+		} else if !crypto.EthereumIsValidAddress(v.Erc20.ReceiverAddress) {
+			errs.AddForProperty("withdraw_ext.erc20.received_address", ErrIsNotValidEthereumAddress)
 		}
 	default:
 		errs.AddForProperty("withdraw_ext.ext", errors.New("unsupported withdraw extended details"))

--- a/commands/withdraw_submission_test.go
+++ b/commands/withdraw_submission_test.go
@@ -34,11 +34,25 @@ func TestWithdrawSubmission(t *testing.T) {
 				Ext: &types.WithdrawExt{
 					Ext: &types.WithdrawExt_Erc20{
 						Erc20: &types.Erc20WithdrawExt{
+							ReceiverAddress: "0x9135f5afd6F055e731bca2348429482eE614CFfA",
+						},
+					},
+				},
+			},
+		},
+		{
+			withdraw: commandspb.WithdrawSubmission{
+				Amount: "100",
+				Asset:  "08dce6ebf50e34fedee32860b6f459824e4b834762ea66a96504fdc57a9c4741",
+				Ext: &types.WithdrawExt{
+					Ext: &types.WithdrawExt_Erc20{
+						Erc20: &types.Erc20WithdrawExt{
 							ReceiverAddress: "0xsomething",
 						},
 					},
 				},
 			},
+			errString: "withdraw_ext.erc20.received_address (is not a valid ethereum address)",
 		},
 		{
 			withdraw: commandspb.WithdrawSubmission{

--- a/libs/crypto/ethereum.go
+++ b/libs/crypto/ethereum.go
@@ -11,3 +11,8 @@ func EthereumChecksumAddress(s string) string {
 	// as per docs the Hex method return EIP-55 compliant hex strings
 	return common.HexToAddress(s).Hex()
 }
+
+// EthereumIsValidAddress returns whether the given string is a valid ethereum address.
+func EthereumIsValidAddress(s string) bool {
+	return common.IsHexAddress(s)
+}


### PR DESCRIPTION
We now call `crypto.EthereumIsValidAddress()` to validate any ethereum addresses found in a transaction. This is mostly to stop us calling `EthereumChecksumAddress()` on a bad address which doesn't fail, but will instead silently checksum the address to `0x0000000000000000000000000000000000000000` 

I also spotted that we do not length check the `reference` sent in a node-vote, so if I were a naughty validator I could send in a transaction with a _massive_ note-vote reference and it would end up getting delivered and logged as an error in the log potentionally filling up disk space? Probably nothing, but log-injection is a thing so I've added an arbitrary max reference length of 1000.


system-test which does a eth-key-rotation and announcing node passing:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/67289/pipeline/