### PR TITLE
feat: add integration test happy paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [8359](https://github.com/vegaprotocol/vega/issues/8359) - Add proto definitions for iceberg orders
 - [8361](https://github.com/vegaprotocol/vega/issues/8361) - Implement iceberg orders in data node
 - [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in core
+- [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in feature tests
 - [8332](https://github.com/vegaprotocol/vega/issues/8332) - Add support in collateral engine for spots
 - [8330](https://github.com/vegaprotocol/vega/issues/8330) - Implement validation on successor market proposals.
 - [8247](https://github.com/vegaprotocol/vega/issues/8247) - Initial support for `Ethereum` `oracles`

--- a/core/integration/features/orders/iceberg-orders.feature
+++ b/core/integration/features/orders/iceberg-orders.feature
@@ -1,0 +1,122 @@
+Feature: Amend orders
+
+  Background:
+    Given the markets:
+      | id        | quote name | asset | risk model                  | margin calculator                  | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC19 | BTC        | BTC   | default-simple-risk-model-2 | default-overkill-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e6                    | 1e6                       |
+    And the following network parameters are set:
+      | name                                    | value |
+      | market.auction.minimumDuration          | 1     |
+      | network.markPriceUpdateMaximumFrequency | 0s    |
+
+  @iceberg
+  Scenario: iceberg basic refresh
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount |
+      | party1 | BTC   | 10000  |
+      | party2 | BTC   | 10000  |
+      | aux    | BTC   | 100000 |
+      | aux2   | BTC   | 100000 |
+
+    # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux   | ETH/DEC19 | buy  | 1      | 1     | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 10001 | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC19 | buy  | 1      | 2     | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 2     | 0                | TYPE_LIMIT | TIF_GTC |
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    When the parties place the following iceberg orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | initial peak | minimum peak |
+      | party1 | ETH/DEC19 | buy  | 100    | 10    | 0                | TYPE_LIMIT | TIF_GTC | 10           | 5            |
+
+    Then the iceberg orders should have the following states:
+      | party  | market id | side | visible volume | price | status        | reserved volume |
+      | party1 | ETH/DEC19 | buy  | 10             | 10    | STATUS_ACTIVE | 90              |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party2 | ETH/DEC19 | sell | 6      | 10    | 1                | TYPE_LIMIT | TIF_GTC |
+
+    Then the iceberg orders should have the following states:
+      | party  | market id | side | visible volume | price | status        | reserved volume |
+      | party1 | ETH/DEC19 | buy  | 10             | 10    | STATUS_ACTIVE | 84              |
+
+  @iceberg
+  Scenario: iceberg refrehes leaving auction
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount |
+      | party1 | BTC   | 10000  |
+      | party2 | BTC   | 10000  |
+      | aux    | BTC   | 100000 |
+      | aux2   | BTC   | 100000 |
+
+    # place an iceberg order that will trade when coming out of auction
+    When the parties place the following iceberg orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | initial peak | minimum peak |
+      | party1 | ETH/DEC19 | buy  | 100    | 2     | 0                | TYPE_LIMIT | TIF_GTC | 10           | 10            |
+
+    # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux   | ETH/DEC19 | buy  | 1      | 1     | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 10001 | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC19 | buy  | 1      | 2     | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 2     | 0                | TYPE_LIMIT | TIF_GTC |
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    Then the iceberg orders should have the following states:
+      | party  | market id | side | visible volume | price | status        | reserved volume |
+      | party1 | ETH/DEC19 | buy  | 10             | 2     | STATUS_ACTIVE | 89              |
+
+
+  @iceberg
+  Scenario: Iceberg increase size success and not losing position in order book
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount |
+      | party1  | BTC   | 10000  |
+      | party2 | BTC   | 10000  |
+      | party3 | BTC   | 10000  |
+      | aux    | BTC   | 100000 |
+      | aux2   | BTC   | 100000 |
+
+    # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux   | ETH/DEC19 | buy  | 1      | 1     | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 10001 | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC19 | buy  | 1      | 2     | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 2     | 0                | TYPE_LIMIT | TIF_GTC |
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+
+    And the parties place the following iceberg orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   | initial peak | minimum peak |
+      | party1 | ETH/DEC19 | sell | 5      | 2     | 0                | TYPE_LIMIT | TIF_GTC | this-order-1 | 2            | 1            |
+      | party2 | ETH/DEC19 | sell | 5      | 2     | 0                | TYPE_LIMIT | TIF_GTC | this-order-2 | 2            | 1            |
+
+    # reducing size
+    Then the parties amend the following orders:
+      | party  | reference    | price | size delta | tif     |
+      | party1 | this-order-1 | 2     | 5          | TIF_GTC |
+
+    # the visible is the same and only the reserve amount has increased
+    Then the iceberg orders should have the following states:
+      | party  | market id | side | visible volume | price | status         | reserved volume |
+      | party1 | ETH/DEC19 | sell  | 2              | 2     | STATUS_ACTIVE  | 8               |
+
+    # matching the order now
+    # this should match with the size 3 order of party1
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party3 | ETH/DEC19 | buy  | 2      | 2     | 1                | TYPE_LIMIT | TIF_GTC | party3 |
+
+    Then the following trades should be executed:
+      | buyer  | seller  | price | size |
+      | party3 | party1  | 2     | 2    |

--- a/core/integration/main_test.go
+++ b/core/integration/main_test.go
@@ -276,6 +276,14 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		return steps.TheAverageBlockDurationIs(execsetup.block, blockTime)
 	})
 
+	s.Step(`^the parties place the following iceberg orders:$`, func(table *godog.Table) error {
+		return steps.PartiesPlaceTheFollowingIcebergOrders(execsetup.executionEngine, execsetup.timeService, table)
+	})
+
+	s.Step(`^the iceberg orders should have the following states:$`, func(table *godog.Table) error {
+		return steps.TheIcebergOrdersShouldHaveTheFollowingStates(execsetup.broker, table)
+	})
+
 	s.Step(`the network moves ahead "([^"]+)" blocks`, func(blocks string) error {
 		return steps.TheNetworkMovesAheadNBlocks(execsetup.executionEngine, execsetup.block, execsetup.timeService, blocks, execsetup.epochEngine)
 	})

--- a/core/integration/steps/parties_place_the_following_iceberg_orders.go
+++ b/core/integration/steps/parties_place_the_following_iceberg_orders.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package steps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"code.vegaprotocol.io/vega/core/integration/stubs"
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/num"
+
+	"github.com/cucumber/godog"
+)
+
+func PartiesPlaceTheFollowingIcebergOrders(
+	exec Execution,
+	ts *stubs.TimeStub,
+	table *godog.Table,
+) error {
+	now := ts.GetTimeNow()
+	for _, r := range parseSubmitIcebergOrderTable(table) {
+		row := submitIcebergOrderRow{row: r}
+
+		orderSubmission := types.OrderSubmission{
+			MarketID:    row.MarketID(),
+			Side:        row.Side(),
+			Price:       row.Price(),
+			Size:        row.Volume(),
+			ExpiresAt:   row.ExpirationDate(now),
+			Type:        row.OrderType(),
+			TimeInForce: row.TimeInForce(),
+			Reference:   row.Reference(),
+			IcebergOrder: &types.IcebergOrder{
+				InitialPeakSize: row.InitialPeak(),
+				MinimumPeakSize: row.MinimumPeak(),
+			},
+		}
+		only := row.Only()
+		switch only {
+		case Post:
+			orderSubmission.PostOnly = true
+		case Reduce:
+			orderSubmission.ReduceOnly = true
+		}
+
+		resp, err := exec.SubmitOrder(context.Background(), &orderSubmission, row.Party())
+		if ceerr := checkExpectedError(row, err, nil); ceerr != nil {
+			return ceerr
+		}
+
+		if !row.ExpectResultingTrades() || err != nil {
+			continue
+		}
+
+		actualTradeCount := int64(len(resp.Trades))
+		if actualTradeCount != row.ResultingTrades() {
+			return formatDiff(fmt.Sprintf("the resulting trades didn't match the expectation for order \"%v\"", row.Reference()),
+				map[string]string{
+					"total": i64ToS(row.ResultingTrades()),
+				},
+				map[string]string{
+					"total": i64ToS(actualTradeCount),
+				},
+			)
+		}
+	}
+	return nil
+}
+
+func parseSubmitIcebergOrderTable(table *godog.Table) []RowWrapper {
+	return StrictParseTable(table, []string{
+		"party",
+		"market id",
+		"side",
+		"volume",
+		"price",
+		"type",
+		"tif",
+		"initial peak",
+		"minimum peak",
+	}, []string{
+		"reference",
+		"error",
+		"resulting trades",
+		"expires in",
+		"only",
+	})
+}
+
+type submitIcebergOrderRow struct {
+	row RowWrapper
+}
+
+func (r submitIcebergOrderRow) Party() string {
+	return r.row.MustStr("party")
+}
+
+func (r submitIcebergOrderRow) MarketID() string {
+	return r.row.MustStr("market id")
+}
+
+func (r submitIcebergOrderRow) Side() types.Side {
+	return r.row.MustSide("side")
+}
+
+func (r submitIcebergOrderRow) Volume() uint64 {
+	return r.row.MustU64("volume")
+}
+
+func (r submitIcebergOrderRow) Price() *num.Uint {
+	return r.row.MustUint("price")
+}
+
+func (r submitIcebergOrderRow) OrderType() types.OrderType {
+	return r.row.MustOrderType("type")
+}
+
+func (r submitIcebergOrderRow) TimeInForce() types.OrderTimeInForce {
+	return r.row.MustTIF("tif")
+}
+
+func (r submitIcebergOrderRow) ExpirationDate(now time.Time) int64 {
+	if r.OrderType() == types.OrderTypeMarket {
+		return 0
+	}
+
+	if r.TimeInForce() == types.OrderTimeInForceGTT {
+		return now.Add(r.row.MustDurationSec("expires in")).Local().UnixNano()
+	}
+	// non GTT orders don't need an expiry time
+	return 0
+}
+
+func (r submitIcebergOrderRow) ExpectResultingTrades() bool {
+	return r.row.HasColumn("resulting trades")
+}
+
+func (r submitIcebergOrderRow) ResultingTrades() int64 {
+	return r.row.I64("resulting trades")
+}
+
+func (r submitIcebergOrderRow) Reference() string {
+	return r.row.Str("reference")
+}
+
+func (r submitIcebergOrderRow) Error() string {
+	return r.row.Str("error")
+}
+
+func (r submitIcebergOrderRow) ExpectError() bool {
+	return r.row.HasColumn("error")
+}
+
+func (r submitIcebergOrderRow) Only() Only {
+	if !r.row.HasColumn("only") {
+		return None
+	}
+	v := r.row.MustStr("only")
+	t, ok := onlyTypes[v]
+	if !ok {
+		panic(fmt.Errorf("unsupported type %v", v))
+	}
+	return t
+}
+
+func (r submitIcebergOrderRow) MinimumPeak() uint64 {
+	return r.row.MustU64("minimum peak")
+}
+
+func (r submitIcebergOrderRow) InitialPeak() uint64 {
+	return r.row.MustU64("initial peak")
+}

--- a/core/integration/steps/the_iceberg_orders_should_have_the_following_states.go
+++ b/core/integration/steps/the_iceberg_orders_should_have_the_following_states.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package steps
+
+import (
+	"fmt"
+
+	"code.vegaprotocol.io/vega/core/integration/stubs"
+	"github.com/cucumber/godog"
+)
+
+func TheIcebergOrdersShouldHaveTheFollowingStates(broker *stubs.BrokerStub, table *godog.Table) error {
+	data := broker.GetOrderEvents()
+
+	for _, row := range parseIcebergOrdersStatesTable(table) {
+		party := row.MustStr("party")
+		marketID := row.MustStr("market id")
+		side := row.MustSide("side")
+		visible := row.MustU64("visible volume")
+		price := row.MustU64("price")
+		status := row.MustOrderStatus("status")
+		ref, hasRef := row.StrB("reference")
+		reservedRemaining := row.MustU64("reserved volume")
+
+		match := false
+		for _, e := range data {
+			o := e.Order()
+			if hasRef {
+				if ref != o.Reference {
+					continue
+				}
+				if o.PartyId == party && o.Status == status && o.MarketId == marketID && o.Side == side {
+					if o.Remaining != visible || stringToU64(o.Price) != price {
+						return fmt.Errorf("side: %s, expected price: %v actual: %v, expected volume: %v, actual %v", side.String(), price, o.Price, visible, o.Size)
+					}
+				}
+			}
+			if o.PartyId != party || o.Status != status || o.MarketId != marketID || o.Side != side || o.Remaining != visible || stringToU64(o.Price) != price {
+				continue
+			}
+
+			if o.IcebergOrder == nil || o.IcebergOrder.ReservedRemaining != reservedRemaining {
+				continue
+			}
+
+			match = true
+			break
+		}
+		if !match {
+			return errOrderEventsNotFound(party, marketID, side, visible, price)
+		}
+	}
+	return nil
+}
+
+func parseIcebergOrdersStatesTable(table *godog.Table) []RowWrapper {
+	return StrictParseTable(table, []string{
+		"party",
+		"market id",
+		"side",
+		"visible volume",
+		"price",
+		"status",
+		"reserved volume",
+	}, []string{"reference"})
+}


### PR DESCRIPTION
closes #8397 

Adds the step:
```
the parties place the following iceberg orders
```
to stay in line with the pre-existing two:
```
the parties place the following orders
the parties place the following pegged orders
```

and also added a state check step so that you can query the visible/hidden volumes of an iceberg order:
```
the iceberg orders should have the following states
```

Flexed these in the following happy-path tests under the tag `@iceberg`:
- iceberg refreshing during continuous trading
- iceberg refreshing when leaving auction
- amending an iceberg order with size increase _does not_ lose its time priority