### PR TITLE
fix: update godog flag binding

### DIFF
--- a/core/integration/main_test.go
+++ b/core/integration/main_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func init() {
-	godog.BindCommandLineFlags("godog.", &gdOpts)
+	godog.BindFlags("godog.", flag.CommandLine, &gdOpts)
 	flag.StringVar(&features, "features", "", "a coma separated list of paths to the feature files")
 }
 


### PR DESCRIPTION
Quick fix, `--godog.format=X` and `--godog.tags` were broken