### PR TITLE
fix: unsubscribe from all data sources when restoring settled market …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - [8453](https://github.com/vegaprotocol/vega/issues/8453) - Do not verify termination timestamp in update market when pre-enacting proposal
 - [8418](https://github.com/vegaprotocol/vega/issues/8418) - Fix data node panics when a bad successor market proposal is rejected
 - [8358](https://github.com/vegaprotocol/vega/issues/8358) - Fix replay protection
+- [8565](https://github.com/vegaprotocol/vega/issues/8565) - Unsubscribe all data sources when restoring a settled market from a snapshot
 - [8451](https://github.com/vegaprotocol/vega/issues/8451) - Fix invalid auction duration for new market proposals.
 - [8500](https://github.com/vegaprotocol/vega/issues/8500) - Fix liquidity provision `ID` is nullable in `GraphQL API`.
 - [8511](https://github.com/vegaprotocol/vega/issues/8511) - Include settled markets in the snapshots

--- a/core/execution/future/market_snapshot.go
+++ b/core/execution/future/market_snapshot.go
@@ -192,7 +192,10 @@ func NewMarketFromSnapshot(
 	liqEngine.SetGetStaticPricesFunc(market.getBestStaticPricesDecimal)
 
 	if mkt.State == types.MarketStateTradingTerminated {
-		market.tradableInstrument.Instrument.Product.UnsubscribeTradingTerminated(ctx)
+		market.tradableInstrument.Instrument.UnsubscribeTradingTerminated(ctx)
+	}
+	if mkt.State == types.MarketStateSettled {
+		market.tradableInstrument.Instrument.Unsubscribe(ctx)
 	}
 
 	if em.Closed {

--- a/core/execution/future/market_snapshot_test.go
+++ b/core/execution/future/market_snapshot_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.VEGA file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package future_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bmocks "code.vegaprotocol.io/vega/core/broker/mocks"
+	"code.vegaprotocol.io/vega/core/collateral"
+	"code.vegaprotocol.io/vega/core/execution/common"
+	"code.vegaprotocol.io/vega/core/execution/common/mocks"
+	"code.vegaprotocol.io/vega/core/execution/future"
+	"code.vegaprotocol.io/vega/core/fee"
+	"code.vegaprotocol.io/vega/core/integration/stubs"
+	"code.vegaprotocol.io/vega/core/liquidity"
+	"code.vegaprotocol.io/vega/core/matching"
+	"code.vegaprotocol.io/vega/core/oracles"
+	"code.vegaprotocol.io/vega/core/positions"
+	"code.vegaprotocol.io/vega/core/products"
+	"code.vegaprotocol.io/vega/core/risk"
+	"code.vegaprotocol.io/vega/core/settlement"
+	"code.vegaprotocol.io/vega/core/types"
+	vegacontext "code.vegaprotocol.io/vega/libs/context"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestoreSettledMarket(t *testing.T) {
+	tm := getSettledMarket(t)
+	em := tm.market.GetState()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	oracleEngine := mocks.NewMockOracleEngine(ctrl)
+
+	var unsubs uint64
+	unsubscribe := func(_ context.Context, id oracles.SubscriptionID) { unsubs++ }
+	oracleEngine.EXPECT().Subscribe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(oracles.SubscriptionID(1), unsubscribe)
+	oracleEngine.EXPECT().Subscribe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(oracles.SubscriptionID(2), unsubscribe)
+
+	snap, err := newMarketFromSnapshot(t, ctrl, em, oracleEngine)
+	require.NoError(t, err)
+	require.NotEmpty(t, snap)
+
+	// check the market is restored settled and that we have unsubscribed the two oracles
+	assert.Equal(t, types.MarketStateSettled, snap.State())
+	assert.Equal(t, uint64(2), unsubs)
+	closed := tm.market.OnTick(vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash()), time.Now())
+	assert.True(t, closed)
+}
+
+func TestRestoreTerminatedMarket(t *testing.T) {
+	tm := getTerminatedMarket(t)
+	em := tm.market.GetState()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	oracleEngine := mocks.NewMockOracleEngine(ctrl)
+
+	var termUnsub bool
+	unsubscribe := func(_ context.Context, id oracles.SubscriptionID) {
+		if id == oracles.SubscriptionID(2) {
+			termUnsub = true
+		}
+	}
+	oracleEngine.EXPECT().Subscribe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(oracles.SubscriptionID(1), unsubscribe)
+	oracleEngine.EXPECT().Subscribe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(oracles.SubscriptionID(2), unsubscribe)
+
+	snap, err := newMarketFromSnapshot(t, ctrl, em, oracleEngine)
+	require.NoError(t, err)
+	require.NotEmpty(t, snap)
+
+	// check the market is restored terminated and that we have unsubscribed one oracles
+	assert.Equal(t, types.MarketStateTradingTerminated, snap.State())
+	assert.True(t, termUnsub)
+	closed := tm.market.OnTick(vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash()), time.Now())
+	assert.False(t, closed)
+}
+
+func getTerminatedMarket(t *testing.T) *testMarket {
+	t.Helper()
+	pubKeys := []*types.Signer{
+		types.CreateSignerFromString("0xDEADBEEF", types.DataSignerTypePubKey),
+	}
+
+	now := time.Unix(10, 0)
+	tm := getTestMarket(t, now, nil, nil)
+	defer tm.ctrl.Finish()
+
+	// terminate the market
+	err := tm.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
+		Signers: pubKeys,
+		Data: map[string]string{
+			"trading.terminated": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.MarketStateTradingTerminated, tm.market.State())
+
+	return tm
+}
+
+func getSettledMarket(t *testing.T) *testMarket {
+	t.Helper()
+
+	tm := getTerminatedMarket(t)
+
+	pubKeys := []*types.Signer{
+		types.CreateSignerFromString("0xDEADBEEF", types.DataSignerTypePubKey),
+	}
+
+	err := tm.oracleEngine.BroadcastData(context.Background(), oracles.OracleData{
+		Signers: pubKeys,
+		Data: map[string]string{
+			"prices.ETH.value": "100",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, types.MarketStateSettled, tm.market.State())
+
+	return tm
+}
+
+// newMarketFromSnapshot is a wrapper for NewMarketFromSnapshot with a lot of defaults handled.
+func newMarketFromSnapshot(t *testing.T, ctrl *gomock.Controller, em *types.ExecMarket, oracleEngine products.OracleEngine) (*future.Market, error) {
+	t.Helper()
+	var (
+		riskConfig       = risk.NewDefaultConfig()
+		positionConfig   = positions.NewDefaultConfig()
+		settlementConfig = settlement.NewDefaultConfig()
+		matchingConfig   = matching.NewDefaultConfig()
+		feeConfig        = fee.NewDefaultConfig()
+		liquidityConfig  = liquidity.NewDefaultConfig()
+	)
+	log := logging.NewTestLogger()
+
+	assets, err := em.Market.GetAssets()
+	require.NoError(t, err)
+	cfgAsset := NewAssetStub(assets[0], em.Market.DecimalPlaces)
+
+	epochEngine := mocks.NewMockEpochEngine(ctrl)
+	epochEngine.EXPECT().NotifyOnEpoch(gomock.Any(), gomock.Any()).Times(1)
+	marketActivityTracker := common.NewMarketActivityTracker(logging.NewTestLogger(), epochEngine)
+	broker := bmocks.NewMockBroker(ctrl)
+	broker.EXPECT().Send(gomock.Any()).AnyTimes()
+	timeService := mocks.NewMockTimeService(ctrl)
+	timeService.EXPECT().GetTimeNow().AnyTimes()
+	collateralEngine := collateral.New(log, collateral.NewDefaultConfig(), timeService, broker)
+
+	positionConfig.StreamPositionVerbose = true
+	return future.NewMarketFromSnapshot(context.Background(), log, em, riskConfig, positionConfig, settlementConfig, matchingConfig,
+		feeConfig, liquidityConfig, collateralEngine, oracleEngine, timeService, broker, stubs.NewStateVar(), cfgAsset, marketActivityTracker,
+		peggedOrderCounterForTest)
+}


### PR DESCRIPTION
closes #8565 

Full system-test run for checking the soak tests: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/23172/pipeline