### PR TITLE
chore: add deprecation section to the release note generator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,7 @@
 changelog:
   exclude:
     labels:
-      - ignore-for-release
+      - ignore-for-release-notes
     authors:
       - renovate
       - dependabot

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,6 +11,9 @@ changelog:
     - title: Breaking Changes 🛠
       labels:
         - breaking-change
+    - title: Deprecations ⚠️
+      labels:
+        - deprecation
     - title: Bug Fixes 🐛
       labels:
         - bug


### PR DESCRIPTION
This adds a section in the release notes for PRs that have the `deprecation` label so that users can see what is being deprecated and will soon be removed and be a breaking change