### PR TITLE
feat: iceberg orders in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [8337](https://github.com/vegaprotocol/vega/issues/8337) - ELS for spots
 - [8359](https://github.com/vegaprotocol/vega/issues/8359) - Add proto definitions for iceberg orders
 - [8361](https://github.com/vegaprotocol/vega/issues/8361) - Implement iceberg orders in data node
+- [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in core
 - [8332](https://github.com/vegaprotocol/vega/issues/8332) - Add support in collateral engine for spots
 - [8330](https://github.com/vegaprotocol/vega/issues/8330) - Implement validation on successor market proposals.
 - [8247](https://github.com/vegaprotocol/vega/issues/8247) - Initial support for `Ethereum` `oracles`

--- a/core/execution/future/market_iceberg_test.go
+++ b/core/execution/future/market_iceberg_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package future_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+
+	"code.vegaprotocol.io/vega/core/events"
+	"code.vegaprotocol.io/vega/core/execution/common"
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/num"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarketSubmitCancelIceberg(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(100000, 0)
+	ctx := vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash())
+	tm := getTestMarket(t, now, nil, nil)
+	defer tm.ctrl.Finish()
+
+	addAccount(t, tm, party1)
+	iceberg := &types.Order{
+		Type:        types.OrderTypeLimit,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Status:      types.OrderStatusActive,
+		ID:          "someid",
+		Side:        types.SideBuy,
+		Party:       party1,
+		MarketID:    tm.market.GetID(),
+		Size:        100,
+		Price:       num.NewUint(100),
+		Remaining:   100,
+		CreatedAt:   now.UnixNano(),
+		Reference:   "party1-buy-order",
+		Version:     common.InitialOrderVersion,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: 10,
+			MinimumPeakSize: 5,
+		},
+	}
+
+	// submit order
+	_, err := tm.market.SubmitOrder(context.Background(), iceberg)
+	require.NoError(t, err)
+
+	tm.now = tm.now.Add(time.Second)
+	tm.market.OnTick(ctx, tm.now)
+	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
+
+	// check that its on the book and the volume is only the visible peak
+	assert.Equal(t, int64(10), tm.market.GetVolumeOnBook())
+
+	// and that the position represents the whole iceberg size
+	tm.market.BlockEnd(vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash()))
+	pos := requirePositionUpdate(t, tm.events)
+	assert.Equal(t, int64(100), pos.PotentialBuys())
+
+	// now cancel the order and check potential buy returns to 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.CancelOrder(context.Background(), iceberg.Party, iceberg.ID, iceberg.ID)
+	require.NoError(t, err)
+	tm.market.BlockEnd(vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash()))
+	pos = requirePositionUpdate(t, tm.events)
+	assert.Equal(t, int64(0), pos.PotentialBuys())
+}
+
+func TestMarketAmendIceberg(t *testing.T) {
+	party1 := "party1"
+	now := time.Unix(100000, 0)
+	ctx := vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash())
+	tm := getTestMarket(t, now, nil, nil)
+	defer tm.ctrl.Finish()
+
+	addAccount(t, tm, party1)
+	iceberg := &types.Order{
+		Type:        types.OrderTypeLimit,
+		TimeInForce: types.OrderTimeInForceGTC,
+		Status:      types.OrderStatusActive,
+		ID:          "someid",
+		Side:        types.SideBuy,
+		Party:       party1,
+		MarketID:    tm.market.GetID(),
+		Size:        100,
+		Price:       num.NewUint(100),
+		Remaining:   100,
+		CreatedAt:   now.UnixNano(),
+		Reference:   "party1-buy-order",
+		Version:     common.InitialOrderVersion,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: 10,
+			MinimumPeakSize: 5,
+		},
+	}
+
+	// submit order
+	_, err := tm.market.SubmitOrder(context.Background(), iceberg)
+	require.NoError(t, err)
+
+	tm.now = tm.now.Add(time.Second)
+	tm.market.OnTick(ctx, tm.now)
+	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
+
+	// now reduce the size of the iceberg so that only the reserved amount is reduced
+	amendedOrder := &types.OrderAmendment{
+		OrderID:     iceberg.ID,
+		Price:       nil,
+		SizeDelta:   -50,
+		TimeInForce: types.OrderTimeInForceGTC,
+	}
+
+	tm.eventCount = 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, vgcrypto.RandomHash())
+	require.NoError(t, err)
+	amended := requireOrderEvent(t, tm.events)
+	assert.Equal(t, uint64(50), amended.Size)
+	assert.Equal(t, iceberg.Remaining, amended.Remaining)
+	assert.Equal(t, uint64(40), amended.IcebergOrder.ReservedRemaining)
+
+	// now increase the size delta and check that reserved remaining is increase, but remaining is the same
+	amendedOrder.SizeDelta = 70
+	tm.eventCount = 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, vgcrypto.RandomHash())
+	require.NoError(t, err)
+	amended = requireOrderEvent(t, tm.events)
+	assert.Equal(t, uint64(120), amended.Size)
+	assert.Equal(t, iceberg.Remaining, amended.Remaining)
+	assert.Equal(t, uint64(110), amended.IcebergOrder.ReservedRemaining)
+
+	// now reduce the size such that reserved is reduce to 0 and some remaining is removed too
+	amendedOrder.SizeDelta = -115
+	tm.eventCount = 0
+	tm.events = tm.events[:0]
+	_, err = tm.market.AmendOrder(context.Background(), amendedOrder, party1, vgcrypto.RandomHash())
+	require.NoError(t, err)
+	amended = requireOrderEvent(t, tm.events)
+	assert.Equal(t, uint64(5), amended.Size)
+	assert.Equal(t, uint64(5), amended.Remaining)
+	assert.Equal(t, uint64(0), amended.IcebergOrder.ReservedRemaining)
+}
+
+func requireOrderEvent(t *testing.T, evts []events.Event) *types.Order {
+	t.Helper()
+	for _, e := range evts {
+		switch evt := e.(type) {
+		case *events.Order:
+			o, err := types.OrderFromProto(evt.Order())
+			require.NoError(t, err)
+			return o
+		}
+	}
+	require.Fail(t, "did not find order event")
+	return nil
+}
+
+func requirePositionUpdate(t *testing.T, evts []events.Event) *events.PositionState {
+	t.Helper()
+	for _, e := range evts {
+		switch evt := e.(type) {
+		case *events.PositionState:
+			return evt
+		}
+	}
+	require.Fail(t, "did not find position update event")
+	return nil
+}

--- a/core/matching/iceberg_orders_test.go
+++ b/core/matching/iceberg_orders_test.go
@@ -1,0 +1,497 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package matching
+
+import (
+	"testing"
+
+	"code.vegaprotocol.io/vega/core/types"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/libs/num"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func submitIcebergOrder(t *testing.T, book *tstOB, size, peak, minPeak uint64, addToBook bool) (*types.Order, *types.OrderConfirmation) {
+	t.Helper()
+	o := &types.Order{
+		ID:            vgcrypto.RandomHash(),
+		Status:        types.OrderStatusActive,
+		MarketID:      book.marketID,
+		Party:         "A",
+		Side:          types.SideBuy,
+		Price:         num.NewUint(100),
+		OriginalPrice: num.NewUint(100),
+		Size:          size,
+		Remaining:     size,
+		TimeInForce:   types.OrderTimeInForceGTT,
+		Type:          types.OrderTypeLimit,
+		ExpiresAt:     10,
+		IcebergOrder: &types.IcebergOrder{
+			InitialPeakSize: peak,
+			MinimumPeakSize: minPeak,
+		},
+	}
+	confirm, err := book.SubmitOrder(o)
+	require.NoError(t, err)
+
+	if addToBook {
+		// aggressive iceberg orders do not naturally sit on the book and are added a different way so
+		// we do that here
+		o.Remaining = peak
+		o.IcebergOrder.ReservedRemaining = size - peak
+		// book.SubmitIcebergOrder(o)
+	}
+	return o, confirm
+}
+
+func submitCrossedOrder(t *testing.T, book *tstOB, size uint64) (*types.Order, *types.OrderConfirmation) {
+	t.Helper()
+	o := &types.Order{
+		ID:            vgcrypto.RandomHash(),
+		Status:        types.OrderStatusActive,
+		MarketID:      book.marketID,
+		Party:         "B",
+		Side:          types.SideSell,
+		Price:         num.NewUint(100),
+		OriginalPrice: num.NewUint(100),
+		Size:          size,
+		Remaining:     size,
+		TimeInForce:   types.OrderTimeInForceGTC,
+		Type:          types.OrderTypeLimit,
+	}
+	confirm, err := book.SubmitOrder(o)
+	require.NoError(t, err)
+	return o, confirm
+}
+
+func getTradesCrossedOrder(t *testing.T, book *tstOB, size uint64) []*types.Trade {
+	t.Helper()
+	o := &types.Order{
+		ID:            vgcrypto.RandomHash(),
+		Status:        types.OrderStatusActive,
+		MarketID:      book.marketID,
+		Party:         "B",
+		Side:          types.SideSell,
+		Price:         num.NewUint(100),
+		OriginalPrice: num.NewUint(100),
+		Size:          size,
+		Remaining:     size,
+		TimeInForce:   types.OrderTimeInForceGTC,
+		Type:          types.OrderTypeLimit,
+	}
+	trades, err := book.GetTrades(o)
+	require.NoError(t, err)
+	return trades
+}
+
+func TestIcebergsFakeUncross(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// check it is now on the book
+	_, err := book.GetOrderByID(iceberg.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+
+	// check the peaks are proper
+	assert.Equal(t, uint64(4), iceberg.Remaining)
+	assert.Equal(t, uint64(96), iceberg.IcebergOrder.ReservedRemaining)
+
+	// submit an order bigger than the peak
+	trades := getTradesCrossedOrder(t, book, 10)
+	assert.Equal(t, 1, len(trades))
+	assert.Equal(t, uint64(10), trades[0].Size)
+
+	// now submit it for real, and check refresh happens
+	o, confirm := submitCrossedOrder(t, book, 10)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, uint64(10), trades[0].Size)
+	assert.Equal(t, uint64(0), o.Remaining)
+}
+
+func TestIcebergFullPeakConsumedExactly(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 40, 10, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// check it is now on the book
+	_, err := book.GetOrderByID(iceberg.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(40))
+
+	trades := getTradesCrossedOrder(t, book, 40)
+	assert.Equal(t, 1, len(trades))
+	assert.Equal(t, uint64(40), trades[0].Size)
+
+	// now submit it and check it gets filled
+	o, confirm := submitCrossedOrder(t, book, 40)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, types.OrderStatusFilled, o.Status)
+
+	// check that the iceberg has been refreshed and book volume is back at 40
+	assert.Equal(t, 1, book.getNumberOfBuyLevels())
+	assert.Equal(t, uint64(40), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(40), iceberg.Remaining)
+	assert.Equal(t, uint64(20), iceberg.IcebergOrder.ReservedRemaining)
+}
+
+func TestIcebergPeakAboveMinimum(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit order that only takes a little off the peak
+	_, confirm = submitCrossedOrder(t, book, 1)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, 1, book.getNumberOfBuyLevels())
+	assert.Equal(t, uint64(3), book.getTotalBuyVolume())
+
+	// now submit another order that *will* remove the rest of the peak
+	_, confirm = submitCrossedOrder(t, book, 3)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	assert.Equal(t, uint64(4), iceberg.Remaining)
+	assert.Equal(t, uint64(92), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+}
+
+func TestIcebergAggressiveTakesAll(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	_, confirm := submitCrossedOrder(t, book, 10)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit the iceberg as an aggressive order and more than its peak is consumed
+	o, confirm := submitIcebergOrder(t, book, 50, 4, 2, false)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, uint64(10), confirm.Trades[0].Size)
+
+	// now check iceberg sits on the book with the correct peaks
+	assert.Equal(t, uint64(4), o.Remaining)
+	assert.Equal(t, uint64(36), o.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+}
+
+func TestAggressiveIcebergFullyFilled(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	_, confirm := submitCrossedOrder(t, book, 1000)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit the aggressice iceberg that will be fully filled
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, false)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	// check that
+	assert.Equal(t, uint64(0), iceberg.Remaining)
+	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusFilled, iceberg.Status)
+	assert.Equal(t, uint64(0), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(900), book.getTotalSellVolume())
+}
+
+func TestIcebergPeakBelowMinimumNotZero(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 4, 2, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// submit an order that takes the berg below its minimum peak, but is not zero
+	_, confirm = submitCrossedOrder(t, book, 3)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	// check it refreshes properly
+	assert.Equal(t, types.OrderStatusActive, iceberg.Status)
+	assert.Equal(t, uint64(4), iceberg.Remaining)
+	assert.Equal(t, uint64(93), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+
+	// put in another order which will eat into the remaining
+	submitCrossedOrder(t, book, 10)
+	assert.Equal(t, uint64(4), iceberg.Remaining)
+	assert.Equal(t, uint64(83), iceberg.IcebergOrder.ReservedRemaining)
+}
+
+func TestIcebergRefreshToPartialPeak(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book with a big peak
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 90, 2, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// expect the volume to be the peak size
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(90))
+
+	// submit an order that takes almost the full peak
+	_, confirm = submitCrossedOrder(t, book, 89)
+	assert.Equal(t, 1, len(confirm.Trades))
+
+	// remaining + reserved < initial peak
+	assert.Equal(t, uint64(11), iceberg.Remaining)
+	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(11))
+
+	// check we can now fill it and the iceberg is removed
+	_, confirm = submitCrossedOrder(t, book, 100)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, uint64(0), iceberg.Remaining)
+	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusFilled, iceberg.Status)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(0))
+}
+
+func TestIcebergHiddenDistribution(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit 3 iceberg orders
+	iceberg1, confirm := submitIcebergOrder(t, book, 300, 100, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	iceberg2, confirm := submitIcebergOrder(t, book, 300, 200, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	iceberg3, _ := submitIcebergOrder(t, book, 200, 100, 2, false)
+
+	// submit a big order such that all three peaks are consumed (100 + 200 + 100 = 400)
+	// and the left over is 300
+	trades := getTradesCrossedOrder(t, book, 700)
+	assert.Equal(t, 3, len(trades))
+	assert.Equal(t, uint64(250), trades[0].Size)
+	assert.Equal(t, uint64(275), trades[1].Size)
+	assert.Equal(t, uint64(175), trades[2].Size)
+
+	// now submit it for real
+	o, confirm := submitCrossedOrder(t, book, 700)
+	assert.Equal(t, 3, len(confirm.Trades))
+	assert.Equal(t, types.OrderStatusFilled, o.Status)
+
+	// check iceberg one has been refresh properly
+	assert.Equal(t, uint64(50), iceberg1.Remaining)
+	assert.Equal(t, uint64(0), iceberg1.IcebergOrder.ReservedRemaining)
+
+	assert.Equal(t, uint64(25), iceberg2.Remaining)
+	assert.Equal(t, uint64(0), iceberg2.IcebergOrder.ReservedRemaining)
+
+	assert.Equal(t, uint64(25), iceberg3.Remaining)
+	assert.Equal(t, uint64(0), iceberg3.IcebergOrder.ReservedRemaining)
+}
+
+func TestIcebergHiddenDistributionCrumbs(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit 3 iceberg orders of equal sizes
+	iceberg1, _ := submitIcebergOrder(t, book, 500, 100, 2, false)
+	iceberg2, _ := submitIcebergOrder(t, book, 500, 100, 2, false)
+	iceberg3, _ := submitIcebergOrder(t, book, 500, 100, 100, false)
+	assert.Equal(t, uint64(300), book.getTotalBuyVolume())
+
+	// submit a big order such that all three peaks are consumed (100 + 100 + 100 = 300)
+	// and the left over is 100 to be divided between three
+	trades := getTradesCrossedOrder(t, book, 400)
+	assert.Equal(t, 3, len(trades))
+	assert.Equal(t, uint64(134), trades[0].Size)
+	assert.Equal(t, uint64(133), trades[1].Size)
+	assert.Equal(t, uint64(133), trades[2].Size)
+
+	// now submit it for real
+	o, confirm := submitCrossedOrder(t, book, 400)
+	assert.Equal(t, 3, len(confirm.Trades))
+	assert.Equal(t, types.OrderStatusFilled, o.Status)
+
+	// check iceberg one has been refresh properly
+	assert.Equal(t, uint64(100), iceberg1.Remaining)
+	assert.Equal(t, uint64(266), iceberg1.IcebergOrder.ReservedRemaining)
+
+	assert.Equal(t, uint64(100), iceberg2.Remaining)
+	assert.Equal(t, uint64(267), iceberg2.IcebergOrder.ReservedRemaining)
+
+	assert.Equal(t, uint64(100), iceberg3.Remaining)
+	assert.Equal(t, uint64(267), iceberg3.IcebergOrder.ReservedRemaining)
+}
+
+func TestIcebergHiddenDistributionFullyConsumed(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit 3 iceberg orders
+	iceberg1, confirm := submitIcebergOrder(t, book, 300, 100, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	iceberg2, confirm := submitIcebergOrder(t, book, 300, 200, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	iceberg3, _ := submitIcebergOrder(t, book, 200, 100, 2, false)
+
+	// submit a big order such that all three peaks are consumed (100 + 200 + 100 = 400)
+	// and all of the hidden volume (200 + 100 + 100 = 400)
+	trades := getTradesCrossedOrder(t, book, 1000)
+	assert.Equal(t, 3, len(trades))
+	assert.Equal(t, uint64(300), trades[0].Size)
+	assert.Equal(t, uint64(300), trades[1].Size)
+	assert.Equal(t, uint64(200), trades[2].Size)
+
+	// now submit it for real
+	o, confirm := submitCrossedOrder(t, book, 1000)
+	assert.Equal(t, 3, len(confirm.Trades))
+	assert.Equal(t, types.OrderStatusActive, o.Status)
+	assert.Equal(t, uint64(200), o.Remaining)
+
+	// check iceberg one has been refresh properly
+	assert.Equal(t, uint64(0), iceberg1.Remaining)
+	assert.Equal(t, uint64(0), iceberg1.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusFilled, iceberg1.Status)
+
+	assert.Equal(t, uint64(0), iceberg2.Remaining)
+	assert.Equal(t, uint64(0), iceberg2.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusFilled, iceberg2.Status)
+
+	assert.Equal(t, uint64(0), iceberg3.Remaining)
+	assert.Equal(t, uint64(0), iceberg3.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusFilled, iceberg2.Status)
+}
+
+func TestIcebergHiddenDistributionPrimeHidden(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit 3 iceberg orders
+	iceberg1, confirm := submitIcebergOrder(t, book, 300, 43, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	iceberg2, confirm := submitIcebergOrder(t, book, 300, 67, 2, false)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	iceberg3, _ := submitIcebergOrder(t, book, 200, 9, 2, false)
+
+	// submit a big order such that all three peaks are consumed (43 + 67 + 9 = 119)
+	// and the individual remaining hidden volumes are prime (257, 233, 191) such
+	// that the distributed amount will make nasty precision crumbs
+	trades := getTradesCrossedOrder(t, book, 250)
+	assert.Equal(t, 3, len(trades))
+	assert.Equal(t, uint64(94), trades[0].Size)
+	assert.Equal(t, uint64(111), trades[1].Size)
+	assert.Equal(t, uint64(45), trades[2].Size)
+
+	// now submit it for real
+	o, confirm := submitCrossedOrder(t, book, 250)
+	assert.Equal(t, 3, len(confirm.Trades))
+	assert.Equal(t, types.OrderStatusFilled, o.Status)
+	assert.Equal(t, uint64(0), o.Remaining)
+
+	// check iceberg one has been refresh properly
+	assert.Equal(t, uint64(43), iceberg1.Remaining)
+	assert.Equal(t, uint64(163), iceberg1.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusActive, iceberg1.Status)
+
+	assert.Equal(t, uint64(67), iceberg2.Remaining)
+	assert.Equal(t, uint64(122), iceberg2.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusActive, iceberg2.Status)
+
+	assert.Equal(t, uint64(9), iceberg3.Remaining)
+	assert.Equal(t, uint64(146), iceberg3.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, types.OrderStatusActive, iceberg2.Status)
+
+	assert.Equal(t, uint64(43+67+9), book.getTotalBuyVolume())
+}
+
+func TestIcebergTimePriorityLostOnRefresh(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book with a big peak
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 10, 8, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// now submit a second order that will be next in line
+	iceberg2, confirm := submitIcebergOrder(t, book, 100, 100, 1, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+
+	// expect the volume to be the peak size
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(110))
+
+	// submit a order that will take out some of the peak of the first iceberg, check its refreshed
+	_, confirm = submitCrossedOrder(t, book, 5)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, uint64(10), iceberg.Remaining)
+	assert.Equal(t, uint64(85), iceberg.IcebergOrder.ReservedRemaining)
+
+	// a new small order will match with the second iceberg
+	_, confirm = submitCrossedOrder(t, book, 1)
+	assert.Equal(t, 1, len(confirm.Trades))
+	assert.Equal(t, iceberg2.ID, confirm.PassiveOrdersAffected[0].ID)
+}
+
+func TestAmendIceberg(t *testing.T) {
+	market := "testMarket"
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	// submit an iceberg order that sits on the book with a big peak
+	iceberg, confirm := submitIcebergOrder(t, book, 100, 10, 8, true)
+	assert.Equal(t, 0, len(confirm.Trades))
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+
+	// amend iceberg such that the size is increased and the reserve is increased
+	amend := iceberg.Clone()
+	amend.Size = 150
+	amend.IcebergOrder.ReservedRemaining = 140
+	err := book.AmendOrder(iceberg, amend)
+	require.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+
+	// amend iceberg such that the volume is decreased but not enough to eat into the peak
+	amend = iceberg.Clone()
+	amend.Size = 140
+	amend.IcebergOrder.ReservedRemaining = 130
+	err = book.AmendOrder(iceberg, amend)
+	require.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+
+	// decrease again such that reserved is 0 and peak is reduced
+	amend = iceberg.Clone()
+	amend.Size = 5
+	amend.Remaining = 5
+	amend.IcebergOrder.ReservedRemaining = 0
+	err = book.AmendOrder(iceberg, amend)
+	require.NoError(t, err)
+	assert.Equal(t, book.getTotalBuyVolume(), uint64(5))
+}

--- a/core/matching/orderbook.go
+++ b/core/matching/orderbook.go
@@ -211,6 +211,9 @@ func (b *OrderBook) LeaveAuction(at time.Time) ([]*types.OrderConfirmation, []*t
 	}
 
 	for _, uo := range uncrossedOrders {
+		// refresh if its an iceberg, noop if not
+		b.icebergRefresh(uo.Order)
+
 		if uo.Order.Remaining == 0 {
 			uo.Order.Status = types.OrderStatusFilled
 			b.remove(uo.Order)
@@ -219,6 +222,10 @@ func (b *OrderBook) LeaveAuction(at time.Time) ([]*types.OrderConfirmation, []*t
 		uo.Order.UpdatedAt = ts
 		for idx, po := range uo.PassiveOrdersAffected {
 			po.UpdatedAt = ts
+
+			// refresh if its an iceberg, noop if not
+			b.icebergRefresh(po)
+
 			// also remove the orders from lookup tables
 			if uo.PassiveOrdersAffected[idx].Remaining == 0 {
 				uo.PassiveOrdersAffected[idx].Status = types.OrderStatusFilled
@@ -846,6 +853,14 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 		}
 	}
 
+	if order.IcebergOrder != nil && order.Status == types.OrderStatusActive {
+		// now trades have been generated for the aggressive iceberg based on the
+		// full size, set the peak limits ready for it to be added to the book.
+		peak := num.MinV(order.Remaining, order.IcebergOrder.InitialPeakSize)
+		order.IcebergOrder.ReservedRemaining = order.Remaining - peak
+		order.Remaining = peak
+	}
+
 	// if order is persistent type add to order book to the correct side
 	// and we did not hit a error / wash trade error
 	if order.IsPersistent() && err == nil {
@@ -885,6 +900,9 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 	}
 
 	for idx := range impactedOrders {
+		// refresh if its an iceberg, noop if not
+		b.icebergRefresh(impactedOrders[idx])
+
 		if impactedOrders[idx].Remaining == 0 {
 			impactedOrders[idx].Status = types.OrderStatusFilled
 
@@ -1106,6 +1124,27 @@ func (b *OrderBook) GetActivePeggedOrderIDs() []string {
 	}
 	sort.Strings(pegged)
 	return pegged
+}
+
+// icebergRefresh will restore the peaks of an iceberg order if they have drifted below the minimum value
+// if not the order remains unchanged.
+func (b *OrderBook) icebergRefresh(o *types.Order) {
+	if !o.IcebergNeedsRefresh() {
+		return
+	}
+
+	// remove it if there is some left
+	if o.Remaining > 0 {
+		if _, err := b.DeleteOrder(o); err != nil {
+			b.log.Panic("could not delete iceberg order during refresh", logging.Error(err), logging.Order(o))
+		}
+	}
+
+	// refresh peaks
+	o.SetIcebergPeaks()
+
+	// put it to the back of the line
+	b.getSide(o.Side).addOrder(o)
 }
 
 // remove removes the given order from all the lookup map.

--- a/core/matching/side.go
+++ b/core/matching/side.go
@@ -133,6 +133,33 @@ func (s *OrderBookSide) BestStaticPriceAndVolume() (*num.Uint, uint64, error) {
 	return num.UintZero(), 0, errors.New("no non pegged orders found on the book")
 }
 
+func (s *OrderBookSide) amendIcebergOrder(amendOrder *types.Order, oldOrder *types.Order, priceLevelIndex int, orderIndex int) (uint64, error) {
+	if amendOrder.Remaining > oldOrder.Remaining {
+		// iceberg amend should never increase the visible remaining
+		return 0, types.ErrOrderAmendFailure
+	}
+
+	// set the new order in the level
+	s.levels[priceLevelIndex].orders[orderIndex] = amendOrder
+
+	// iceberg orders are a little different because they can be increased or decreased in size but
+	// amended in place. This is because on increase only the reserve amount it changed.
+	oldReserved := oldOrder.IcebergOrder.ReservedRemaining
+	amendReserved := amendOrder.IcebergOrder.ReservedRemaining
+	if amendReserved > oldReserved {
+		// only increased the reserve so the book volume is not changed
+		return 0, nil
+	}
+
+	if amendReserved < oldReserved {
+		reduceBy := oldOrder.Remaining - amendOrder.Remaining
+		s.levels[priceLevelIndex].reduceVolume(reduceBy)
+		return reduceBy, nil
+	}
+
+	return 0, nil
+}
+
 func (s *OrderBookSide) amendOrder(orderAmend *types.Order) (uint64, error) {
 	priceLevelIndex := -1
 	orderIndex := -1
@@ -160,12 +187,16 @@ func (s *OrderBookSide) amendOrder(orderAmend *types.Order) (uint64, error) {
 		return 0, types.ErrOrderAmendFailure
 	}
 
-	if oldOrder.Size < orderAmend.Size &&
-		oldOrder.Remaining < orderAmend.Size {
+	if oldOrder.Reference != orderAmend.Reference {
 		return 0, types.ErrOrderAmendFailure
 	}
 
-	if oldOrder.Reference != orderAmend.Reference {
+	if oldOrder.IcebergOrder != nil {
+		return s.amendIcebergOrder(orderAmend, oldOrder, priceLevelIndex, orderIndex)
+	}
+
+	if oldOrder.Size < orderAmend.Size &&
+		oldOrder.Remaining < orderAmend.Size {
 		return 0, types.ErrOrderAmendFailure
 	}
 
@@ -410,6 +441,7 @@ func (s *OrderBookSide) fakeUncross(agg *types.Order, checkWashTrades bool) ([]*
 		if err != nil && err == ErrWashTrade {
 			break
 		}
+
 		// the orders are still part of the levels, so we just have to move on anyway
 		idx--
 	}

--- a/core/positions/market_position.go
+++ b/core/positions/market_position.go
@@ -65,11 +65,11 @@ func (p *MarketPosition) Closed() bool {
 func (p *MarketPosition) SetParty(party string) { p.partyID = party }
 
 func (p *MarketPosition) RegisterOrder(log *logging.Logger, order *types.Order) {
-	p.UpdateOnOrderChange(log, order.Side, order.Price, order.Remaining, true)
+	p.UpdateOnOrderChange(log, order.Side, order.Price, order.TrueRemaining(), true)
 }
 
 func (p *MarketPosition) UnregisterOrder(log *logging.Logger, order *types.Order) {
-	p.UpdateOnOrderChange(log, order.Side, order.Price, order.Remaining, false)
+	p.UpdateOnOrderChange(log, order.Side, order.Price, order.TrueRemaining(), false)
 }
 
 func (p *MarketPosition) UpdateOnOrderChange(log *logging.Logger, side types.Side, price *num.Uint, sizeChange uint64, add bool) {
@@ -124,13 +124,13 @@ func (p *MarketPosition) UpdateOnOrderChange(log *logging.Logger, side types.Sid
 func (p *MarketPosition) AmendOrder(log *logging.Logger, originalOrder, newOrder *types.Order) {
 	switch originalOrder.Side {
 	case types.SideBuy:
-		if uint64(p.buy) < originalOrder.Remaining {
+		if uint64(p.buy) < originalOrder.TrueRemaining() {
 			log.Panic("cannot amend order with remaining > potential buy",
 				logging.Order(*originalOrder),
 				logging.Int64("potential-buy", p.buy))
 		}
 	case types.SideSell:
-		if uint64(p.sell) < originalOrder.Remaining {
+		if uint64(p.sell) < originalOrder.TrueRemaining() {
 			log.Panic("cannot amend order with remaining > potential sell",
 				logging.Order(*originalOrder),
 				logging.Int64("potential-sell", p.sell))

--- a/core/types/matching.go
+++ b/core/types/matching.go
@@ -68,6 +68,53 @@ func (o *Order) ClearUpExtraRemaining() {
 	o.extraRemaining = 0
 }
 
+// TrueRemaining is the full remaining size of an order. If this is an iceberg order
+// it will return the visible peak + the hidden volume.
+func (o *Order) TrueRemaining() uint64 {
+	rem := o.Remaining
+	if o.IcebergOrder != nil {
+		rem += o.IcebergOrder.ReservedRemaining
+	}
+	return rem
+}
+
+// IcebergNeedsRefresh returns whether the given iceberg order's visible peak has
+// dropped below the minimum peak value, and there is hidden volume available to
+// restore it.
+func (o *Order) IcebergNeedsRefresh() bool {
+	if o.IcebergOrder == nil {
+		// not an iceberg
+		return false
+	}
+
+	if o.IcebergOrder.ReservedRemaining == 0 {
+		// nothing to refresh with
+		return false
+	}
+
+	if o.Remaining >= o.IcebergOrder.MinimumPeakSize {
+		// not under the minimum
+		return false
+	}
+
+	return true
+}
+
+// SetIcebergPeaks will restore the given iceberg orders visible size with
+// some of its hidden volume.
+func (o *Order) SetIcebergPeaks() {
+	if o.IcebergOrder == nil {
+		return
+	}
+
+	// calculate the refill amount
+	refill := o.IcebergOrder.InitialPeakSize - o.Remaining
+	refill = num.MinV(refill, o.IcebergOrder.ReservedRemaining)
+
+	o.Remaining += refill
+	o.IcebergOrder.ReservedRemaining -= refill
+}
+
 func (o Order) IntoSubmission() *OrderSubmission {
 	sub := &OrderSubmission{
 		MarketID:    o.MarketID,


### PR DESCRIPTION
closes #8301
closes #8374

Its the iceberg orders again.

The main change since last time is in how we prevent iceberg orders crossing after refresh when an aggressive order bigger than an icebergs peak comes in. 

The solution is [this](https://vegaprotocol.slack.com/archives/CAHA5EX0F/p1685537029033049?thread_ts=1685439563.629449&cid=CAHA5EX0F), along with refreshes happening after every order submission and not at the end of every transaction. Given that it happens during execution it means most of the iceberg logic is now in the matching engine.

Amending an iceberg is exactly the same as it was before, so no changes there since the other PR.

system test from before still passes:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/72852/pipeline