### PR TITLE
fix: put snapshot.db back in the same place

### DIFF
--- a/core/snapshot/databases/metadata/level_db.go
+++ b/core/snapshot/databases/metadata/level_db.go
@@ -48,7 +48,7 @@ func (a *LevelDBAdapter) Clear() error {
 }
 
 func NewLevelDBAdapter(vegaPaths paths.Paths) (*LevelDBAdapter, error) {
-	filePath := vegaPaths.StatePathFor(paths.SnapshotMetadataDBStateFile)
+	filePath := vegaPaths.StatePathFor(paths.SnapshotStateHome)
 
 	underlyingAdapter, err := initializeUnderlyingAdapter(filePath)
 	if err != nil {

--- a/core/snapshot/databases/snapshot/level_db.go
+++ b/core/snapshot/databases/snapshot/level_db.go
@@ -37,7 +37,7 @@ func (d *LevelDBDatabase) Clear() error {
 }
 
 func NewLevelDBDatabase(vegaPaths paths.Paths) (*LevelDBDatabase, error) {
-	filePath := vegaPaths.StatePathFor(paths.SnapshotDBStateFile)
+	filePath := vegaPaths.StatePathFor(paths.SnapshotStateHome)
 
 	adapter, err := initializeUnderlyingAdapter(filePath)
 	if err != nil {


### PR DESCRIPTION
Recent reshuffle of snapshots things has accidently moved the directory. 

It used to be in
```
VEGA_HOME/state/node/snapshots/snapshot.db
```

but is now being made in
```
VEGA_HOME/state/node/snapshots/snapshot.db/snapshot.db
```
which will probably cause problems with the protocol-upgrade.

Found while wondering why my selection of snapshot related scripts stopped working.