### PR TITLE
chore: remove unused rewards related network parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased 0.72.0
 
 ### 🚨 Breaking changes
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [8280](https://github.com/vegaprotocol/vega/issues/8280) - Removed unused reward related network parameter
 
 ### 🗑️ Deprecation
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -

--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -150,14 +150,10 @@ func defaultNetParams() map[string]value {
 		DelegationMinAmount: NewDecimal(gtD0).Mutable(true).MustUpdate("1"),
 
 		// staking and delegation
-		StakingAndDelegationRewardPayoutFraction: NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("1.0"),
-		StakingAndDelegationRewardPayoutDelay:    NewDuration(DurationGTE(0 * time.Second)).Mutable(true).MustUpdate("24h0m0s"),
-
 		StakingAndDelegationRewardMaxPayoutPerParticipant: NewDecimal(gteD0).Mutable(true).MustUpdate("0"),
 		StakingAndDelegationRewardDelegatorShare:          NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0.883"),
 		StakingAndDelegationRewardMinimumValidatorStake:   NewDecimal(gteD0).Mutable(true).MustUpdate("0"),
 		StakingAndDelegationRewardCompetitionLevel:        NewDecimal(gteD1).Mutable(true).MustUpdate("1.1"),
-		StakingAndDelegationRewardMaxPayoutPerEpoch:       NewDecimal(gteD0).Mutable(true).MustUpdate("7000000000000000000000"),
 		StakingAndDelegationRewardsMinValidators:          NewInt(gteI1, lteI500).Mutable(true).MustUpdate("5"),
 		StakingAndDelegationRewardOptimalStakeMultiplier:  NewDecimal(gteD1).Mutable(true).MustUpdate("3.0"),
 

--- a/core/netparams/keys.go
+++ b/core/netparams/keys.go
@@ -97,13 +97,10 @@ const (
 	GovernanceProposalFreeformMinVoterBalance       = "governance.proposal.freeform.minVoterBalance"
 
 	// staking and delegation reward network params.
-	StakingAndDelegationRewardPayoutFraction          = "reward.staking.delegation.payoutFraction"
 	StakingAndDelegationRewardMaxPayoutPerParticipant = "reward.staking.delegation.maxPayoutPerParticipant"
-	StakingAndDelegationRewardPayoutDelay             = "reward.staking.delegation.payoutDelay"
 	StakingAndDelegationRewardDelegatorShare          = "reward.staking.delegation.delegatorShare"
 	StakingAndDelegationRewardMinimumValidatorStake   = "reward.staking.delegation.minimumValidatorStake"
 	StakingAndDelegationRewardCompetitionLevel        = "reward.staking.delegation.competitionLevel"
-	StakingAndDelegationRewardMaxPayoutPerEpoch       = "reward.staking.delegation.maxPayoutPerEpoch"
 	StakingAndDelegationRewardsMinValidators          = "reward.staking.delegation.minValidators"
 	StakingAndDelegationRewardOptimalStakeMultiplier  = "reward.staking.delegation.optimalStakeMultiplier"
 
@@ -242,15 +239,12 @@ var AllKeys = map[string]struct{}{
 	MarketMinProbabilityOfTradingForLPOrders:                 {},
 	ValidatorsEpochLength:                                    {},
 	DelegationMinAmount:                                      {},
-	StakingAndDelegationRewardPayoutFraction:                 {},
 	StakingAndDelegationRewardMaxPayoutPerParticipant:        {},
-	StakingAndDelegationRewardPayoutDelay:                    {},
 	StakingAndDelegationRewardDelegatorShare:                 {},
 	StakingAndDelegationRewardMinimumValidatorStake:          {},
 	ValidatorsVoteRequired:                                   {},
 	NetworkCheckpointTimeElapsedBetweenCheckpoints:           {},
 	MarketValueWindowLength:                                  {},
-	StakingAndDelegationRewardMaxPayoutPerEpoch:              {},
 	SpamProtectionMinTokensForProposal:                       {},
 	SpamProtectionMaxVotes:                                   {},
 	SpamProtectionMaxProposals:                               {},

--- a/core/netparams/netparams_test.go
+++ b/core/netparams/netparams_test.go
@@ -64,9 +64,9 @@ func TestNetParams(t *testing.T) {
 }
 
 func TestCheckpoint(t *testing.T) {
-	t.Run("test get snapshot not empty", testNonEmptyCheckpoint)
-	t.Run("test get snapshot not empty with overwrite", testNonEmptyCheckpointWithOverWrite)
-	t.Run("test get snapshot invalid", testInvalidCheckpoint)
+	t.Run("test get checkpoint not empty", testNonEmptyCheckpoint)
+	t.Run("test get checkpoint not empty with overwrite", testNonEmptyCheckpointWithOverWrite)
+	t.Run("test get checkpoint invalid", testInvalidCheckpoint)
 	t.Run("test notification is sent after checkpoint load", testCheckpointNotificationsDelivered)
 }
 

--- a/core/netparams/snapshot_test.go
+++ b/core/netparams/snapshot_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package netparams_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"code.vegaprotocol.io/vega/core/netparams"
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/proto"
+	snapshot "code.vegaprotocol.io/vega/protos/vega/snapshot/v1"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetParamsSnapshots(t *testing.T) {
+	t.Run("snapshot success", testSnapshotSuccess)
+	t.Run("snapshot restore removed key", testSnapshotRestoreRemovedKey)
+}
+
+func testSnapshotSuccess(t *testing.T) {
+	netp := getTestNetParams(t)
+	defer netp.ctrl.Finish()
+
+	state, _, err := netp.GetState("all")
+	require.NoError(t, err)
+	assert.Greater(t, len(state), 0)
+
+	// change a network parameter away from default
+	netp.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+	err = netp.Update(
+		context.Background(), netparams.GovernanceProposalMarketMinClose, "1m")
+	assert.NoError(t, err)
+
+	nv, err := netp.Get(netparams.GovernanceProposalMarketMinClose)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, nv)
+
+	// check state is now different
+	state2, _, err := netp.GetState("all")
+	require.NoError(t, err)
+	assert.NotEqual(t, state, state2)
+
+	var pl snapshot.Payload
+	proto.Unmarshal(state2, &pl)
+	payload := types.PayloadFromProto(&pl)
+
+	// load state
+	snap := getTestNetParams(t)
+	snap.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	_, err = snap.LoadState(context.Background(), payload)
+	require.NoError(t, err)
+
+	// check update value persists
+	restored, err := snap.Get(netparams.GovernanceProposalMarketMinClose)
+	fmt.Println(restored)
+	require.NoError(t, err)
+	assert.Equal(t, restored, nv)
+}
+
+func testSnapshotRestoreRemovedKey(t *testing.T) {
+	netp := getTestNetParams(t)
+	defer netp.ctrl.Finish()
+
+	// fiddle with the payload to add a nonsense network parameter to emulate a
+	// deprecated parameter being removed over a PUP
+	nps := &types.PayloadNetParams{
+		NetParams: &types.NetParams{
+			Params: []*types.NetworkParameter{
+				{
+					Key:   "hello",
+					Value: "goodbye",
+				},
+			},
+		},
+	}
+
+	pl := &types.Payload{
+		Data: nps,
+	}
+
+	// load state
+	_, err := netp.LoadState(context.Background(), pl)
+	require.NoError(t, err)
+
+	_, err = netp.Get("hello")
+	assert.ErrorIs(t, err, netparams.ErrUnknownKey)
+}


### PR DESCRIPTION
closes #8280 

A whole year ago three network parameters were "deprecated" and removed entirely from all specs:
https://github.com/vegaprotocol/specs/pull/1072

It terms of core code they still existed, but simply did nothing.

This PR removes them entirely.

This may not be what we want to do, and I don't think we've ever discussed if this is to be the full deprecation flow of network parameters, so maybe now is that time.

What could is break?
- anything that is starting a chain from genesis will need updating i.e capsule configs and the market-sim's genesis file
- checkpoints are fine since we can tweak them and remove stuff
- protocol-upgrades are also fine since we were already accidentally ignoring unknown network parameters during a snapshot restore (I've formalised this a little more)

For my sanity I did a little pretend protocol-upgrade using the nullchain by starting a node using develop, stopping it and building this branch. Then loading from a snapshot with the netparams into a version that doesn't know about them and everything is fine and the removed network parameters are just ignored:
```
2023-05-11T13:31:15.886+0100	INFO	core.protocol.snapshot	snapshot/engine.go:388	loading snapshot for height	{"height": -1}
2023-05-11T13:31:15.902+0100	INFO	core.protocol.banking	banking/snapshot.go:298	restoring seen	{"n": 0}
2023-05-11T13:31:15.902+0100	WARN	core.protocol.netparams	netparams/snapshot.go:138	cannot restore netparam as it is no longer known	{"key": "reward.staking.delegation.maxPayoutPerEpoch", "value": "7000000000000000000000"}
2023-05-11T13:31:15.902+0100	WARN	core.protocol.netparams	netparams/snapshot.go:138	cannot restore netparam as it is no longer known	{"key": "reward.staking.delegation.payoutDelay", "value": "24h0m0s"}
2023-05-11T13:31:15.902+0100	WARN	core.protocol.netparams	netparams/snapshot.go:138	cannot restore netparam as it is no longer known	{"key": "reward.staking.delegation.payoutFraction", "value": "1.0"}
2023-05-11T13:31:15.902+0100	INFO	core.protocol.statevar	statevar/engine.go:138	ValidatorsVoteRequired updated	{"validatorVotesRequired": "0.67"}
2023-05-11T13:31:15.902+0100	INFO	core.protocol.statevar	statevar/engine.go:130	updating floating point update frequency	{"updateFrequency": "5m0s"}
2023-05-11T13:31:15.902+0100	DEBUG	core.protocol.event-forwarder	evtforward/engine.go:193	Starting Ethereum configuration is a no-op
2023-05-11T13:31:15.903+0100	INFO	core.protocol.processor	processor/abci.go:562	ABCI service INFO requested	{"version": "v0.71.0", "app-version": 1, "height": 20, "hash": "3fa92a3744790e3b2dd3a1ffc14983d88aaff48ca1dbbd420d263c7e145dc247"}
2023-05-11T13:31:15.903+0100	INFO	core.nullchain	nullchain/nullchain.go:138	protocol loaded from snapshot	{"height": 20}
```