### PR TITLE
fix: set iceberg peaks only if it is going to be added to the book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - [8341](https://github.com/vegaprotocol/vega/issues/8341) - Remind the user to check his internet connection if the wallet can't connect to a node.
 - [8343](https://github.com/vegaprotocol/vega/issues/8343) - Make the service starter easier to instantiate
 - [8429](https://github.com/vegaprotocol/vega/issues/8429) - Release margin when decreasing iceberg size like normal orders do
+- [8429](https://github.com/vegaprotocol/vega/issues/8429) - Set order status to stopped if an iceberg order instantly causes a wash trade
 - [8376](https://github.com/vegaprotocol/vega/issues/8376) - Ensure the structure fields match their JSON counter parts in the wallet API requests and responses.
 - [8363](https://github.com/vegaprotocol/vega/issues/8363) - Add missing name property in `admin.describe_key` wallet API example
 - [8313](https://github.com/vegaprotocol/vega/issues/8313) - Assure liquidation price estimate works with 0 open volume

--- a/core/matching/orderbook.go
+++ b/core/matching/orderbook.go
@@ -867,15 +867,15 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 		}
 	}
 
-	if order.IcebergOrder != nil && order.Status == types.OrderStatusActive {
-		// now trades have been generated for the aggressive iceberg based on the
-		// full size, set the peak limits ready for it to be added to the book.
-		order.SetIcebergPeaks()
-	}
-
 	// if order is persistent type add to order book to the correct side
 	// and we did not hit a error / wash trade error
 	if order.IsPersistent() && err == nil {
+		if order.IcebergOrder != nil && order.Status == types.OrderStatusActive {
+			// now trades have been generated for the aggressive iceberg based on the
+			// full size, set the peak limits ready for it to be added to the book.
+			order.SetIcebergPeaks()
+		}
+
 		b.getSide(order.Side).addOrder(order)
 		// also add it to the indicative price and volume if in auction
 		if b.auction {


### PR DESCRIPTION
closes #8518 

Iceberg orders only have their initial peak values set if they are definitely going to be added to the book. This prevents us from setting the wrong order status if it wash trades.