### PR TITLE
fix: do not verify termination timestamp in update market when pre-en…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - [8313](https://github.com/vegaprotocol/vega/issues/8313) - Assure liquidation price estimate works with 0 open volume
 - [8412](https://github.com/vegaprotocol/vega/issues/8412) - Fix non deterministic ordering of events emitted on auto delegation
 - [8414](https://github.com/vegaprotocol/vega/issues/8414) - Fix corruption on order subscription
+- [8453](https://github.com/vegaprotocol/vega/issues/8453) - Do not verify termination timestamp in update market when pre-enacting proposal
 - [8418](https://github.com/vegaprotocol/vega/issues/8418) - Fix data node panics when a bad successor market proposal is rejected
 - [8358](https://github.com/vegaprotocol/vega/issues/8358) - Fix replay protection
 - [8451](https://github.com/vegaprotocol/vega/issues/8451) - Fix invalid auction duration for new market proposals.

--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -1208,7 +1208,7 @@ func (e *Engine) updatedMarketFromProposal(p *proposal) (*types.Market, types.Pr
 		return nil, types.ProposalErrorUnsupportedProduct, ErrUnsupportedProduct
 	}
 
-	if perr, err := validateUpdateMarketChange(terms, &enactmentTime{current: p.Terms.EnactmentTimestamp}); err != nil {
+	if perr, err := validateUpdateMarketChange(terms, &enactmentTime{current: p.Terms.EnactmentTimestamp, shouldNotVerify: true}); err != nil {
 		return nil, perr, err
 	}
 

--- a/core/governance/engine_update_market_test.go
+++ b/core/governance/engine_update_market_test.go
@@ -34,7 +34,7 @@ func TestProposalForMarketUpdate(t *testing.T) {
 	t.Run("Submitting a proposal for market update with internal time termination succeeds", testSubmittingProposalForMarketUpdateWithInternalTimeTerminationSucceeds)
 	t.Run("Submitting a proposal for market update with internal settling fails", testSubmittingProposalForMarketUpdateWithInternalTimeSetllingFails)
 	t.Run("Submitting a proposal for market update with internal time termination and 'less than' condition fails", testSubmittingProposalForMarketUpdateWithInternalTimeTerminationWithLessThanConditionFails)
-	t.Run("Submitting a proposal for market update with termination in the past succeeds", TestSubmittingProposalForMarketUpdateWithEarlyTerminationSucceeds)
+	t.Run("Submitting a proposal for market update with termination in the past succeeds", testSubmittingProposalForMarketUpdateWithEarlyTerminationSucceeds)
 	t.Run("Submitting a proposal for market update with external termination using internal time key succeeds", testSubmittingProposalForMarketUpdateWithExternalSourceUsingInternalKeyTimeForTerminationSucceeds)
 	t.Run("Submitting a proposal for market update on unknown market fails", testSubmittingProposalForMarketUpdateForUnknownMarketFails)
 	t.Run("Submitting a proposal with internal time termination for market update on unknown market fails", testSubmittingProposalForMarketUpdateWithInternalTimeTerminationForUnknownMarketFails)
@@ -402,10 +402,11 @@ func testSubmittingProposalForMarketUpdateWithExternalSourceUsingInternalKeyTime
 	require.NotNil(t, toSubmit)
 }
 
-func TestSubmittingProposalForMarketUpdateWithEarlyTerminationSucceeds(t *testing.T) {
+func testSubmittingProposalForMarketUpdateWithEarlyTerminationSucceeds(t *testing.T) {
 	eng := getTestEngine(t)
 	defer eng.ctrl.Finish()
 
+	// Submit proposal.
 	// given
 	proposer := vgrand.RandomStr(5)
 	proposal := eng.newProposalForMarketUpdate("market-1", proposer, eng.tsvc.GetTimeNow(), nil, nil, true)
@@ -421,7 +422,7 @@ func TestSubmittingProposalForMarketUpdateWithEarlyTerminationSucceeds(t *testin
 				Conditions: []*types.DataSourceSpecCondition{
 					{
 						Operator: datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
-						Value:    "0",
+						Value:    "0", // change to internal timestamp that is in the past
 					},
 				},
 			},
@@ -430,19 +431,96 @@ func TestSubmittingProposalForMarketUpdateWithEarlyTerminationSucceeds(t *testin
 	proposal.Terms.Change.(*types.ProposalTermsUpdateMarket).UpdateMarket.Changes.Instrument.Product.(*types.UpdateInstrumentConfigurationFuture).Future.DataSourceSpecBinding.TradingTerminationProperty = "vegaprotocol.builtin.timestamp"
 
 	// setup
-	eng.ensureTokenBalanceForParty(t, proposer, 1000)
-	eng.ensureEquityLikeShareForMarketAndParty(t, marketID, proposer, 0.1)
+	eng.ensureEquityLikeShareForMarketAndParty(t, marketID, proposer, 0.7)
 	eng.ensureExistingMarket(t, marketID)
+	eng.ensureTokenBalanceForParty(t, proposer, 1)
+	eng.ensureAllAssetEnabled(t)
 
 	// expect
 	eng.expectOpenProposalEvent(t, proposer, proposal.ID)
 
 	// when
-	toSubmit, err := eng.submitProposal(t, proposal)
+	_, err := eng.submitProposal(t, proposal)
 
 	// then
 	require.NoError(t, err)
-	require.NotNil(t, toSubmit)
+
+	// Vote 'YES' with 10 tokens.
+	// given
+	voterWithToken1 := vgrand.RandomStr(5)
+
+	// setup
+	eng.ensureTokenBalanceForParty(t, voterWithToken1, 10)
+	eng.ensureEquityLikeShareForMarketAndParty(t, marketID, voterWithToken1, 0)
+
+	// expect
+	eng.expectVoteEvent(t, voterWithToken1, proposal.ID)
+
+	// when
+	err = eng.addYesVote(t, voterWithToken1, proposal.ID)
+
+	// then
+	require.NoError(t, err)
+
+	// Vote 'NO' with 2 tokens.
+	// given
+	voterWithToken2 := vgrand.RandomStr(5)
+
+	// Close the proposal.
+	// given
+	afterClosing := time.Unix(proposal.Terms.ClosingTimestamp, 0).Add(time.Second)
+
+	// setup
+	eng.ensureStakingAssetTotalSupply(t, 13)
+	eng.ensureTokenBalanceForParty(t, voterWithToken1, 10)
+	eng.ensureTokenBalanceForParty(t, voterWithToken2, 2)
+
+	// expect
+	eng.expectPassedProposalEvent(t, proposal.ID)
+	eng.expectVoteEvents(t)
+	eng.expectGetMarketState(t, marketID)
+
+	// when
+	eng.OnTick(context.Background(), afterClosing)
+
+	// Enact the proposal.
+	// given
+	afterEnactment := time.Unix(proposal.Terms.EnactmentTimestamp, 0).Add(time.Second)
+	existingMarket := types.Market{
+		ID: marketID,
+		TradableInstrument: &types.TradableInstrument{
+			Instrument: &types.Instrument{
+				Name: vgrand.RandomStr(10),
+				Product: &types.InstrumentFuture{
+					Future: &types.Future{
+						SettlementAsset: "BTC",
+					},
+				},
+			},
+		},
+		DecimalPlaces:         3,
+		PositionDecimalPlaces: 4,
+		OpeningAuction: &types.AuctionDuration{
+			Duration: 42,
+		},
+	}
+
+	// setup
+	eng.ensureGetMarket(t, marketID, existingMarket)
+
+	// when
+	enacted, _ := eng.OnTick(context.Background(), afterEnactment)
+
+	// then
+	require.NotEmpty(t, enacted)
+	require.True(t, enacted[0].IsUpdateMarket())
+	updatedMarket := enacted[0].UpdateMarket()
+	assert.Equal(t, existingMarket.ID, updatedMarket.ID)
+	assert.Equal(t, existingMarket.TradableInstrument.Instrument.Name, updatedMarket.TradableInstrument.Instrument.Name)
+	assert.Equal(t, existingMarket.TradableInstrument.Instrument.Product.(*types.InstrumentFuture).Future.SettlementAsset, updatedMarket.TradableInstrument.Instrument.Product.(*types.InstrumentFuture).Future.SettlementAsset)
+	assert.Equal(t, existingMarket.DecimalPlaces, updatedMarket.DecimalPlaces)
+	assert.Equal(t, existingMarket.PositionDecimalPlaces, updatedMarket.PositionDecimalPlaces)
+	assert.Equal(t, existingMarket.OpeningAuction.Duration, updatedMarket.OpeningAuction.Duration)
 }
 
 func testSubmittingProposalForMarketUpdateForUnknownMarketFails(t *testing.T) {


### PR DESCRIPTION
closes #8453 

This allows proposing a market update where an internal-timestamp oracle is in the past. This will commonly happen during a market-update of an already terminated market where the internal-timestamp oracle will be left unchanged.

Some system-tests passing:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/77217/tests
