### PR TITLE
fix: add iceberg order fields to live_orders trigger function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 - [8418](https://github.com/vegaprotocol/vega/issues/8418) - Fix data node panics when a bad successor market proposal is rejected
 - [8358](https://github.com/vegaprotocol/vega/issues/8358) - Fix replay protection
 - [8565](https://github.com/vegaprotocol/vega/issues/8565) - Unsubscribe all data sources when restoring a settled market from a snapshot
+- [8578](https://github.com/vegaprotocol/vega/issues/8578) - Add iceberg option fields to live orders trigger
 - [8451](https://github.com/vegaprotocol/vega/issues/8451) - Fix invalid auction duration for new market proposals.
 - [8500](https://github.com/vegaprotocol/vega/issues/8500) - Fix liquidity provision `ID` is nullable in `GraphQL API`.
 - [8511](https://github.com/vegaprotocol/vega/issues/8511) - Include settled markets in the snapshots

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -363,12 +363,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmSZrLL2E3Q7XijyvJaYR6zt1vxkRUkLq3UFYbFSnqLiR8", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmQ2N7VS1wMWCDLJ7zgY6bmGJuqd2bZ5P63rmSM2UhHPt9", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmS86xTYxqHTtC4Km9K4PTf8EzgD5hgtxZv27D1oKAimG8", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmSJE8twXuNwN8JaFQQnEYmWjEmMVPYjiNSBUaRqYCfBiG", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmRRkNZLeRn7rKLwUBEEtDg6E1uRfPSMqPeauR8o34TJPv", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmXFiddBzYCVXF4iwigQAnWks6a49Uj4Z85qSiqKwXm4kv", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "Qmdh4wMnFpVuWj8nDgSkPo6ZDvK6ZSg951VsQERWEdAcg4", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmbkWbpwLa5Avv3kZV8DmN2zMu6RgXs92ZxHkDiQhBa3Wo", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmRDUTgdZYjYb6p9waGMHUXPxSgTc3bQm2kWBSeoJHf5X9", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmRFPgojy6rUAJxQ3ihNfEFrcMLjKWtTFRZrENnrTw1cWe", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmXkkomy4zRA7TLJnGcL3PDeEpVAWxA4Le4wU3KGvZ2FMA", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmfP1215QNekU7ngK4uv1cMA3DxViMKHaVYsEJmzr7wmRP", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0008_iceberg_live_orders.sql
+++ b/datanode/sqlstore/migrations/0008_iceberg_live_orders.sql
@@ -1,0 +1,68 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE OR REPLACE FUNCTION archive_orders()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL AS
+$$
+BEGIN
+
+    DELETE from orders_live
+    WHERE id = NEW.id;
+
+    -- As per https://github.com/vegaprotocol/specs-internal/blob/master/protocol/0024-OSTA-order_status.md
+-- we consider an order 'live' if it either ACTIVE (status=1) or PARKED (status=8). Orders
+-- with statuses other than this are discarded by core, so we consider them candidates for
+-- eventual deletion according to the data retention policy by placing them in orders_history.
+-- As per https://github.com/vegaprotocol/vega/issues/8149, only LIMIT type (1) orders with status active (1) and parked (8)
+-- and time_in_force != IOC (3) and time_in_force != FOK (4) are considered live.
+    IF NEW.status IN (1, 8) AND NEW.type = 1 AND NEW.time_in_force NOT IN (3, 4)
+    THEN
+        INSERT INTO orders_live
+        VALUES(new.id, new.market_id, new.party_id, new.side, new.price,
+               new.size, new.remaining, new.time_in_force, new.type, new.status,
+               new.reference, new.reason, new.version, new.batch_id, new.pegged_offset,
+               new.pegged_reference, new.lp_id, new.created_at, new.updated_at, new.expires_at,
+               new.tx_hash, new.vega_time, new.seq_num, new.post_only, new.reduce_only, new.reserved_remaining, new.peak_size, new.minimum_visible_size);
+    END IF;
+
+    RETURN NEW;
+
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+
+CREATE OR REPLACE FUNCTION archive_orders()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL AS
+$$
+BEGIN
+
+    DELETE from orders_live
+    WHERE id = NEW.id;
+
+    -- As per https://github.com/vegaprotocol/specs-internal/blob/master/protocol/0024-OSTA-order_status.md
+-- we consider an order 'live' if it either ACTIVE (status=1) or PARKED (status=8). Orders
+-- with statuses other than this are discarded by core, so we consider them candidates for
+-- eventual deletion according to the data retention policy by placing them in orders_history.
+-- As per https://github.com/vegaprotocol/vega/issues/8149, only LIMIT type (1) orders with status active (1) and parked (8)
+-- and time_in_force != IOC (3) and time_in_force != FOK (4) are considered live.
+    IF NEW.status IN (1, 8) AND NEW.type = 1 AND NEW.time_in_force NOT IN (3, 4)
+    THEN
+        INSERT INTO orders_live
+        VALUES(new.id, new.market_id, new.party_id, new.side, new.price,
+               new.size, new.remaining, new.time_in_force, new.type, new.status,
+               new.reference, new.reason, new.version, new.batch_id, new.pegged_offset,
+               new.pegged_reference, new.lp_id, new.created_at, new.updated_at, new.expires_at,
+               new.tx_hash, new.vega_time, new.seq_num, new.post_only, new.reduce_only);
+    END IF;
+
+    RETURN NEW;
+
+END;
+$$;
+-- +goose StatementEnd

--- a/datanode/sqlstore/orders_test.go
+++ b/datanode/sqlstore/orders_test.go
@@ -244,6 +244,21 @@ func TestOrders(t *testing.T) {
 			assert.Equal(t, berg.ReservedRemaining, o.ReservedRemaining)
 		}
 	})
+	t.Run("GetLiveOrders_Icebergs", func(t *testing.T) {
+		orders, err := os.GetLiveOrders(ctx)
+		require.NoError(t, err)
+		om := map[string]entities.Order{}
+		for _, o := range orders {
+			om[o.ID.String()] = o
+		}
+		for _, berg := range icebergs {
+			cmp, ok := om[berg.ID.String()]
+			require.True(t, ok)
+			assert.Equal(t, berg.PeakSize, cmp.PeakSize)
+			assert.Equal(t, berg.MinimumVisibleSize, cmp.MinimumVisibleSize)
+			assert.Equal(t, berg.ReservedRemaining, cmp.ReservedRemaining)
+		}
+	})
 }
 
 func generateTestBlocks(t *testing.T, ctx context.Context, numBlocks int, bs *sqlstore.Blocks) []entities.Block {


### PR DESCRIPTION
closes #8578 

In the other iceberg migration file I forgot to add the new fields to the `archive_orders()` trigger thing which meant when querying live order, the iceberg fields of an iceberg order would not show.