### PR TITLE
feat: add release process markdown file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,9 @@ changelog:
       - renovate
       - dependabot
   categories:
+    - title: Vulnerabilities 🔐
+      labels:
+        - vulnerability
     - title: Breaking Changes 🛠
       labels:
         - breaking-change

--- a/.spelling
+++ b/.spelling
@@ -9,6 +9,7 @@ allowlist
 allowlisted
 api
 app_state
+artifacts
 assetActions
 async
 barnabee

--- a/.spelling
+++ b/.spelling
@@ -31,6 +31,7 @@ datetime
 denylist
 delegator
 Devnet
+devops
 dlv
 DoD
 DoR

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -61,11 +61,20 @@ Once the above steps have been taken for the required type of release, the follo
 
    *20YY-MM-DD*
 
-   Features: <-- no hashes here
-   - #123 Add a thing
+   Security vulnerabilities: <-- no hashes here
+   - #123 Fix a vulnerability
+
+   Breaking changes: <-- no hashes here
+   - #124 Rename a thing
+
+   Deprecation: <-- no hashes here
+   - #125 Deprecate a thing
 
    Improvements: <-- no hashes here
-   - #124 Fix a bug
+   - #126 Add a thing
+
+   Fixes: <-- no hashes here
+   - #126 Fix a bug
    EOF
    git tag "v$NEWVER" -F /tmp/tagcommitmsg.txt "$(git log -n1 | awk '/^commit / {print $2}')"
    git show "v$NEWVER" # Check the tag message

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -18,7 +18,7 @@ This document outlines the steps required in order to create a core protocol rel
     - run `git commit -asm "chore: release version vX.Y.Z`
 1. Create a pull request to merge `release/vX.Y.Z` into `master` and have it reviewed and merged
 1. Once the pull request has been merged, create a tag on the `master` branch
-1. The CI will see the tag and create all the release artefacts
+1. The CI will see the tag and create all the release artifacts
 1. Follow the [common release process](./#common-release-process) steps
 
 ## Patch release process
@@ -39,7 +39,7 @@ This document outlines the steps required in order to create a core protocol rel
     - run `make proto`
     - run `git commit -asm "chore: release version vX.Y.Z`
 1. Create a tag on the patch `release/vX.Y.Z` branch
-1. The CI will see the tag and create all the release artefacts
+1. The CI will see the tag and create all the release artifacts
 1. Follow the [common release process](./#common-release-process) steps
 
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -6,7 +6,7 @@ This document outlines the steps required in order to create a core protocol rel
 
 1. The default branch is: `develop`.
 1. Create a `release/vX.Y.Z` branch off the head of **`develop`**.
-1. Update readmes, changelog, and set version strings where needed:
+1. Update all readme files, changelog, and set version strings as required:
   - remove `Unreleased` from the changelog for the version to be released
   - ensure that the readme is up-to-date for the version being released
   - update the version number in `version/version.go`
@@ -28,7 +28,7 @@ This document outlines the steps required in order to create a core protocol rel
 1. Cherry pick the fixes into the `release/vX.Y.Z` branch
   - use the merge commit hash of a PR for the cherry picks
   - run `git cherry-pick -m 1 <merge commit hash>`
-1. Update readmes, changelog, and set version strings where needed.
+1. Update all readme files, changelog, and set version strings as required:
   - ensure the changelog is correct for the patch version to be released
   - ensure that the readme is up-to-date for the patch version being released
   - update the version number in `version/version.go`

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -15,7 +15,7 @@ This document outlines the steps required in order to create a core protocol rel
     - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
     - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
     - run `make proto`
-    - run `git commit -asm "chore: release verison vX.Y.Z`
+    - run `git commit -asm "chore: release version vX.Y.Z`
 1. Create a pull request to merge `release/vX.Y.Z` into `master` and have it reviewed and merged
 1. Once the pull request has been merged, create a tag on the `master` branch
 1. The CI will see the tag and create all the release artefacts

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -23,7 +23,7 @@ This document outlines the steps required in order to create a core protocol rel
 
 ## Patch release process
 
-1. Get hotfix PRs merged into `develop`
+1. Get the patch fix pull requests merged into `develop`
 1. Create a `release/vX.Y.Z` branch off **`master`** or previous release branch
 1. Cherry pick the fixes into the `release/vX.Y.Z` branch
   - use the merge commit hash of a PR for the cherry picks

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -85,5 +85,9 @@ Once the above steps have been taken for the required type of release, the follo
    git merge master
    git push origin develop
    ```
+1. The GitHub release notes can be auto-generated when creating/editing the release in the GitHub UI using the `Generate release notes` button:
+    - the [`release.yml`](https://github.com/vegaprotocol/vega/blob/develop/.github/release.yml) details the headings and associated labels used to generate the release notes
+    - check that all pull requests in the release have the correct labels paying special attention to those related to the labels `vulnerability`, `breaking-change` and `deprecation`
+    - when all pull requests have been checked run the `Generate release notes` action
 1. Notify devops that the release version needs to be deployed onto the `stagnet1` environment for verification
 1. Notify the `@release` group on Slack in the `#engineering` channel

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -37,7 +37,7 @@ This document outlines the steps required in order to create a core protocol rel
     - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
     - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
     - run `make proto`
-    - run `git commit -asm "chore: release verison vX.Y.Z`
+    - run `git commit -asm "chore: release version vX.Y.Z`
 1. Create a tag on the patch `release/vX.Y.Z` branch
 1. The CI will see the tag and create all the release artefacts
 1. Follow the [common release process](./#common-release-process) steps

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,15 +7,15 @@ This document outlines the steps required in order to create a core protocol rel
 1. The default branch is: `develop`.
 1. Create a `release/vX.Y.Z` branch off the head of **`develop`**.
 1. Update all readme files, changelog, and set version strings as required:
-  - remove `Unreleased` from the changelog for the version to be released
-  - ensure that the readme is up-to-date for the version being released
-  - update the version number in `version/version.go`
-  - update the version number in `protos/sources/vega/api/v1/core.proto`
-  - update the version number in `protos/sources/vega/api/v1/corestate.proto`
-  - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
-  - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
-  - run `make proto`
-  - run `git commit -asm "chore: release verison vX.Y.Z`
+    - remove `Unreleased` from the changelog for the version to be released
+    - ensure that the readme is up-to-date for the version being released
+    - update the version number in `version/version.go`
+    - update the version number in `protos/sources/vega/api/v1/core.proto`
+    - update the version number in `protos/sources/vega/api/v1/corestate.proto`
+    - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
+    - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
+    - run `make proto`
+    - run `git commit -asm "chore: release verison vX.Y.Z`
 1. Create a pull request to merge `release/vX.Y.Z` into `master` and have it reviewed and merged
 1. Once the pull request has been merged, create a tag on the `master` branch
 1. The CI will see the tag and create all the release artefacts
@@ -26,18 +26,18 @@ This document outlines the steps required in order to create a core protocol rel
 1. Get the patch fix pull requests merged into `develop`
 1. Create a `release/vX.Y.Z` branch off **`master`** or previous release branch
 1. Cherry pick the fixes into the `release/vX.Y.Z` branch
-  - use the merge commit hash of a PR for the cherry picks
-  - run `git cherry-pick -m 1 <merge commit hash>`
+    - use the merge commit hash of a PR for the cherry picks
+    - run `git cherry-pick -m 1 <merge commit hash>`
 1. Update all readme files, changelog, and set version strings as required:
-  - ensure the changelog is correct for the patch version to be released
-  - ensure that the readme is up-to-date for the patch version being released
-  - update the version number in `version/version.go`
-  - update the version number in `protos/sources/vega/api/v1/core.proto`
-  - update the version number in `protos/sources/vega/api/v1/corestate.proto`
-  - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
-  - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
-  - run `make proto`
-  - run `git commit -asm "chore: release verison vX.Y.Z`
+    - ensure the changelog is correct for the patch version to be released
+    - ensure that the readme is up-to-date for the patch version being released
+    - update the version number in `version/version.go`
+    - update the version number in `protos/sources/vega/api/v1/core.proto`
+    - update the version number in `protos/sources/vega/api/v1/corestate.proto`
+    - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
+    - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
+    - run `make proto`
+    - run `git commit -asm "chore: release verison vX.Y.Z`
 1. Create a tag on the patch `release/vX.Y.Z` branch
 1. The CI will see the tag and create all the release artefacts
 1. Follow the [common release process](./#common-release-process) steps
@@ -48,7 +48,6 @@ This document outlines the steps required in order to create a core protocol rel
 Once the above steps have been taken for the required type of release, the following steps for all releases need to be taken:
 
 1. Cut and paste the following instructions
-
    ```bash
    git fetch --all
    git checkout master
@@ -77,6 +76,5 @@ Once the above steps have been taken for the required type of release, the follo
    git merge master
    git push origin develop
    ```
-
 1. Notify devops that the release version needs to be deployed onto the `stagnet1` environment for verification
 1. Notify the `@release` group on Slack in the `#engineering` channel

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,82 @@
+# Release processes
+
+This document outlines the steps required in order to create a core protocol release.
+
+## Major/minor release process
+
+1. The default branch is: `develop`.
+1. Create a `release/vX.Y.Z` branch off the head of **`develop`**.
+1. Update readmes, changelog, and set version strings where needed:
+  - remove `Unreleased` from the changelog for the version to be released
+  - ensure that the readme is up-to-date for the version being released
+  - update the version number in `version/version.go`
+  - update the version number in `protos/sources/vega/api/v1/core.proto`
+  - update the version number in `protos/sources/vega/api/v1/corestate.proto`
+  - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
+  - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
+  - run `make proto`
+  - run `git commit -asm "chore: release verison vX.Y.Z`
+1. Create a pull request to merge `release/vX.Y.Z` into `master` and have it reviewed and merged
+1. Once the pull request has been merged, create a tag on the `master` branch
+1. The CI will see the tag and create all the release artefacts
+1. Follow the [common release process](./#common-release-process) steps
+
+## Patch release process
+
+1. Get hotfix PRs merged into `develop`
+1. Create a `release/vX.Y.Z` branch off **`master`** or previous release branch
+1. Cherry pick the fixes into the `release/vX.Y.Z` branch
+  - use the merge commit hash of a PR for the cherry picks
+  - run `git cherry-pick -m 1 <merge commit hash>`
+1. Update readmes, changelog, and set version strings where needed.
+  - ensure the changelog is correct for the patch version to be released
+  - ensure that the readme is up-to-date for the patch version being released
+  - update the version number in `version/version.go`
+  - update the version number in `protos/sources/vega/api/v1/core.proto`
+  - update the version number in `protos/sources/vega/api/v1/corestate.proto`
+  - update the version number in `protos/sources/datanode/api/v2/trading_data.proto`
+  - update the version number in `protos/sources/blockexplorer/api/v1/blockexplorer.proto`
+  - run `make proto`
+  - run `git commit -asm "chore: release verison vX.Y.Z`
+1. Create a tag on the patch `release/vX.Y.Z` branch
+1. The CI will see the tag and create all the release artefacts
+1. Follow the [common release process](./#common-release-process) steps
+
+
+## Common release process
+
+Once the above steps have been taken for the required type of release, the following steps for all releases need to be taken:
+
+1. Cut and paste the following instructions
+
+   ```bash
+   git fetch --all
+   git checkout master
+   git pull --rebase origin master
+
+   # Create a message for the tag.
+   # NOTE: Do not use markdown headings with '#'. Lines beginning with '#' are
+   #       ignored by git.
+   cat >/tmp/tagcommitmsg.txt <<-EOF
+   Release vX.Y.Z <-- insert v$NEWVER
+
+   *20YY-MM-DD*
+
+   Features: <-- no hashes here
+   - #123 Add a thing
+
+   Improvements: <-- no hashes here
+   - #124 Fix a bug
+   EOF
+   git tag "v$NEWVER" -F /tmp/tagcommitmsg.txt "$(git log -n1 | awk '/^commit / {print $2}')"
+   git show "v$NEWVER" # Check the tag message
+   git push --tags origin master
+   # Wait for the pipeline for the tag to finish, to reduce resource contention.
+   git checkout develop
+   git pull --rebase origin develop
+   git merge master
+   git push origin develop
+   ```
+
+1. Notify devops that the release version needs to be deployed onto the `stagnet1` environment for verification
+1. Notify the `@release` group on Slack in the `#engineering` channel


### PR DESCRIPTION
As part of the cosmic elevator kick off session it was discussed that any core project team member should be able to create a release of the protocol.

This PR adds 

- a stepped guide in how to create a release in order for devops to deploy
- details on auto-generating release notes 
- updates the release notes GH action to account for security vulnerabilities.