### PR TITLE
fix: database meta data should return empty when database version is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🐛 Fixes
 - [8208](https://github.com/vegaprotocol/vega/issues/8208) - Fix block explorer API documentation
 - [8203](https://github.com/vegaprotocol/vega/issues/8203) - Fix `assetId` parsing for Ledger entries export to `CSV` file.
+- [8226](https://github.com/vegaprotocol/vega/issues/8226) - Fix auto initialise failure when initialising empty node
 - [8206](https://github.com/vegaprotocol/vega/issues/8206) - Add number of decimal places to oracle spec.
 
 

--- a/datanode/networkhistory/snapshot/database_meta_data.go
+++ b/datanode/networkhistory/snapshot/database_meta_data.go
@@ -57,6 +57,10 @@ func NewDatabaseMetaData(ctx context.Context, connPool *pgxpool.Pool) (DatabaseM
 		return DatabaseMetadata{}, fmt.Errorf("failed to get database version: %w", err)
 	}
 
+	if dbVersion == 0 {
+		return DatabaseMetadata{}, nil
+	}
+
 	tableNames, err := sqlstore.GetAllTableNames(ctx, connPool)
 	if err != nil {
 		return DatabaseMetadata{}, fmt.Errorf("failed to get names of tables to copy:%w", err)


### PR DESCRIPTION
closes #8226 - When creating database metadata on empty database it was attempting to query timescale tables that do not yet exist as the database is at version 0 and has no schema.  This fix returns an empty metadata object in this scenario.