### PR TITLE
fix: misleading changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@
 
 ### 🚨 Breaking changes
 
-- [7794](https://github.com/vegaprotocol/vega/issues/7794) - Add `marketIds` and `partyIds` to orders queries' filter.
+- [7794](https://github.com/vegaprotocol/vega/issues/7794) - Change `marketId` and `partyId` to `marketIds` and `partyIds` in the orders queries' filter.
 - [7876](https://github.com/vegaprotocol/vega/issues/7876) - Change `DeliverOn` on one-off transfer to be in nanoseconds as everything else.
 - [7326](https://github.com/vegaprotocol/vega/issues/7326) - Rename table `current liquidity provisions` to `live liquiditiy provisions` and add a `live` option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@
 
 ### 🚨 Breaking changes
 
-- [7794](https://github.com/vegaprotocol/vega/issues/7794) - Change `marketId` and `partyId` to `marketIds` and `partyIds` in the orders queries' filter.
+- [7794](https://github.com/vegaprotocol/vega/issues/7794) - Rename `marketId` and `partyId` to `marketIds` and `partyIds` in the orders queries' filter.
 - [7876](https://github.com/vegaprotocol/vega/issues/7876) - Change `DeliverOn` on one-off transfer to be in nanoseconds as everything else.
 - [7326](https://github.com/vegaprotocol/vega/issues/7326) - Rename table `current liquidity provisions` to `live liquiditiy provisions` and add a `live` option
 


### PR DESCRIPTION
This PR relates to the docs feedback from a market maker where by the breaking change description was not very good in the changelog and the PR had no description. :

- Docs [release summary updates](https://github.com/vegaprotocol/documentation/pull/666)
- PR [description has been updated](https://github.com/vegaprotocol/vega/pull/7893) 