### PR TITLE
fix: better error handling in ListEntities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [8226](https://github.com/vegaprotocol/vega/issues/8226) - Fix auto initialise failure when initialising empty node
 - [8186](https://github.com/vegaprotocol/vega/issues/8186) - Set a close timestamp when closing a market
 - [8206](https://github.com/vegaprotocol/vega/issues/8206) - Add number of decimal places to oracle spec.
+- [8225](https://github.com/vegaprotocol/vega/issues/8225) - Better error handling in `ListEntities`
 - [8222](https://github.com/vegaprotocol/vega/issues/8222) - `EstimatePositions` does not correctly validate data.
 
 

--- a/datanode/api/errors.go
+++ b/datanode/api/errors.go
@@ -285,7 +285,9 @@ var (
 	// MarginLevels...
 	ErrMarginLevelsGetByTxHash = errors.New("failed to get margin levels for tx hash")
 
-	ErrMissingEmptyTxHash = errors.New("missing or empty tx hash")
+	// TxHashes...
+	ErrMissingEmptyTxHash = newInvalidArgumentError("missing or empty transaction hash")
+	ErrInvalidTxHash      = newInvalidArgumentError("not a valid transaction hash")
 )
 
 // errorMap contains a mapping between errors and Vega numeric error codes.

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -3523,11 +3523,14 @@ func (t *TradingDataServiceV2) ListEntities(ctx context.Context, req *v2.ListEnt
 	defer metrics.StartAPIRequestAndTimeGRPC("ListEntities")()
 
 	if len(req.GetTransactionHash()) == 0 {
-		return nil, ErrMissingEmptyTxHash
+		return nil, formatE(ErrMissingEmptyTxHash)
+	}
+
+	if !crypto.IsValidVegaID(req.GetTransactionHash()) {
+		return nil, formatE(ErrInvalidTxHash)
 	}
 
 	txHash := entities.TxHash(req.GetTransactionHash())
-
 	eg, ctx := errgroup.WithContext(ctx)
 
 	// query


### PR DESCRIPTION
closes #8225 

Error handling has been improved and now returns `InvalidArgument` if you pass in a bad txHash:
<img width="1169" alt="Screenshot 2023-05-02 at 09 34 02" src="https://user-images.githubusercontent.com/1857660/235618899-c63de4a8-fecd-449d-b709-ab5e939ab1be.png">

With regard to the claim that it doesn't find a proposal corresponding to a transaction with hash `6c2d2bd3665dad09b846fecb9bdc46c15a95527db34a7e956566a83cafc8d97d` it did for me on `stagnet3`:
<img width="1169" alt="Screenshot 2023-05-02 at 09 34 15" src="https://user-images.githubusercontent.com/1857660/235619301-333ddbd4-bbee-4bfa-b575-8cb201fe8b2e.png">



@edd can you try again? Maybe you were asking fairground by mistake?