### PR TITLE
fix: pass context into witness resource check method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [8334](https://github.com/vegaprotocol/vega/issues/8334) - Implement market succession in execution engine.
 - [8354](https://github.com/vegaprotocol/vega/issues/8354) - refactor execution package
 - [8394](https://github.com/vegaprotocol/vega/issues/8394) - Get rid of spot liquidity provision commands and data structures.
+- [8613](https://github.com/vegaprotocol/vega/issues/8613) - Pass context into witness resource check method 
 - [8402](https://github.com/vegaprotocol/vega/issues/8402) - Avoid division by 0 in market activity tracker
 - [8347](https://github.com/vegaprotocol/vega/issues/8347) - Market state (`ELS`) to be included in checkpoint data.
 - [8303](https://github.com/vegaprotocol/vega/issues/8303) - Add support for successor markets in datanode.

--- a/core/banking/asset_action.go
+++ b/core/banking/asset_action.go
@@ -13,6 +13,7 @@
 package banking
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 
@@ -129,7 +130,7 @@ func (t *assetAction) String() string {
 	}
 }
 
-func (t *assetAction) Check() error {
+func (t *assetAction) Check(ctx context.Context) error {
 	switch {
 	case t.IsBuiltinAssetDeposit():
 		return t.checkBuiltinAssetDeposit()

--- a/core/banking/checkpoint_test.go
+++ b/core/banking/checkpoint_test.go
@@ -50,7 +50,7 @@ func TestDepositFinalisedAfterCheckpoint(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc
-	eng.erc.r.Check()
+	eng.erc.r.Check(context.Background())
 	eng.erc.f(eng.erc.r, true)
 
 	// now we take a checkpoint

--- a/core/banking/engine_test.go
+++ b/core/banking/engine_test.go
@@ -116,7 +116,7 @@ func testDepositSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc
-	eng.erc.r.Check()
+	eng.erc.r.Check(context.Background())
 	eng.erc.f(eng.erc.r, true)
 
 	// then we call time update, which should call the collateral to
@@ -146,7 +146,7 @@ func testDepositSuccessNoTxDuplicate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc
-	eng.erc.r.Check()
+	eng.erc.r.Check(context.Background())
 	eng.erc.f(eng.erc.r, true)
 
 	// then we call time update, which should call the collateral to
@@ -161,7 +161,7 @@ func testDepositSuccessNoTxDuplicate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc
-	eng.erc.r.Check()
+	eng.erc.r.Check(context.Background())
 	eng.erc.f(eng.erc.r, true)
 
 	// then we call time update, which should call the collateral to
@@ -191,7 +191,7 @@ func testDepositFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	// then we call the callback from the fake erc
-	eng.erc.r.Check()
+	eng.erc.r.Check(context.Background())
 	eng.erc.f(eng.erc.r, false)
 
 	// then we call time update, expect collateral to never be called

--- a/core/governance/node_validation.go
+++ b/core/governance/node_validation.go
@@ -65,7 +65,7 @@ func (n *nodeProposal) GetType() types.NodeVoteType {
 	return types.NodeVoteTypeGovernanceValidateAsset
 }
 
-func (n *nodeProposal) Check() error {
+func (n *nodeProposal) Check(ctx context.Context) error {
 	// always keep the last error
 	err := n.checker()
 	if err != nil {

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -159,7 +159,7 @@ func newExecutionTestSetup() *executionTestSetup {
 	marketActivityTracker := common.NewMarketActivityTracker(execsetup.log, execsetup.epochEngine)
 	commander := stubs.NewCommanderStub()
 	execsetup.netDeposits = num.UintZero()
-	execsetup.witness = validators.NewWitness(execsetup.log, validators.NewDefaultConfig(), execsetup.topology, commander, execsetup.timeService)
+	execsetup.witness = validators.NewWitness(context.Background(), execsetup.log, validators.NewDefaultConfig(), execsetup.topology, commander, execsetup.timeService)
 
 	execsetup.ntry = notary.NewWithSnapshot(execsetup.log, notary.NewDefaultConfig(), execsetup.topology, execsetup.broker, commander)
 	execsetup.assetsEngine = stubs.NewAssetStub()

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -196,7 +196,7 @@ func newServices(
 	}
 
 	svcs.protocolUpgradeEngine = protocolupgrade.New(svcs.log, svcs.conf.ProtocolUpgrade, svcs.broker, svcs.topology, version.Get())
-	svcs.witness = validators.NewWitness(svcs.log, svcs.conf.Validators, svcs.topology, svcs.commander, svcs.timeService)
+	svcs.witness = validators.NewWitness(svcs.ctx, svcs.log, svcs.conf.Validators, svcs.topology, svcs.commander, svcs.timeService)
 
 	// this is done to go around circular deps...
 	svcs.erc20MultiSigTopology.SetWitness(svcs.witness)

--- a/core/staking/accounting.go
+++ b/core/staking/accounting.go
@@ -89,7 +89,7 @@ func (p pendingStakeTotalSupply) GetType() types.NodeVoteType {
 	return types.NodeVoteTypeStakeTotalSupply
 }
 
-func (p *pendingStakeTotalSupply) Check() error { return p.check() }
+func (p *pendingStakeTotalSupply) Check(ctx context.Context) error { return p.check() }
 
 func NewAccounting(
 	log *logging.Logger,

--- a/core/staking/stake_verifier.go
+++ b/core/staking/stake_verifier.go
@@ -89,18 +89,18 @@ type pendingSD struct {
 	check func() error
 }
 
-func (p pendingSD) GetID() string               { return p.ID }
-func (p pendingSD) GetType() types.NodeVoteType { return types.NodeVoteTypeStakeDeposited }
-func (p *pendingSD) Check() error               { return p.check() }
+func (p pendingSD) GetID() string                    { return p.ID }
+func (p pendingSD) GetType() types.NodeVoteType      { return types.NodeVoteTypeStakeDeposited }
+func (p *pendingSD) Check(ctx context.Context) error { return p.check() }
 
 type pendingSR struct {
 	*types.StakeRemoved
 	check func() error
 }
 
-func (p pendingSR) GetID() string               { return p.ID }
-func (p pendingSR) GetType() types.NodeVoteType { return types.NodeVoteTypeStakeRemoved }
-func (p *pendingSR) Check() error               { return p.check() }
+func (p pendingSR) GetID() string                    { return p.ID }
+func (p pendingSR) GetType() types.NodeVoteType      { return types.NodeVoteTypeStakeRemoved }
+func (p *pendingSR) Check(ctx context.Context) error { return p.check() }
 
 func NewStakeVerifier(
 	log *logging.Logger,

--- a/core/validators/erc20multisig/topology.go
+++ b/core/validators/erc20multisig/topology.go
@@ -111,7 +111,7 @@ func (p pendingSigner) GetType() types.NodeVoteType {
 	return ty
 }
 
-func (p *pendingSigner) Check() error { return p.check() }
+func (p *pendingSigner) Check(ctx context.Context) error { return p.check() }
 
 type pendingThresholdSet struct {
 	*types.SignerThresholdSetEvent
@@ -122,7 +122,7 @@ func (p pendingThresholdSet) GetID() string { return p.ID }
 func (p pendingThresholdSet) GetType() types.NodeVoteType {
 	return types.NodeVoteTypeSignerThresholdSet
 }
-func (p *pendingThresholdSet) Check() error { return p.check() }
+func (p *pendingThresholdSet) Check(ctx context.Context) error { return p.check() }
 
 func NewTopology(
 	config Config,

--- a/core/validators/witness_test.go
+++ b/core/validators/witness_test.go
@@ -48,7 +48,7 @@ func getTestWitness(t *testing.T) *testWitness {
 
 	now := time.Now()
 	tsvc.EXPECT().GetTimeNow().Times(1).Return(now)
-	w := validators.NewWitness(
+	w := validators.NewWitness(context.Background(),
 		logging.NewTestLogger(), validators.NewDefaultConfig(), top, cmd, tsvc)
 	assert.NotNil(t, w)
 
@@ -379,7 +379,7 @@ func (t testRes) GetID() string { return t.id }
 func (t testRes) GetType() commandspb.NodeVote_Type {
 	return commandspb.NodeVote_TYPE_FUNDS_DEPOSITED
 }
-func (t testRes) Check() error { return t.check() }
+func (t testRes) Check(ctx context.Context) error { return t.check() }
 
 func newPublicKey(k string) crypto.PublicKey {
 	pubKeyB := []byte(k)


### PR DESCRIPTION
closes #8613 pass in context to the check method of witness resources  (required for ethereum oracles)