### PR TITLE
chore: speed up unittest where possible

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -348,7 +348,7 @@ pipeline {
                     options { retry(3) }
                     steps {
                         dir('vega') {
-                            sh 'go test  -timeout 30m -v ./... 2>&1 | tee unit-test-results.txt && cat unit-test-results.txt | go-junit-report > vega-unit-test-report.xml'
+                            sh 'go test -short -timeout 30m -v ./... 2>&1 | tee unit-test-results.txt && cat unit-test-results.txt | go-junit-report > vega-unit-test-report.xml'
                             junit checksName: 'Unit Tests', testResults: 'vega-unit-test-report.xml'
                         }
                     }
@@ -360,7 +360,7 @@ pipeline {
                     options { retry(3) }
                     steps {
                         dir('vega') {
-                            sh 'go test -timeout 30m  -v -race ./... 2>&1 | tee unit-test-race-results.txt && cat unit-test-race-results.txt | go-junit-report > vega-unit-test-race-report.xml'
+                            sh 'go test -short -timeout 30m  -v -race ./... 2>&1 | tee unit-test-race-results.txt && cat unit-test-race-results.txt | go-junit-report > vega-unit-test-race-report.xml'
                             junit checksName: 'Unit Tests with Race', testResults: 'vega-unit-test-race-report.xml'
                         }
                     }
@@ -378,7 +378,7 @@ pipeline {
                     options { retry(3) }
                     steps {
                         dir('vega/datanode/integration') {
-                            sh 'go test -integration -v ./... 2>&1 | tee integration-test-results.txt && cat integration-test-results.txt | go-junit-report > datanode-integration-test-report.xml'
+                            sh 'go test -v ./... 2>&1 | tee integration-test-results.txt && cat integration-test-results.txt | go-junit-report > datanode-integration-test-report.xml'
                             junit checksName: 'Datanode Integration Tests', testResults: 'datanode-integration-test-report.xml'
                         }
                     }

--- a/cmd/vegawallet/commands/init_test.go
+++ b/cmd/vegawallet/commands/init_test.go
@@ -13,6 +13,7 @@ func TestInit(t *testing.T) {
 }
 
 func testInitialisingSoftwareSucceeds(t *testing.T) {
+	t.Parallel()
 	testDir := t.TempDir()
 
 	// given
@@ -28,6 +29,7 @@ func testInitialisingSoftwareSucceeds(t *testing.T) {
 }
 
 func testForcingSoftwareInitialisationSucceeds(t *testing.T) {
+	t.Parallel()
 	testDir := t.TempDir()
 
 	// given

--- a/core/governance/engine_test.go
+++ b/core/governance/engine_test.go
@@ -811,7 +811,7 @@ func testMultipleProposalsLifecycle(t *testing.T) {
 	eng.tokenBal[partyA] = 200
 	eng.tokenBal[partyB] = 100
 
-	const howMany = 100
+	const howMany = 10
 	passed := map[string]*types.Proposal{}
 	declined := map[string]*types.Proposal{}
 	var afterClosing time.Time

--- a/core/integration/main_test.go
+++ b/core/integration/main_test.go
@@ -14,7 +14,9 @@ package core_test
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"testing"
@@ -26,7 +28,6 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -42,12 +43,17 @@ var (
 
 func init() {
 	godog.BindCommandLineFlags("godog.", &gdOpts)
-	pflag.StringVar(&features, "features", "", "a coma separated list of paths to the feature files")
+	flag.StringVar(&features, "features", "", "a coma separated list of paths to the feature files")
 }
 
 func TestMain(m *testing.M) {
-	pflag.Parse()
-	gdOpts.Paths = pflag.Args()
+	flag.Parse()
+	gdOpts.Paths = flag.Args()
+
+	if testing.Short() {
+		log.Print("Skipping core integration tests, go test run with -short")
+		return
+	}
 
 	status := godog.TestSuite{
 		Name:                 "godogs",

--- a/core/statevar/state_var_test.go
+++ b/core/statevar/state_var_test.go
@@ -142,17 +142,15 @@ func setupValidators(t *testing.T, numValidators int, startCalc func(string, typ
 }
 
 func TestStateVar(t *testing.T) {
-	for i := 0; i < 10; i++ {
-		now = time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
-		t.Run("test converters from/to native data type/key value bundle", testConverters)
-		t.Run("new event comes in, no previous active event - triggers calculation", testEventTriggeredNoPreviousEvent)
-		t.Run("new event comes in aborting an existing event", testEventTriggeredWithPreviousEvent)
-		t.Run("new event comes in and triggers a calculation that result in an error", testEventTriggeredCalculationError)
-		t.Run("perfect match through quorum", testBundleReceivedPerfectMatchOfQuorum)
-		t.Run("reach consensus through random selection of one that is within reach of 2/3+1 of the others", testBundleReceivedReachingConsensusSuccessfuly)
-		t.Run("no consensus can be reached", testBundleReceivedReachingConsensusNotSuccessful)
-		t.Run("time based trigger", testTimeBasedEvent)
-	}
+	now = time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
+	t.Run("test converters from/to native data type/key value bundle", testConverters)
+	t.Run("new event comes in, no previous active event - triggers calculation", testEventTriggeredNoPreviousEvent)
+	t.Run("new event comes in aborting an existing event", testEventTriggeredWithPreviousEvent)
+	t.Run("new event comes in and triggers a calculation that result in an error", testEventTriggeredCalculationError)
+	t.Run("perfect match through quorum", testBundleReceivedPerfectMatchOfQuorum)
+	t.Run("reach consensus through random selection of one that is within reach of 2/3+1 of the others", testBundleReceivedReachingConsensusSuccessfuly)
+	t.Run("no consensus can be reached", testBundleReceivedReachingConsensusNotSuccessful)
+	t.Run("time based trigger", testTimeBasedEvent)
 }
 
 func testConverters(t *testing.T) {

--- a/core/validators/announce_node_test.go
+++ b/core/validators/announce_node_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestTendermintKey(t *testing.T) {
+	t.Parallel()
 	notBase64 := "170ffakjde"
 	require.Error(t, validators.VerifyTendermintKey(notBase64))
 
@@ -35,20 +36,16 @@ func TestTendermintKey(t *testing.T) {
 	require.NoError(t, validators.VerifyTendermintKey(validKey))
 }
 
-func TestSignVerifyAnnounceNode(t *testing.T) {
-	cmd := createSignedAnnounceCommand(t)
-	require.NoError(t, validators.VerifyAnnounceNode(cmd))
-}
-
-func TestDoubleAnnounce(t *testing.T) {
+func TestAnnounceNode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
 	tt := getTestTopology(t)
 	cmd := createSignedAnnounceCommand(t)
-	ctx := context.Background()
 
-	// Add it once
+	// Now announce it and check the signature verify
 	require.NoError(t, tt.Topology.ProcessAnnounceNode(ctx, cmd))
 
-	// Add it again
+	// Announce it again
 	require.ErrorIs(t, tt.Topology.ProcessAnnounceNode(ctx, cmd), validators.ErrVegaNodeAlreadyRegisterForChain)
 }
 
@@ -95,11 +92,11 @@ func createTestNodeWallets(t *testing.T) *nodewallets.NodeWallets {
 	walletsPass := vgrand.RandomStr(10)
 
 	if _, err := nodewallets.GenerateEthereumWallet(vegaPaths, registryPass, walletsPass, "", false); err != nil {
-		panic("couldn't generate Ethereum node wallet for tests")
+		t.Fatal("couldn't generate Ethereum node wallet for tests")
 	}
 
 	if _, err := nodewallets.GenerateVegaWallet(vegaPaths, registryPass, walletsPass, false); err != nil {
-		panic("couldn't generate Vega node wallet for tests")
+		t.Fatal("couldn't generate Vega node wallet for tests")
 	}
 	nw, err := nodewallets.GetNodeWallets(config, vegaPaths, registryPass)
 	require.NoError(t, err)

--- a/core/validators/erc20multisig/checkpoint_test.go
+++ b/core/validators/erc20multisig/checkpoint_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMultisigTopologySheckpoint(t *testing.T) {
+func TestMultisigTopologyCheckpoint(t *testing.T) {
 	top := getTestTopology(t)
 	defer top.ctrl.Finish()
 

--- a/core/validators/topology_checkpoint_test.go
+++ b/core/validators/topology_checkpoint_test.go
@@ -54,10 +54,8 @@ func hexEncode(str string) string {
 }
 
 func TestTopologyCheckpoint(t *testing.T) {
-	for i := 0; i < 100; i++ {
-		t.Run("test checkpoint success", testTopologyCheckpointSuccess)
-		t.Run("test checkpoint uses relative block height", testTopologyCheckpointUsesRelativeBlockHeight)
-	}
+	t.Run("test checkpoint success", testTopologyCheckpointSuccess)
+	t.Run("test checkpoint uses relative block height", testTopologyCheckpointUsesRelativeBlockHeight)
 }
 
 func TestCheckPointLoading(t *testing.T) {

--- a/core/validators/witness_snapshot_test.go
+++ b/core/validators/witness_snapshot_test.go
@@ -27,85 +27,86 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
-	for i := 0; i < 100; i++ {
-		erc := getTestWitness(t)
-		defer erc.ctrl.Finish()
-		defer erc.Stop()
+	erc := getTestWitness(t)
+	defer erc.ctrl.Finish()
+	defer erc.Stop()
 
-		key := (&types.PayloadWitness{}).Key()
+	key := (&types.PayloadWitness{}).Key()
 
-		state1, _, err := erc.Witness.GetState(key)
-		require.Nil(t, err)
+	state1, _, err := erc.Witness.GetState(key)
+	require.Nil(t, err)
 
-		erc.top.EXPECT().IsValidator().AnyTimes().Return(true)
+	erc.top.EXPECT().IsValidator().AnyTimes().Return(true)
 
-		res := testRes{"resource-id-1", func() error {
-			return nil
-		}}
-		checkUntil := erc.startTime.Add(700 * time.Second)
-		cb := func(interface{}, bool) {}
+	ctx, cancel := context.WithCancel(context.Background())
+	res := testRes{"resource-id-1", func() error {
+		cancel()
+		return nil
+	}}
+	checkUntil := erc.startTime.Add(700 * time.Second)
 
-		err = erc.StartCheck(res, cb, checkUntil)
-		assert.NoError(t, err)
+	cb := func(interface{}, bool) {}
+	err = erc.StartCheck(res, cb, checkUntil)
+	assert.NoError(t, err)
 
-		time.Sleep(10 * time.Millisecond)
+	// wait until we've done a check
+	<-ctx.Done()
 
-		// take a snapshot after the resource has been added
-		state2, _, err := erc.Witness.GetState(key)
-		require.Nil(t, err)
+	// take a snapshot after the resource has been added
+	state2, _, err := erc.Witness.GetState(key)
+	require.Nil(t, err)
 
-		// verify it has changed from before the resource
-		require.False(t, bytes.Equal(state1, state2))
+	// verify it has changed from before the resource
+	require.False(t, bytes.Equal(state1, state2))
 
-		var pl snapshot.Payload
-		proto.Unmarshal(state2, &pl)
-		payload := types.PayloadFromProto(&pl)
+	var pl snapshot.Payload
+	proto.Unmarshal(state2, &pl)
+	payload := types.PayloadFromProto(&pl)
 
-		// reload the state
-		erc2 := getTestWitness(t)
-		defer erc2.ctrl.Finish()
-		defer erc2.Stop()
-		erc2.top.EXPECT().IsValidator().AnyTimes().Return(true)
-		erc2.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("1234")
+	// reload the state
+	erc2 := getTestWitness(t)
+	defer erc2.ctrl.Finish()
+	defer erc2.Stop()
+	erc2.top.EXPECT().IsValidator().AnyTimes().Return(true)
+	erc2.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("1234")
 
-		_, err = erc2.LoadState(context.Background(), payload)
-		require.Nil(t, err)
-		erc2.RestoreResource(res, cb)
+	_, err = erc2.LoadState(context.Background(), payload)
+	require.Nil(t, err)
+	erc2.RestoreResource(res, cb)
 
-		// expect the hash and state have been restored successfully
-		state3, _, err := erc2.GetState(key)
-		require.Nil(t, err)
-		require.True(t, bytes.Equal(state2, state3))
+	// expect the hash and state have been restored successfully
+	state3, _, err := erc2.GetState(key)
+	require.Nil(t, err)
+	require.True(t, bytes.Equal(state2, state3))
 
-		// add a vote
-		pubkey := newPublicKey("1234")
-		erc2.top.EXPECT().IsValidatorVegaPubKey(pubkey.Hex()).Times(1).Return(true)
-		erc2.top.EXPECT().IsTendermintValidator(pubkey.Hex()).AnyTimes().Return(true)
-		err = erc2.AddNodeCheck(context.Background(), &commandspb.NodeVote{Reference: res.id}, pubkey)
+	// add a vote
+	pubkey := newPublicKey("1234")
+	erc2.top.EXPECT().IsValidatorVegaPubKey(pubkey.Hex()).Times(1).Return(true)
+	erc2.top.EXPECT().IsTendermintValidator(pubkey.Hex()).AnyTimes().Return(true)
+	err = erc2.AddNodeCheck(context.Background(), &commandspb.NodeVote{Reference: res.id}, pubkey)
 
-		assert.NoError(t, err)
+	assert.NoError(t, err)
 
-		// expect the hash/state to have changed
-		state4, _, err := erc2.GetState(key)
-		require.Nil(t, err)
-		require.False(t, bytes.Equal(state4, state3))
+	// expect the hash/state to have changed
+	state4, _, err := erc2.GetState(key)
+	require.Nil(t, err)
+	require.False(t, bytes.Equal(state4, state3))
 
-		// restore from the state with vote
-		proto.Unmarshal(state4, &pl)
-		payload = types.PayloadFromProto(&pl)
+	// restore from the state with vote
+	proto.Unmarshal(state4, &pl)
+	payload = types.PayloadFromProto(&pl)
 
-		erc3 := getTestWitness(t)
-		defer erc3.ctrl.Finish()
-		defer erc3.Stop()
-		erc3.top.EXPECT().IsValidator().AnyTimes().Return(true)
-		erc3.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("1234")
+	erc3 := getTestWitness(t)
+	defer erc3.ctrl.Finish()
+	defer erc3.Stop()
+	erc3.top.EXPECT().IsValidator().AnyTimes().Return(true)
+	erc3.top.EXPECT().SelfVegaPubKey().AnyTimes().Return("1234")
 
-		_, err = erc3.LoadState(context.Background(), payload)
-		require.Nil(t, err)
-		erc3.RestoreResource(res, cb)
+	_, err = erc3.LoadState(context.Background(), payload)
+	require.Nil(t, err)
+	erc3.RestoreResource(res, cb)
 
-		state5, _, err := erc3.GetState(key)
-		require.Nil(t, err)
-		require.True(t, bytes.Equal(state5, state4))
-	}
+	state5, _, err := erc3.GetState(key)
+	require.Nil(t, err)
+	require.True(t, bytes.Equal(state5, state4))
 }

--- a/datanode/integration/integration_test.go
+++ b/datanode/integration/integration_test.go
@@ -55,11 +55,10 @@ const (
 )
 
 var (
-	client                  *graphql.Client
-	integrationTestsEnabled = flag.Bool("integration", false, "run integration tests")
-	blockWhenDone           = flag.Bool("block", false, "leave services running after tests are complete NOTE: EMBEDDED POSGRESQL WILL NOT SHUT DOWN PROPERLY")
-	writeGolden             = flag.Bool("golden", false, "write query results to 'golden' files for comparison")
-	goldenDir               string
+	client        *graphql.Client
+	blockWhenDone = flag.Bool("block", false, "leave services running after tests are complete NOTE: EMBEDDED POSGRESQL WILL NOT SHUT DOWN PROPERLY")
+	writeGolden   = flag.Bool("golden", false, "write query results to 'golden' files for comparison")
+	goldenDir     string
 )
 
 func TestMain(m *testing.M) {
@@ -67,8 +66,8 @@ func TestMain(m *testing.M) {
 	ctx, cfunc := context.WithCancel(context.Background())
 	defer cfunc()
 
-	if !*integrationTestsEnabled {
-		log.Print("Skipping integration tests. To enable pass -integration flag to 'go test'")
+	if testing.Short() {
+		log.Print("Skipping datanode integration tests, go test run with -short")
 		return
 	}
 

--- a/datanode/sqlstore/blocks_test.go
+++ b/datanode/sqlstore/blocks_test.go
@@ -24,6 +24,17 @@ import (
 	"code.vegaprotocol.io/vega/datanode/sqlstore"
 )
 
+type testBlockSource struct {
+	blockStore *sqlstore.Blocks
+	blockTime  time.Time
+}
+
+func (bs *testBlockSource) getNextBlock(t *testing.T, ctx context.Context) entities.Block {
+	t.Helper()
+	bs.blockTime = bs.blockTime.Add(1 * time.Second)
+	return addTestBlockForTime(t, ctx, bs.blockStore, bs.blockTime)
+}
+
 func addTestBlock(t *testing.T, ctx context.Context, bs *sqlstore.Blocks) entities.Block {
 	t.Helper()
 	return addTestBlockForTime(t, ctx, bs, time.Now())

--- a/datanode/sqlstore/deposits_test.go
+++ b/datanode/sqlstore/deposits_test.go
@@ -152,7 +152,8 @@ func testInsertDepositUpdatesIfNewBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, ctx, bs)
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	depositProto := getTestDeposit(testID, testID, testID, testAmount, testID, time.Now().UnixNano())
 
 	deposit, err := entities.DepositFromProto(depositProto, generateTxHash(), block.VegaTime)
@@ -164,9 +165,7 @@ func testInsertDepositUpdatesIfNewBlock(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, rowCount)
 
-	time.Sleep(time.Second)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	depositProto.Status = vega.Deposit_STATUS_FINALIZED
 	deposit, err = entities.DepositFromProto(depositProto, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting market proto to database entity")
@@ -187,14 +186,14 @@ func testDepositsGetByID(t *testing.T) {
 	ctx, rollback := tempTransaction(t)
 	defer rollback()
 	bs, ds, conn := setupDepositStoreTests(t)
-
 	var rowCount int
 
 	err := conn.QueryRow(ctx, `select count(*) from deposits`).Scan(&rowCount)
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, ctx, bs)
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	depositProto := getTestDeposit(testID, testID, testID, testAmount, testID, time.Now().UnixNano())
 
 	deposit, err := entities.DepositFromProto(depositProto, generateTxHash(), block.VegaTime)
@@ -206,9 +205,7 @@ func testDepositsGetByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, rowCount)
 
-	time.Sleep(time.Second)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	depositProto.Status = vega.Deposit_STATUS_FINALIZED
 	deposit, err = entities.DepositFromProto(depositProto, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting market proto to database entity")
@@ -237,7 +234,8 @@ func testDepositsGetByParty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, ctx, bs)
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	depositProto1 := getTestDeposit(testID, testID, testID, testAmount, testID, time.Now().UnixNano())
 	depositProto1.Id = "deadbeef01"
 
@@ -252,9 +250,7 @@ func testDepositsGetByParty(t *testing.T) {
 	err = ds.Upsert(ctx, deposit)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 500)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	depositProto1.Status = vega.Deposit_STATUS_FINALIZED
 	deposit, err = entities.DepositFromProto(depositProto1, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting market proto to database entity")
@@ -267,18 +263,14 @@ func testDepositsGetByParty(t *testing.T) {
 
 	want = append(want, *deposit)
 
-	time.Sleep(time.Millisecond * 500)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	deposit, err = entities.DepositFromProto(depositProto2, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting market proto to database entity")
 
 	err = ds.Upsert(ctx, deposit)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 500)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	deposit, err = entities.DepositFromProto(depositProto2, generateTxHash(), block.VegaTime)
 	depositProto2.Status = vega.Deposit_STATUS_FINALIZED
 	require.NoError(t, err, "Converting market proto to database entity")
@@ -340,9 +332,9 @@ func addDeposits(ctx context.Context, t *testing.T, bs *sqlstore.Blocks, ds *sql
 	vegaTime := time.Now().Truncate(time.Microsecond)
 	amount := int64(1000)
 	deposits := make([]entities.Deposit, 0, 10)
+	source := &testBlockSource{bs, time.Now()}
 	for i := 0; i < 10; i++ {
-		addTestBlockForTime(t, ctx, bs, vegaTime)
-
+		source.getNextBlock(t, ctx)
 		depositProto := getTestDeposit(fmt.Sprintf("deadbeef%02d", i+1), testID, testID,
 			strconv.FormatInt(amount, 10), helpers.GenerateID(), vegaTime.UnixNano())
 		deposit, err := entities.DepositFromProto(depositProto, generateTxHash(), vegaTime)

--- a/datanode/sqlstore/helpers/helpers.go
+++ b/datanode/sqlstore/helpers/helpers.go
@@ -1,15 +1,10 @@
 package helpers
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"math/rand"
-	"strconv"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
 )
 
 // GenerateID generates a 256 bit pseudo-random hash ID.
 func GenerateID() string {
-	randomString := strconv.FormatInt(rand.Int63(), 10)
-	hash := sha256.Sum256([]byte(randomString))
-	return hex.EncodeToString(hash[:])
+	return vgcrypto.RandomHash()
 }

--- a/datanode/sqlstore/liquidity_provision_test.go
+++ b/datanode/sqlstore/liquidity_provision_test.go
@@ -120,8 +120,9 @@ func testGetLPByReferenceAndParty(t *testing.T) {
 	// Test with all LP orders
 	lpProto := getTestLiquidityProvision(false)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -131,8 +132,6 @@ func testGetLPByReferenceAndParty(t *testing.T) {
 
 		data.CreatedAt = data.CreatedAt.Truncate(time.Microsecond)
 		data.UpdatedAt = data.UpdatedAt.Truncate(time.Microsecond)
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from liquidity_provisions").Scan(&rowCount))
@@ -159,8 +158,9 @@ func testGetLPByReferenceAndPartyLiveOrders(t *testing.T) {
 	// Test with live LP orders
 	lpProto := getTestLiquidityProvision(true)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -170,8 +170,6 @@ func testGetLPByReferenceAndPartyLiveOrders(t *testing.T) {
 
 		data.CreatedAt = data.CreatedAt.Truncate(time.Microsecond)
 		data.UpdatedAt = data.UpdatedAt.Truncate(time.Microsecond)
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from live_liquidity_provisions").Scan(&rowCount))
@@ -196,8 +194,9 @@ func testLiquidityProvisionGetByTxHash(t *testing.T) {
 	assert.Equal(t, 0, rowCount)
 
 	lps := []entities.LiquidityProvision{}
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range getTestLiquidityProvision(true) {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -207,8 +206,6 @@ func testLiquidityProvisionGetByTxHash(t *testing.T) {
 
 		data.CreatedAt = data.CreatedAt.Truncate(time.Microsecond)
 		data.UpdatedAt = data.UpdatedAt.Truncate(time.Microsecond)
-
-		time.Sleep(100 * time.Millisecond)
 
 		lps = append(lps, data)
 	}
@@ -244,8 +241,9 @@ func testGetLPByPartyOnly(t *testing.T) {
 
 	want := make([]entities.LiquidityProvision, 0)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -257,8 +255,6 @@ func testGetLPByPartyOnly(t *testing.T) {
 		data.UpdatedAt = data.UpdatedAt.Truncate(time.Microsecond)
 
 		want = append(want, data)
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from liquidity_provisions").Scan(&rowCount))
@@ -287,8 +283,9 @@ func testGetLPByPartyOnlyLiveOrders(t *testing.T) {
 
 	want := make([]entities.LiquidityProvision, 0)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -300,8 +297,6 @@ func testGetLPByPartyOnlyLiveOrders(t *testing.T) {
 		data.UpdatedAt = data.UpdatedAt.Truncate(time.Microsecond)
 
 		want = append(want, data)
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from live_liquidity_provisions").Scan(&rowCount))
@@ -332,8 +327,9 @@ func testGetLPByPartyAndMarket(t *testing.T) {
 
 	want := make([]entities.LiquidityProvision, 0)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -347,8 +343,6 @@ func testGetLPByPartyAndMarket(t *testing.T) {
 		if data.MarketID.String() == wantMarketID {
 			want = append(want, data)
 		}
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from liquidity_provisions").Scan(&rowCount))
@@ -379,8 +373,9 @@ func testGetLPByPartyAndMarketLiveOrders(t *testing.T) {
 
 	want := make([]entities.LiquidityProvision, 0)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -394,8 +389,6 @@ func testGetLPByPartyAndMarketLiveOrders(t *testing.T) {
 		if data.MarketID.String() == wantMarketID {
 			want = append(want, data)
 		}
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from live_liquidity_provisions").Scan(&rowCount))
@@ -438,8 +431,9 @@ func testGetLPNoPartyWithMarket(t *testing.T) {
 	wantMarketID := "dabbad00"
 	want := make([]entities.LiquidityProvision, 0)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -453,8 +447,6 @@ func testGetLPNoPartyWithMarket(t *testing.T) {
 		if data.MarketID.String() == wantMarketID {
 			want = append(want, data)
 		}
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from liquidity_provisions").Scan(&rowCount))
@@ -482,8 +474,9 @@ func testGetLPNoPartyWithMarketLiveOrders(t *testing.T) {
 	wantMarketID := "dabbad00"
 	want := make([]entities.LiquidityProvision, 0)
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, lpp := range lpProto {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 
 		data, err := entities.LiquidityProvisionFromProto(lpp, generateTxHash(), block.VegaTime)
 		require.NoError(t, err)
@@ -497,8 +490,6 @@ func testGetLPNoPartyWithMarketLiveOrders(t *testing.T) {
 		if data.MarketID.String() == wantMarketID {
 			want = append(want, data)
 		}
-
-		time.Sleep(100 * time.Millisecond)
 	}
 
 	assert.NoError(t, conn.QueryRow(ctx, "select count(*) from live_liquidity_provisions").Scan(&rowCount))

--- a/datanode/sqlstore/margin_level_test.go
+++ b/datanode/sqlstore/margin_level_test.go
@@ -58,17 +58,6 @@ func TestMarginLevels(t *testing.T) {
 	t.Run("GetMarginLevelsByIDWithCursorPagination should return the requested page of margin levels for a given market if last is set with before cursor - Newest First", testGetMarginLevelsByIDPaginationWithMarketLastAndBeforeCursorNewestFirst)
 }
 
-type testBlockSource struct {
-	blockStore *sqlstore.Blocks
-	blockTime  time.Time
-}
-
-func (bs *testBlockSource) getNextBlock(t *testing.T, ctx context.Context) entities.Block {
-	t.Helper()
-	bs.blockTime = bs.blockTime.Add(1 * time.Second)
-	return addTestBlockForTime(t, ctx, bs.blockStore, bs.blockTime)
-}
-
 func setupMarginLevelTests(t *testing.T, ctx context.Context) (*testBlockSource, *sqlstore.MarginLevels, *sqlstore.Accounts, sqlstore.Connection) {
 	t.Helper()
 
@@ -310,8 +299,6 @@ func testGetMarginLevelsByMarketID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, rowCount)
 
-	time.Sleep(time.Second)
-
 	block = blockSource.getNextBlock(t, ctx)
 	marginLevel3, err := entities.MarginLevelsFromProto(ctx, ml3, accountStore, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting margin levels proto to database entity")
@@ -394,8 +381,6 @@ func testGetMarginLevelsByID(t *testing.T) {
 	err = conn.QueryRow(ctx, `select count(*) from margin_levels`).Scan(&rowCount)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, rowCount)
-
-	time.Sleep(time.Second)
 
 	block = blockSource.getNextBlock(t, ctx)
 	marginLevel3, err := entities.MarginLevelsFromProto(ctx, ml3, accountStore, generateTxHash(), block.VegaTime)

--- a/datanode/sqlstore/markets_test.go
+++ b/datanode/sqlstore/markets_test.go
@@ -238,8 +238,7 @@ func shouldUpdateAValidMarketRecord(t *testing.T) {
 	t.Run("should add the updated market record to the database if the block number has changed", func(t *testing.T) {
 		newMarketProto := marketProto.DeepClone()
 		newMarketProto.TradableInstrument.Instrument.Metadata.Tags = append(newMarketProto.TradableInstrument.Instrument.Metadata.Tags, "DDD")
-		time.Sleep(time.Second)
-		newBlock := addTestBlock(t, ctx, bs)
+		newBlock := addTestBlockForTime(t, ctx, bs, time.Now().Add(time.Second))
 
 		market, err := entities.NewMarketFromProto(newMarketProto, generateTxHash(), newBlock.VegaTime)
 		require.NoError(t, err, "Converting market proto to database entity")
@@ -428,13 +427,13 @@ func populateTestMarkets(ctx context.Context, t *testing.T, bs *sqlstore.Blocks,
 		},
 	}
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, market := range markets {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 		market.VegaTime = block.VegaTime
 		blockTimes[market.ID.String()] = block.VegaTime
 		err := md.Upsert(ctx, &market)
 		require.NoError(t, err)
-		time.Sleep(time.Microsecond * 100)
 	}
 }
 

--- a/datanode/sqlstore/orders_test.go
+++ b/datanode/sqlstore/orders_test.go
@@ -217,10 +217,11 @@ func TestOrders(t *testing.T) {
 
 func generateTestBlocks(t *testing.T, ctx context.Context, numBlocks int, bs *sqlstore.Blocks) []entities.Block {
 	t.Helper()
+
+	source := &testBlockSource{bs, time.Now()}
 	blocks := make([]entities.Block, numBlocks)
 	for i := 0; i < numBlocks; i++ {
-		blocks[i] = addTestBlock(t, ctx, bs)
-		time.Sleep(time.Millisecond)
+		blocks[i] = source.getNextBlock(t, ctx)
 	}
 	return blocks
 }
@@ -239,7 +240,6 @@ func generateOrderIDs(t *testing.T, numIDs int) []entities.OrderID {
 	orderIDs := make([]entities.OrderID, numIDs)
 	for i := 0; i < numIDs; i++ {
 		orderIDs[i] = entities.OrderID(helpers.GenerateID())
-		time.Sleep(time.Millisecond)
 	}
 
 	return orderIDs

--- a/datanode/sqlstore/parties_test.go
+++ b/datanode/sqlstore/parties_test.go
@@ -121,13 +121,13 @@ func populateTestParties(ctx context.Context, t *testing.T, bs *sqlstore.Blocks,
 		},
 	}
 
+	source := &testBlockSource{bs, time.Now()}
 	for _, party := range parties {
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 		party.VegaTime = &block.VegaTime
 		blockTimes[party.ID.String()] = block.VegaTime
 		err := ps.Add(ctx, party)
 		require.NoError(t, err)
-		time.Sleep(time.Microsecond * 100)
 	}
 }
 

--- a/datanode/sqlstore/risk_factor_test.go
+++ b/datanode/sqlstore/risk_factor_test.go
@@ -44,7 +44,9 @@ func testUpdateMarketRiskFactors(t *testing.T) {
 	bs, rfStore := setupRiskFactorTests(t)
 
 	// Add a risk factor for market 'aa' in one block
-	block := addTestBlock(t, ctx, bs)
+
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	marketID := entities.MarketID("aa")
 	rf := entities.RiskFactor{
 		MarketID: marketID,
@@ -61,8 +63,7 @@ func testUpdateMarketRiskFactors(t *testing.T) {
 	assert.Equal(t, fetched, rf)
 
 	// Upsert a new risk factor for the same in a different block
-	time.Sleep(5 * time.Microsecond) // Ensure we get a different vega time
-	block2 := addTestBlock(t, ctx, bs)
+	block2 := source.getNextBlock(t, ctx)
 	rf2 := entities.RiskFactor{
 		MarketID: marketID,
 		Short:    decimal.NewFromInt(101),

--- a/datanode/sqlstore/trades_test.go
+++ b/datanode/sqlstore/trades_test.go
@@ -353,16 +353,15 @@ func populateTestTrades(ctx context.Context, t *testing.T, bs *sqlstore.Blocks, 
 			Type:      entities.TradeTypeDefault,
 		},
 	}
-
+	source := &testBlockSource{bs, time.Now()}
 	for _, td := range trades {
 		trade := td
-		block := addTestBlock(t, ctx, bs)
+		block := source.getNextBlock(t, ctx)
 		trade.SyntheticTime = block.VegaTime
 		trade.VegaTime = block.VegaTime
 		blockTimes[trade.ID.String()] = block.VegaTime
 		err := ts.Add(&trade)
 		require.NoError(t, err)
-		time.Sleep(time.Microsecond * 100)
 	}
 
 	_, err := ts.Flush(ctx)

--- a/datanode/sqlstore/withdrawals_test.go
+++ b/datanode/sqlstore/withdrawals_test.go
@@ -139,7 +139,8 @@ func testInsertWithdrawalUpdatesIfNewBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, ctx, bs)
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	withdrawalProto := getTestWithdrawal(testID, testID, testID, testAmount, testID, block.VegaTime)
 
 	withdrawal, err := entities.WithdrawalFromProto(withdrawalProto, generateTxHash(), block.VegaTime)
@@ -151,9 +152,7 @@ func testInsertWithdrawalUpdatesIfNewBlock(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, rowCount)
 
-	time.Sleep(time.Second)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	withdrawalProto.Status = vega.Withdrawal_STATUS_FINALIZED
 	withdrawal, err = entities.WithdrawalFromProto(withdrawalProto, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting withdrawal proto to database entity")
@@ -179,7 +178,8 @@ func testWithdrawalsGetByID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, ctx, bs)
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	withdrawalProto := getTestWithdrawal(testID, testID, testID, testAmount, testID, block.VegaTime)
 
 	withdrawal, err := entities.WithdrawalFromProto(withdrawalProto, generateTxHash(), block.VegaTime)
@@ -191,9 +191,7 @@ func testWithdrawalsGetByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, rowCount)
 
-	time.Sleep(time.Second)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	withdrawalProto.Status = vega.Withdrawal_STATUS_FINALIZED
 	withdrawal, err = entities.WithdrawalFromProto(withdrawalProto, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting withdrawal proto to database entity")
@@ -219,7 +217,8 @@ func testWithdrawalsGetByParty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, rowCount)
 
-	block := addTestBlock(t, ctx, bs)
+	source := &testBlockSource{bs, time.Now()}
+	block := source.getNextBlock(t, ctx)
 	withdrawalProto1 := getTestWithdrawal(testID, testID, testID, testAmount, testID, block.VegaTime)
 	withdrawalProto1.Id = "deadbeef01"
 
@@ -234,9 +233,7 @@ func testWithdrawalsGetByParty(t *testing.T) {
 	err = ws.Upsert(ctx, withdrawal)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 500)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	withdrawalProto1.Status = vega.Withdrawal_STATUS_FINALIZED
 	withdrawal, err = entities.WithdrawalFromProto(withdrawalProto1, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting withdrawal proto to database entity")
@@ -249,18 +246,14 @@ func testWithdrawalsGetByParty(t *testing.T) {
 
 	want = append(want, *withdrawal)
 
-	time.Sleep(time.Millisecond * 500)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	withdrawal, err = entities.WithdrawalFromProto(withdrawalProto2, generateTxHash(), block.VegaTime)
 	require.NoError(t, err, "Converting withdrawal proto to database entity")
 
 	err = ws.Upsert(ctx, withdrawal)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 500)
-
-	block = addTestBlock(t, ctx, bs)
+	block = source.getNextBlock(t, ctx)
 	withdrawal, err = entities.WithdrawalFromProto(withdrawalProto2, generateTxHash(), block.VegaTime)
 	withdrawalProto2.Status = vega.Withdrawal_STATUS_FINALIZED
 	require.NoError(t, err, "Converting withdrawal proto to database entity")

--- a/libs/crypto/proof_of_work_test.go
+++ b/libs/crypto/proof_of_work_test.go
@@ -61,38 +61,36 @@ func TestCountZeros(t *testing.T) {
 		difficulty uint
 	}{
 		{
-			// 00000e31f8ac983354f5885d46b7631bc75f69ec82e8f6178bae53db0ab7e054
-			name:       "with difficulty set to 20",
+			// 00001315c698aae3e559e9de507c43260e4b89e992840c281c68d54663eb02ae
+			name:       "with difficulty set to 19",
 			blockHash:  "2E7A16D9EF690F0D2BEED115FBA13BA2AAA16C8F971910AD88C72B9DB010C7D4",
 			txID:       "DFE522E234D67E6AE3F017859F898E576B3928EA57310B765398615A0D3FDE2F",
-			difficulty: 20,
+			difficulty: 19,
 		}, {
-			// 0000077b7d66117b57e45ccba0c31554e61c9853cc1cd9a2cf09c41b0aa9c22e
-			name:       "with difficulty set to 21",
+			// 00000d9ae20dd3c9ed57260ffe67832a98ccb43f797bba82f8a21be137e0ae5b
+			name:       "with difficulty set to 20",
 			blockHash:  "2E7A16D9EF690F0D2BEED115FBA13BA2AAA16C8F971910AD88C72B9DB010C7D4",
 			txID:       "5B87F9DFA41DABE84A11CA78D9FE11DA8FC2AA926004CA66454A7AF0A206480D",
-			difficulty: 21,
+			difficulty: 20,
 		}, {
 			// 000003bbf0cde49e3899ad23282b18defbc12a65f07c95d768464b87024df368
-			name:       "with difficulty set to 22",
+			name:       "with difficulty set to 21",
 			blockHash:  "2E7A16D9EF690F0D2BEED115FBA13BA2AAA16C8F971910AD88C72B9DB010C7D4",
 			txID:       "B14DD602ED48C9F7B5367105A4A97FFC9199EA0C9E1490B786534768DD1538EF",
-			difficulty: 22,
+			difficulty: 21,
 		}, {
-			// 000001e1084b865aba27df7a445753a24a3d89d63c7739a62c11dab3ee6eae32
-			name:       "with difficulty set to 23",
+			// 0000039c42f8c0a62ad39e1459393803104d8fdc2cd15410daaec3d8de7b85a0
+			name:       "with difficulty set to 22",
 			blockHash:  "B14DD602ED48C9F7B5367105A4A97FFC9199EA0C9E1490B786534768DD1538EF",
 			txID:       "94A9CB1532011081B013CCD8E6AAA832CAB1CBA603F0C5A093B14C4961E5E7F0",
-			difficulty: 23,
+			difficulty: 22,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(tt *testing.T) {
 			tt.Parallel()
-
 			_, hash, err := crypto.PoW(tc.blockHash, tc.txID, tc.difficulty, crypto.Sha3)
-
 			require.NoError(tt, err)
 			assert.NotEmpty(tt, hash)
 

--- a/wallet/service/v1/auth_test.go
+++ b/wallet/service/v1/auth_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"code.vegaprotocol.io/vega/wallet/service/v1"
+	v1 "code.vegaprotocol.io/vega/wallet/service/v1"
 	"code.vegaprotocol.io/vega/wallet/service/v1/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -47,6 +47,7 @@ func TestAuth(t *testing.T) {
 }
 
 func testVerifyValidToken(t *testing.T) {
+	t.Parallel()
 	auth := getTestAuth(t)
 	w := "jeremy"
 
@@ -61,6 +62,7 @@ func testVerifyValidToken(t *testing.T) {
 }
 
 func testVerifyInvalidToken(t *testing.T) {
+	t.Parallel()
 	auth := getTestAuth(t)
 	tok := "that's not a token"
 
@@ -70,6 +72,7 @@ func testVerifyInvalidToken(t *testing.T) {
 }
 
 func testRevokeValidToken(t *testing.T) {
+	t.Parallel()
 	auth := getTestAuth(t)
 	walletName := "jeremy"
 
@@ -93,6 +96,7 @@ func testRevokeValidToken(t *testing.T) {
 }
 
 func testRevokeInvalidToken(t *testing.T) {
+	t.Parallel()
 	auth := getTestAuth(t)
 	tok := "hehehe that's not a toekn"
 


### PR DESCRIPTION
closes #8269 

Things fixed:
- core integration tests no longer run in the unittest job
- A large amount of `time.Sleep()`'s have been removed from the data node `sqlstore` tests
- I've dialed down the pow difficulty in a particular test by 1, that reduces the run time of the test substantially
- I've removed loops on tests that existed just to test that the test code was stable, and not the stability of the code being tested
- I have removed an long `AnnounceNode` test that was just a duplicate of another test

The current "longest job" in the branch CI runs are now the docker-build steps which take +30mins. Not sure why. I've tried un-paralising them in case it was the fact that 3 docker builds at the same time was causing issues. Running sequentially they are quicker individually but overall they still take the same time...