### PR TITLE
feat: uncrossing iceberg orders when leaving auction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in core
 - [8301](https://github.com/vegaprotocol/vega/issues/8301) - Implement iceberg orders in feature tests
 - [8429](https://github.com/vegaprotocol/vega/issues/8429) - Implement iceberg orders in `graphQL`
+- [8429](https://github.com/vegaprotocol/vega/issues/8429) - Implement iceberg orders during auction uncrossing
 - [8459](https://github.com/vegaprotocol/vega/issues/8459) - Market depth and book volume include iceberg reserves
 - [8332](https://github.com/vegaprotocol/vega/issues/8332) - Add support in collateral engine for spots
 - [8330](https://github.com/vegaprotocol/vega/issues/8330) - Implement validation on successor market proposals.

--- a/core/matching/orderbook_iceberg_uncrossing_test.go
+++ b/core/matching/orderbook_iceberg_uncrossing_test.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package matching_test
+
+import (
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/core/types"
+	vgrand "code.vegaprotocol.io/vega/libs/rand"
+	"code.vegaprotocol.io/vega/logging"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeIceberg(t *testing.T, orderbook *tstOB, market string, id string, side types.Side, price uint64, partyid string, size uint64) *types.Order {
+	t.Helper()
+	order := getOrder(t, market, id, side, price, partyid, size)
+	order.IcebergOrder = &types.IcebergOrder{
+		InitialPeakSize: 1,
+		MinimumPeakSize: 1,
+	}
+	_, err := orderbook.ob.SubmitOrder(order)
+	assert.NoError(t, err)
+	return order
+}
+
+func requireUncrossedBook(t *testing.T, book *tstOB) {
+	t.Helper()
+
+	ask, err := book.ob.GetBestAskPrice()
+	require.NoError(t, err)
+
+	bid, err := book.ob.GetBestBidPrice()
+	require.NoError(t, err)
+	require.True(t, bid.LT(ask))
+}
+
+func assertTradeSizes(t *testing.T, trades []*types.Trade, sizes ...uint64) {
+	t.Helper()
+	require.Equal(t, len(sizes), len(trades))
+	for i := range trades {
+		assert.Equal(t, trades[i].Size, sizes[i])
+	}
+}
+
+func TestIcebergExtractedSide(t *testing.T) {
+	market := vgrand.RandomStr(5)
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	logger := logging.NewTestLogger()
+	defer logger.Sync()
+
+	// Switch to auction mode
+	book.ob.EnterAuction()
+
+	// the iceberg order is on the side with the smallest uncrossing volume and should be
+	// fully consumed after uncrossing
+	o := makeIceberg(t, book, market, "BuyOrder01", types.SideBuy, 101, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder02", types.SideBuy, 100, "party01", 10)
+	makeOrder(t, book, market, "BuyOrder03", types.SideBuy, 99, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder04", types.SideBuy, 98, "party01", 10)
+
+	sell1 := makeOrder(t, book, market, "SellOrder01", types.SideSell, 100, "party02", 10)
+	sell2 := makeOrder(t, book, market, "SellOrder02", types.SideSell, 101, "party02", 15)
+	makeOrder(t, book, market, "SellOrder03", types.SideSell, 102, "party02", 5)
+	makeOrder(t, book, market, "SellOrder04", types.SideSell, 103, "party02", 10)
+
+	// Get indicative auction price and volume
+	price, volume, side := book.ob.GetIndicativePriceAndVolume()
+	assert.Equal(t, price.Uint64(), uint64(101))
+	assert.Equal(t, volume, uint64(20))
+	assert.Equal(t, side, types.SideBuy)
+	price = book.ob.GetIndicativePrice()
+	assert.Equal(t, price.Uint64(), uint64(101))
+
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	assertTradeSizes(t, trades, 10, 10)
+
+	// Leave auction and uncross the book
+	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
+	assert.Nil(t, err)
+	requireUncrossedBook(t, book)
+	assert.Equal(t, len(uncrossedOrders), 1)
+	assert.Equal(t, len(cancels), 0)
+
+	// the uncrossed order should be the iceberg and it is fully filled and traded
+	// fully with sellf order 1, and half of sell order 2
+	trades = uncrossedOrders[0].Trades
+	assert.Equal(t, o.ID, uncrossedOrders[0].Order.ID)
+	assertTradeSizes(t, trades, 10, 10)
+
+	assert.Equal(t, types.OrderStatusFilled, sell1.Status)
+	assert.Equal(t, types.OrderStatusActive, sell2.Status)
+	assert.Equal(t, uint64(5), sell2.Remaining)
+	assert.Equal(t, uint64(10), trades[0].Size)
+	assert.Equal(t, uint64(10), trades[1].Size)
+}
+
+func TestIcebergAllPriceLevel(t *testing.T) {
+	market := vgrand.RandomStr(5)
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	logger := logging.NewTestLogger()
+	defer logger.Sync()
+
+	// Switch to auction mode
+	book.ob.EnterAuction()
+
+	// this order will be big enough to eat into all of the first two icebergs and some of a third at a different pricelevel
+	makeOrder(t, book, market, "BuyOrder01", types.SideBuy, 101, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder02", types.SideBuy, 100, "party01", 10)
+	makeOrder(t, book, market, "BuyOrder03", types.SideBuy, 99, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder04", types.SideBuy, 98, "party01", 10)
+
+	// We have two icebergs at one price level with a small peak
+	sell1 := makeIceberg(t, book, market, "SellOrder01", types.SideSell, 100, "party02", 5)
+	sell2 := makeIceberg(t, book, market, "SellOrder02", types.SideSell, 100, "party02", 5)
+	sell3 := makeIceberg(t, book, market, "SellOrder03", types.SideSell, 101, "party02", 15)
+	makeOrder(t, book, market, "SellOrder04", types.SideSell, 102, "party02", 5)
+	makeOrder(t, book, market, "SellOrder05", types.SideSell, 103, "party02", 10)
+
+	// Get indicative auction price and volume
+	price, volume, side := book.ob.GetIndicativePriceAndVolume()
+	assert.Equal(t, price.Uint64(), uint64(101))
+	assert.Equal(t, volume, uint64(20))
+	assert.Equal(t, side, types.SideBuy)
+
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	assertTradeSizes(t, trades, 5, 5, 10)
+	assert.Equal(t, 3, len(trades))
+
+	// Leave auction and uncross the book
+	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
+	assert.Nil(t, err)
+	requireUncrossedBook(t, book)
+	assert.Equal(t, 1, len(uncrossedOrders))
+	assert.Equal(t, 0, len(cancels))
+	assertTradeSizes(t, uncrossedOrders[0].Trades, 5, 5, 10)
+
+	// first two sell icebergs should be fully filled
+	assert.Equal(t, types.OrderStatusFilled, sell1.Status)
+	assert.Equal(t, uint64(0), sell1.TrueRemaining())
+	assert.Equal(t, types.OrderStatusFilled, sell2.Status)
+	assert.Equal(t, uint64(0), sell2.TrueRemaining())
+
+	// and the third iceberg should be refreshed
+	assert.Equal(t, types.OrderStatusActive, sell3.Status)
+	assert.Equal(t, uint64(5), sell3.TrueRemaining())
+	assert.Equal(t, uint64(1), sell3.Remaining)
+
+	// check pricelevel count to be sure the sell side at 100 was removed
+	assert.Equal(t, uint64(6), book.ob.GetOrderBookLevelCount())
+}
+
+func TestIcebergsDoubleProrata(t *testing.T) {
+	market := vgrand.RandomStr(5)
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	logger := logging.NewTestLogger()
+	defer logger.Sync()
+
+	// Switch to auction mode
+	book.ob.EnterAuction()
+
+	// this first order will take off all their peaks, and then 1 off each reserve
+	_ = makeOrder(t, book, market, "BuyOrder01", types.SideBuy, 101, "party01", 6)
+	// this will then pro-rated take 1 of each reserve again, the icebergs won't refresh in between
+	_ = makeOrder(t, book, market, "BuyOrder02", types.SideBuy, 101, "party01", 6)
+	makeOrder(t, book, market, "BuyOrder04", types.SideBuy, 99, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder05", types.SideBuy, 98, "party01", 10)
+
+	// Populate sell side the three icebergs will be matched pro-rated, twice
+	_ = makeIceberg(t, book, market, "SellOrder01", types.SideSell, 100, "party02", 10)
+	_ = makeIceberg(t, book, market, "SellOrder02", types.SideSell, 100, "party02", 10)
+	_ = makeIceberg(t, book, market, "SellOrder03", types.SideSell, 100, "party02", 10)
+	makeOrder(t, book, market, "SellOrder04", types.SideSell, 102, "party02", 5)
+	makeOrder(t, book, market, "SellOrder05", types.SideSell, 103, "party02", 10)
+
+	// Get indicative auction price and volume
+	price, volume, side := book.ob.GetIndicativePriceAndVolume()
+	assert.Equal(t, uint64(100), price.Uint64())
+	assert.Equal(t, volume, uint64(12))
+	assert.Equal(t, side, types.SideBuy)
+
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	assertTradeSizes(t, trades, 2, 2, 2, 2, 2, 2)
+
+	// Leave auction and uncross the book
+	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
+	assert.Nil(t, err)
+	requireUncrossedBook(t, book)
+	assert.Equal(t, len(uncrossedOrders), 2)
+	assert.Equal(t, len(cancels), 0)
+	assertTradeSizes(t, uncrossedOrders[0].Trades, 2, 2, 2)
+	assertTradeSizes(t, uncrossedOrders[1].Trades, 2, 2, 2)
+	assert.Equal(t, 3, len(uncrossedOrders[0].PassiveOrdersAffected))
+	assert.Equal(t, 3, len(uncrossedOrders[1].PassiveOrdersAffected))
+
+	// check pricelevel count to be sure the empty ones were removed
+	assert.Equal(t, uint64(5), book.ob.GetOrderBookLevelCount())
+}
+
+func TestIcebergsAndNormalOrders(t *testing.T) {
+	// this is basically TestIcebergsDoubleProrata with some non-iceberg orders thrown into the uncrossing too
+	market := vgrand.RandomStr(5)
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	logger := logging.NewTestLogger()
+	defer logger.Sync()
+
+	// Switch to auction mode
+	book.ob.EnterAuction()
+
+	// this first order will take off all their peaks, the non-iceberg order, and then 1 off each reserve
+	_ = makeOrder(t, book, market, "BuyOrder01", types.SideBuy, 101, "party01", 16)
+	// this will then pro-rated take 1 of each reserve again, the icebergs won't refresh in between
+	_ = makeOrder(t, book, market, "BuyOrder02", types.SideBuy, 101, "party01", 6)
+	makeOrder(t, book, market, "BuyOrder04", types.SideBuy, 99, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder05", types.SideBuy, 98, "party01", 10)
+
+	// Populate sell side the three icebergs will be matched pro-rated, twice
+	_ = makeIceberg(t, book, market, "SellOrder01", types.SideSell, 100, "party02", 10)
+	_ = makeIceberg(t, book, market, "SellOrder02", types.SideSell, 100, "party02", 10)
+	_ = makeIceberg(t, book, market, "SellOrder03", types.SideSell, 100, "party02", 10)
+	_ = makeOrder(t, book, market, "SellOrder04", types.SideSell, 100, "party02", 10)
+	makeOrder(t, book, market, "SellOrder05", types.SideSell, 102, "party02", 5)
+	makeOrder(t, book, market, "SellOrder06", types.SideSell, 103, "party02", 10)
+
+	// Get indicative auction price and volume
+	price, volume, side := book.ob.GetIndicativePriceAndVolume()
+	assert.Equal(t, uint64(100), price.Uint64())
+	assert.Equal(t, volume, uint64(22))
+	assert.Equal(t, side, types.SideBuy)
+
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	assertTradeSizes(t, trades, 2, 2, 2, 10, 2, 2, 2)
+
+	// Leave auction and uncross the book
+	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
+	assert.Nil(t, err)
+	requireUncrossedBook(t, book)
+	assert.Equal(t, len(uncrossedOrders), 2)
+	assert.Equal(t, len(cancels), 0)
+	assertTradeSizes(t, uncrossedOrders[0].Trades, 2, 2, 2, 10)
+	assertTradeSizes(t, uncrossedOrders[1].Trades, 2, 2, 2)
+	assert.Equal(t, 4, len(uncrossedOrders[0].PassiveOrdersAffected))
+	assert.Equal(t, 3, len(uncrossedOrders[1].PassiveOrdersAffected))
+
+	// check pricelevel count to be sure the empty ones were removed
+	assert.Equal(t, uint64(5), book.ob.GetOrderBookLevelCount())
+}
+
+func TestIcebergsAndNormalOrders2(t *testing.T) {
+	// this is basically TestIcebergsDoubleProrata with some non-iceberg orders thrown into the uncrossing too
+	market := vgrand.RandomStr(5)
+	book := getTestOrderBook(t, market)
+	defer book.Finish()
+
+	logger := logging.NewTestLogger()
+	defer logger.Sync()
+
+	// Switch to auction mode
+	book.ob.EnterAuction()
+
+	// this first order will take off all their peaks, the non-iceberg order, and then 1 off each reserve
+	_ = makeOrder(t, book, market, "BuyOrder01", types.SideBuy, 101, "party01", 40)
+	makeOrder(t, book, market, "BuyOrder04", types.SideBuy, 99, "party01", 20)
+	makeOrder(t, book, market, "BuyOrder05", types.SideBuy, 98, "party01", 10)
+
+	// Populate sell side the three icebergs will be matched pro-rated, twice
+	_ = makeIceberg(t, book, market, "SellOrder01", types.SideSell, 100, "party02", 10)
+	_ = makeIceberg(t, book, market, "SellOrder02", types.SideSell, 100, "party02", 10)
+	_ = makeIceberg(t, book, market, "SellOrder03", types.SideSell, 100, "party02", 10)
+	_ = makeOrder(t, book, market, "SellOrder04", types.SideSell, 100, "party02", 10)
+	makeOrder(t, book, market, "SellOrder05", types.SideSell, 102, "party02", 5)
+	makeOrder(t, book, market, "SellOrder06", types.SideSell, 103, "party02", 10)
+
+	// Get indicative auction price and volume
+	price, volume, side := book.ob.GetIndicativePriceAndVolume()
+	assert.Equal(t, uint64(100), price.Uint64())
+	assert.Equal(t, volume, uint64(40))
+	assert.Equal(t, side, types.SideBuy)
+
+	// Get indicative trades
+	trades, err := book.ob.GetIndicativeTrades()
+	assert.NoError(t, err)
+	assertTradeSizes(t, trades, 10, 10, 10, 10)
+
+	// Leave auction and uncross the book
+	uncrossedOrders, cancels, err := book.ob.LeaveAuction(time.Now())
+	assert.Nil(t, err)
+	requireUncrossedBook(t, book)
+	assert.Equal(t, 1, len(uncrossedOrders))
+	assert.Equal(t, len(cancels), 0)
+	assertTradeSizes(t, uncrossedOrders[0].Trades, 10, 10, 10, 10)
+	assert.Equal(t, 4, len(uncrossedOrders[0].PassiveOrdersAffected))
+
+	// check pricelevel count to be sure the empty ones were removed
+	assert.Equal(t, uint64(4), book.ob.GetOrderBookLevelCount())
+}

--- a/core/matching/orderbook_test.go
+++ b/core/matching/orderbook_test.go
@@ -2238,11 +2238,12 @@ func TestOrderBook_PartialFillIOCOrder(t *testing.T) {
 	assert.Nil(t, nonorder)
 }
 
-func makeOrder(t *testing.T, orderbook *tstOB, market string, id string, side types.Side, price uint64, partyid string, size uint64) {
+func makeOrder(t *testing.T, orderbook *tstOB, market string, id string, side types.Side, price uint64, partyid string, size uint64) *types.Order {
 	t.Helper()
 	order := getOrder(t, market, id, side, price, partyid, size)
 	_, err := orderbook.ob.SubmitOrder(order)
 	assert.Equal(t, err, nil)
+	return order
 }
 
 func getOrder(t *testing.T, market string, id string, side types.Side, price uint64, partyid string, size uint64) *types.Order {

--- a/core/matching/pricelevel.go
+++ b/core/matching/pricelevel.go
@@ -15,6 +15,7 @@ package matching
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/libs/num"
@@ -32,6 +33,21 @@ type PriceLevel struct {
 	price  *num.Uint
 	orders []*types.Order
 	volume uint64
+}
+
+// trackIceberg holds together information about iceberg orders while we are uncrossing
+// so we can trade against them all again but distributed evenly.
+type trackIceberg struct {
+	// the iceberg order
+	order *types.Order
+	// the trade that occurred with the icebergs visible peak
+	trade *types.Trade
+	// the index of the iceberg order in the price-level slice
+	idx int
+}
+
+func (t *trackIceberg) reservedRemaining() uint64 {
+	return t.order.IcebergOrder.ReservedRemaining
 }
 
 // NewPriceLevel instantiate a new PriceLevel.
@@ -72,15 +88,15 @@ func (l *PriceLevel) removeOrder(index int) {
 
 // uncrossIcebergs when a large aggressive order consumes the peak of iceberg orders, we trade with the hidden portion of
 // the icebergs such that when they are refreshed the book does not cross.
-func (l *PriceLevel) uncrossIcebergs(agg *types.Order, icebergs []*types.Order, trades []*types.Trade, fake bool) {
+func (l *PriceLevel) uncrossIcebergs(agg *types.Order, tracked []*trackIceberg, fake bool) ([]*types.Trade, []*types.Order) {
 	var totalReserved uint64
-	for _, b := range icebergs {
-		totalReserved += b.IcebergOrder.ReservedRemaining
+	for _, t := range tracked {
+		totalReserved += t.reservedRemaining()
 	}
 
 	if totalReserved == 0 {
 		// nothing to do
-		return
+		return nil, nil
 	}
 
 	// either the amount left of the aggressive order, or the rest of all the iceberg orders
@@ -93,8 +109,8 @@ func (l *PriceLevel) uncrossIcebergs(agg *types.Order, icebergs []*types.Order, 
 	// divide up between icebergs
 	var sum uint64
 	extraTraded := []uint64{}
-	for _, b := range icebergs {
-		rr := num.DecimalFromInt64(int64(b.IcebergOrder.ReservedRemaining))
+	for _, t := range tracked {
+		rr := num.DecimalFromInt64(int64(t.reservedRemaining()))
 		extra := uint64(rr.Mul(totalCrossedDec).Div(totalReservedDec).IntPart())
 		sum += extra
 		extraTraded = append(extraTraded, extra)
@@ -103,8 +119,8 @@ func (l *PriceLevel) uncrossIcebergs(agg *types.Order, icebergs []*types.Order, 
 	// if there is some left over due to the rounding when dividing then
 	// it is traded against the iceberg with the highest time priority
 	if rem := totalCrossed - sum; rem > 0 {
-		for i := range icebergs {
-			max := icebergs[i].IcebergOrder.ReservedRemaining - extraTraded[i]
+		for i, t := range tracked {
+			max := t.reservedRemaining() - extraTraded[i]
 			dd := num.MinV(max, rem) // can allocate the smallest of the remainder and whats left in the berg
 
 			extraTraded[i] += dd
@@ -120,16 +136,27 @@ func (l *PriceLevel) uncrossIcebergs(agg *types.Order, icebergs []*types.Order, 
 	}
 
 	// increase traded sizes based on consumed hidden iceberg volume
-	for i := range icebergs {
+	newTrades := []*types.Trade{}
+	newImpacted := []*types.Order{}
+	for i, t := range tracked {
 		extra := extraTraded[i]
 		agg.Remaining -= extra
-		trades[i].Size += extra
+
+		// if there was not a previous trade with the iceberg's peak, make a fresh one
+		if t.trade == nil {
+			t.trade = newTrade(agg, t.order, 0)
+			newTrades = append(newTrades, t.trade)
+			newImpacted = append(newImpacted, t.order)
+		}
+		t.trade.Size += extra
+
 		if !fake {
 			// only change values in passive orders if uncrossing is for real and not just to see potential trades.
-			icebergs[i].IcebergOrder.ReservedRemaining -= extra
+			t.order.IcebergOrder.ReservedRemaining -= extra
 			l.volume -= extra
 		}
 	}
+	return newTrades, newImpacted
 }
 
 // fakeUncross - this updates a copy of the order passed to it, the copied order is returned.
@@ -142,9 +169,8 @@ func (l *PriceLevel) fakeUncross(o *types.Order, checkWashTrades bool) (agg *typ
 		return
 	}
 
-	icebergs := []*types.Order{}
-	icebergTrades := []*types.Trade{}
-	for _, order := range l.orders {
+	icebergs := []*trackIceberg{}
+	for i, order := range l.orders {
 		if checkWashTrades {
 			if order.Party == agg.Party {
 				err = ErrWashTrade
@@ -155,6 +181,15 @@ func (l *PriceLevel) fakeUncross(o *types.Order, checkWashTrades bool) (agg *typ
 		// Get size and make newTrade
 		size := l.getVolumeAllocation(agg, order)
 		if size <= 0 {
+			// this is only fine if it is an iceberg order with only reserve and in that case
+			// we need to trade with it later in uncrossIcebergs
+			if order.IcebergOrder != nil &&
+				order.Remaining == 0 &&
+				order.IcebergOrder.ReservedRemaining != 0 {
+				icebergs = append(icebergs, &trackIceberg{order, nil, i})
+				continue
+			}
+
 			panic("Trade.size > order.remaining")
 		}
 
@@ -170,8 +205,7 @@ func (l *PriceLevel) fakeUncross(o *types.Order, checkWashTrades bool) (agg *typ
 		// if the passive order is an iceberg with a hidden quantity make a note of it and
 		// its trade incase we need to uncross further
 		if order.IcebergOrder != nil && order.IcebergOrder.ReservedRemaining > 0 {
-			icebergs = append(icebergs, order)
-			icebergTrades = append(icebergTrades, trade)
+			icebergs = append(icebergs, &trackIceberg{order, trade, i})
 		}
 
 		// Exit when done
@@ -182,7 +216,8 @@ func (l *PriceLevel) fakeUncross(o *types.Order, checkWashTrades bool) (agg *typ
 
 	// if the aggressive trade is not filled uncross with iceberg hidden quantity
 	if agg.Remaining != 0 && len(icebergs) > 0 {
-		l.uncrossIcebergs(agg, icebergs, icebergTrades, true)
+		newTrades, _ := l.uncrossIcebergs(agg, icebergs, true)
+		trades = append(trades, newTrades...)
 	}
 
 	return agg, trades, err
@@ -196,10 +231,9 @@ func (l *PriceLevel) uncross(agg *types.Order, checkWashTrades bool) (filled boo
 	}
 
 	var (
-		icebergs      []*types.Order
-		icebergTrades []*types.Trade
-		toRemove      []int
-		removed       int
+		icebergs []*trackIceberg
+		toRemove []int
+		removed  int
 	)
 
 	// l.orders is always sorted by timestamps, that is why when iterating we always start from the beginning
@@ -214,7 +248,16 @@ func (l *PriceLevel) uncross(agg *types.Order, checkWashTrades bool) (filled boo
 
 		// Get size and make newTrade
 		size := l.getVolumeAllocation(agg, order)
+
 		if size <= 0 {
+			// this is only fine if it is an iceberg order with only reserve and in that case
+			// we need to trade with it later in uncrossIcebergs
+			if order.IcebergOrder != nil &&
+				order.Remaining == 0 &&
+				order.IcebergOrder.ReservedRemaining != 0 {
+				icebergs = append(icebergs, &trackIceberg{order, nil, i})
+				continue
+			}
 			panic("Trade.size > order.remaining")
 		}
 
@@ -226,8 +269,7 @@ func (l *PriceLevel) uncross(agg *types.Order, checkWashTrades bool) (filled boo
 		order.Remaining -= size
 		l.volume -= size
 
-		// Schedule order for deletion
-		if order.Remaining == 0 {
+		if order.TrueRemaining() == 0 {
 			toRemove = append(toRemove, i)
 		}
 
@@ -238,8 +280,7 @@ func (l *PriceLevel) uncross(agg *types.Order, checkWashTrades bool) (filled boo
 		// if the passive order is an iceberg with a hidden quantity make a note of it and
 		// its trade incase we need to uncross further
 		if order.IcebergOrder != nil && order.IcebergOrder.ReservedRemaining > 0 {
-			icebergs = append(icebergs, order)
-			icebergTrades = append(icebergTrades, trade)
+			icebergs = append(icebergs, &trackIceberg{order, trade, i})
 		}
 
 		// Exit when done
@@ -248,9 +289,20 @@ func (l *PriceLevel) uncross(agg *types.Order, checkWashTrades bool) (filled boo
 		}
 	}
 
-	// if the aggressive trade is not filled uncross with iceberg hidden quantity
+	// if the aggressive trade is not filled uncross with iceberg hidden reserves
 	if agg.Remaining > 0 && len(icebergs) > 0 {
-		l.uncrossIcebergs(agg, icebergs, icebergTrades, false)
+		newTrades, newImpacted := l.uncrossIcebergs(agg, icebergs, false)
+		trades = append(trades, newTrades...)
+		impactedOrders = append(impactedOrders, newImpacted...)
+
+		// only remove fully depleted icebergs, icebergs with 0 remaining but some in reserve
+		// stay at the pricelevel until they refresh at the end of execution, or the end of auction uncrossing
+		for _, t := range icebergs {
+			if t.order.TrueRemaining() == 0 {
+				toRemove = append(toRemove, t.idx)
+			}
+		}
+		sort.Ints(toRemove)
 	}
 
 	// FIXME(jeremy): these need to be optimized, we can make a single copy


### PR DESCRIPTION
closes #8426

Auction uncrossing with icebergs no longer leave the orderbook crossed after the icebergs refresh. The flow now goes:
- the side of the book which will have its crossed price-levels fully consumed has all its icebergs in that region un-iceberged (because they are going to be fully traded away at the uncrossing price, it makes no difference refreshing as they go along)
- as we uncross with the "other" side, any icebergs on that side with consumed peaks remain on the pricelevel until the uncrossing has finished. This is so that subsequent incoming orders being uncrossed can continue to trade with them pro-rated on that price level until they are all used up. This nicely extends the way we already handle large incoming order against icebergs in continuous trading, where the continuous version is equivalent to an auction uncrossing with a single uncrossed orders.
- all remaining icebergs on the "other" side are then refreshed
- done