### PR TITLE
fix: network history status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - [8155](https://github.com/vegaprotocol/vega/issues/8155) - Visor - allow restart without snapshot.
 - [8129](https://github.com/vegaprotocol/vega/issues/8129) - Keep liquidity fee remainder in fee account.
 - [8022](https://github.com/vegaprotocol/vega/issues/8022) - Improve `ListTransfers` API documentation.
+- [8231](https://github.com/vegaprotocol/vega/issues/8231) - Fix `GetNetworkHistoryStatus`
 - [8154](https://github.com/vegaprotocol/vega/issues/8154) - Visor - added option for delaying stop of binaries.
 - [8169](https://github.com/vegaprotocol/vega/issues/8169) - Add `buf` format
 - [7997](https://github.com/vegaprotocol/vega/issues/7997) - Clean up `API` comments when returned value is signed/unsigned.

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -3470,8 +3470,8 @@ func (t *TradingDataServiceV2) GetActiveNetworkHistoryPeerAddresses(context.Cont
 }
 
 // NetworkHistoryStatus returns the network history status.
-func (t *TradingDataServiceV2) NetworkHistoryStatus(context.Context, *v2.GetNetworkHistoryStatusRequest) (*v2.GetNetworkHistoryStatusResponse, error) {
-	defer metrics.StartAPIRequestAndTimeGRPC("NetworkHistoryStatus")()
+func (t *TradingDataServiceV2) GetNetworkHistoryStatus(context.Context, *v2.GetNetworkHistoryStatusRequest) (*v2.GetNetworkHistoryStatusResponse, error) {
+	defer metrics.StartAPIRequestAndTimeGRPC("GetNetworkHistoryStatus")()
 
 	connectedPeerAddresses, err := t.NetworkHistoryService.GetConnectedPeerAddresses()
 	if err != nil {
@@ -3498,7 +3498,7 @@ func (t *TradingDataServiceV2) NetworkHistoryStatus(context.Context, *v2.GetNetw
 }
 
 // NetworkHistoryBootstrapPeers returns the network history bootstrap peers.
-func (t *TradingDataServiceV2) NetworkHistoryBootstrapPeers(context.Context, *v2.GetNetworkHistoryBootstrapPeersRequest) (*v2.GetNetworkHistoryBootstrapPeersResponse, error) {
+func (t *TradingDataServiceV2) GetNetworkHistoryBootstrapPeers(context.Context, *v2.GetNetworkHistoryBootstrapPeersRequest) (*v2.GetNetworkHistoryBootstrapPeersResponse, error) {
 	return &v2.GetNetworkHistoryBootstrapPeersResponse{BootstrapPeers: t.NetworkHistoryService.GetBootstrapPeers()}, nil
 }
 


### PR DESCRIPTION
closes #8231 

working locally:
```
wwestgarth@wwestgarth-macbook ~ -  $ curl localhost:3008/api/v2/networkhistory | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   270  100   270    0     0  45000      0 --:--:-- --:--:-- --:--:-- 45000
{
  "ipfsAddress": "/ip4/0.0.0.0/tcp/4001/p2p/12D3KooWEuDEeER36MzTHUptVAzmuTg3HUR3T8AwmihsL3d5wGCf",
  "swarmKey": "/key/swarm/psk/1.0.0/\n/base16/\n766567612d6465766e6574312d32303233303331353135303800000000000000",
  "swarmKeySeed": "vega-devnet1-202303151508",
  "connectedPeers": []
}
```

and bootstrap peers:
```
wwestgarth@wwestgarth-macbook ~ -  $ curl localhost:3008/api/v2/networkhistory/bootstrap | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   210  100   210    0     0  30000      0 --:--:-- --:--:-- --:--:-- 30000
{
  "bootstrapPeers": [
    "/dns/n06.devnet1.vega.xyz/tcp/4001/ipfs/12D3KooWEbFqpQc2srFtrPcYK5t1e8mfouDutyzwW3XBEPhqYrLi",
    "/dns/n07.devnet1.vega.xyz/tcp/4001/ipfs/12D3KooWSjnLDRMwrNxWqyyzkWCkiP7JaHpKkgbNGpo8fWWfkXoy"
  ]
}
```