### PR TITLE
chore: sync docstrings about icebergs with the truth

### DIFF
--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -27,7 +27,7 @@ type PeggedOrder {
 
 "Details of the iceberg order"
 type IcebergOrder {
-  "Size of the order that will be made visible if the iceberg order is refreshed at the end of a transaction"
+  "Size of the order that will be made visible if the iceberg order is refreshed after a trade has occurred"
   initialPeakSize: String!
   "Threshold at which the order's visible remaining size will be refreshed back to its initial peak size"
   minimumPeakSize: String!

--- a/protos/sources/vega/commands/v1/commands.proto
+++ b/protos/sources/vega/commands/v1/commands.proto
@@ -62,7 +62,7 @@ message OrderSubmission {
 
 // Iceberg order options
 message IcebergOpts {
-  // Size of the order that is initially made visible and can cause a trade within a single transaction.
+  // Size of the order that is initially made visible and can cause a trade during the execution of a single order.
   uint64 initial_peak_size = 1;
   // Threshold at which the order's visible remaining size will be refreshed back to its initial peak size.
   uint64 minimum_peak_size = 2;

--- a/protos/sources/vega/vega.proto
+++ b/protos/sources/vega/vega.proto
@@ -110,7 +110,7 @@ message PeggedOrder {
 
 // Details of an iceberg order
 message IcebergOrder {
-  // Size of the order that will be made visible if the iceberg order is refreshed at the end of a transaction.
+  // Size of the order that will be made visible if the iceberg order is refreshed after a trade has occurred.
   uint64 initial_peak_size = 1;
   // Threshold at which the order's visible remaining size will be refreshed back to its initial peak size.
   uint64 minimum_peak_size = 2;

--- a/protos/vega/commands/v1/commands.pb.go
+++ b/protos/vega/commands/v1/commands.pb.go
@@ -305,7 +305,7 @@ type IcebergOpts struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Size of the order that is initially made visible and can cause a trade within a single transaction.
+	// Size of the order that is initially made visible and can cause a trade during the execution of a single order.
 	InitialPeakSize uint64 `protobuf:"varint,1,opt,name=initial_peak_size,json=initialPeakSize,proto3" json:"initial_peak_size,omitempty"`
 	// Threshold at which the order's visible remaining size will be refreshed back to its initial peak size.
 	MinimumPeakSize uint64 `protobuf:"varint,2,opt,name=minimum_peak_size,json=minimumPeakSize,proto3" json:"minimum_peak_size,omitempty"`

--- a/protos/vega/vega.pb.go
+++ b/protos/vega/vega.pb.go
@@ -1759,7 +1759,7 @@ type IcebergOrder struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Size of the order that will be made visible if the iceberg order is refreshed at the end of a transaction.
+	// Size of the order that will be made visible if the iceberg order is refreshed after a trade has occurred.
 	InitialPeakSize uint64 `protobuf:"varint,1,opt,name=initial_peak_size,json=initialPeakSize,proto3" json:"initial_peak_size,omitempty"`
 	// Threshold at which the order's visible remaining size will be refreshed back to its initial peak size.
 	MinimumPeakSize uint64 `protobuf:"varint,2,opt,name=minimum_peak_size,json=minimumPeakSize,proto3" json:"minimum_peak_size,omitempty"`


### PR DESCRIPTION
Brings the proto docs in line with the spec after the spec changed so that iceberg orders are refreshed after each order submission and *not* at the end of a transaction.