### PR TITLE
fix: ensure the asset used for asset for metrics exists in transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - [8586](https://github.com/vegaprotocol/vega/issues/8586) - Fix cancel governance transfer proposal validation
 - [8597](https://github.com/vegaprotocol/vega/issues/8597) - Enact governance transfer cancellation
 - [8428](https://github.com/vegaprotocol/vega/issues/8428) - Add missing `LastTradedPrice` field in market data
+- [8335](https://github.com/vegaprotocol/vega/issues/8335) - Validate asset for metrics in transfers to be an actual asset
 
 ## 0.71.0
 

--- a/core/banking/recurring_transfers.go
+++ b/core/banking/recurring_transfers.go
@@ -49,6 +49,19 @@ func (e *Engine) recurringTransfer(
 		return fmt.Errorf("could not transfer funds: %w", err)
 	}
 
+	if transfer.DispatchStrategy != nil {
+		hasAsset := len(transfer.DispatchStrategy.AssetForMetric) > 0
+		// ensure the asset transfer is correct
+		if hasAsset {
+			_, err := e.assets.Get(transfer.DispatchStrategy.AssetForMetric)
+			if err != nil {
+				transfer.Status = types.TransferStatusRejected
+				e.log.Debug("cannot transfer funds, invalid asset for metric", logging.Error(err))
+				return fmt.Errorf("could not transfer funds, invalid asset for metric: %w", err)
+			}
+		}
+	}
+
 	if err := transfer.IsValid(); err != nil {
 		transfer.Status = types.TransferStatusRejected
 		return err


### PR DESCRIPTION
close #8335  