### PR TITLE
fix: pass along max request duration when submitting transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - [8551](https://github.com/vegaprotocol/vega/issues/8551) - Reload market checkpoint data on snapshot loaded.
 - [8486](https://github.com/vegaprotocol/vega/issues/8486) - Fix enactment timestamp being lost in checkpoints.
 - [8572](https://github.com/vegaprotocol/vega/issues/8572) - Fix governance fraction validation
+- [8580](https://github.com/vegaprotocol/vega/issues/8580) - Fix wallet `CLI` ignoring max-request-duration
 
 ## 0.71.0
 

--- a/wallet/api/admin_send_transaction.go
+++ b/wallet/api/admin_send_transaction.go
@@ -249,11 +249,12 @@ func validateAdminSendTransactionParams(rawParams jsonrpc.Params) (ParsedAdminSe
 	}
 
 	return ParsedAdminSendTransactionParams{
-		Wallet:         params.Wallet,
-		PublicKey:      params.PublicKey,
-		RawTransaction: string(tx),
-		Network:        params.Network,
-		NodeAddress:    params.NodeAddress,
-		Retries:        params.Retries,
+		Wallet:                 params.Wallet,
+		PublicKey:              params.PublicKey,
+		RawTransaction:         string(tx),
+		Network:                params.Network,
+		NodeAddress:            params.NodeAddress,
+		Retries:                params.Retries,
+		MaximumRequestDuration: params.MaximumRequestDuration,
 	}, nil
 }


### PR DESCRIPTION
closes #8580 