### PR TITLE
feat: implement iceberg orders in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [8337](https://github.com/vegaprotocol/vega/issues/8337) - ELS for spots
 - [8359](https://github.com/vegaprotocol/vega/issues/8359) - Add proto definitions for iceberg orders
 - [8361](https://github.com/vegaprotocol/vega/issues/8361) - Implement iceberg orders in data node
+- [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in core
 - [8332](https://github.com/vegaprotocol/vega/issues/8332) - Add support in collateral engine for spots
 - [8330](https://github.com/vegaprotocol/vega/issues/8330) - Implement validation on successor market proposals.
 - [8247](https://github.com/vegaprotocol/vega/issues/8247) - Initial support for `Ethereum` `oracles`

--- a/core/execution/engine.go
+++ b/core/execution/engine.go
@@ -1252,3 +1252,12 @@ func (e *Engine) OnSuccessorMarketTimeWindowUpdate(ctx context.Context, window t
 	e.successorWindow = window
 	return nil
 }
+
+func (e *Engine) TransactionFinished(ctx context.Context, marketID string) {
+	mkt, ok := e.markets[marketID]
+	if !ok {
+		e.log.Error("market does not exist at the end of order transaction", logging.String("mid", marketID))
+		return
+	}
+	mkt.TransactionFinished(ctx)
+}

--- a/core/execution/future/market_iceberg_test.go
+++ b/core/execution/future/market_iceberg_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package future_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+
+	"code.vegaprotocol.io/vega/core/events"
+	"code.vegaprotocol.io/vega/core/execution/common"
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/num"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarketSubmitIceberg(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(100000, 0)
+	ctx := vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash())
+	tm := getTestMarket(t, now, nil, nil)
+	defer tm.ctrl.Finish()
+
+	addAccount(t, tm, party1)
+	iceberg := &types.Order{
+		Type:        types.OrderTypeLimit,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Status:      types.OrderStatusActive,
+		ID:          "someid",
+		Side:        types.SideBuy,
+		Party:       party1,
+		MarketID:    tm.market.GetID(),
+		Size:        100,
+		Price:       num.NewUint(100),
+		Remaining:   100,
+		CreatedAt:   now.UnixNano(),
+		Reference:   "party1-buy-order",
+		Version:     common.InitialOrderVersion,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: 10,
+			MinimumPeakSize: 5,
+		},
+	}
+
+	// submit order
+	_, err := tm.market.SubmitOrder(context.Background(), iceberg)
+	require.NoError(t, err)
+
+	tm.now = tm.now.Add(time.Second)
+	tm.market.OnTick(ctx, tm.now)
+	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
+
+	// check that its on the book and the volume is only the visible peak
+	assert.Equal(t, int64(10), tm.market.GetVolumeOnBook())
+}
+
+func TestMarketAmendIceberg(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(100000, 0)
+	ctx := vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash())
+	tm := getTestMarket(t, now, nil, nil)
+	defer tm.ctrl.Finish()
+
+	addAccount(t, tm, party1)
+	iceberg := &types.Order{
+		Type:        types.OrderTypeLimit,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Status:      types.OrderStatusActive,
+		ID:          "someid",
+		Side:        types.SideBuy,
+		Party:       party1,
+		MarketID:    tm.market.GetID(),
+		Size:        100,
+		Price:       num.NewUint(100),
+		Remaining:   100,
+		CreatedAt:   now.UnixNano(),
+		Reference:   "party1-buy-order",
+		Version:     common.InitialOrderVersion,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: 10,
+			MinimumPeakSize: 5,
+		},
+	}
+
+	// submit order
+	_, err := tm.market.SubmitOrder(context.Background(), iceberg)
+	require.NoError(t, err)
+
+	tm.now = tm.now.Add(time.Second)
+	tm.market.OnTick(ctx, tm.now)
+	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
+
+	// now reduce the size of the iceberg so that only the reserved amount is reduced
+	amendedOrder := &types.OrderAmendment{
+		OrderID:     iceberg.ID,
+		Price:       nil,
+		SizeDelta:   -50,
+		TimeInForce: types.OrderTimeInForceGTC,
+	}
+
+	tm.eventCount = 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, vgcrypto.RandomHash())
+	require.NoError(t, err)
+	amended := requireOrderEvent(t, tm.events)
+	assert.Equal(t, uint64(50), amended.Size)
+	assert.Equal(t, iceberg.Remaining, amended.Remaining)
+	assert.Equal(t, uint64(40), amended.IcebergOrder.ReservedRemaining)
+
+	// now increase the size delta and check that reserved remaining is increase, but remaining is the same
+	amendedOrder.SizeDelta = 70
+	tm.eventCount = 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, vgcrypto.RandomHash())
+	require.NoError(t, err)
+	amended = requireOrderEvent(t, tm.events)
+	assert.Equal(t, uint64(120), amended.Size)
+	assert.Equal(t, iceberg.Remaining, amended.Remaining)
+	assert.Equal(t, uint64(110), amended.IcebergOrder.ReservedRemaining)
+
+	// now reduce the size such that reserved is reduce to 0 and some remaining is removed too
+	amendedOrder.SizeDelta = -115
+	tm.eventCount = 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, vgcrypto.RandomHash())
+	require.NoError(t, err)
+	amended = requireOrderEvent(t, tm.events)
+	assert.Equal(t, uint64(5), amended.Size)
+	assert.Equal(t, uint64(5), amended.Remaining)
+	assert.Equal(t, uint64(0), amended.IcebergOrder.ReservedRemaining)
+}
+
+func TestMarketIcebergRefresh(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(100000, 0)
+	ctx := vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash())
+	tm := getTestMarket(t, now, nil, nil)
+	defer tm.ctrl.Finish()
+
+	addAccount(t, tm, party1)
+	iceberg := &types.Order{
+		Type:        types.OrderTypeLimit,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Status:      types.OrderStatusActive,
+		ID:          "someid",
+		Side:        types.SideBuy,
+		Party:       party1,
+		MarketID:    tm.market.GetID(),
+		Size:        30,
+		Price:       num.NewUint(100),
+		Remaining:   100,
+		CreatedAt:   now.UnixNano(),
+		Reference:   "party1-buy-order",
+		Version:     common.InitialOrderVersion,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: 10,
+			MinimumPeakSize: 5,
+		},
+	}
+
+	// submit order
+	_, err := tm.market.SubmitOrder(context.Background(), iceberg)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), tm.market.GetVolumeOnBook())
+
+	// pretend we've had some trades and the new iceberg has its remaining reduced
+	// so that its below the peak
+	iceberg.Remaining = 4
+	full := iceberg.Remaining + iceberg.IcebergOrder.ReservedRemaining
+	require.True(t, iceberg.NeedsRefreshing())
+	tm.market.RefreshIcebergOrders(ctx, []*types.Order{iceberg})
+	assert.Equal(t, uint64(10), iceberg.Remaining)                      // refreshes full peak
+	assert.Equal(t, uint64(14), iceberg.IcebergOrder.ReservedRemaining) // reserve is now 35 - initial_peak (10) - trade_size (6)
+	assert.Equal(t, full, iceberg.Remaining+iceberg.IcebergOrder.ReservedRemaining)
+
+	// now do the same an pretend a trade took it to zero
+	iceberg.Remaining = 0
+	full = iceberg.Remaining + iceberg.IcebergOrder.ReservedRemaining
+	require.True(t, iceberg.NeedsRefreshing())
+	tm.market.RefreshIcebergOrders(ctx, []*types.Order{iceberg})
+	assert.Equal(t, uint64(10), iceberg.Remaining)                     // refreshes full peak
+	assert.Equal(t, uint64(4), iceberg.IcebergOrder.ReservedRemaining) // reserve is now 19 - trade_size (10)
+	assert.Equal(t, full, iceberg.Remaining+iceberg.IcebergOrder.ReservedRemaining)
+
+	// now the last trade takes us to one remaining and not enough in reserve for a full peak
+	iceberg.Remaining = 1
+	full = iceberg.Remaining + iceberg.IcebergOrder.ReservedRemaining
+	require.True(t, iceberg.NeedsRefreshing())
+	tm.market.RefreshIcebergOrders(ctx, []*types.Order{iceberg})
+	assert.Equal(t, uint64(5), iceberg.Remaining)                      // refreshes partial peak
+	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining) // reserve is now 19 - trade_size (10)
+	assert.Equal(t, full, iceberg.Remaining+iceberg.IcebergOrder.ReservedRemaining)
+}
+
+func requireOrderEvent(t *testing.T, evts []events.Event) *types.Order {
+	t.Helper()
+	for _, e := range evts {
+		switch evt := e.(type) {
+		case *events.Order:
+			o, err := types.OrderFromProto(evt.Order())
+			require.NoError(t, err)
+			return o
+		}
+	}
+	require.Fail(t, "did not find order event")
+	return nil
+}

--- a/core/matching/iceberg_orders_test.go
+++ b/core/matching/iceberg_orders_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package matching
+
+import (
+	"testing"
+
+	"code.vegaprotocol.io/vega/core/types"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/libs/num"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func submitIcebergOrder(t *testing.T, book *tstOB, size, peak, minPeak uint64, addToBook bool) (*types.Order, *types.OrderConfirmation) {
+	t.Helper()
+	o := &types.Order{
+		ID:            vgcrypto.RandomHash(),
+		Status:        types.OrderStatusActive,
+		MarketID:      book.marketID,
+		Party:         "A",
+		Side:          types.SideBuy,
+		Price:         num.NewUint(100),
+		OriginalPrice: num.NewUint(100),
+		Size:          size,
+		Remaining:     size,
+		TimeInForce:   types.OrderTimeInForceGTT,
+		Type:          types.OrderTypeLimit,
+		ExpiresAt:     10,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: peak,
+			MinimumPeakSize: minPeak,
+		},
+	}
+	confirm, err := book.SubmitOrder(o)
+	require.NoError(t, err)
+
+	if addToBook {
+		// aggressive iceberg orders do not naturally sit on the book and are added a different way so
+		// we do that here
+		o.Remaining = peak
+		o.IcebergOrder.ReservedRemaining = size - peak
+		book.SubmitIcebergOrder(o)
+	}
+	return o, confirm
+}
+
+func submitCrossedOrder(t *testing.T, book *tstOB, size uint64) (*types.Order, *types.OrderConfirmation) {
+	t.Helper()
+	o := &types.Order{
+		ID:            vgcrypto.RandomHash(),
+		Status:        types.OrderStatusActive,
+		MarketID:      book.marketID,
+		Party:         "B",
+		Side:          types.SideSell,
+		Price:         num.NewUint(100),
+		OriginalPrice: num.NewUint(100),
+		Size:          size,
+		Remaining:     size,
+		TimeInForce:   types.OrderTimeInForceGTC,
+		Type:          types.OrderTypeLimit,
+	}
+	confirm, err := book.SubmitOrder(o)
+	require.NoError(t, err)
+	return o, confirm
+}
+
+func TestIcebergFullPeakConsumed(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// it doesn't get added to the book because they are special
+	_, err := book.GetOrderByID(iceberg.ID)
+	assert.ErrorIs(t, err, ErrOrderDoesNotExist)
+
+	// we add it in our special way after doing the peak shuffle
+	iceberg.Remaining = 4
+	iceberg.IcebergOrder.ReservedRemaining = 96
+	book.SubmitIcebergOrder(iceberg)
+
+	// check it is now on the book
+	_, err = book.GetOrderByID(iceberg.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+
+	// submit an order bigger than the peak
+	o, confirm := submitCrossedOrder(t, book, 10)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, uint64(6), o.Remaining)
+
+	// there will be no buy level or volume because the iceberg's peak has been consumed
+	assert.Equal(t, 0, book.getNumberOfBuyLevels())
+	assert.Equal(t, uint64(0), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(0), iceberg.Remaining)
+	assert.Equal(t, uint64(96), iceberg.IcebergOrder.ReservedRemaining)
+
+	// check the the iceberg is ready for a refresh and refresh it
+	require.True(t, iceberg.NeedsRefreshing())
+
+	// cancel and resubmit
+	book.CancelOrder(iceberg)
+	iceberg.Remaining = 4
+	iceberg.IcebergOrder.ReservedRemaining = 92
+	book.SubmitIcebergOrder(iceberg)
+
+	// it is now on the book and the buy volume has increased by the peak
+	assert.Equal(t, 1, book.getNumberOfBuyLevels())
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+}
+
+func TestIcebergPeakAboveMinimum(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit order that only takes a little off the peak
+	_, confirm = submitCrossedOrder(t, book, 1)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, 1, book.getNumberOfBuyLevels())
+	assert.Equal(t, uint64(3), book.getTotalBuyVolume())
+
+	// check a refresh is not needed
+	require.False(t, iceberg.NeedsRefreshing())
+
+	// now submit another order that *will* remove the peak
+	_, confirm = submitCrossedOrder(t, book, 1000)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	assert.Equal(t, uint64(0), iceberg.Remaining)
+	assert.Equal(t, uint64(96), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(0))
+}
+
+func TestIcebergAggressiveTakesAll(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	_, confirm := submitCrossedOrder(t, book, 10)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit the iceberg as an aggressive order and more than its peak is consumed
+	_, confirm = submitIcebergOrder(t, book, 50, 4, 2, false)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, uint64(10), confirm.Trades[0].Size)
+}
+
+func TestAggressiveIcebergFullyFilled(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	_, confirm := submitCrossedOrder(t, book, 1000)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit the aggressice iceberg that will be fully filled
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, false)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	// check that
+	assert.Equal(t, uint64(0), iceberg.Remaining)
+	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusFilled, iceberg.Status)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(0))
+	assert.False(t, iceberg.NeedsRefreshing())
+}
+
+func TestIcebergPeakAboveMinimumTradeToZero(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit an order that takes the berg below its minimum peak, but is not zero
+	_, confirm = submitCrossedOrder(t, book, 3)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	assert.Equal(t, types.OrderStatusActive, iceberg.Status)
+	assert.True(t, iceberg.NeedsRefreshing())
+	assert.Equal(t, uint64(1), iceberg.Remaining)
+	assert.Equal(t, uint64(96), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(1))
+
+	// without refreshing submit another order to take the rest
+	_, confirm = submitCrossedOrder(t, book, 10)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	// check it still needs a refresh
+	assert.Equal(t, uint64(0), iceberg.Remaining)
+	assert.Equal(t, uint64(96), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(0))
+	assert.True(t, iceberg.NeedsRefreshing())
+
+	// send in *another* order and check it doesn't trade since the iceberg
+	// is hidden until a refresh
+	_, confirm = submitCrossedOrder(t, book, 100)
+	assert.Equal(t, 0, len(confirm.Trades))
+}
+
+func TestIcebergRefreshToPartialPeak(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book with a big peak
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 90, 2, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// expect the volume to be the peak size
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(90))
+
+	// submit an order that takes almost the full peak
+	_, confirm = submitCrossedOrder(t, book, 89)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	// remaining + reserver < initial peak
+	assert.Equal(t, uint64(1), iceberg.Remaining)
+	assert.Equal(t, uint64(10), iceberg.IcebergOrder.ReservedRemaining)
+
+	// check the the iceberg is ready for a refresh and refresh it
+	require.True(t, iceberg.NeedsRefreshing())
+
+	book.CancelOrder(iceberg)
+	iceberg.Remaining = 11
+	iceberg.IcebergOrder.ReservedRemaining = 0
+	book.SubmitIcebergOrder(iceberg)
+
+	// check volume change
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(11))
+}
+
+func TestIcebergTimePriorityLostOnRefresh(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book with a big peak
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 10, 8, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// now submit a second order that will be next in line
+	iceberg2, confirm := submitIcebergOrder(t, book, 100, 100, 1, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// expect the volume to be the peak size
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(110))
+
+	// submit a order that will take out some of the peak of the first iceberg
+	_, confirm = submitCrossedOrder(t, book, 5)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	assert.Equal(t, uint64(5), iceberg.Remaining)
+	assert.Equal(t, uint64(90), iceberg.IcebergOrder.ReservedRemaining)
+
+	// check the the iceberg is ready for a refresh and refresh it
+	require.True(t, iceberg.NeedsRefreshing())
+
+	// submit a small order and check it still trades with iceberg1
+	_, confirm = submitCrossedOrder(t, book, 1)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, iceberg.ID, confirm.PassiveOrdersAffected[0].ID)
+
+	// refresh the first iceberg
+	book.CancelOrder(iceberg)
+	iceberg.Remaining = 10
+	iceberg.IcebergOrder.ReservedRemaining = 85
+	book.SubmitIcebergOrder(iceberg)
+
+	// a new small order will match with the second iceberg
+	_, confirm = submitCrossedOrder(t, book, 1)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, iceberg2.ID, confirm.PassiveOrdersAffected[0].ID)
+}
+
+func TestAmendIceberg(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book with a big peak
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 10, 8, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+
+	// amend iceberg such that the size is increased and the reserve is increased
+	amend := iceberg.Clone()
+	amend.Size = 150
+	amend.IcebergOrder.ReservedRemaining = 140
+	err := book.AmendOrder(iceberg, amend)
+	require.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+
+	// amend iceberg such that the volume is decreased but not enough to eat into the peak
+	amend = iceberg.Clone()
+	amend.Size = 140
+	amend.IcebergOrder.ReservedRemaining = 130
+	err = book.AmendOrder(iceberg, amend)
+	require.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+
+	// decrease again such that reserved is 0 and peak is reduced
+	amend = iceberg.Clone()
+	amend.Size = 5
+	amend.Remaining = 5
+	amend.IcebergOrder.ReservedRemaining = 0
+	err = book.AmendOrder(iceberg, amend)
+	require.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(5))
+}

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -1349,6 +1349,8 @@ func (app *App) DeliverSubmitOrder(ctx context.Context, tx abci.Tx, deterministi
 			logging.Error(err))
 	}
 
+	app.exec.TransactionFinished(ctx, os.MarketID)
+
 	return err
 }
 
@@ -1404,6 +1406,9 @@ func (app *App) DeliverAmendOrder(
 		app.log.Error("error on amending order", logging.String("order-id", order.OrderId), logging.Error(err))
 		return err
 	}
+
+	app.exec.TransactionFinished(ctx, oa.MarketID)
+
 	if app.cfg.LogOrderAmendDebug {
 		app.log.Debug("Order amended", logging.Order(*msg.Order))
 	}

--- a/core/processor/batch_market_instructions_processor_test.go
+++ b/core/processor/batch_market_instructions_processor_test.go
@@ -68,6 +68,7 @@ func TestBatchMarketInstructionsCannotSubmitMultipleAmendForSameID(t *testing.T)
 	}
 
 	amendCnt := 0
+	exec.EXPECT().TransactionFinished(gomock.Any(), "926df3b689a5440fe21cad7069ebcedc46f75b2b23ce11002a1ee2254e339f23").Times(1)
 	exec.EXPECT().AmendOrder(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2).DoAndReturn(
 		func(ctx context.Context, order *types.OrderAmendment, party string, idgen common.IDGenerator) ([]*types.OrderConfirmation, error) {
 			amendCnt++
@@ -151,6 +152,7 @@ func TestBatchMarketInstructionsContinueProcessingOnError(t *testing.T) {
 	}
 
 	cancelCnt := 0
+	exec.EXPECT().TransactionFinished(gomock.Any(), "926df3b689a5440fe21cad7069ebcedc46f75b2b23ce11002a1ee2254e339f23").Times(1)
 	exec.EXPECT().CancelOrder(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
 		func(ctx context.Context, order *types.OrderCancellation, party string, idgen common.IDGenerator) ([]*types.OrderCancellationConfirmation, error) {
 			cancelCnt++
@@ -263,6 +265,7 @@ func TestBatchMarketInstructionsEnsureAllErrorReturnNonPartialError(t *testing.T
 			return nil, nil
 		},
 	)
+	exec.EXPECT().TransactionFinished(gomock.Any(), "926df3b689a5440fe21cad7069ebcedc46f75b2b23ce11002a1ee2254e339f23").Times(1)
 
 	err := proc.ProcessBatch(
 		context.Background(),

--- a/core/processor/mocks/mocks.go
+++ b/core/processor/mocks/mocks.go
@@ -434,6 +434,18 @@ func (mr *MockExecutionEngineMockRecorder) SucceedMarket(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SucceedMarket", reflect.TypeOf((*MockExecutionEngine)(nil).SucceedMarket), arg0, arg1, arg2, arg3)
 }
 
+// TransactionFinished mocks base method.
+func (m *MockExecutionEngine) TransactionFinished(arg0 context.Context, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "TransactionFinished", arg0, arg1)
+}
+
+// TransactionFinished indicates an expected call of TransactionFinished.
+func (mr *MockExecutionEngineMockRecorder) TransactionFinished(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionFinished", reflect.TypeOf((*MockExecutionEngine)(nil).TransactionFinished), arg0, arg1)
+}
+
 // UpdateMarket mocks base method.
 func (m *MockExecutionEngine) UpdateMarket(arg0 context.Context, arg1 *types.Market) error {
 	m.ctrl.T.Helper()

--- a/core/processor/processor.go
+++ b/core/processor/processor.go
@@ -71,6 +71,7 @@ type ExecutionEngine interface {
 	SubmitOrder(ctx context.Context, orderSubmission *types.OrderSubmission, party string, idgen common.IDGenerator, orderID string) (*types.OrderConfirmation, error)
 	CancelOrder(ctx context.Context, order *types.OrderCancellation, party string, idgen common.IDGenerator) ([]*types.OrderCancellationConfirmation, error)
 	AmendOrder(ctx context.Context, order *types.OrderAmendment, party string, idgen common.IDGenerator) (*types.OrderConfirmation, error)
+	TransactionFinished(ctx context.Context, marketid string)
 
 	// market stuff
 	SubmitMarket(ctx context.Context, marketConfig *types.Market, proposer string) error

--- a/core/types/matching.go
+++ b/core/types/matching.go
@@ -381,6 +381,23 @@ func (i IcebergOrder) String() string {
 	)
 }
 
+func (o *Order) NeedsRefreshing() bool {
+	if o.IcebergOrder == nil {
+		return false
+	}
+
+	// not under the peak yet
+	if o.Remaining > o.IcebergOrder.MinimumPeakSize {
+		return false
+	}
+
+	// nothing left to refresh with
+	if o.IcebergOrder.ReservedRemaining == 0 {
+		return false
+	}
+	return true
+}
+
 type OrderConfirmation struct {
 	Order                 *Order
 	Trades                []*Trade


### PR DESCRIPTION
closes #8301 

Basic system test which:
- submits an iceberg
- submits another order which trades bringing the iceberg below its minimum peak, it refreshes
- submits another order which trades but iceberg remains above the minimum peak, doesn't refresh
- submits another order with takes out all of the iceberg's peak, refresh happens
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/72101/pipeline/

Know issues being fixed in https://github.com/vegaprotocol/vega/issues/8398:
- pegged-icebergs don't fully work
- cancelling an iceberg order doesn't always return potential buy/sell to 0

Also there is this ticket to weave it into spots markets, when that becomes possible:
- https://github.com/vegaprotocol/vega/issues/8399