### PR TITLE
Add a command line on the wallet to locate the wallet files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🛠 Improvements
 - [7906](https://github.com/vegaprotocol/vega/issues/7906) - Connection tokens on the wallet survive reboot.
+- [8264](https://github.com/vegaprotocol/vega/issues/8264) - Add a command line on the wallet to locate the wallet files
 
 
 ### 🐛 Fixes

--- a/cmd/vegawallet/commands/root.go
+++ b/cmd/vegawallet/commands/root.go
@@ -93,6 +93,7 @@ func BuildCmdRoot(w io.Writer) *cobra.Command {
 	cmd.AddCommand(NewCmdDescribeWallet(w, f))
 	cmd.AddCommand(NewCmdImportWallet(w, f))
 	cmd.AddCommand(NewCmdListWallets(w, f))
+	cmd.AddCommand(NewCmdLocateWallets(w, f))
 	cmd.AddCommand(NewCmdRenameWallet(w, f))
 
 	return cmd

--- a/cmd/vegawallet/commands/wallet_locate.go
+++ b/cmd/vegawallet/commands/wallet_locate.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"code.vegaprotocol.io/vega/cmd/vegawallet/commands/cli"
+	"code.vegaprotocol.io/vega/cmd/vegawallet/commands/flags"
+	"code.vegaprotocol.io/vega/cmd/vegawallet/commands/printer"
+	"code.vegaprotocol.io/vega/paths"
+	"code.vegaprotocol.io/vega/wallet/wallets"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	locateWalletsLong = cli.LongDesc(`
+		Locate the folder in which all the wallet files are stored.
+	`)
+
+	locateWalletsExample = cli.Examples(`
+		# Locate wallet files
+		{{.Software}} locate
+	`)
+)
+
+type LocateWalletsResponse struct {
+	Path string `json:"path"`
+}
+
+type LocateWalletsHandler func() (*LocateWalletsResponse, error)
+
+func NewCmdLocateWallets(w io.Writer, rf *RootFlags) *cobra.Command {
+	h := func() (*LocateWalletsResponse, error) {
+		vegaPaths := paths.New(rf.Home)
+
+		walletStore, err := wallets.InitialiseStoreFromPaths(vegaPaths, false)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't initialise networks store: %w", err)
+		}
+
+		return &LocateWalletsResponse{
+			Path: walletStore.GetWalletsPath(),
+		}, nil
+	}
+
+	return BuildCmdLocateWallets(w, h, rf)
+}
+
+func BuildCmdLocateWallets(w io.Writer, handler LocateWalletsHandler, rf *RootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "locate",
+		Short:   "Locate the folder containing the wallet files",
+		Long:    locateWalletsLong,
+		Example: locateWalletsExample,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			resp, err := handler()
+			if err != nil {
+				return err
+			}
+
+			switch rf.Output {
+			case flags.InteractiveOutput:
+				PrintLocateWalletsResponse(w, resp)
+			case flags.JSONOutput:
+				return printer.FprintJSON(w, resp)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func PrintLocateWalletsResponse(w io.Writer, resp *LocateWalletsResponse) {
+	p := printer.NewInteractivePrinter(w)
+
+	str := p.String()
+	defer p.Print(str)
+
+	str.Text("Wallet files are located at: ").SuccessText(resp.Path).NextLine()
+}

--- a/wallet/wallet/store/v1/file_store.go
+++ b/wallet/wallet/store/v1/file_store.go
@@ -600,6 +600,10 @@ func (s *FileStore) broadcastEvent(ctx context.Context, eventToBroadcast wallet.
 	}()
 }
 
+func (s *FileStore) GetWalletsPath() string {
+	return s.walletsHome
+}
+
 func checkContextStatus(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err


### PR DESCRIPTION
Close #8264 

## Testing protocol

1. `vega wallet locate --home ~/Vega/Fairground/` should display the right folder
2.  `vega wallet locate`  should display the right folder