### PR TITLE
Check filters before sending ethereum call chain events 

### DIFF
--- a/core/evtforward/ethcall/call.go
+++ b/core/evtforward/ethcall/call.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"math/big"
 
+	"code.vegaprotocol.io/vega/core/oracles/filters"
 	"code.vegaprotocol.io/vega/core/types"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -19,6 +21,7 @@ type Call struct {
 	args    []byte
 	abi     abi.ABI
 	abiJSON []byte
+	filters filters.Filters
 }
 
 func NewCall(spec types.EthCallSpec) (Call, error) {
@@ -43,6 +46,11 @@ func NewCall(spec types.EthCallSpec) (Call, error) {
 		return Call{}, fmt.Errorf("failed to pack inputs: %w", err)
 	}
 
+	filters, err := filters.NewFilters(spec.Filters, true)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to create filters: %w", err)
+	}
+
 	return Call{
 		address: common.HexToAddress(spec.Address),
 		method:  spec.Method,
@@ -50,6 +58,7 @@ func NewCall(spec types.EthCallSpec) (Call, error) {
 		abi:     abi,
 		abiJSON: abiJSON,
 		spec:    spec,
+		filters: filters,
 	}, nil
 }
 

--- a/core/evtforward/ethcall/call_test.go
+++ b/core/evtforward/ethcall/call_test.go
@@ -7,6 +7,7 @@ import (
 
 	"code.vegaprotocol.io/vega/core/evtforward/ethcall"
 	"code.vegaprotocol.io/vega/core/types"
+	v1 "code.vegaprotocol.io/vega/protos/vega/data/v1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,4 +86,53 @@ func TestContractCall2(t *testing.T) {
 	assert.Equal(t, args, res.Values)
 
 	assert.Equal(t, map[string]string{"static": "66"}, res.Normalised)
+}
+
+func TestContractFilters(t *testing.T) {
+	ctx := context.Background()
+	tc, err := NewToyChain()
+	require.NoError(t, err)
+
+	args := []any{
+		int64(42),
+		big.NewInt(42),
+		"hello",
+		true,
+		common.HexToAddress("0xb794f5ea0ba39494ce839613fffba74279579268"),
+	}
+
+	argsJson, err := ethcall.AnyArgsToJson(args)
+	require.NoError(t, err)
+
+	spec := types.EthCallSpec{
+		ArgsJson:    argsJson,
+		Address:     tc.contractAddr.Hex(),
+		AbiJson:     tc.abiBytes,
+		Method:      "testy1",
+		Normalisers: map[string]string{"badger": `$[0]`, "static": "66"},
+		Filters: []*types.DataSourceSpecFilter{
+			{
+				Key: &types.DataSourceSpecPropertyKey{
+					Name: "badger",
+					Type: v1.PropertyKey_TYPE_INTEGER,
+				},
+				Conditions: []*types.DataSourceSpecCondition{
+					{
+						Operator: v1.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+						Value:    "50",
+					},
+				},
+			},
+		},
+	}
+
+	call, err := ethcall.NewCall(spec)
+	require.NoError(t, err)
+
+	res, err := call.Call(ctx, tc.client, 1)
+	require.NoError(t, err)
+	assert.NotEmpty(t, res.Bytes)
+	assert.False(t, res.PassesFilters)
+	assert.Equal(t, []any{int64(42), big.NewInt(42), "hello", true, common.HexToAddress("0xb794f5ea0ba39494ce839613fffba74279579268")}, res.Values)
+	assert.Equal(t, map[string]string{"badger": "42", "static": "66"}, res.Normalised)
 }

--- a/core/evtforward/ethcall/result.go
+++ b/core/evtforward/ethcall/result.go
@@ -35,20 +35,10 @@ func newResult(call Call, bytes []byte) (Result, error) {
 		return Result{}, fmt.Errorf("failed to normalise contract call result: %w", err)
 	}
 
-	passesFilters := true
-	// TO BE BE REPLACED BY PHILTER CHANGES - COMMENT IN TO RUN AGAINST SYSTEM TESTS
-	/*
-		passesFilters = false
-		for _, val := range normalised {
-			ival, err := strconv.Atoi(val)
-			if err != nil {
-				return Result{}, fmt.Errorf("unable to convert value to int: %v", err)
-			}
-
-			if ival > 25 {
-				passesFilters = true
-			}
-		} */
+	passesFilters, err := call.filters.Match(normalised)
+	if err != nil {
+		return Result{}, fmt.Errorf("error evaluating filters: %w", err)
+	}
 
 	return Result{
 		Bytes:         bytes,

--- a/core/oracles/filters/filters.go
+++ b/core/oracles/filters/filters.go
@@ -1,0 +1,403 @@
+package filters
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"code.vegaprotocol.io/vega/core/types"
+	"code.vegaprotocol.io/vega/libs/num"
+	datapb "code.vegaprotocol.io/vega/protos/vega/data/v1"
+)
+
+// ErrMissingPropertyKey is returned when a property key is undefined.
+var (
+	ErrMissingPropertyKey = errors.New("a property key is required")
+	// ErrInvalidTimestamp is returned when the timestamp has a negative value
+	// which may happen in case of unsigned integer overflow.
+	ErrInvalidTimestamp = errors.New("invalid timestamp")
+)
+
+type filter struct {
+	propertyName     string
+	propertyType     datapb.PropertyKey_Type
+	numberOfDecimals uint64
+	conditions       []condition
+}
+
+type condition func(string) (bool, error)
+
+type Filters struct {
+	filters map[string]filter
+}
+
+func NewFilters(filtersFromSpec []*types.DataSourceSpecFilter, isExtType bool) (Filters, error) {
+	typedFilters := map[string]filter{}
+	for _, f := range filtersFromSpec {
+		if isExtType {
+			if types.DataSourceSpecPropertyKeyIsEmpty(f.Key) {
+				return Filters{}, ErrMissingPropertyKey
+			}
+
+			_, exist := typedFilters[f.Key.Name]
+			if exist {
+				return Filters{}, types.ErrDataSourceSpecHasMultipleSameKeyNamesInFilterList
+			}
+
+			for _, condition := range f.Conditions {
+				if f.Key.Type == datapb.PropertyKey_TYPE_TIMESTAMP {
+					if condition.Operator == datapb.Condition_OPERATOR_LESS_THAN || condition.Operator == datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL {
+						return Filters{}, types.ErrDataSourceSpecHasInvalidTimeCondition
+					}
+				}
+			}
+
+			conditions, err := toConditions(f.Key.Type, f.Conditions)
+			if err != nil {
+				return Filters{}, err
+			}
+
+			typedFilter, ok := typedFilters[f.Key.Name]
+			var dp uint64
+			if f.Key.NumberDecimalPlaces != nil {
+				dp = *f.Key.NumberDecimalPlaces
+			}
+			if !ok {
+				typedFilters[f.Key.Name] = filter{
+					propertyName:     f.Key.Name,
+					propertyType:     f.Key.Type,
+					numberOfDecimals: dp,
+					conditions:       conditions,
+				}
+				continue
+			}
+
+			if typedFilter.propertyType != f.Key.Type {
+				return Filters{}, errMismatchPropertyType(typedFilter.propertyName, typedFilter.propertyType, f.Key.Type)
+			}
+
+			typedFilter.conditions = append(typedFilter.conditions, conditions...)
+		} else {
+			if len(f.Conditions) < 1 {
+				return Filters{}, types.ErrInternalTimeDataSourceMissingConditions
+			}
+
+			if (f.Conditions[0].Operator == datapb.Condition_OPERATOR_LESS_THAN) || (f.Conditions[0].Operator == datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL) {
+				return Filters{}, types.ErrDataSourceSpecHasInvalidTimeCondition
+			}
+
+			// Currently VEGA network uses only one type of internal data source - time triggered
+			// that uses the property name "vegaprotocol.builtin.timestamp"
+			// https://github.com/vegaprotocol/specs/blob/master/protocol/0048-DSRI-data_source_internal.md#13-vega-time-changed
+			conditions, err := toConditions(datapb.PropertyKey_TYPE_TIMESTAMP, f.Conditions)
+			if err != nil {
+				return Filters{}, err
+			}
+			typedFilters[f.Key.Name] = filter{
+				propertyName: "vegaprotocol.builtin.timestamp",
+				propertyType: datapb.PropertyKey_TYPE_TIMESTAMP,
+				conditions:   []condition{conditions[0]},
+			}
+		}
+	}
+
+	return Filters{
+		filters: typedFilters,
+	}, nil
+}
+
+func (f Filters) Match(data map[string]string) (bool, error) {
+	for propertyName, filter := range f.filters {
+		dataValue, ok := data[propertyName]
+		if !ok {
+			return false, nil
+		}
+
+		for _, condition := range filter.conditions {
+			if matched, err := condition(dataValue); !matched || err != nil {
+				return false, err
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func (f Filters) EnsureBoundableProperty(property string, propType datapb.PropertyKey_Type) error {
+	filter, ok := f.filters[property]
+	if !ok {
+		return fmt.Errorf("bound property \"%s\" not filtered by oracle spec", property)
+	}
+
+	if filter.propertyType != propType {
+		return fmt.Errorf("bound type \"%v\" doesn't match filtered property type \"%s\"", propType, filter.propertyType)
+	}
+
+	return nil
+}
+
+var conditionConverters = map[datapb.PropertyKey_Type]func(*types.OracleSpecCondition) (condition, error){
+	datapb.PropertyKey_TYPE_INTEGER:   toIntegerCondition,
+	datapb.PropertyKey_TYPE_DECIMAL:   toDecimalCondition,
+	datapb.PropertyKey_TYPE_BOOLEAN:   toBooleanCondition,
+	datapb.PropertyKey_TYPE_TIMESTAMP: toTimestampCondition,
+	datapb.PropertyKey_TYPE_STRING:    toStringCondition,
+}
+
+func toConditions(typ datapb.PropertyKey_Type, cs []*types.OracleSpecCondition) ([]condition, error) {
+	converter, ok := conditionConverters[typ]
+	if !ok {
+		return nil, errUnsupportedPropertyType(typ)
+	}
+
+	conditions := make([]condition, 0, len(cs))
+	for _, c := range cs {
+		cond, err := converter(c)
+		if err != nil {
+			return nil, err
+		}
+
+		conditions = append(conditions, cond)
+	}
+	return conditions, nil
+}
+
+func toIntegerCondition(c *types.OracleSpecCondition) (condition, error) {
+	condValue, err := ToInteger(c.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	matcher, ok := integerMatchers[c.Operator]
+	if !ok {
+		return nil, err
+	}
+
+	return func(dataValue string) (bool, error) {
+		parsedDataValue, err := ToInteger(dataValue)
+		if err != nil {
+			return false, err
+		}
+		return matcher(parsedDataValue, condValue), nil
+	}, nil
+}
+
+func ToInteger(value string) (*num.Int, error) {
+	convertedValue, hasError := num.IntFromString(value, 10)
+	if hasError {
+		return nil, fmt.Errorf("value \"%s\" is not a valid integer", value)
+	}
+	return convertedValue, nil
+}
+
+var integerMatchers = map[datapb.Condition_Operator]func(*num.Int, *num.Int) bool{
+	datapb.Condition_OPERATOR_EQUALS:                equalsInteger,
+	datapb.Condition_OPERATOR_GREATER_THAN:          greaterThanInteger,
+	datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL: greaterThanOrEqualInteger,
+	datapb.Condition_OPERATOR_LESS_THAN:             lessThanInteger,
+	datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL:    lessThanOrEqualInteger,
+}
+
+func equalsInteger(dataValue, condValue *num.Int) bool {
+	return dataValue.EQ(condValue)
+}
+
+func greaterThanInteger(dataValue, condValue *num.Int) bool {
+	return dataValue.GT(condValue)
+}
+
+func greaterThanOrEqualInteger(dataValue, condValue *num.Int) bool {
+	return dataValue.GTE(condValue)
+}
+
+func lessThanInteger(dataValue, condValue *num.Int) bool {
+	return dataValue.LT(condValue)
+}
+
+func lessThanOrEqualInteger(dataValue, condValue *num.Int) bool {
+	return dataValue.LTE(condValue)
+}
+
+func toDecimalCondition(c *types.OracleSpecCondition) (condition, error) {
+	condValue, err := ToDecimal(c.Value)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing decimal: %s", err.Error())
+	}
+
+	matcher, ok := decimalMatchers[c.Operator]
+	if !ok {
+		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_DECIMAL)
+	}
+
+	return func(dataValue string) (bool, error) {
+		parsedDataValue, err := ToDecimal(dataValue)
+		if err != nil {
+			return false, fmt.Errorf("error parsing decimal: %s", err.Error())
+		}
+		return matcher(parsedDataValue, condValue), nil
+	}, nil
+}
+
+func ToDecimal(value string) (num.Decimal, error) {
+	return num.DecimalFromString(value)
+}
+
+var decimalMatchers = map[datapb.Condition_Operator]func(num.Decimal, num.Decimal) bool{
+	datapb.Condition_OPERATOR_EQUALS:                equalsDecimal,
+	datapb.Condition_OPERATOR_GREATER_THAN:          greaterThanDecimal,
+	datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL: greaterThanOrEqualDecimal,
+	datapb.Condition_OPERATOR_LESS_THAN:             lessThanDecimal,
+	datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL:    lessThanOrEqualDecimal,
+}
+
+func equalsDecimal(dataValue, condValue num.Decimal) bool {
+	return dataValue.Equal(condValue)
+}
+
+func greaterThanDecimal(dataValue, condValue num.Decimal) bool {
+	return dataValue.GreaterThan(condValue)
+}
+
+func greaterThanOrEqualDecimal(dataValue, condValue num.Decimal) bool {
+	return dataValue.GreaterThanOrEqual(condValue)
+}
+
+func lessThanDecimal(dataValue, condValue num.Decimal) bool {
+	return dataValue.LessThan(condValue)
+}
+
+func lessThanOrEqualDecimal(dataValue, condValue num.Decimal) bool {
+	return dataValue.LessThanOrEqual(condValue)
+}
+
+func toTimestampCondition(c *types.OracleSpecCondition) (condition, error) {
+	condValue, err := ToTimestamp(c.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	matcher, ok := timestampMatchers[c.Operator]
+	if !ok {
+		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_TIMESTAMP)
+	}
+
+	return func(dataValue string) (bool, error) {
+		parsedDataValue, err := ToTimestamp(dataValue)
+		if err != nil {
+			return false, err
+		}
+		return matcher(parsedDataValue, condValue), nil
+	}, nil
+}
+
+func ToTimestamp(value string) (int64, error) {
+	parsedValue, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return parsedValue, ErrInvalidTimestamp
+	}
+
+	if parsedValue < 0 {
+		return parsedValue, ErrInvalidTimestamp
+	}
+	return parsedValue, nil
+}
+
+var timestampMatchers = map[datapb.Condition_Operator]func(int64, int64) bool{
+	datapb.Condition_OPERATOR_EQUALS:                equalsTimestamp,
+	datapb.Condition_OPERATOR_GREATER_THAN:          greaterThanTimestamp,
+	datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL: greaterThanOrEqualTimestamp,
+	datapb.Condition_OPERATOR_LESS_THAN:             lessThanTimestamp,
+	datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL:    lessThanOrEqualTimestamp,
+}
+
+func equalsTimestamp(dataValue, condValue int64) bool {
+	return dataValue == condValue
+}
+
+func greaterThanTimestamp(dataValue, condValue int64) bool {
+	return dataValue > condValue
+}
+
+func greaterThanOrEqualTimestamp(dataValue, condValue int64) bool {
+	return dataValue >= condValue
+}
+
+func lessThanTimestamp(dataValue, condValue int64) bool {
+	return dataValue < condValue
+}
+
+func lessThanOrEqualTimestamp(dataValue, condValue int64) bool {
+	return dataValue <= condValue
+}
+
+func toBooleanCondition(c *types.OracleSpecCondition) (condition, error) {
+	condValue, err := ToBoolean(c.Value)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing boolean: %s", err.Error())
+	}
+
+	matcher, ok := booleanMatchers[c.Operator]
+	if !ok {
+		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_BOOLEAN)
+	}
+
+	return func(dataValue string) (bool, error) {
+		parsedDataValue, err := ToBoolean(dataValue)
+		if err != nil {
+			return false, fmt.Errorf("error parsing boolean: %s", err.Error())
+		}
+		return matcher(parsedDataValue, condValue), nil
+	}, nil
+}
+
+func ToBoolean(value string) (bool, error) {
+	return strconv.ParseBool(value)
+}
+
+var booleanMatchers = map[datapb.Condition_Operator]func(bool, bool) bool{
+	datapb.Condition_OPERATOR_EQUALS: equalsBoolean,
+}
+
+func equalsBoolean(dataValue, condValue bool) bool {
+	return dataValue == condValue
+}
+
+func toStringCondition(c *types.OracleSpecCondition) (condition, error) {
+	matcher, ok := stringMatchers[c.Operator]
+	if !ok {
+		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_STRING)
+	}
+
+	return func(dataValue string) (bool, error) {
+		return matcher(dataValue, c.Value), nil
+	}, nil
+}
+
+var stringMatchers = map[datapb.Condition_Operator]func(string, string) bool{
+	datapb.Condition_OPERATOR_EQUALS: equalsString,
+}
+
+func equalsString(dataValue, condValue string) bool {
+	return dataValue == condValue
+}
+
+// errUnsupportedOperatorForType is returned when the property type does not
+// support the specified operator.
+func errUnsupportedOperatorForType(o datapb.Condition_Operator, t datapb.PropertyKey_Type) error {
+	return fmt.Errorf("unsupported operator %s for type %s", o, t)
+}
+
+// errUnsupportedPropertyType is returned when the filter specifies an
+// unsupported property key type.
+func errUnsupportedPropertyType(typ datapb.PropertyKey_Type) error {
+	return fmt.Errorf("property type %s", typ)
+}
+
+// errMismatchPropertyType is returned when a property is redeclared in
+// conditions but with a different type.
+func errMismatchPropertyType(prop string, first, newP datapb.PropertyKey_Type) error {
+	return fmt.Errorf(
+		"cannot redeclared property %s with different type, first %s then %s",
+		prop, first, newP,
+	)
+}

--- a/core/oracles/oracle_data.go
+++ b/core/oracles/oracle_data.go
@@ -15,6 +15,7 @@ package oracles
 import (
 	"fmt"
 
+	"code.vegaprotocol.io/vega/core/oracles/filters"
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/libs/num"
 	"code.vegaprotocol.io/vega/logging"
@@ -47,7 +48,7 @@ func (d OracleData) GetInteger(propertyName string) (*num.Int, error) {
 	if !ok {
 		return num.IntZero(), errPropertyNotFound(propertyName)
 	}
-	return toInteger(value)
+	return filters.ToInteger(value)
 }
 
 // GetDecimal converts the value associated to propertyName into a decimal.
@@ -56,7 +57,7 @@ func (d OracleData) GetDecimal(propertyName string) (num.Decimal, error) {
 	if !ok {
 		return num.DecimalZero(), errPropertyNotFound(propertyName)
 	}
-	return toDecimal(value)
+	return filters.ToDecimal(value)
 }
 
 // GetBoolean converts the value associated to propertyName into a boolean.
@@ -65,7 +66,7 @@ func (d OracleData) GetBoolean(propertyName string) (bool, error) {
 	if !ok {
 		return false, errPropertyNotFound(propertyName)
 	}
-	return toBoolean(value)
+	return filters.ToBoolean(value)
 }
 
 // GetString returns the value associated to propertyName.
@@ -83,7 +84,7 @@ func (d OracleData) GetTimestamp(propertyName string) (int64, error) {
 	if !ok {
 		return 0, errPropertyNotFound(propertyName)
 	}
-	return toTimestamp(value)
+	return filters.ToTimestamp(value)
 }
 
 // FromInternalOracle returns true if the oracle data has been emitted by an

--- a/core/oracles/oracle_spec.go
+++ b/core/oracles/oracle_spec.go
@@ -14,12 +14,10 @@ package oracles
 
 import (
 	"errors"
-	"fmt"
-	"strconv"
 	"strings"
 
+	"code.vegaprotocol.io/vega/core/oracles/filters"
 	"code.vegaprotocol.io/vega/core/types"
-	"code.vegaprotocol.io/vega/libs/num"
 	datapb "code.vegaprotocol.io/vega/protos/vega/data/v1"
 )
 
@@ -31,11 +29,7 @@ var (
 	// has no expected properties nor filters. At least one of these should be
 	// defined.
 	ErrAtLeastOneFilterIsRequired = errors.New("at least one filter is required")
-	// ErrInvalidTimestamp is returned when the timestamp has a negative value
-	// which may happen in case of unsigned integer overflow.
-	ErrInvalidTimestamp = errors.New("invalid timestamp")
-	// ErrMissingPropertyKey is returned when a property key is undefined.
-	ErrMissingPropertyKey = errors.New("a property key is required")
+
 	// ErrMissingPropertyName is returned when a property as no name.
 	ErrMissingPropertyName = errors.New("a property name is required")
 	// ErrInvalidPropertyKey is returned if validation finds a reserved Vega property key.
@@ -54,19 +48,10 @@ type OracleSpec struct {
 
 	// filters holds all the expected property keys with the conditions they
 	// should match.
-	filters map[string]*filter
+	filters filters.Filters
 	// OriginalSpec is the protobuf description of OracleSpec
 	OriginalSpec *types.OracleSpec
 }
-
-type filter struct {
-	propertyName     string
-	propertyType     datapb.PropertyKey_Type
-	numberOfDecimals uint64
-	conditions       []condition
-}
-
-type condition func(string) (bool, error)
 
 // NewOracleSpec builds an OracleSpec from a types.OracleSpec (currently uses one level below - types.ExternalDataSourceSpec) in a form that
 // suits the processing of the filters.
@@ -93,82 +78,21 @@ func NewOracleSpec(originalSpec types.ExternalDataSourceSpec) (*OracleSpec, erro
 		}
 	}
 
-	// We check if the filters list is empty in the proposal submission step.
-	// We do not need to double that logic here.
-
 	builtInKey := false
-	typedFilters := map[string]*filter{}
 	for _, f := range filtersFromSpec {
 		if isExtType {
-			if types.DataSourceSpecPropertyKeyIsEmpty(f.Key) {
-				return nil, ErrMissingPropertyKey
-			}
-
-			_, exist := typedFilters[f.Key.Name]
-			if exist {
-				return nil, types.ErrDataSourceSpecHasMultipleSameKeyNamesInFilterList
-			}
-
 			if strings.HasPrefix(f.Key.Name, "vegaprotocol.builtin") && f.Key.Type == datapb.PropertyKey_TYPE_TIMESTAMP {
 				builtInKey = true
 			}
-
-			for _, condition := range f.Conditions {
-				if f.Key.Type == datapb.PropertyKey_TYPE_TIMESTAMP {
-					if condition.Operator == datapb.Condition_OPERATOR_LESS_THAN || condition.Operator == datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL {
-						return nil, types.ErrDataSourceSpecHasInvalidTimeCondition
-					}
-				}
-			}
-
-			conditions, err := toConditions(f.Key.Type, f.Conditions)
-			if err != nil {
-				return nil, err
-			}
-
-			typedFilter, ok := typedFilters[f.Key.Name]
-			var dp uint64
-			if f.Key.NumberDecimalPlaces != nil {
-				dp = *f.Key.NumberDecimalPlaces
-			}
-			if !ok {
-				typedFilters[f.Key.Name] = &filter{
-					propertyName:     f.Key.Name,
-					propertyType:     f.Key.Type,
-					numberOfDecimals: dp,
-					conditions:       conditions,
-				}
-				continue
-			}
-
-			if typedFilter.propertyType != f.Key.Type {
-				return nil, errMismatchPropertyType(typedFilter.propertyName, typedFilter.propertyType, f.Key.Type)
-			}
-
-			typedFilter.conditions = append(typedFilter.conditions, conditions...)
-		} else {
-			if len(f.Conditions) < 1 {
-				return nil, types.ErrInternalTimeDataSourceMissingConditions
-			}
-
-			if (f.Conditions[0].Operator == datapb.Condition_OPERATOR_LESS_THAN) || (f.Conditions[0].Operator == datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL) {
-				return nil, types.ErrDataSourceSpecHasInvalidTimeCondition
-			}
-
-			// Currently VEGA network uses only one type of internal data source - time triggered
-			// that uses the property name "vegaprotocol.builtin.timestamp"
-			// https://github.com/vegaprotocol/specs/blob/master/protocol/0048-DSRI-data_source_internal.md#13-vega-time-changed
-			conditions, err := toConditions(datapb.PropertyKey_TYPE_TIMESTAMP, f.Conditions)
-			if err != nil {
-				return nil, err
-			}
-			typedFilters[f.Key.Name] = &filter{
-				propertyName: "vegaprotocol.builtin.timestamp",
-				propertyType: datapb.PropertyKey_TYPE_TIMESTAMP,
-				conditions:   []condition{conditions[0]},
-			}
 		}
 	}
+
+	typedFilters, err := filters.NewFilters(filtersFromSpec, isExtType)
+	if err != nil {
+		return nil, err
+	}
+	// We check if the filters list is empty in the proposal submission step.
+	// We do not need to double that logic here.
 
 	signers := map[string]struct{}{}
 	if !builtInKey && isExtType {
@@ -201,16 +125,7 @@ func NewOracleSpec(originalSpec types.ExternalDataSourceSpec) (*OracleSpec, erro
 }
 
 func (s OracleSpec) EnsureBoundableProperty(property string, propType datapb.PropertyKey_Type) error {
-	filter, ok := s.filters[property]
-	if !ok {
-		return fmt.Errorf("bound property \"%s\" not filtered by oracle spec", property)
-	}
-
-	if filter.propertyType != propType {
-		return fmt.Errorf("bound type \"%v\" doesn't match filtered property type \"%s\"", propType, filter.propertyType)
-	}
-
-	return nil
+	return s.filters.EnsureBoundableProperty(property, propType)
 }
 
 func isInternalOracleData(data OracleData) bool {
@@ -238,20 +153,7 @@ func (s *OracleSpec) MatchData(data OracleData) (bool, error) {
 		return false, nil
 	}
 
-	for propertyName, filter := range s.filters {
-		dataValue, ok := data.Data[propertyName]
-		if !ok {
-			return false, nil
-		}
-
-		for _, condition := range filter.conditions {
-			if matched, err := condition(dataValue); !matched || err != nil {
-				return false, err
-			}
-		}
-	}
-
-	return true, nil
+	return s.filters.Match(data.Data)
 }
 
 // containsRequiredSigners verifies if all the public keys in the OracleData
@@ -263,270 +165,4 @@ func containsRequiredSigners(dataSigners []*types.Signer, authPks map[string]str
 		}
 	}
 	return true
-}
-
-var conditionConverters = map[datapb.PropertyKey_Type]func(*types.OracleSpecCondition) (condition, error){
-	datapb.PropertyKey_TYPE_INTEGER:   toIntegerCondition,
-	datapb.PropertyKey_TYPE_DECIMAL:   toDecimalCondition,
-	datapb.PropertyKey_TYPE_BOOLEAN:   toBooleanCondition,
-	datapb.PropertyKey_TYPE_TIMESTAMP: toTimestampCondition,
-	datapb.PropertyKey_TYPE_STRING:    toStringCondition,
-}
-
-func toConditions(typ datapb.PropertyKey_Type, cs []*types.OracleSpecCondition) ([]condition, error) {
-	converter, ok := conditionConverters[typ]
-	if !ok {
-		return nil, errUnsupportedPropertyType(typ)
-	}
-
-	conditions := make([]condition, 0, len(cs))
-	for _, c := range cs {
-		cond, err := converter(c)
-		if err != nil {
-			return nil, err
-		}
-
-		conditions = append(conditions, cond)
-	}
-	return conditions, nil
-}
-
-func toIntegerCondition(c *types.OracleSpecCondition) (condition, error) {
-	condValue, err := toInteger(c.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	matcher, ok := integerMatchers[c.Operator]
-	if !ok {
-		return nil, err
-	}
-
-	return func(dataValue string) (bool, error) {
-		parsedDataValue, err := toInteger(dataValue)
-		if err != nil {
-			return false, err
-		}
-		return matcher(parsedDataValue, condValue), nil
-	}, nil
-}
-
-func toInteger(value string) (*num.Int, error) {
-	convertedValue, hasError := num.IntFromString(value, 10)
-	if hasError {
-		return nil, fmt.Errorf("value \"%s\" is not a valid integer", value)
-	}
-	return convertedValue, nil
-}
-
-var integerMatchers = map[datapb.Condition_Operator]func(*num.Int, *num.Int) bool{
-	datapb.Condition_OPERATOR_EQUALS:                equalsInteger,
-	datapb.Condition_OPERATOR_GREATER_THAN:          greaterThanInteger,
-	datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL: greaterThanOrEqualInteger,
-	datapb.Condition_OPERATOR_LESS_THAN:             lessThanInteger,
-	datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL:    lessThanOrEqualInteger,
-}
-
-func equalsInteger(dataValue, condValue *num.Int) bool {
-	return dataValue.EQ(condValue)
-}
-
-func greaterThanInteger(dataValue, condValue *num.Int) bool {
-	return dataValue.GT(condValue)
-}
-
-func greaterThanOrEqualInteger(dataValue, condValue *num.Int) bool {
-	return dataValue.GTE(condValue)
-}
-
-func lessThanInteger(dataValue, condValue *num.Int) bool {
-	return dataValue.LT(condValue)
-}
-
-func lessThanOrEqualInteger(dataValue, condValue *num.Int) bool {
-	return dataValue.LTE(condValue)
-}
-
-func toDecimalCondition(c *types.OracleSpecCondition) (condition, error) {
-	condValue, err := toDecimal(c.Value)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing decimal: %s", err.Error())
-	}
-
-	matcher, ok := decimalMatchers[c.Operator]
-	if !ok {
-		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_DECIMAL)
-	}
-
-	return func(dataValue string) (bool, error) {
-		parsedDataValue, err := toDecimal(dataValue)
-		if err != nil {
-			return false, fmt.Errorf("error parsing decimal: %s", err.Error())
-		}
-		return matcher(parsedDataValue, condValue), nil
-	}, nil
-}
-
-func toDecimal(value string) (num.Decimal, error) {
-	return num.DecimalFromString(value)
-}
-
-var decimalMatchers = map[datapb.Condition_Operator]func(num.Decimal, num.Decimal) bool{
-	datapb.Condition_OPERATOR_EQUALS:                equalsDecimal,
-	datapb.Condition_OPERATOR_GREATER_THAN:          greaterThanDecimal,
-	datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL: greaterThanOrEqualDecimal,
-	datapb.Condition_OPERATOR_LESS_THAN:             lessThanDecimal,
-	datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL:    lessThanOrEqualDecimal,
-}
-
-func equalsDecimal(dataValue, condValue num.Decimal) bool {
-	return dataValue.Equal(condValue)
-}
-
-func greaterThanDecimal(dataValue, condValue num.Decimal) bool {
-	return dataValue.GreaterThan(condValue)
-}
-
-func greaterThanOrEqualDecimal(dataValue, condValue num.Decimal) bool {
-	return dataValue.GreaterThanOrEqual(condValue)
-}
-
-func lessThanDecimal(dataValue, condValue num.Decimal) bool {
-	return dataValue.LessThan(condValue)
-}
-
-func lessThanOrEqualDecimal(dataValue, condValue num.Decimal) bool {
-	return dataValue.LessThanOrEqual(condValue)
-}
-
-func toTimestampCondition(c *types.OracleSpecCondition) (condition, error) {
-	condValue, err := toTimestamp(c.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	matcher, ok := timestampMatchers[c.Operator]
-	if !ok {
-		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_TIMESTAMP)
-	}
-
-	return func(dataValue string) (bool, error) {
-		parsedDataValue, err := toTimestamp(dataValue)
-		if err != nil {
-			return false, err
-		}
-		return matcher(parsedDataValue, condValue), nil
-	}, nil
-}
-
-func toTimestamp(value string) (int64, error) {
-	parsedValue, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return parsedValue, ErrInvalidTimestamp
-	}
-
-	if parsedValue < 0 {
-		return parsedValue, ErrInvalidTimestamp
-	}
-	return parsedValue, nil
-}
-
-var timestampMatchers = map[datapb.Condition_Operator]func(int64, int64) bool{
-	datapb.Condition_OPERATOR_EQUALS:                equalsTimestamp,
-	datapb.Condition_OPERATOR_GREATER_THAN:          greaterThanTimestamp,
-	datapb.Condition_OPERATOR_GREATER_THAN_OR_EQUAL: greaterThanOrEqualTimestamp,
-	datapb.Condition_OPERATOR_LESS_THAN:             lessThanTimestamp,
-	datapb.Condition_OPERATOR_LESS_THAN_OR_EQUAL:    lessThanOrEqualTimestamp,
-}
-
-func equalsTimestamp(dataValue, condValue int64) bool {
-	return dataValue == condValue
-}
-
-func greaterThanTimestamp(dataValue, condValue int64) bool {
-	return dataValue > condValue
-}
-
-func greaterThanOrEqualTimestamp(dataValue, condValue int64) bool {
-	return dataValue >= condValue
-}
-
-func lessThanTimestamp(dataValue, condValue int64) bool {
-	return dataValue < condValue
-}
-
-func lessThanOrEqualTimestamp(dataValue, condValue int64) bool {
-	return dataValue <= condValue
-}
-
-func toBooleanCondition(c *types.OracleSpecCondition) (condition, error) {
-	condValue, err := toBoolean(c.Value)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing boolean: %s", err.Error())
-	}
-
-	matcher, ok := booleanMatchers[c.Operator]
-	if !ok {
-		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_BOOLEAN)
-	}
-
-	return func(dataValue string) (bool, error) {
-		parsedDataValue, err := toBoolean(dataValue)
-		if err != nil {
-			return false, fmt.Errorf("error parsing boolean: %s", err.Error())
-		}
-		return matcher(parsedDataValue, condValue), nil
-	}, nil
-}
-
-func toBoolean(value string) (bool, error) {
-	return strconv.ParseBool(value)
-}
-
-var booleanMatchers = map[datapb.Condition_Operator]func(bool, bool) bool{
-	datapb.Condition_OPERATOR_EQUALS: equalsBoolean,
-}
-
-func equalsBoolean(dataValue, condValue bool) bool {
-	return dataValue == condValue
-}
-
-func toStringCondition(c *types.OracleSpecCondition) (condition, error) {
-	matcher, ok := stringMatchers[c.Operator]
-	if !ok {
-		return nil, errUnsupportedOperatorForType(c.Operator, datapb.PropertyKey_TYPE_STRING)
-	}
-
-	return func(dataValue string) (bool, error) {
-		return matcher(dataValue, c.Value), nil
-	}, nil
-}
-
-var stringMatchers = map[datapb.Condition_Operator]func(string, string) bool{
-	datapb.Condition_OPERATOR_EQUALS: equalsString,
-}
-
-func equalsString(dataValue, condValue string) bool {
-	return dataValue == condValue
-}
-
-// errMismatchPropertyType is returned when a property is redeclared in
-// conditions but with a different type.
-func errMismatchPropertyType(prop string, first, newP datapb.PropertyKey_Type) error {
-	return fmt.Errorf(
-		"cannot redeclared property %s with different type, first %s then %s",
-		prop, first, newP,
-	)
-}
-
-// errUnsupportedOperatorForType is returned when the property type does not
-// support the specified operator.
-func errUnsupportedOperatorForType(o datapb.Condition_Operator, t datapb.PropertyKey_Type) error {
-	return fmt.Errorf("unsupported operator %s for type %s", o, t)
-}
-
-// errUnsupportedPropertyType is returned when the filter specifies an
-// unsupported property key type.
-func errUnsupportedPropertyType(typ datapb.PropertyKey_Type) error {
-	return fmt.Errorf("property type %s", typ)
 }


### PR DESCRIPTION
Required moving out the filter logic in the oracle package into a sub-package to prevent circular imports