### PR TITLE
fix: force init after removing old snapshot data

### DIFF
--- a/core/snapshot/engine.go
+++ b/core/snapshot/engine.go
@@ -310,6 +310,7 @@ func (e *Engine) ClearAndInitialise() error {
 			if err := os.RemoveAll(p); err != nil {
 				return err
 			}
+			e.initialised = false
 		}
 	}
 	if err := e.initialiseTree(); err != nil {


### PR DESCRIPTION
Fixing this issues when restarting from statesync:
```
2023-06-27T11:33:53.894Z        WARN    core.protocol.snapshot  snapshot/engine.go:309  removing old snapshot data      {"dbpath": "/usr/local/vega/vega-node/state/node/snapshots/snapshot.db"}
2023-06-27T11:33:53.894Z        WARN    core.protocol.snapshot  snapshot/engine.go:309  removing old snapshot data      {"dbpath": "/usr/local/vega/vega-node/state/node/snapshots/snapshot_meta.db"}
2023-06-27T11:33:53.895Z        INFO    core.protocol.snapshot  snapshot/engine.go:319  snapshot engine successfully initialised
2023-06-27T11:33:53.991Z        ERROR   core.protocol.snapshot  snapshot/engine.go:546  failed to recreate tree {"error": "could not commit imported tree: open /usr/local/vega/vega-node/state/node/snapshots/snapshot.db/000002.log: no such file or directory"}
2023-06-27T11:33:53.991Z        ERROR   core.protocol.processor processor/abci.go:661   failed to apply snapshot        {"error": "could not commit imported tree: open /usr/local/vega/vega-node/state/node/snapshots/snapshot.db/000002.log: no such file or directory"}
```