### PR TITLE
fix: better validation for protocol upgrade semver + use default tendermint rpc if not specified as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [8467](https://github.com/vegaprotocol/vega/issues/8467) - Add stop orders data structures
 - [8516](https://github.com/vegaprotocol/vega/issues/8516) - Add stop orders network parameter
 - [8470](https://github.com/vegaprotocol/vega/issues/8470) - Stop orders snapshots
+- [8548](https://github.com/vegaprotocol/vega/issues/8548) - Use default for tendermint `RPC` address and better validation for `semver`
 
 ### 🐛 Fixes
 

--- a/cmd/vega/commands/announce_node.go
+++ b/cmd/vega/commands/announce_node.go
@@ -189,7 +189,13 @@ func getNodeWalletCommander(log *logging.Logger, registryPass string, vegaPaths 
 		return nil, nil, nil, fmt.Errorf("couldn't get Vega node wallet: %w", err)
 	}
 
-	abciClient, err := abci.NewClient(cfg.Blockchain.Tendermint.RPCAddr)
+	rpcAddr := cfg.Blockchain.Tendermint.RPCAddr
+	if len(rpcAddr) <= 0 {
+		rpcAddr = "tcp://127.0.0.1:26657"
+		log.Warn("Blockchain.Tendermint.RPCAddr is empty, using default", logging.String("address", rpcAddr))
+	}
+
+	abciClient, err := abci.NewClient(rpcAddr)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("couldn't initialise ABCI client: %w", err)
 	}

--- a/cmd/vega/commands/propose_upgrade.go
+++ b/cmd/vega/commands/propose_upgrade.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"code.vegaprotocol.io/vega/core/config"
 	"code.vegaprotocol.io/vega/core/protocolupgrade"
@@ -64,6 +65,10 @@ func (opts *ProposeUpgradeCmd) Execute(_ []string) error {
 
 	if !conf.IsValidator() {
 		return errors.New("node is not a validator")
+	}
+
+	if !strings.HasPrefix(opts.VegaReleaseTag, "v") {
+		return errors.New("invalid vega release tag, expected prefix 'v' (example: v0.71.9)")
 	}
 
 	cmd := commandspb.ProtocolUpgradeProposal{


### PR DESCRIPTION
close #8548  