### PR TITLE
feat: iceberg orders in the data node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [8339](https://github.com/vegaprotocol/vega/issues/8339) - Target stake for spots
 - [8337](https://github.com/vegaprotocol/vega/issues/8337) - ELS for spots
 - [8359](https://github.com/vegaprotocol/vega/issues/8359) - Add proto definitions for iceberg orders
+- [8361](https://github.com/vegaprotocol/vega/issues/8361) - Implement iceberg orders in data node
 - [8332](https://github.com/vegaprotocol/vega/issues/8332) - Add support in collateral engine for spots
 - [8330](https://github.com/vegaprotocol/vega/issues/8330) - Implement validation on successor market proposals.
 - [8247](https://github.com/vegaprotocol/vega/issues/8247) - Initial support for `Ethereum` `oracles`

--- a/datanode/entities/order.go
+++ b/datanode/entities/order.go
@@ -56,6 +56,11 @@ type Order struct {
 	SeqNum          uint64
 	PostOnly        bool
 	ReduceOnly      bool
+
+	// Iceberg fields
+	ReservedRemaining *int64
+	InitialPeakSize   *int64
+	MinimumPeakSize   *int64
 }
 
 func (o Order) ToProto() *vega.Order {
@@ -70,6 +75,15 @@ func (o Order) ToProto() *vega.Order {
 	var reason *OrderError
 	if o.Reason != OrderErrorUnspecified {
 		reason = ptr.From(o.Reason)
+	}
+
+	var icebergOrder *vega.IcebergOrder
+	if o.InitialPeakSize != nil {
+		icebergOrder = &vega.IcebergOrder{
+			ReservedRemaining: uint64(*o.ReservedRemaining),
+			InitialPeakSize:   uint64(*o.InitialPeakSize),
+			MinimumPeakSize:   uint64(*o.MinimumPeakSize),
+		}
 	}
 
 	vo := vega.Order{
@@ -94,6 +108,7 @@ func (o Order) ToProto() *vega.Order {
 		LiquidityProvisionId: hex.EncodeToString(o.LpID),
 		PostOnly:             o.PostOnly,
 		ReduceOnly:           o.ReduceOnly,
+		IcebergOrder:         icebergOrder,
 	}
 	return &vo
 }
@@ -112,22 +127,22 @@ func OrderFromProto(po *vega.Order, seqNum uint64, txHash TxHash) (Order, error)
 	}
 
 	if po.Size > math.MaxInt64 {
-		return Order{}, fmt.Errorf("size is to large for int64: %v", po.Size)
+		return Order{}, fmt.Errorf("size is larger than a 64-bit integer: %v", po.Size)
 	}
 	size := int64(po.Size)
 
-	if po.Size > math.MaxInt64 {
-		return Order{}, fmt.Errorf("remaining is to large for int64: %v", po.Remaining)
+	if po.Remaining > math.MaxInt64 {
+		return Order{}, fmt.Errorf("remaining is larger than a 64-bit integer: %v", po.Remaining)
 	}
 	remaining := int64(po.Remaining)
 
 	if po.Version >= math.MaxInt32 {
-		return Order{}, fmt.Errorf("version is too large for int32: %v", po.Version)
+		return Order{}, fmt.Errorf("version is larger than a 32-bit integer: %v", po.Version)
 	}
 	version := int32(po.Version)
 
 	if po.BatchId >= math.MaxInt32 {
-		return Order{}, fmt.Errorf("batch ID is too large for int32: %v", po.Version)
+		return Order{}, fmt.Errorf("batch ID is larger than a 32-bit integer: %v", po.Version)
 	}
 	batchID := int32(po.BatchId)
 
@@ -141,7 +156,7 @@ func OrderFromProto(po *vega.Order, seqNum uint64, txHash TxHash) (Order, error)
 	if po.PeggedOrder != nil {
 		peggedOffset, err = decimal.NewFromString(po.PeggedOrder.Offset)
 		if err != nil {
-			return Order{}, fmt.Errorf("pegged Offset not valid int32: %v", po.Price)
+			return Order{}, fmt.Errorf("pegged Offset not a valid decimal: %v", po.Price)
 		}
 		peggedReference = po.PeggedOrder.Reference
 	}
@@ -151,31 +166,52 @@ func OrderFromProto(po *vega.Order, seqNum uint64, txHash TxHash) (Order, error)
 		reason = *po.Reason
 	}
 
+	var initialPeakSize, minimumPeakSize, reservedRemaining *int64
+	if po.IcebergOrder != nil {
+		if po.IcebergOrder.ReservedRemaining > math.MaxInt64 {
+			return Order{}, fmt.Errorf("iceberg reserved remaining is larger than a 64-bit integer: %v", po.Remaining)
+		}
+		reservedRemaining = ptr.From(int64(po.IcebergOrder.ReservedRemaining))
+
+		if po.IcebergOrder.InitialPeakSize > math.MaxInt64 {
+			return Order{}, fmt.Errorf("iceberg initial peak size is larger than a 64-bit integer: %v", po.Remaining)
+		}
+		initialPeakSize = ptr.From(int64(po.IcebergOrder.InitialPeakSize))
+
+		if po.IcebergOrder.MinimumPeakSize > math.MaxInt64 {
+			return Order{}, fmt.Errorf("iceberg minimum peak size is larger than a 64-bit integer: %v", po.Remaining)
+		}
+		minimumPeakSize = ptr.From(int64(po.IcebergOrder.MinimumPeakSize))
+	}
+
 	o := Order{
-		ID:              OrderID(po.Id),
-		MarketID:        MarketID(po.MarketId),
-		PartyID:         PartyID(po.PartyId),
-		Side:            po.Side,
-		Price:           price,
-		Size:            size,
-		Remaining:       remaining,
-		TimeInForce:     po.TimeInForce,
-		Type:            po.Type,
-		Status:          po.Status,
-		Reference:       po.Reference,
-		Reason:          reason,
-		Version:         version,
-		PeggedOffset:    peggedOffset,
-		BatchID:         batchID,
-		PeggedReference: peggedReference,
-		LpID:            lpID,
-		CreatedAt:       NanosToPostgresTimestamp(po.CreatedAt),
-		UpdatedAt:       NanosToPostgresTimestamp(po.UpdatedAt),
-		ExpiresAt:       NanosToPostgresTimestamp(po.ExpiresAt),
-		SeqNum:          seqNum,
-		TxHash:          txHash,
-		PostOnly:        po.PostOnly,
-		ReduceOnly:      po.ReduceOnly,
+		ID:                OrderID(po.Id),
+		MarketID:          MarketID(po.MarketId),
+		PartyID:           PartyID(po.PartyId),
+		Side:              po.Side,
+		Price:             price,
+		Size:              size,
+		Remaining:         remaining,
+		TimeInForce:       po.TimeInForce,
+		Type:              po.Type,
+		Status:            po.Status,
+		Reference:         po.Reference,
+		Reason:            reason,
+		Version:           version,
+		PeggedOffset:      peggedOffset,
+		BatchID:           batchID,
+		PeggedReference:   peggedReference,
+		LpID:              lpID,
+		CreatedAt:         NanosToPostgresTimestamp(po.CreatedAt),
+		UpdatedAt:         NanosToPostgresTimestamp(po.UpdatedAt),
+		ExpiresAt:         NanosToPostgresTimestamp(po.ExpiresAt),
+		SeqNum:            seqNum,
+		TxHash:            txHash,
+		PostOnly:          po.PostOnly,
+		ReduceOnly:        po.ReduceOnly,
+		ReservedRemaining: reservedRemaining,
+		InitialPeakSize:   initialPeakSize,
+		MinimumPeakSize:   minimumPeakSize,
 	}
 
 	return o, nil
@@ -197,7 +233,8 @@ func (o Order) ToRow() []interface{} {
 		o.Size, o.Remaining, o.TimeInForce, o.Type, o.Status,
 		o.Reference, o.Reason, o.Version, o.PeggedOffset, o.BatchID,
 		o.PeggedReference, o.LpID, o.CreatedAt, o.UpdatedAt, o.ExpiresAt,
-		o.TxHash, o.VegaTime, o.SeqNum, o.PostOnly, o.ReduceOnly,
+		o.TxHash, o.VegaTime, o.SeqNum, o.PostOnly, o.ReduceOnly, o.ReservedRemaining,
+		o.InitialPeakSize, o.MinimumPeakSize,
 	}
 }
 
@@ -206,7 +243,8 @@ var OrderColumns = []string{
 	"size", "remaining", "time_in_force", "type", "status",
 	"reference", "reason", "version", "pegged_offset", "batch_id",
 	"pegged_reference", "lp_id", "created_at", "updated_at", "expires_at",
-	"tx_hash", "vega_time", "seq_num", "post_only", "reduce_only",
+	"tx_hash", "vega_time", "seq_num", "post_only", "reduce_only", "reserved_remaining",
+	"initial_peak_size", "minimum_peak_size",
 }
 
 type OrderCursor struct {

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -365,12 +365,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmReLZTKojmVKS8mHtPTDzzrvmEGEuVKst1MdmYMfjji1J", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "Qmd4vt1L7wJtvK1waqvYVbXbBHFGTiTGJYyvdEHPwQBP9B", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmWLggxH4BWBbUvZkjb8Na2EdRa4SpFaXtgth9KeH2Jqtg", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmWj8vahvf1WmAX9FcW9X2DxMpHy3k18BoH9k2DzfhhQL8", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmeaR38HbW7viQzwRHK21rSYrj9QnMBmyABP5AtmJvhfeb", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmQenffJziQjy9LjiiDoRVdinT11m7V2HGUwxx7V7SaJYJ", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmexEaBDabtaFCUyidBz3NzAUTDK1DmBkufQPmzcmQrsuR", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmUZXh3jVhwk27PfBai34zmuS7urz3M9VBfN5tvchx1Mst", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmdmppHJ7aMAzU61WTDYeSp3mBt8xxFud9SL7cpxwnKTDC", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmYUi1Lb3QTpoccGCV6qhRDVFtVdVQwkD3f3xowE5hhGsv", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmV6vHyep8mh58YdrNcpp9MeobrLvJKX99kRPxssURzP7c", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmaYNGjUzmpr3uMfHjwAhcWQRPHcuE1scKmVBbuQ1os52p", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0002_iceberg_orders.sql
+++ b/datanode/sqlstore/migrations/0002_iceberg_orders.sql
@@ -1,0 +1,89 @@
+-- +goose Up
+
+ALTER TABLE orders
+      ADD COLUMN reserved_remaining BIGINT,
+      ADD COLUMN initial_peak_size BIGINT,
+      ADD COLUMN minimum_peak_size BIGINT;
+
+ALTER TABLE orders_live
+      ADD COLUMN reserved_remaining BIGINT,
+      ADD COLUMN initial_peak_size BIGINT,
+      ADD COLUMN minimum_peak_size BIGINT;
+
+CREATE OR REPLACE VIEW orders_current_versions AS (
+   SELECT DISTINCT ON (id, version) * FROM orders ORDER BY id, version DESC, vega_time DESC
+);
+
+CREATE OR REPLACE VIEW orders_current_desc
+ AS
+SELECT DISTINCT ON (orders.created_at, orders.id) *
+FROM orders
+ORDER BY orders.created_at DESC, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+
+CREATE OR REPLACE VIEW orders_current_desc_by_market
+ AS
+SELECT DISTINCT ON (orders.created_at, orders.market_id, orders.id) *
+FROM orders
+ORDER BY orders.created_at DESC, orders.market_id, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+CREATE OR REPLACE VIEW orders_current_desc_by_party
+AS
+SELECT DISTINCT ON (orders.created_at, orders.party_id, orders.id) *
+        FROM orders
+        ORDER BY orders.created_at DESC, orders.party_id, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+CREATE OR REPLACE VIEW orders_current_desc_by_reference
+AS
+SELECT DISTINCT ON (orders.created_at, orders.reference, orders.id) *
+        FROM orders
+        ORDER BY orders.created_at DESC, orders.reference, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+
+-- +goose Down
+
+drop view orders_current_versions;
+drop view orders_current_desc;
+drop view orders_current_desc_by_reference;
+drop view orders_current_desc_by_party;
+drop view orders_current_desc_by_market;
+
+
+ALTER TABLE orders
+      DROP COLUMN IF EXISTS reserved_remaining,
+      DROP COLUMN IF EXISTS initial_peak_size,
+      DROP COLUMN IF EXISTS minimum_peak_size;
+
+ALTER TABLE orders_live
+      DROP COLUMN IF EXISTS reserved_remaining,
+      DROP COLUMN IF EXISTS initial_peak_size,
+      DROP COLUMN IF EXISTS minimum_peak_size;
+
+CREATE OR REPLACE VIEW orders_current_versions AS (
+   SELECT DISTINCT ON (id, version) * FROM orders ORDER BY id, version DESC, vega_time DESC
+);
+
+CREATE VIEW orders_current_desc
+ AS
+SELECT DISTINCT ON (orders.created_at, orders.id) *
+FROM orders
+ORDER BY orders.created_at DESC, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+
+CREATE VIEW orders_current_desc_by_market
+ AS
+SELECT DISTINCT ON (orders.created_at, orders.market_id, orders.id) *
+FROM orders
+ORDER BY orders.created_at DESC, orders.market_id, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+CREATE VIEW orders_current_desc_by_party
+AS
+SELECT DISTINCT ON (orders.created_at, orders.party_id, orders.id) *
+        FROM orders
+        ORDER BY orders.created_at DESC, orders.party_id, orders.id, orders.vega_time DESC, orders.seq_num DESC;
+
+CREATE VIEW orders_current_desc_by_reference
+AS
+SELECT DISTINCT ON (orders.created_at, orders.reference, orders.id) *
+        FROM orders
+        ORDER BY orders.created_at DESC, orders.reference, orders.id, orders.vega_time DESC, orders.seq_num DESC;

--- a/datanode/sqlstore/orders.go
+++ b/datanode/sqlstore/orders.go
@@ -32,7 +32,8 @@ const (
                        size, remaining, time_in_force, type, status,
                        reference, reason, version, batch_id, pegged_offset,
                        pegged_reference, lp_id, created_at, updated_at, expires_at,
-                       tx_hash, vega_time, seq_num, post_only, reduce_only`
+                       tx_hash, vega_time, seq_num, post_only, reduce_only, reserved_remaining, 
+                       initial_peak_size, minimum_peak_size`
 
 	ordersFilterDateColumn = "vega_time"
 
@@ -65,7 +66,7 @@ func (os *Orders) Flush(ctx context.Context) ([]entities.Order, error) {
 	return os.batcher.Flush(ctx, os.Connection)
 }
 
-// Add inserts an order update row into the database if an row for this (block time, order id, version)
+// Add inserts an order update row into the database if a row for this (block time, order id, version)
 // does not already exist; otherwise update the existing row with information supplied.
 // Currently we only store the last update to an order per block, so the order history is not
 // complete if multiple updates happen in one block.


### PR DESCRIPTION
closes #8361 

The iceberg order fields are now saved into the database, and visible through the data node API.

A hacky little system test where I submit an iceberg then query for it returns the iceberg peak information:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/71723/pipeline/526

```
[test_iceberg_submit]:[5723] {'id': '8f7e67481b0dcacb48d1fe896d6c7f1a80a122bb2193e77a59fa187c917de376', ... , 'icebergOrder': {'initialPeakSize': '10', 'minimumPeakSize': '2', 'reservedRemaining': '0'}, ... }

```