### PR TITLE
fix: set a close timestamp when a market is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [8203](https://github.com/vegaprotocol/vega/issues/8203) - Fix `assetId` parsing for Ledger entries export to `CSV` file.
 - [8251](https://github.com/vegaprotocol/vega/issues/8251) - Fix bug in expired orders optimisation resulting in non deterministic order sequence numbers
 - [8226](https://github.com/vegaprotocol/vega/issues/8226) - Fix auto initialise failure when initialising empty node
+- [8186](https://github.com/vegaprotocol/vega/issues/8186) - Set a close timestamp when closing a market
 - [8206](https://github.com/vegaprotocol/vega/issues/8206) - Add number of decimal places to oracle spec.
 - [8222](https://github.com/vegaprotocol/vega/issues/8222) - `EstimatePositions` does not correctly validate data.
 

--- a/core/execution/market.go
+++ b/core/execution/market.go
@@ -846,6 +846,7 @@ func (m *Market) cleanMarketWithState(ctx context.Context, mktState types.Market
 
 	m.mkt.State = mktState
 	m.mkt.TradingMode = types.MarketTradingModeNoTrading
+	m.mkt.MarketTimestamps.Close = m.timeService.GetTimeNow().UnixNano()
 	m.broker.Send(events.NewMarketUpdatedEvent(ctx, *m.mkt))
 
 	return nil


### PR DESCRIPTION
closes #8186 

Added a check that the timestamp is non-zero in the system-test `test_market_lifecycle`:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/68630/pipeline

Looking into the events even closer we get an oracle-data event that looks like this:
```
"data":[{"name":"oracle.test.settlement3E05D","value":"1300000"}],"matchedSpecIds":["bbe003c15e16d6c063831aa2a77425d74a35296c57ce669a6165ceb4beeddcc7"],"broadcastAt":"1683020893305815656"}}}
```
and a market update event with market-timestamps of:
```
"marketTimestamps":{"proposed":"1683020851361298194","pending":"1683020862108074453","open":"1683020876734072114","close":"1683020893305815656"}
```

notably
```
"broadcastAt":"1683020893305815656" == "close":"1683020893305815656"
```