### PR TITLE
fix: if liquidity fee account is empty do not create 0 amount transfe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - [8429](https://github.com/vegaprotocol/vega/issues/8429) - Set order status to stopped if an iceberg order instantly causes a wash trade
 - [8376](https://github.com/vegaprotocol/vega/issues/8376) - Ensure the structure fields match their JSON counter parts in the wallet API requests and responses.
 - [8363](https://github.com/vegaprotocol/vega/issues/8363) - Add missing name property in `admin.describe_key` wallet API example
+- [8536](https://github.com/vegaprotocol/vega/issues/8536) - If liquidity fee account is empty do not create 0 amount transfers to insurance pool when clearing market
 - [8313](https://github.com/vegaprotocol/vega/issues/8313) - Assure liquidation price estimate works with 0 open volume
 - [8412](https://github.com/vegaprotocol/vega/issues/8412) - Fix non deterministic ordering of events emitted on auto delegation
 - [8414](https://github.com/vegaprotocol/vega/issues/8414) - Fix corruption on order subscription

--- a/core/collateral/engine_test.go
+++ b/core/collateral/engine_test.go
@@ -2332,14 +2332,19 @@ func TestClearMarket(t *testing.T) {
 	party := "okparty"
 
 	// create parties
-	eng.broker.EXPECT().Send(gomock.Any()).Times(11)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(12)
 
 	eng.IncrementBalance(context.Background(), eng.marketInsuranceID, num.NewUint(1000))
 
-	acc, _ := eng.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
-	eng.IncrementBalance(context.Background(), acc, num.NewUint(500))
-	_, err := eng.CreatePartyMarginAccount(context.Background(), party, testMarketID, testMarketAsset)
+	_, err := eng.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
 	assert.Nil(t, err)
+	acc, err := eng.CreatePartyMarginAccount(context.Background(), party, testMarketID, testMarketAsset)
+	eng.IncrementBalance(context.Background(), acc, num.NewUint(500))
+	assert.Nil(t, err)
+
+	// increment the balance on the lpFee account so we can check it gets cleared
+	liqAcc, _ := eng.GetMarketLiquidityFeeAccount(testMarketID, testMarketAsset)
+	eng.IncrementBalance(context.Background(), liqAcc.ID, num.NewUint(250))
 
 	parties := []string{party}
 
@@ -2348,13 +2353,31 @@ func TestClearMarket(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(responses))
 
+	// this will be from the margin account to the general account
 	assert.Equal(t, 1, len(responses[0].Entries))
-	assert.Equal(t, num.NewUint(500), responses[0].Entries[0].ToAccountBalance)
-	assert.Equal(t, num.NewUint(500), responses[0].Entries[0].ToAccountBalance)
+	entry := responses[0].Entries[0]
+	assert.Equal(t, types.AccountTypeMargin, entry.FromAccount.Type)
+	assert.Equal(t, types.AccountTypeGeneral, entry.ToAccount.Type)
+	assert.Equal(t, num.NewUint(0), entry.FromAccountBalance)
+	assert.Equal(t, num.NewUint(500), entry.ToAccountBalance)
+	assert.Equal(t, num.NewUint(500), entry.Amount)
 
+	// This will be liquidity fees being cleared into the insurance account
 	assert.Equal(t, 1, len(responses[1].Entries))
-	assert.Equal(t, num.NewUint(1000), responses[1].Entries[0].ToAccountBalance)
-	assert.Equal(t, num.NewUint(1000), responses[1].Entries[0].ToAccountBalance)
+	entry = responses[1].Entries[0]
+	assert.Equal(t, types.AccountTypeFeesLiquidity, entry.FromAccount.Type)
+	assert.Equal(t, types.AccountTypeInsurance, entry.ToAccount.Type)
+	assert.Equal(t, num.NewUint(0), entry.FromAccountBalance)
+	assert.Equal(t, num.NewUint(1250), entry.ToAccountBalance)
+	assert.Equal(t, num.NewUint(250), entry.Amount)
+
+	// This will be the insurance account going into the global rewards pool
+	entry = responses[2].Entries[0]
+	assert.Equal(t, types.AccountTypeInsurance, entry.FromAccount.Type)
+	assert.Equal(t, types.AccountTypeGlobalReward, entry.ToAccount.Type)
+	assert.Equal(t, num.NewUint(0), entry.FromAccountBalance)
+	assert.Equal(t, num.NewUint(1250), entry.ToAccountBalance)
+	assert.Equal(t, num.NewUint(1250), entry.Amount)
 }
 
 func TestClearMarketNoMargin(t *testing.T) {
@@ -2363,7 +2386,7 @@ func TestClearMarketNoMargin(t *testing.T) {
 	party := "okparty"
 
 	// create parties
-	eng.broker.EXPECT().Send(gomock.Any()).Times(5)
+	eng.broker.EXPECT().Send(gomock.Any()).Times(3)
 	acc, _ := eng.CreatePartyGeneralAccount(context.Background(), party, testMarketAsset)
 	eng.IncrementBalance(context.Background(), acc, num.NewUint(500))
 
@@ -2371,8 +2394,9 @@ func TestClearMarketNoMargin(t *testing.T) {
 
 	responses, err := eng.ClearMarket(context.Background(), testMarketID, testMarketAsset, parties, false)
 
+	// we expect no ledger movements as all accounts to clear were empty
 	assert.NoError(t, err)
-	assert.Equal(t, len(responses), 1)
+	assert.Equal(t, len(responses), 0)
 }
 
 func TestRewardDepositOK(t *testing.T) {


### PR DESCRIPTION
closes #8536 

When a market is being removed because its been cancelled/settled/whatever we clear any assets in the markets LP-fee account by moving it to the insurance pool (and then to other market's insurance pool or the global reward account). If the LP-fee account was empty, we were processing a `0` amount transfer. This was causing the data node to blow up. We now do not do this.

In the test in question (`test_oracle_terminate_during_checkpoint`) we have a market with a time-based trigger for termination, if a checkpoint restore reinstates that markets *after* the termination timestamp, then the market is immediately cancelled:
```
Markets with internal time trigger for trading terminated that rings between shutdown and restore
(0073-LIMN-060) The market is not restored (it is marked as cancelled i.e. it's not possible to submit orders or LP
    provisions to this market)
```

What this meant is that we would create an new empty LP-fee account when we instantiated a market, send the datanode an account event with balance 0, then the cancellation of the market would instantly clear the accounts and send another `0` balance account update in the same block.

System test now passing:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/76410/tests