### PR TITLE
Ethereum oracle network parameter

### DIFF
--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -68,6 +68,9 @@ func defaultNetParams() map[string]value {
 		// spots
 		SpotMarketTradingEnabled: NewInt(gteI0, lteI1).Mutable(true).MustUpdate("0"),
 
+		// ethereum oracles
+		EthereumOraclesEnabled: NewInt(gteI0, lteI1).Mutable(true).MustUpdate("0"),
+
 		// markets
 		MarketMarginScalingFactors:                      NewJSON(&proto.ScalingFactors{}, checks.MarginScalingFactor(), checks.MarginScalingFactorRange(num.DecimalOne(), num.DecimalFromInt64(100))).Mutable(true).MustUpdate(`{"search_level": 1.1, "initial_margin": 1.2, "collateral_release": 1.4}`),
 		MarketFeeFactorsMakerFee:                        NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0.00025"),

--- a/core/netparams/keys.go
+++ b/core/netparams/keys.go
@@ -14,6 +14,7 @@ package netparams
 
 const (
 	SpotMarketTradingEnabled = "spot.market.trading.enabled"
+	EthereumOraclesEnabled   = "ethereum.oracles.enabled"
 
 	// market related parameters.
 	MarketMarginScalingFactors                      = "market.margin.scalingFactors"
@@ -206,6 +207,7 @@ var Deprecated = map[string]struct{}{
 
 var AllKeys = map[string]struct{}{
 	SpotMarketTradingEnabled:                                 {},
+	EthereumOraclesEnabled:                                   {},
 	MaxPeggedOrders:                                          {},
 	MaxGasPerBlock:                                           {},
 	DefaultGas:                                               {},

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -222,10 +222,6 @@ func newServices(
 
 	svcs.ethCallEngine = ethcall.NewEngine(svcs.log, svcs.conf.EvtForward.EthCall, svcs.ethClient, svcs.eventForwarder)
 
-	if svcs.conf.IsValidator() {
-		go svcs.ethCallEngine.Start()
-	}
-
 	svcs.ethereumOraclesVerifier = oracles.NewEthereumOracleVerifier(svcs.log, svcs.witness, svcs.timeService, svcs.broker,
 		svcs.oracle, svcs.ethCallEngine, svcs.ethConfirmations)
 
@@ -572,6 +568,15 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 				}
 
 				return svcs.eventForwarderEngine.SetupEthereumEngine(svcs.ethClient, svcs.eventForwarder, svcs.conf.EvtForward.Ethereum, ethCfg, svcs.assets)
+			},
+		},
+		{
+			Param: netparams.EthereumOraclesEnabled,
+			Watcher: func(ctx context.Context, isEnabled int64) error {
+				if isEnabled == 1 && svcs.conf.IsValidator() {
+					go svcs.ethCallEngine.Start()
+				}
+				return nil
 			},
 		},
 		{

--- a/core/types/data_source_external_eth_oracle.go
+++ b/core/types/data_source_external_eth_oracle.go
@@ -125,3 +125,7 @@ func (s EthCallSpec) DeepClone() dataSourceType {
 		Normalisers:           clonedNormalisers,
 	}
 }
+
+func (s EthCallSpec) IsZero() bool {
+	return s.Address == "" && s.Method == "" && s.Trigger == nil && s.RequiredConfirmations == 0 && len(s.AbiJson) == 0 && len(s.ArgsJson) == 0 && len(s.Filters) == 0 && len(s.Normalisers) == 0
+}


### PR DESCRIPTION
Defaults to disabled. When disabled, don't start the eth call engine and reject market proposals that contain data sources that require ethereum oracles.