### PR TITLE
fix: restore netparams from snapshot without validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [8225](https://github.com/vegaprotocol/vega/issues/8225) - Better error handling in `ListEntities`
 - [8222](https://github.com/vegaprotocol/vega/issues/8222) - `EstimatePositions` does not correctly validate data.
 - [8266](https://github.com/vegaprotocol/vega/issues/8266) - Fix HTTPS with `autocert`.
+- [8471](https://github.com/vegaprotocol/vega/issues/8471) - Restore network parameters from snapshot without validation to avoid order dependence.
 - [8290](https://github.com/vegaprotocol/vega/issues/8290) - Calling network history `API` without network history enabled caused panics in data node.
 - [8299](https://github.com/vegaprotocol/vega/issues/8299) - Fix listing of internal data sources in GraphQL.
 - [8279](https://github.com/vegaprotocol/vega/issues/8279) - Avoid overriding a map entry while iterating on it, on the wallet connection manager.

--- a/core/netparams/snapshot.go
+++ b/core/netparams/snapshot.go
@@ -131,7 +131,9 @@ func (s *Store) LoadState(ctx context.Context, pl *types.Payload) ([]types.State
 	}
 
 	for _, kv := range np.NetParams.Params {
-		s.Update(ctx, kv.Key, kv.Value)
+		if err := s.UpdateOptionalValidation(ctx, kv.Key, kv.Value, false); err != nil {
+			return nil, err
+		}
 	}
 
 	// Now they have been loaded, dispatch the changes so that the other engines pick them up

--- a/core/netparams/snapshot_test.go
+++ b/core/netparams/snapshot_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package netparams_test
+
+import (
+	"context"
+	"testing"
+
+	"code.vegaprotocol.io/vega/core/netparams"
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/proto"
+	snapshot "code.vegaprotocol.io/vega/protos/vega/snapshot/v1"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotRestoreDependentNetparams(t *testing.T) {
+	netp := getTestNetParams(t)
+	defer netp.ctrl.Finish()
+	ctx := context.Background()
+
+	netp.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	// get the original default value
+	err := netp.Update(
+		context.Background(), netparams.MarketAuctionMinimumDuration, "1s")
+	assert.NoError(t, err)
+
+	// now change max
+	err = netp.Update(
+		context.Background(), netparams.MarketAuctionMaximumDuration, "10s")
+	assert.NoError(t, err)
+
+	// now snapshot restore
+	data, _, err := netp.GetState("all")
+	require.NoError(t, err)
+
+	snap := &snapshot.Payload{}
+	err = proto.Unmarshal(data, snap)
+	require.Nil(t, err)
+
+	snapNetp := getTestNetParams(t)
+	snapNetp.broker.EXPECT().Send(gomock.Any()).AnyTimes()
+	_, err = snapNetp.LoadState(ctx, types.PayloadFromProto(snap))
+	require.NoError(t, err)
+
+	v1, err := snapNetp.Get(netparams.MarketAuctionMaximumDuration)
+	require.NoError(t, err)
+	v2, err := netp.Get(netparams.MarketAuctionMaximumDuration)
+	require.NoError(t, err)
+
+	require.Equal(t, v1, v2)
+}


### PR DESCRIPTION
closes #8471 

This switches off network parameter validation when we load from a snapshot so we don't need to care about which order we restore `MarketAuctionMinimumDuration` and `MarketAuctionMaximumDuration`.  They are dependent network parameters where `min < max` always, so if we restore them the wrong way we get in a tangle.