### PR TITLE
Add network parameters for SLA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - [8548](https://github.com/vegaprotocol/vega/issues/8548) - Use default for tendermint `RPC` address and better validation for `semver`
 - [8472](https://github.com/vegaprotocol/vega/issues/8472) - Add support for stop orders with batch market instructions
 - [8567](https://github.com/vegaprotocol/vega/issues/8567) - Add virtual stake and market growth to market data.
+- [8508](https://github.com/vegaprotocol/vega/issues/8508) - Add network parameters for SLA.
 
 ### 🐛 Fixes
 

--- a/cmd/vega/commands/verify/genesis_test.go
+++ b/cmd/vega/commands/verify/genesis_test.go
@@ -27,17 +27,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
+func TestGenesis(t *testing.T) {
 	t.Run("verify default genesis", testVerifyDefaultGenesis)
 	t.Run("verify ERC20 assets", testVerifyERC20Assets)
 	t.Run("verify builtin assets", testVerifyBuiltinAssets)
 	t.Run("verify netparams", testVerifyNetworkParams)
 	t.Run("verify validators", TestVerifyValidators)
-	t.Run("verify unknown appstate field", testUnknownAppstateField)
+	t.Run("verify unknown appstate field", testUnknownAppStateField)
 }
 
 func testVerifyDefaultGenesis(t *testing.T) {
-	testFile := getFileFromAppstate(t, genesis.DefaultState())
+	testFile := writeGenesisFileWithState(t, genesis.DefaultState())
 
 	cmd := verify.GenesisCmd{}
 	assert.NoError(t, cmd.Execute([]string{testFile}))
@@ -57,7 +57,7 @@ func testVerifyBuiltinAssets(t *testing.T) {
 		},
 	}
 
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Max faucet amount not a bignum
 	gs = genesis.DefaultState()
@@ -70,7 +70,7 @@ func testVerifyBuiltinAssets(t *testing.T) {
 		},
 	}
 
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Completely Valid
 	gs = genesis.DefaultState()
@@ -83,7 +83,7 @@ func testVerifyBuiltinAssets(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.NoError(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 }
 
 func testVerifyERC20Assets(t *testing.T) {
@@ -99,7 +99,7 @@ func testVerifyERC20Assets(t *testing.T) {
 			},
 		},
 	}
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Invalid contract address
 	gs = genesis.DefaultState()
@@ -111,7 +111,7 @@ func testVerifyERC20Assets(t *testing.T) {
 			},
 		},
 	}
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Completely valid
 	gs = genesis.DefaultState()
@@ -124,7 +124,7 @@ func testVerifyERC20Assets(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.NoError(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 }
 
 func testVerifyNetworkParams(t *testing.T) {
@@ -133,24 +133,24 @@ func testVerifyNetworkParams(t *testing.T) {
 	// Check for invalid network parameter
 	gs := genesis.DefaultState()
 	gs.NetParams["NOTREAL"] = "something"
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Check for network parameter with bad value
 	gs = genesis.DefaultState()
 	gs.NetParams["snapshot.interval.length"] = "always"
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Check for invalid checkpoint overwrite network parameter
 	gs = genesis.DefaultState()
 	gs.NetParamsOverwrite = []string{"NOTREAL"}
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Check for deprecated parameter in genesis
 	gs = genesis.DefaultState()
 	for k := range netparams.Deprecated {
 		gs.NetParams[k] = "hello"
 	}
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 }
 
 func TestVerifyValidators(t *testing.T) {
@@ -166,36 +166,36 @@ func TestVerifyValidators(t *testing.T) {
 	// Valid validator information
 	gs := genesis.DefaultState()
 	gs.Validators[valid.TmPubKey] = valid
-	assert.NoError(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.NoError(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Mismatch TM key
 	gs = genesis.DefaultState()
 	gs.Validators["WRONG"] = valid
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// Invalid pubkey index
 	gs = genesis.DefaultState()
 	invalid := valid
 	invalid.VegaPubKeyIndex = 0
 	gs.Validators[valid.TmPubKey] = invalid
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// invalid ID
 	gs = genesis.DefaultState()
 	invalid = valid
 	invalid.ID = "too short"
 	gs.Validators[valid.TmPubKey] = invalid
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 
 	// invalid pubkey
 	gs = genesis.DefaultState()
 	invalid = valid
 	invalid.VegaPubKey = "too short"
 	gs.Validators[valid.TmPubKey] = invalid
-	assert.Error(t, cmd.Execute([]string{getFileFromAppstate(t, gs)}))
+	assert.Error(t, cmd.Execute([]string{writeGenesisFileWithState(t, gs)}))
 }
 
-func testUnknownAppstateField(t *testing.T) {
+func testUnknownAppStateField(t *testing.T) {
 	cmd := verify.GenesisCmd{}
 	gs := genesis.DefaultState()
 
@@ -226,12 +226,12 @@ func testUnknownAppstateField(t *testing.T) {
 	assert.Error(t, cmd.Execute([]string{testFile}))
 }
 
-func getFileFromAppstate(t *testing.T, gs genesis.State) string {
+func writeGenesisFileWithState(t *testing.T, gs genesis.State) string {
 	t.Helper()
 
-	testFile := filepath.Join(t.TempDir(), "genesistest.json")
+	genesisFilePath := filepath.Join(t.TempDir(), "genesistest.json")
 
-	genesis := struct {
+	genesisPayload := struct {
 		AppState        genesis.State `json:"app_state"`
 		ConsensusParams struct {
 			Block struct {
@@ -239,13 +239,13 @@ func getFileFromAppstate(t *testing.T, gs genesis.State) string {
 			} `json:"block"`
 		} `json:"consensus_params"`
 	}{AppState: gs}
-	genesis.ConsensusParams.Block.TimeIotaMs = "1"
-	// marshall it
-	file, _ := json.MarshalIndent(genesis, "", " ")
+	genesisPayload.ConsensusParams.Block.TimeIotaMs = "1"
 
-	err := os.WriteFile(testFile, file, 0o644)
-
-	// write to file
+	file, err := json.MarshalIndent(genesisPayload, "", " ")
 	require.NoError(t, err)
-	return testFile
+
+	err = os.WriteFile(genesisFilePath, file, 0o644)
+	require.NoError(t, err)
+
+	return genesisFilePath
 }

--- a/core/execution/engine.go
+++ b/core/execution/engine.go
@@ -100,19 +100,28 @@ type netParamsValues struct {
 	marketCreationQuantumMultiple        num.Decimal
 	markPriceUpdateMaximumFrequency      time.Duration
 	marketPartiesMaximumStopOrdersUpdate *num.Uint
+
+	// Liquidity version 2.
+	liquidityV2BondPenaltyFactor                 num.Decimal
+	liquidityV2EarlyExitPenalty                  num.Decimal
+	liquidityV2MaxLiquidityFee                   num.Decimal
+	liquidityV2SLANonPerformanceBondPenaltyMax   num.Decimal
+	liquidityV2SLANonPerformanceBondPenaltySlope num.Decimal
+	liquidityV2SuppliedStakeToObligationFactor   num.Decimal
 }
 
 func defaultNetParamsValues() netParamsValues {
 	return netParamsValues{
-		shapesMaxSize:                        -1,
-		feeDistributionTimeStep:              -1,
-		marketValueWindowLength:              -1,
-		suppliedStakeToObligationFactor:      num.DecimalFromInt64(-1),
-		infrastructureFee:                    num.DecimalFromInt64(-1),
-		makerFee:                             num.DecimalFromInt64(-1),
-		scalingFactors:                       nil,
-		maxLiquidityFee:                      num.DecimalFromInt64(-1),
-		bondPenaltyFactor:                    num.DecimalFromInt64(-1),
+		shapesMaxSize:                   -1,
+		feeDistributionTimeStep:         -1,
+		marketValueWindowLength:         -1,
+		suppliedStakeToObligationFactor: num.DecimalFromInt64(-1),
+		infrastructureFee:               num.DecimalFromInt64(-1),
+		makerFee:                        num.DecimalFromInt64(-1),
+		scalingFactors:                  nil,
+		maxLiquidityFee:                 num.DecimalFromInt64(-1),
+		bondPenaltyFactor:               num.DecimalFromInt64(-1),
+
 		auctionMinDuration:                   -1,
 		probabilityOfTradingTauScaling:       num.DecimalFromInt64(-1),
 		minProbabilityOfTradingLPOrders:      num.DecimalFromInt64(-1),
@@ -120,6 +129,14 @@ func defaultNetParamsValues() netParamsValues {
 		marketCreationQuantumMultiple:        num.DecimalFromInt64(-1),
 		markPriceUpdateMaximumFrequency:      5 * time.Second, // default is 5 seconds, should come from net params though
 		marketPartiesMaximumStopOrdersUpdate: num.UintZero(),
+
+		// Liquidity version 2.
+		liquidityV2BondPenaltyFactor:                 num.DecimalFromInt64(-1),
+		liquidityV2EarlyExitPenalty:                  num.DecimalFromInt64(-1),
+		liquidityV2MaxLiquidityFee:                   num.DecimalFromInt64(-1),
+		liquidityV2SLANonPerformanceBondPenaltyMax:   num.DecimalFromInt64(-1),
+		liquidityV2SLANonPerformanceBondPenaltySlope: num.DecimalFromInt64(-1),
+		liquidityV2SuppliedStakeToObligationFactor:   num.DecimalFromInt64(-1),
 	}
 }
 
@@ -514,10 +531,37 @@ func (e *Engine) submitMarket(ctx context.Context, marketConfig *types.Market, o
 	// is already proven to exists a few line before
 	_, _, _ = e.collateral.CreateMarketAccounts(ctx, marketConfig.ID, asset)
 
-	return e.propagateInitialNetParams(ctx, mkt)
+	return e.propagateInitialNetParamsToFutureMarket(ctx, mkt)
 }
 
-func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *future.Market) error {
+// TODO To wire to spot market initialisation.
+func (e *Engine) propagateInitialNetParamsToSpotMarket() { //nolint:unused
+	if !e.npv.liquidityV2BondPenaltyFactor.Equal(num.DecimalFromInt64(-1)) { //nolint:staticcheck
+		// TODO To propagate to spot market.
+	}
+
+	if !e.npv.liquidityV2EarlyExitPenalty.Equal(num.DecimalFromInt64(-1)) { //nolint:staticcheck
+		// TODO To propagate to spot market.
+	}
+
+	if !e.npv.liquidityV2MaxLiquidityFee.Equal(num.DecimalFromInt64(-1)) { //nolint:staticcheck
+		// TODO To propagate to spot market.
+	}
+
+	if !e.npv.liquidityV2SLANonPerformanceBondPenaltySlope.Equal(num.DecimalFromInt64(-1)) { //nolint:staticcheck
+		// TODO To propagate to spot market.
+	}
+
+	if !e.npv.liquidityV2SLANonPerformanceBondPenaltyMax.Equal(num.DecimalFromInt64(-1)) { //nolint:staticcheck
+		// TODO To propagate to spot market.
+	}
+
+	if !e.npv.liquidityV2SuppliedStakeToObligationFactor.Equal(num.DecimalFromInt64(-1)) { //nolint:staticcheck
+		// TODO To propagate to spot market.
+	}
+}
+
+func (e *Engine) propagateInitialNetParamsToFutureMarket(ctx context.Context, mkt *future.Market) error {
 	if !e.npv.probabilityOfTradingTauScaling.Equal(num.DecimalFromInt64(-1)) {
 		mkt.OnMarketProbabilityOfTradingTauScalingUpdate(ctx, e.npv.probabilityOfTradingTauScaling)
 	}
@@ -565,6 +609,7 @@ func (e *Engine) propagateInitialNetParams(ctx context.Context, mkt *future.Mark
 	if !e.npv.suppliedStakeToObligationFactor.Equal(num.DecimalFromInt64(-1)) {
 		mkt.OnSuppliedStakeToObligationFactorUpdate(e.npv.suppliedStakeToObligationFactor)
 	}
+
 	if !e.npv.bondPenaltyFactor.Equal(num.DecimalFromInt64(-1)) {
 		mkt.BondPenaltyFactorUpdate(ctx, e.npv.bondPenaltyFactor)
 	}
@@ -1097,6 +1142,90 @@ func (e *Engine) OnMarketLiquidityBondPenaltyUpdate(ctx context.Context, d num.D
 	}
 
 	e.npv.bondPenaltyFactor = d
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityV2BondPenaltyUpdate(ctx context.Context, d num.Decimal) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update market liquidity bond penalty (liquidity v2)",
+			logging.Decimal("bond-penalty-factor", d),
+		)
+	}
+
+	// TODO To propagate to spot markets.
+
+	e.npv.liquidityV2BondPenaltyFactor = d
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityV2EarlyExitPenaltyUpdate(_ context.Context, d num.Decimal) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update market liquidity early exit penalty (liquidity v2)",
+			logging.Decimal("early-exit-penalty", d),
+		)
+	}
+
+	// TODO To propagate to spot markets.
+
+	e.npv.liquidityV2EarlyExitPenalty = d
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityV2MaximumLiquidityFeeFactorLevelUpdate(_ context.Context, d num.Decimal) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update liquidity provision max liquidity fee factor (liquidity v2)",
+			logging.Decimal("max-liquidity-fee", d),
+		)
+	}
+
+	// TODO To propagate to spot markets.
+
+	e.npv.liquidityV2MaxLiquidityFee = d
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityV2SLANonPerformanceBondPenaltySlopeUpdate(_ context.Context, d num.Decimal) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update market SLA non performance bond penalty slope (liquidity v2)",
+			logging.Decimal("bond-penalty-slope", d),
+		)
+	}
+
+	// TODO To propagate to spot markets.
+
+	e.npv.liquidityV2SLANonPerformanceBondPenaltySlope = d
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityV2SLANonPerformanceBondPenaltyMaxUpdate(_ context.Context, d num.Decimal) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update market SLA non performance bond penalty max (liquidity v2)",
+			logging.Decimal("bond-penalty-max", d),
+		)
+	}
+
+	// TODO To propagate to spot markets.
+
+	e.npv.liquidityV2SLANonPerformanceBondPenaltyMax = d
+
+	return nil
+}
+
+func (e *Engine) OnMarketLiquidityV2SuppliedStakeToObligationFactorUpdate(_ context.Context, d num.Decimal) error {
+	if e.log.IsDebug() {
+		e.log.Debug("update supplied stake to obligation factor (liquidity v2)",
+			logging.Decimal("factor", d),
+		)
+	}
+
+	// TODO To propagate to spot markets.
+
+	e.npv.liquidityV2SuppliedStakeToObligationFactor = d
 
 	return nil
 }

--- a/core/execution/engine_snapshot.go
+++ b/core/execution/engine_snapshot.go
@@ -118,7 +118,7 @@ func (e *Engine) restoreMarket(ctx context.Context, em *types.ExecMarket) (*futu
 	e.markets[marketConfig.ID] = mkt
 	e.marketsCpy = append(e.marketsCpy, mkt)
 
-	if err := e.propagateInitialNetParams(ctx, mkt); err != nil {
+	if err := e.propagateInitialNetParamsToFutureMarket(ctx, mkt); err != nil {
 		return nil, err
 	}
 	// ensure this is set correctly

--- a/core/execution/future/market_callbacks.go
+++ b/core/execution/future/market_callbacks.go
@@ -29,7 +29,7 @@ func (m *Market) OnMarketMinProbabilityOfTradingLPOrdersUpdate(_ context.Context
 	m.liquidity.OnMinProbabilityOfTradingLPOrdersUpdate(d)
 }
 
-func (m *Market) BondPenaltyFactorUpdate(ctx context.Context, d num.Decimal) {
+func (m *Market) BondPenaltyFactorUpdate(_ context.Context, d num.Decimal) {
 	m.bondPenaltyFactor = d
 }
 

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -270,7 +270,7 @@ func (e *executionTestSetup) registerNetParamsCallbacks() error {
 			Watcher: e.executionEngine.OnMarketValueWindowLengthUpdate,
 		},
 		netparams.WatchParam{
-			Param:   netparams.MarketLiquidityProvidersFeeDistribitionTimeStep,
+			Param:   netparams.MarketLiquidityProvidersFeeDistributionTimeStep,
 			Watcher: e.executionEngine.OnMarketLiquidityProvidersFeeDistributionTimeStep,
 		},
 		netparams.WatchParam{
@@ -285,6 +285,32 @@ func (e *executionTestSetup) registerNetParamsCallbacks() error {
 			Param:   netparams.MarketLiquidityBondPenaltyParameter,
 			Watcher: e.executionEngine.OnMarketLiquidityBondPenaltyUpdate,
 		},
+		// Liquidity version 2.
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityV2BondPenaltyParameter,
+			Watcher: e.executionEngine.OnMarketLiquidityV2BondPenaltyUpdate,
+		},
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityV2EarlyExitPenalty,
+			Watcher: e.executionEngine.OnMarketLiquidityV2EarlyExitPenaltyUpdate,
+		},
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityV2MaximumLiquidityFeeFactorLevel,
+			Watcher: e.executionEngine.OnMarketLiquidityV2MaximumLiquidityFeeFactorLevelUpdate,
+		},
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityV2SLANonPerformanceBondPenaltySlope,
+			Watcher: e.executionEngine.OnMarketLiquidityV2SLANonPerformanceBondPenaltySlopeUpdate,
+		},
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityV2SLANonPerformanceBondPenaltyMax,
+			Watcher: e.executionEngine.OnMarketLiquidityV2SLANonPerformanceBondPenaltyMaxUpdate,
+		},
+		netparams.WatchParam{
+			Param:   netparams.MarketLiquidityV2StakeToCCYVolume,
+			Watcher: e.executionEngine.OnMarketLiquidityV2SLANonPerformanceBondPenaltySlopeUpdate,
+		},
+		// End of liquidity version 2.
 		netparams.WatchParam{
 			Param:   netparams.MarketAuctionMinimumDuration,
 			Watcher: e.executionEngine.OnMarketAuctionMinimumDurationUpdate,

--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -77,7 +77,7 @@ func defaultNetParams() map[string]value {
 		MarketLiquidityBondPenaltyParameter:             NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("1"),
 		MarketLiquidityMaximumLiquidityFeeFactorLevel:   NewDecimal(gtD0, lteD1).Mutable(true).MustUpdate("1"),
 		MarketLiquidityStakeToCCYVolume:                 NewDecimal(gteD0, lteD100).Mutable(true).MustUpdate("1"),
-		MarketLiquidityProvidersFeeDistribitionTimeStep: NewDuration(gte0s, lte1mo).Mutable(true).MustUpdate("0s"),
+		MarketLiquidityProvidersFeeDistributionTimeStep: NewDuration(gte0s, lte1mo).Mutable(true).MustUpdate("0s"),
 		MarketLiquidityTargetStakeTriggeringRatio:       NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0"),
 		MarketProbabilityOfTradingTauScaling:            NewDecimal(gteD1, lteD1000).Mutable(true).MustUpdate("1"),
 		MarketMinProbabilityOfTradingForLPOrders:        NewDecimal(DecimalGTE(num.MustDecimalFromString("1e-12")), DecimalLTE(num.MustDecimalFromString("0.1"))).Mutable(true).MustUpdate("1e-8"),
@@ -88,6 +88,14 @@ func defaultNetParams() map[string]value {
 		MarketLiquidityProvisionShapesMaxSize:           NewInt(gteI1, lteI1000).Mutable(true).MustUpdate("5"),
 		MarketMinLpStakeQuantumMultiple:                 NewDecimal(gtD0, DecimalLT(num.MustDecimalFromString("1e10"))).Mutable(true).MustUpdate("1"),
 		RewardMarketCreationQuantumMultiple:             NewDecimal(gteD1, DecimalLT(num.MustDecimalFromString("1e20"))).Mutable(true).MustUpdate("10000000"),
+
+		// Liquidity version 2.
+		MarketLiquidityV2BondPenaltyParameter:              NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("0.1"),
+		MarketLiquidityV2EarlyExitPenalty:                  NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("0.1"),
+		MarketLiquidityV2MaximumLiquidityFeeFactorLevel:    NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("1"),
+		MarketLiquidityV2SLANonPerformanceBondPenaltyMax:   NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0.5"),
+		MarketLiquidityV2SLANonPerformanceBondPenaltySlope: NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("2"),
+		MarketLiquidityV2StakeToCCYVolume:                  NewDecimal(gteD0, lteD100).Mutable(true).MustUpdate("1"),
 
 		// governance market proposal
 		GovernanceProposalMarketMinClose:              NewDuration(gte1s, lte1y).Mutable(true).MustUpdate("48h0m0s"),

--- a/core/netparams/keys.go
+++ b/core/netparams/keys.go
@@ -24,7 +24,7 @@ const (
 	MarketLiquidityBondPenaltyParameter             = "market.liquidity.bondPenaltyParameter"
 	MarketLiquidityMaximumLiquidityFeeFactorLevel   = "market.liquidity.maximumLiquidityFeeFactorLevel"
 	MarketLiquidityStakeToCCYVolume                 = "market.liquidity.stakeToCcyVolume"
-	MarketLiquidityProvidersFeeDistribitionTimeStep = "market.liquidity.providers.fee.distributionTimeStep"
+	MarketLiquidityProvidersFeeDistributionTimeStep = "market.liquidity.providers.fee.distributionTimeStep"
 	MarketLiquidityTargetStakeTriggeringRatio       = "market.liquidity.targetstake.triggering.ratio"
 	MarketProbabilityOfTradingTauScaling            = "market.liquidity.probabilityOfTrading.tau.scaling"
 	MarketMinProbabilityOfTradingForLPOrders        = "market.liquidity.minimum.probabilityOfTrading.lpOrders"
@@ -35,6 +35,14 @@ const (
 	MarketLiquidityProvisionShapesMaxSize           = "market.liquidityProvision.shapes.maxSize"
 	MarketMinLpStakeQuantumMultiple                 = "market.liquidityProvision.minLpStakeQuantumMultiple"
 	MarketSuccessorLaunchWindow                     = "market.liquidity.successorLaunchWindowLength"
+
+	// Parameters for liquidity framework version 2.
+	MarketLiquidityV2BondPenaltyParameter              = "market.liquidityV2.bondPenaltyParameter"
+	MarketLiquidityV2EarlyExitPenalty                  = "market.liquidityV2.earlyExitPenalty"
+	MarketLiquidityV2MaximumLiquidityFeeFactorLevel    = "market.liquidityV2.maximumLiquidityFeeFactorLevel"
+	MarketLiquidityV2SLANonPerformanceBondPenaltyMax   = "market.liquidityV2.sla.nonPerformanceBondPenaltyMax"
+	MarketLiquidityV2SLANonPerformanceBondPenaltySlope = "market.liquidityV2.sla.nonPerformanceBondPenaltySlope"
+	MarketLiquidityV2StakeToCCYVolume                  = "market.liquidityV2.stakeToCcyVolume"
 
 	RewardAsset = "reward.asset"
 
@@ -211,8 +219,14 @@ var AllKeys = map[string]struct{}{
 	MarketLiquidityBondPenaltyParameter:                      {},
 	MarketLiquidityMaximumLiquidityFeeFactorLevel:            {},
 	MarketLiquidityStakeToCCYVolume:                          {},
-	MarketLiquidityProvidersFeeDistribitionTimeStep:          {},
+	MarketLiquidityProvidersFeeDistributionTimeStep:          {},
 	MarketLiquidityTargetStakeTriggeringRatio:                {},
+	MarketLiquidityV2BondPenaltyParameter:                    {},
+	MarketLiquidityV2EarlyExitPenalty:                        {},
+	MarketLiquidityV2MaximumLiquidityFeeFactorLevel:          {},
+	MarketLiquidityV2SLANonPerformanceBondPenaltySlope:       {},
+	MarketLiquidityV2SLANonPerformanceBondPenaltyMax:         {},
+	MarketLiquidityV2StakeToCCYVolume:                        {},
 	MarketTargetStakeTimeWindow:                              {},
 	MarketTargetStakeScalingFactor:                           {},
 	MarketPriceMonitoringDefaultParameters:                   {},

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -550,7 +550,7 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 			Watcher: svcs.executionEngine.OnMaxPeggedOrderUpdate,
 		},
 		{
-			Param:   netparams.MarketLiquidityProvidersFeeDistribitionTimeStep,
+			Param:   netparams.MarketLiquidityProvidersFeeDistributionTimeStep,
 			Watcher: svcs.executionEngine.OnMarketLiquidityProvidersFeeDistributionTimeStep,
 		},
 		{
@@ -585,6 +585,32 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 			Param:   netparams.MarketMinProbabilityOfTradingForLPOrders,
 			Watcher: svcs.executionEngine.OnMarketMinProbabilityOfTradingForLPOrdersUpdate,
 		},
+		// Liquidity version 2.
+		{
+			Param:   netparams.MarketLiquidityV2BondPenaltyParameter,
+			Watcher: svcs.executionEngine.OnMarketLiquidityV2BondPenaltyUpdate,
+		},
+		{
+			Param:   netparams.MarketLiquidityV2EarlyExitPenalty,
+			Watcher: svcs.executionEngine.OnMarketLiquidityV2EarlyExitPenaltyUpdate,
+		},
+		{
+			Param:   netparams.MarketLiquidityV2MaximumLiquidityFeeFactorLevel,
+			Watcher: svcs.executionEngine.OnMarketLiquidityV2MaximumLiquidityFeeFactorLevelUpdate,
+		},
+		{
+			Param:   netparams.MarketLiquidityV2SLANonPerformanceBondPenaltySlope,
+			Watcher: svcs.executionEngine.OnMarketLiquidityV2SLANonPerformanceBondPenaltySlopeUpdate,
+		},
+		{
+			Param:   netparams.MarketLiquidityV2SLANonPerformanceBondPenaltyMax,
+			Watcher: svcs.executionEngine.OnMarketLiquidityV2SLANonPerformanceBondPenaltyMaxUpdate,
+		},
+		{
+			Param:   netparams.MarketLiquidityV2StakeToCCYVolume,
+			Watcher: svcs.executionEngine.OnMarketLiquidityV2SuppliedStakeToObligationFactorUpdate,
+		},
+		// End of liquidity version 2.
 		{
 			Param:   netparams.ValidatorsEpochLength,
 			Watcher: svcs.epochService.OnEpochLengthUpdate,
@@ -633,7 +659,6 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 			Param:   netparams.NetworkCheckpointTimeElapsedBetweenCheckpoints,
 			Watcher: svcs.checkpoint.OnTimeElapsedUpdate,
 		},
-
 		{
 			Param:   netparams.SnapshotIntervalLength,
 			Watcher: svcs.snapshot.OnSnapshotIntervalUpdate,

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -62,8 +62,6 @@ var (
 	eventsDir          string
 	eventsFile         string
 
-	networkHistoryService *networkhistory.Service
-
 	goldenSourceHistorySegment map[int64]segment.Full
 
 	expectedHistorySegmentsFromHeights = []int64{1, 1001, 2001, 2501, 3001, 4001}
@@ -314,18 +312,18 @@ func TestMain(t *testing.M) {
 		datanodeConfig := config2.NewDefaultConfig()
 		cfg := networkhistory.NewDefaultConfig()
 
-		networkHistoryService, err = networkhistory.NewWithStore(outerCtx, log, chainID, cfg, networkHistoryConnPool, snapshotService,
+		_, err = networkhistory.NewWithStore(outerCtx, log, chainID, cfg, networkHistoryConnPool, snapshotService,
 			networkHistoryStore, datanodeConfig.API.Port, snapshotCopyToPath)
 
 		if err != nil {
 			panic(err)
 		}
 
-		start := time.Now()
+		startTime := time.Now()
 		timeout := 1 * time.Minute
 
 		for {
-			if time.Now().After(start.Add(timeout)) {
+			if time.Now().After(startTime.Add(timeout)) {
 				panic(fmt.Sprintf("history not found in network store after %s", timeout))
 			}
 
@@ -396,7 +394,7 @@ func TestRestoringNodeThatAlreadyContainsData(t *testing.T) {
 
 	log := logging.NewTestLogger()
 
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 	emptyDatabaseAndSetSchemaVersion(highestMigrationNumber)
 
 	snapshotCopyToPath := t.TempDir()
@@ -503,7 +501,7 @@ func TestRestoringNodeThatAlreadyContainsData(t *testing.T) {
 func TestRestoringNodeWithDataOlderAndNewerThanItContainsLoadsTheNewerData(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 
 	log := logging.NewTestLogger()
 
@@ -534,7 +532,7 @@ func TestRestoringNodeWithDataOlderAndNewerThanItContainsLoadsTheNewerData(t *te
 	assert.Equal(t, int64(4000), loaded.LoadedToHeight)
 
 	// Now try to load in history from 0 to 5000
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 	snapshotCopyToPath = t.TempDir()
 	inputSnapshotService = setupSnapshotService(snapshotCopyToPath)
 
@@ -567,7 +565,7 @@ func TestRestoringNodeWithDataOlderAndNewerThanItContainsLoadsTheNewerData(t *te
 func TestRestoringNodeWithHistoryOnlyFromBeforeTheNodesOldestBlockFails(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 
 	log := logging.NewTestLogger()
 
@@ -597,7 +595,7 @@ func TestRestoringNodeWithHistoryOnlyFromBeforeTheNodesOldestBlockFails(t *testi
 	assert.Equal(t, int64(4000), loaded.LoadedToHeight)
 
 	// Now try to load in history from 1000 to 2000
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 	snapshotCopyToPath = t.TempDir()
 	inputSnapshotService = setupSnapshotService(snapshotCopyToPath)
 
@@ -624,7 +622,7 @@ func TestRestoringNodeWithExistingDataFailsWhenLoadingWouldResultInNonContiguous
 
 	log := logging.NewTestLogger()
 
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 	emptyDatabaseAndSetSchemaVersion(highestMigrationNumber)
 
 	snapshotCopyToPath := t.TempDir()
@@ -681,7 +679,7 @@ func TestRestoringNodeWithExistingDataFailsWhenLoadingWouldResultInNonContiguous
 func TestRestoringFromDifferentHeightsWithFullHistory(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 
 	log := logging.NewTestLogger()
 
@@ -724,7 +722,7 @@ func TestRestoringFromDifferentHeightsWithFullHistory(t *testing.T) {
 func TestRestoreFromPartialHistoryAndProcessEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 
 	var err error
 	log := logging.NewTestLogger()
@@ -813,7 +811,7 @@ func TestRestoreFromPartialHistoryAndProcessEvents(t *testing.T) {
 func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 
 	var err error
 	log := logging.NewTestLogger()
@@ -916,7 +914,7 @@ func TestRestoreFromFullHistorySnapshotAndProcessEvents(t *testing.T) {
 func TestRestoreFromFullHistorySnapshotWithIndexesAndOrderTriggersAndProcessEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 
 	var err error
 	log := logging.NewTestLogger()
@@ -1045,7 +1043,7 @@ func TestRollingBackToHeightAcrossSchemaUpdateBoundary(t *testing.T) {
 
 	log := logging.NewTestLogger()
 
-	networkHistoryStore.ResetIndex()
+	require.NoError(t, networkHistoryStore.ResetIndex())
 	emptyDatabaseAndSetSchemaVersion(highestMigrationNumber)
 
 	snapshotCopyToPath := t.TempDir()
@@ -1496,7 +1494,7 @@ func setupTestSQLMigrations() (int64, fs.FS) {
 		panic(err)
 	}
 
-	if os.Mkdir(filepath.Join(testMigrationsDir, sqlstore.SQLMigrationsDir), fs.ModePerm); err != nil {
+	if err := os.Mkdir(filepath.Join(testMigrationsDir, sqlstore.SQLMigrationsDir), fs.ModePerm); err != nil {
 		panic(fmt.Errorf("failed to create migrations dir: %w", err))
 	}
 


### PR DESCRIPTION
I duplicated the network parameters that are both related to the liquidity framework v1 and v2, to prevent them from stepping on each other and provide a clean migration later on. Not all parameter have been duplicated because some are consumed by the underlying `supplied engine` n both engine v1 and v2, as a result we can assume they can be safely mutualized.

Close #8508 