### PR TITLE
chore: deprecate network parameters by disallowing update proposals a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [](https://github.com/vegaprotocol/vega/issues/xxxx) -
 
 ### 🗑️ Deprecation
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [8280](https://github.com/vegaprotocol/vega/issues/8280) - Unused rewards related network parameters are now deprecated and will be removed
 
 ### 🛠 Improvements
 - [7906](https://github.com/vegaprotocol/vega/issues/7906) - Connection tokens on the wallet survive reboot.

--- a/core/netparams/keys.go
+++ b/core/netparams/keys.go
@@ -174,6 +174,12 @@ const (
 	ValidatorPerformanceScalingFactor = "validator.performance.scaling.factor"
 )
 
+var deprecated = map[string]struct{}{
+	StakingAndDelegationRewardPayoutFraction:    {},
+	StakingAndDelegationRewardPayoutDelay:       {},
+	StakingAndDelegationRewardMaxPayoutPerEpoch: {},
+}
+
 var AllKeys = map[string]struct{}{
 	MaxPeggedOrders:                                          {},
 	MaxGasPerBlock:                                           {},

--- a/core/netparams/netparams.go
+++ b/core/netparams/netparams.go
@@ -31,6 +31,9 @@ var (
 	ErrNetworkParameterUpdateDisabledFor = func(key string) error {
 		return fmt.Errorf("network parameter update disabled for %v", key)
 	}
+	ErrNetworkParameterDeprecated = func(key string) error {
+		return fmt.Errorf("network parameter has been deprecated: %v", key)
+	}
 	// a list of network parameter which cannot be updated.
 	updateDisallowed = []string{
 		BlockchainsEthereumConfig,
@@ -437,6 +440,10 @@ func (s *Store) IsUpdateAllowed(key string) error {
 	_, ok := s.store[key]
 	if !ok {
 		return ErrUnknownKey
+	}
+
+	if _, ok := deprecated[key]; ok {
+		return ErrNetworkParameterDeprecated(key)
 	}
 
 	for _, v := range updateDisallowed {

--- a/datanode/integration/testdata/golden/TestNetParams_Network_Parameters
+++ b/datanode/integration/testdata/golden/TestNetParams_Network_Parameters
@@ -522,12 +522,6 @@
 				},
 				{
 					"node": {
-						"key": "reward.staking.delegation.maxPayoutPerEpoch",
-						"value": "7000000000000000000000"
-					}
-				},
-				{
-					"node": {
 						"key": "reward.staking.delegation.maxPayoutPerParticipant",
 						"value": "0"
 					}
@@ -548,18 +542,6 @@
 					"node": {
 						"key": "reward.staking.delegation.optimalStakeMultiplier",
 						"value": "3.0"
-					}
-				},
-				{
-					"node": {
-						"key": "reward.staking.delegation.payoutDelay",
-						"value": "0s"
-					}
-				},
-				{
-					"node": {
-						"key": "reward.staking.delegation.payoutFraction",
-						"value": ".1"
 					}
 				},
 				{


### PR DESCRIPTION
closes #8280 

A whole year ago three network parameters were "deprecated" and removed entirely from all specs:
https://github.com/vegaprotocol/specs/pull/1072

but they still exist in core but don't do anything. I had originally [just removed them everywhere](https://github.com/vegaprotocol/vega/pull/8288) because it seemed trivial, but really it is a breaking change that people would need to react to as the removed parameters will need to be removed from all genesis files. For example, anyone using vegacapsule or the nullchain would need to actively make a change to their environments for them continue to work.

So, being mindful of having proper deprecation paths, the unused network parameters are in a deprecated state which means:
- they do nothing internally in core (which was already true)
- they can no longer have their value changed by governance (a proposal causes a checkTx error)
- are hidden by the data node API so they no longer can be seen to exist
- have a CHANGELOG entry in the `deprecation` section giving people warning to react

This is a _non-breaking change_ which will become a breaking change when they are removed entirely at a later date.

System test which tries to query/change the value of one of the no-longer-available network-parameters:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/70129/tests