### PR TITLE
fix: convert the transfer timestamp correctly

### DIFF
--- a/core/types/banking.go
+++ b/core/types/banking.go
@@ -147,7 +147,7 @@ func OneOffTransferFromEvent(p *eventspb.Transfer) *OneOffTransfer {
 			Amount:          amount,
 			Reference:       p.Reference,
 			Status:          p.Status,
-			Timestamp:       time.Unix(p.Timestamp/int64(time.Second), p.Timestamp%int64(time.Second)),
+			Timestamp:       time.Unix(0, p.Timestamp),
 		},
 		DeliverOn: deliverOn,
 	}
@@ -363,7 +363,7 @@ func RecurringTransferFromEvent(p *eventspb.Transfer) *RecurringTransfer {
 			Amount:          amount,
 			Reference:       p.Reference,
 			Status:          p.Status,
-			Timestamp:       time.Unix(p.Timestamp/int64(time.Second), p.Timestamp%int64(time.Second)),
+			Timestamp:       time.Unix(0, p.Timestamp),
 		},
 		StartEpoch:       p.GetRecurring().GetStartEpoch(),
 		EndEpoch:         endEpoch,


### PR DESCRIPTION
I think we left this incorrect when we changed transfer timestamp to be in nanoseconds. 