### PR TITLE
feat: ethereum oracle error handling refactor

### DIFF
--- a/core/evtforward/ethcall/engine.go
+++ b/core/evtforward/ethcall/engine.go
@@ -196,7 +196,7 @@ func (e *Engine) OnTick(ctx context.Context, wallTime time.Time) {
 			res, err := call.Call(ctx, e.client, ethBlock.NumberU64())
 			if err != nil {
 				e.log.Errorf("failed to call contract: %w", err)
-				event := makeErrorChainEvent(err, specID, ethBlock)
+				event := makeErrorChainEvent(err.Error(), specID, ethBlock)
 				e.forwarder.ForwardFromSelf(event)
 				continue
 			}
@@ -227,8 +227,7 @@ func makeChainEvent(res Result, specID string, block blockish) *commandspb.Chain
 	return &ce
 }
 
-func makeErrorChainEvent(err error, specID string, block blockish) *commandspb.ChainEvent {
-	errMsg := err.Error()
+func makeErrorChainEvent(errMsg string, specID string, block blockish) *commandspb.ChainEvent {
 	ce := commandspb.ChainEvent{
 		TxId:  "internal", // NA
 		Nonce: 0,          // NA


### PR DESCRIPTION
close: #8533 
Change to the error handling such that an error that occurs consistently across all validators will result in an oracle data event with error attached.  All other errors (node specific) are logged but do not result in an oracle data event.