### PR TITLE
fix: delete the correct folder when clearing up

### DIFF
--- a/core/snapshot/databases/metadata/level_db.go
+++ b/core/snapshot/databases/metadata/level_db.go
@@ -12,6 +12,7 @@ import (
 const metaDBName = "snapshot_meta"
 
 type LevelDBAdapter struct {
+	dbPath   string
 	filePath string
 
 	underlyingAdapter *db.GoLevelDB
@@ -34,7 +35,7 @@ func (a *LevelDBAdapter) Clear() error {
 		return fmt.Errorf("could not close the connection: %w", err)
 	}
 
-	if err := os.RemoveAll(a.filePath); err != nil {
+	if err := os.RemoveAll(a.dbPath); err != nil {
 		return fmt.Errorf("could not remove the database file: %w", err)
 	}
 
@@ -49,6 +50,7 @@ func (a *LevelDBAdapter) Clear() error {
 
 func NewLevelDBAdapter(vegaPaths paths.Paths) (*LevelDBAdapter, error) {
 	filePath := vegaPaths.StatePathFor(paths.SnapshotStateHome)
+	dbPath := vegaPaths.StatePathFor(paths.SnapshotMetadataDBStateFile)
 
 	underlyingAdapter, err := initializeUnderlyingAdapter(filePath)
 	if err != nil {
@@ -56,6 +58,7 @@ func NewLevelDBAdapter(vegaPaths paths.Paths) (*LevelDBAdapter, error) {
 	}
 
 	return &LevelDBAdapter{
+		dbPath:            dbPath,
 		filePath:          filePath,
 		underlyingAdapter: underlyingAdapter,
 	}, nil

--- a/core/snapshot/databases/snapshot/level_db.go
+++ b/core/snapshot/databases/snapshot/level_db.go
@@ -15,6 +15,7 @@ const dbName = "snapshot"
 type LevelDBDatabase struct {
 	*db.GoLevelDB
 
+	dbPath   string
 	filePath string
 }
 
@@ -23,7 +24,7 @@ func (d *LevelDBDatabase) Clear() error {
 		return fmt.Errorf("could not close the connection: %w", err)
 	}
 
-	if err := os.RemoveAll(d.filePath); err != nil {
+	if err := os.RemoveAll(d.dbPath); err != nil {
 		return fmt.Errorf("could not remove the database file: %w", err)
 	}
 
@@ -38,6 +39,7 @@ func (d *LevelDBDatabase) Clear() error {
 
 func NewLevelDBDatabase(vegaPaths paths.Paths) (*LevelDBDatabase, error) {
 	filePath := vegaPaths.StatePathFor(paths.SnapshotStateHome)
+	dbPath := vegaPaths.StatePathFor(paths.SnapshotDBStateFile)
 
 	adapter, err := initializeUnderlyingAdapter(filePath)
 	if err != nil {
@@ -45,6 +47,7 @@ func NewLevelDBDatabase(vegaPaths paths.Paths) (*LevelDBDatabase, error) {
 	}
 
 	return &LevelDBDatabase{
+		dbPath:    dbPath,
 		filePath:  filePath,
 		GoLevelDB: adapter,
 	}, nil


### PR DESCRIPTION
My hasty [fix yesterday](https://github.com/vegaprotocol/vega/pull/8641) introduced another bug which meant snapshots weren't being clean up properly and [broke all the soak-tests](https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-nightly/detail/system-tests-nightly/986/pipeline/33/).

This fix comes with a full system-test run:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/23455/pipeline/