### PR TITLE
Optimise ci times

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -71,7 +71,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the GitHub Container Registry
-        if: ${{ inputs.publish || startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ inputs.publish || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -108,7 +108,22 @@ jobs:
         run: |
           docker run --rm vegaprotocol/${{ matrix.app }}:local version || docker run --rm vegaprotocol/${{ matrix.app }}:local software version
 
-      - name: Build and push to Docker registries
+      - name: Build and push to GitHub Container Registry
+        id: docker_build_github
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ inputs.publish || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' }}
+          file: ./docker/${{ matrix.app }}.dockerfile
+          platforms: ${{ inputs.archs || 'linux/amd64, linux/arm64' }}
+          tags: |
+            ghcr.io/vegaprotocol/vega/${{ matrix.app }}:latest
+            ghcr.io/vegaprotocol/vega/${{ matrix.app }}:${{ steps.tags.outputs.version }}
+
+      - name: GitHub docker image digest
+        run: echo ${{ steps.docker_build_github.outputs.digest }}
+
+      - name: Build and push to DockerHub
         id: docker_build
         uses: docker/build-push-action@v3
         with:
@@ -117,10 +132,8 @@ jobs:
           file: ./docker/${{ matrix.app }}.dockerfile
           platforms: ${{ inputs.archs || 'linux/amd64, linux/arm64' }}
           tags: |
-            ghcr.io/vegaprotocol/vega/${{ matrix.app }}:latest
-            ghcr.io/vegaprotocol/vega/${{ matrix.app }}:${{ steps.tags.outputs.version }}
             vegaprotocol/${{ matrix.app }}:latest
             vegaprotocol/${{ matrix.app }}:${{ steps.tags.outputs.version }}
 
-      - name: Image digest
+      - name: DockerHub docker image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -215,89 +215,6 @@ pipeline {
                         }
                     }
                 }
-                stage('protos') {
-                    environment {
-                        GOPATH = "${env.WORKSPACE}/GOPATH"
-                        GOBIN = "${env.GOPATH}/bin"
-                        PATH = "${env.GOBIN}:${env.PATH}"
-                    }
-                    stages {
-                        stage('Install dependencies') {
-                            // We are using specific tools versions
-                            // Please use exactly the same versions when modifying protos
-                            options { retry(3) }
-                            steps {
-                                dir('vega') {
-                                    sh 'printenv'
-                                    sh './script/gettools.sh'
-                                }
-                            }
-                        }
-                        stage('buf lint') {
-                            options { retry(3) }
-                            steps {
-                                dir('vega') {
-                                    sh '''#!/bin/bash -e
-                                        buf lint
-                                    '''
-                                }
-                            }
-                            post {
-                                failure {
-                                    sh 'printenv'
-                                    echo "params=${params}"
-                                    sh 'buf --version'
-                                    sh 'which buf'
-                                    sh 'git diff'
-                                }
-                            }
-                        }
-                        stage('proto format check') {
-                            options { retry(3) }
-                            steps {
-                                dir('vega') {
-                                    sh '''#!/bin/bash -e
-                                        make proto_format_check
-                                    '''
-                                }
-                            }
-                            post {
-                                failure {
-                                    sh 'printenv'
-                                    echo "params=${params}"
-                                    sh 'buf --version'
-                                    sh 'which buf'
-                                    sh 'git diff'
-                                }
-                            }
-                        }
-                        stage('proto check') {
-                            options { retry(3) }
-                            steps {
-                                sh label: 'copy vega repo', script: '''#!/bin/bash -e
-                                        cp -r ./vega ./vega-proto-check
-                                    '''
-                                dir('vega-proto-check') {
-                                    sh '''#!/bin/bash -e
-                                        make proto_check
-                                    '''
-                                }
-                                sh label: 'remove vega copy', script: '''#!/bin/bash -e
-                                        rm -rf ./vega-proto-check
-                                    '''
-                            }
-                            post {
-                                failure {
-                                    sh 'printenv'
-                                    echo "params=${params}"
-                                    sh 'buf --version'
-                                    sh 'which buf'
-                                    sh 'git diff'
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
         //
@@ -423,6 +340,89 @@ pipeline {
                             echo "params=${params}"
                             dir('vega') {
                                 sh 'git diff'
+                            }
+                        }
+                    }
+                }
+                stage('protos') {
+                    environment {
+                        GOPATH = "${env.WORKSPACE}/GOPATH"
+                        GOBIN = "${env.GOPATH}/bin"
+                        PATH = "${env.GOBIN}:${env.PATH}"
+                    }
+                    stages {
+                        stage('Install dependencies') {
+                            // We are using specific tools versions
+                            // Please use exactly the same versions when modifying protos
+                            options { retry(3) }
+                            steps {
+                                dir('vega') {
+                                    sh 'printenv'
+                                    sh './script/gettools.sh'
+                                }
+                            }
+                        }
+                        stage('buf lint') {
+                            options { retry(3) }
+                            steps {
+                                dir('vega') {
+                                    sh '''#!/bin/bash -e
+                                        buf lint
+                                    '''
+                                }
+                            }
+                            post {
+                                failure {
+                                    sh 'printenv'
+                                    echo "params=${params}"
+                                    sh 'buf --version'
+                                    sh 'which buf'
+                                    sh 'git diff'
+                                }
+                            }
+                        }
+                        stage('proto format check') {
+                            options { retry(3) }
+                            steps {
+                                dir('vega') {
+                                    sh '''#!/bin/bash -e
+                                        make proto_format_check
+                                    '''
+                                }
+                            }
+                            post {
+                                failure {
+                                    sh 'printenv'
+                                    echo "params=${params}"
+                                    sh 'buf --version'
+                                    sh 'which buf'
+                                    sh 'git diff'
+                                }
+                            }
+                        }
+                        stage('proto check') {
+                            options { retry(3) }
+                            steps {
+                                sh label: 'copy vega repo', script: '''#!/bin/bash -e
+                                        cp -r ./vega ./vega-proto-check
+                                    '''
+                                dir('vega-proto-check') {
+                                    sh '''#!/bin/bash -e
+                                        make proto_check
+                                    '''
+                                }
+                                sh label: 'remove vega copy', script: '''#!/bin/bash -e
+                                        rm -rf ./vega-proto-check
+                                    '''
+                            }
+                            post {
+                                failure {
+                                    sh 'printenv'
+                                    echo "params=${params}"
+                                    sh 'buf --version'
+                                    sh 'which buf'
+                                    sh 'git diff'
+                                }
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,43 +117,6 @@ pipeline {
         //
 
         //
-        // Begin COMPILE
-        //
-        stage('Compile') {
-            options { retry(3) }
-            steps {
-                sh 'printenv'
-                dir('vega') {
-                    sh label: 'Compile', script: """#!/bin/bash -e
-                        go build -v \
-                            -o ../build/ \
-                            ./cmd/vega \
-                            ./cmd/data-node \
-                            ./cmd/vegawallet
-                    """
-                    sh label: 'check for modifications', script: 'git diff'
-                }
-                dir("build") {
-                    sh label: 'list files', script: '''#!/bin/bash -e
-                        pwd
-                        ls -lah
-                    '''
-                    sh label: 'Sanity check', script: '''#!/bin/bash -e
-                        file *
-                    '''
-                    sh label: 'get version', script: '''#!/bin/bash -e
-                        ./vega version
-                        ./data-node version
-                        ./vegawallet software version
-                    '''
-                }
-            }
-        }
-        //
-        // End COMPILE
-        //
-
-        //
         // Begin LINTERS
         //
         stage('Linters') {
@@ -424,6 +387,32 @@ pipeline {
                                     sh 'git diff'
                                 }
                             }
+                        }
+                    }
+                }
+                stage('Compile visor') {
+                    options { retry(3) }
+                    steps {
+                        sh 'printenv'
+                        dir('vega') {
+                            sh label: 'Compile', script: """#!/bin/bash -e
+                                go build -v \
+                                    -o ../build/ \
+                                    ./cmd/visor
+                            """
+                            sh label: 'check for modifications', script: 'git diff'
+                        }
+                        dir("build") {
+                            sh label: 'list files', script: '''#!/bin/bash -e
+                                pwd
+                                ls -lah
+                            '''
+                            sh label: 'Sanity check', script: '''#!/bin/bash -e
+                                file *
+                            '''
+                            sh label: 'get version', script: '''#!/bin/bash -e
+                                ./visor version
+                            '''
                         }
                     }
                 }


### PR DESCRIPTION
closes vegaprotocol/devops-infra#1906

Changes:
- remove building docker images from Jenkins,
- move the proto-check step from the `Linters` section to the `Tests` section,
- enable publishing docker images for `develop` branch commits in GitHub Workflow,
- move compilation under `Tests` section, and compile `visor` only.