### PR TITLE
feat: market-depth and book volume include iceberg reserves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in core
 - [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in feature tests
 - [8429](https://github.com/vegaprotocol/vega/issues/8429) - Implement iceberg orders in `graphQL`
+- [8459](https://github.com/vegaprotocol/vega/issues/8459) - Market depth and book volume include iceberg reserves
 - [8332](https://github.com/vegaprotocol/vega/issues/8332) - Add support in collateral engine for spots
 - [8330](https://github.com/vegaprotocol/vega/issues/8330) - Implement validation on successor market proposals.
 - [8247](https://github.com/vegaprotocol/vega/issues/8247) - Initial support for `Ethereum` `oracles`

--- a/core/execution/future/market_iceberg_test.go
+++ b/core/execution/future/market_iceberg_test.go
@@ -66,7 +66,7 @@ func TestMarketSubmitCancelIceberg(t *testing.T) {
 	require.Equal(t, types.MarketStateSuspended, tm.market.State()) // enter auction
 
 	// check that its on the book and the volume is only the visible peak
-	assert.Equal(t, int64(10), tm.market.GetVolumeOnBook())
+	assert.Equal(t, int64(100), tm.market.GetVolumeOnBook())
 
 	// and that the position represents the whole iceberg size
 	tm.market.BlockEnd(vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash()))

--- a/core/matching/iceberg_orders_test.go
+++ b/core/matching/iceberg_orders_test.go
@@ -108,7 +108,7 @@ func TestIcebergsFakeUncross(t *testing.T) {
 	// check it is now on the book
 	_, err := book.GetOrderByID(iceberg.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+	assert.Equal(t, uint64(100), book.getTotalBuyVolume())
 
 	// check the peaks are proper
 	assert.Equal(t, uint64(4), iceberg.Remaining)
@@ -138,7 +138,7 @@ func TestIcebergFullPeakConsumedExactly(t *testing.T) {
 	// check it is now on the book
 	_, err := book.GetOrderByID(iceberg.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(40))
+	assert.Equal(t, uint64(100), book.getTotalBuyVolume())
 
 	trades := getTradesCrossedOrder(t, book, 40)
 	assert.Equal(t, 1, len(trades))
@@ -151,7 +151,7 @@ func TestIcebergFullPeakConsumedExactly(t *testing.T) {
 
 	// check that the iceberg has been refreshed and book volume is back at 40
 	assert.Equal(t, 1, book.getNumberOfBuyLevels())
-	assert.Equal(t, uint64(40), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(60), book.getTotalBuyVolume())
 	assert.Equal(t, uint64(40), iceberg.Remaining)
 	assert.Equal(t, uint64(20), iceberg.IcebergOrder.ReservedRemaining)
 }
@@ -168,7 +168,7 @@ func TestIcebergPeakAboveMinimum(t *testing.T) {
 	_, confirm = submitCrossedOrder(t, book, 1)
 	assert.Equal(t, 1, len(confirm.Trades))
 	assert.Equal(t, 1, book.getNumberOfBuyLevels())
-	assert.Equal(t, uint64(3), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(99), book.getTotalBuyVolume())
 
 	// now submit another order that *will* remove the rest of the peak
 	_, confirm = submitCrossedOrder(t, book, 3)
@@ -176,7 +176,7 @@ func TestIcebergPeakAboveMinimum(t *testing.T) {
 
 	assert.Equal(t, uint64(4), iceberg.Remaining)
 	assert.Equal(t, uint64(92), iceberg.IcebergOrder.ReservedRemaining)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+	assert.Equal(t, uint64(96), book.getTotalBuyVolume())
 }
 
 func TestIcebergAggressiveTakesAll(t *testing.T) {
@@ -195,7 +195,7 @@ func TestIcebergAggressiveTakesAll(t *testing.T) {
 	// now check iceberg sits on the book with the correct peaks
 	assert.Equal(t, uint64(4), o.Remaining)
 	assert.Equal(t, uint64(36), o.IcebergOrder.ReservedRemaining)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+	assert.Equal(t, uint64(40), book.getTotalBuyVolume())
 }
 
 func TestAggressiveIcebergFullyFilled(t *testing.T) {
@@ -234,12 +234,13 @@ func TestIcebergPeakBelowMinimumNotZero(t *testing.T) {
 	assert.Equal(t, types.OrderStatusActive, iceberg.Status)
 	assert.Equal(t, uint64(4), iceberg.Remaining)
 	assert.Equal(t, uint64(93), iceberg.IcebergOrder.ReservedRemaining)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(4))
+	assert.Equal(t, uint64(97), book.getTotalBuyVolume())
 
 	// put in another order which will eat into the remaining
 	submitCrossedOrder(t, book, 10)
 	assert.Equal(t, uint64(4), iceberg.Remaining)
 	assert.Equal(t, uint64(83), iceberg.IcebergOrder.ReservedRemaining)
+	assert.Equal(t, uint64(87), book.getTotalBuyVolume())
 }
 
 func TestIcebergRefreshToPartialPeak(t *testing.T) {
@@ -252,7 +253,7 @@ func TestIcebergRefreshToPartialPeak(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	// expect the volume to be the peak size
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(90))
+	assert.Equal(t, uint64(100), book.getTotalBuyVolume())
 
 	// submit an order that takes almost the full peak
 	_, confirm = submitCrossedOrder(t, book, 89)
@@ -261,7 +262,7 @@ func TestIcebergRefreshToPartialPeak(t *testing.T) {
 	// remaining + reserved < initial peak
 	assert.Equal(t, uint64(11), iceberg.Remaining)
 	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(11))
+	assert.Equal(t, uint64(11), book.getTotalBuyVolume())
 
 	// check we can now fill it and the iceberg is removed
 	_, confirm = submitCrossedOrder(t, book, 100)
@@ -269,7 +270,7 @@ func TestIcebergRefreshToPartialPeak(t *testing.T) {
 	assert.Equal(t, uint64(0), iceberg.Remaining)
 	assert.Equal(t, uint64(0), iceberg.IcebergOrder.ReservedRemaining)
 	assert.Equal(t, types.OrderStatusFilled, iceberg.Status)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(0))
+	assert.Equal(t, uint64(0), book.getTotalBuyVolume())
 }
 
 func TestIcebergHiddenDistribution(t *testing.T) {
@@ -319,7 +320,7 @@ func TestIcebergHiddenDistributionCrumbs(t *testing.T) {
 	iceberg1, _ := submitIcebergOrder(t, book, 500, 100, 2, false)
 	iceberg2, _ := submitIcebergOrder(t, book, 500, 100, 2, false)
 	iceberg3, _ := submitIcebergOrder(t, book, 500, 100, 100, false)
-	assert.Equal(t, uint64(300), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(1500), book.getTotalBuyVolume())
 
 	// submit a big order such that all three peaks are consumed (100 + 100 + 100 = 300)
 	// and the left over is 100 to be divided between three
@@ -429,7 +430,7 @@ func TestIcebergHiddenDistributionPrimeHidden(t *testing.T) {
 	assert.Equal(t, uint64(146), iceberg3.IcebergOrder.ReservedRemaining)
 	assert.Equal(t, types.OrderStatusActive, iceberg2.Status)
 
-	assert.Equal(t, uint64(43+67+9), book.getTotalBuyVolume())
+	assert.Equal(t, uint64(550), book.getTotalBuyVolume())
 }
 
 func TestIcebergTimePriorityLostOnRefresh(t *testing.T) {
@@ -446,7 +447,7 @@ func TestIcebergTimePriorityLostOnRefresh(t *testing.T) {
 	assert.Equal(t, 0, len(confirm.Trades))
 
 	// expect the volume to be the peak size
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(110))
+	assert.Equal(t, uint64(200), book.getTotalBuyVolume())
 
 	// submit a order that will take out some of the peak of the first iceberg, check its refreshed
 	_, confirm = submitCrossedOrder(t, book, 5)
@@ -468,7 +469,7 @@ func TestAmendIceberg(t *testing.T) {
 	// submit an iceberg order that sits on the book with a big peak
 	iceberg, confirm := submitIcebergOrder(t, book, 100, 10, 8, true)
 	assert.Equal(t, 0, len(confirm.Trades))
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+	assert.Equal(t, uint64(100), book.getTotalBuyVolume())
 
 	// amend iceberg such that the size is increased and the reserve is increased
 	amend := iceberg.Clone()
@@ -476,7 +477,7 @@ func TestAmendIceberg(t *testing.T) {
 	amend.IcebergOrder.ReservedRemaining = 140
 	err := book.AmendOrder(iceberg, amend)
 	require.NoError(t, err)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+	assert.Equal(t, uint64(150), book.getTotalBuyVolume())
 
 	// amend iceberg such that the volume is decreased but not enough to eat into the peak
 	amend = iceberg.Clone()
@@ -484,7 +485,7 @@ func TestAmendIceberg(t *testing.T) {
 	amend.IcebergOrder.ReservedRemaining = 130
 	err = book.AmendOrder(iceberg, amend)
 	require.NoError(t, err)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(10))
+	assert.Equal(t, uint64(140), book.getTotalBuyVolume())
 
 	// decrease again such that reserved is 0 and peak is reduced
 	amend = iceberg.Clone()
@@ -493,5 +494,5 @@ func TestAmendIceberg(t *testing.T) {
 	amend.IcebergOrder.ReservedRemaining = 0
 	err = book.AmendOrder(iceberg, amend)
 	require.NoError(t, err)
-	assert.Equal(t, book.getTotalBuyVolume(), uint64(5))
+	assert.Equal(t, uint64(5), book.getTotalBuyVolume())
 }

--- a/core/matching/pricelevel.go
+++ b/core/matching/pricelevel.go
@@ -59,12 +59,12 @@ func (l *PriceLevel) getOrdersByParty(partyID string) []*types.Order {
 func (l *PriceLevel) addOrder(o *types.Order) {
 	// add orders to slice of orders on this price level
 	l.orders = append(l.orders, o)
-	l.volume += o.Remaining
+	l.volume += o.TrueRemaining()
 }
 
 func (l *PriceLevel) removeOrder(index int) {
 	// decrease total volume
-	l.volume -= l.orders[index].Remaining
+	l.volume -= l.orders[index].TrueRemaining()
 	// remove the orders at index
 	copy(l.orders[index:], l.orders[index+1:])
 	l.orders = l.orders[:len(l.orders)-1]


### PR DESCRIPTION
closes #8459 

A small change in reaction to https://vegaprotocol.slack.com/archives/CAHA5EX0F/p1686217649242679 where we now include iceberg orders' reserve volume in market-depth etc etc. Mostly a lot of updates to unittests.
 