### PR TITLE
fix: set market close timestamp when market closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - [8453](https://github.com/vegaprotocol/vega/issues/8453) - Do not verify termination timestamp in update market when pre-enacting proposal
 - [8418](https://github.com/vegaprotocol/vega/issues/8418) - Fix data node panics when a bad successor market proposal is rejected
 - [8358](https://github.com/vegaprotocol/vega/issues/8358) - Fix replay protection
+- [8655](https://github.com/vegaprotocol/vega/issues/8655) - Set market close timestamp when market closes
 - [8362](https://github.com/vegaprotocol/vega/issues/8362) - Fix `PnL` flickering bug.
 - [8565](https://github.com/vegaprotocol/vega/issues/8565) - Unsubscribe all data sources when restoring a settled market from a snapshot
 - [8578](https://github.com/vegaprotocol/vega/issues/8578) - Add iceberg option fields to live orders trigger

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -843,6 +843,7 @@ func (m *Market) cleanMarketWithState(ctx context.Context, mktState types.Market
 
 	m.mkt.State = mktState
 	m.mkt.TradingMode = types.MarketTradingModeNoTrading
+	m.mkt.MarketTimestamps.Close = m.timeService.GetTimeNow().UnixNano()
 	m.broker.Send(events.NewMarketUpdatedEvent(ctx, *m.mkt))
 
 	return nil

--- a/core/execution/future/market_test.go
+++ b/core/execution/future/market_test.go
@@ -719,6 +719,10 @@ func TestMarketClosing(t *testing.T) {
 		Data:    properties,
 	})
 	require.NoError(t, err)
+
+	assert.Equal(t, closingAt.UnixNano(), tm.market.Mkt().MarketTimestamps.Close)
+	assert.Equal(t, types.MarketStateSettled, tm.market.State())
+
 	closingAt = closingAt.Add(time.Second)
 	tm.now = closingAt
 	closed = tm.market.OnTick(vegacontext.WithTraceID(context.Background(), vgcrypto.RandomHash()), closingAt)


### PR DESCRIPTION
closes #8655 

Was previously fixed here: https://github.com/vegaprotocol/vega/pull/8238 but got lost in some refactoring.

Ran the test referenced in the ticket. The last market update event now contains:
```
{"proposed":"1688140305250989669","pending":"1688140309000000000","open":"1688140320255728525","close":"1688140322822776341"}
```

https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/79600/artifact/test_logs/tests.settlement.settlement_test/test_settlement_with_simple_oracle/BUS_EVENT_TYPE_MARKET_UPDATED.txt