### PR TITLE
Send market data update after setting mark price for final MTM prior to settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🛠 Improvements
 
-- [](https://github.com/vegaprotocol/vega/issues/xxxx) -
+- [8718](https://github.com/vegaprotocol/vega/issues/8718) - Emit market data event after setting mark price prior to final settlement.
 
 ### 🐛 Fixes
 

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -3789,6 +3789,8 @@ func (m *Market) tradingTerminatedWithFinalState(ctx context.Context, finalState
 			// we have trades, and the market has been closed. Perform MTM sequence now so the final settlement
 			// works as expected.
 			m.markPrice = mp
+			// send market data event with the updated mark price
+			m.broker.Send(events.NewMarketDataEvent(ctx, m.GetMarketData()))
 			m.confirmMTM(ctx, true)
 		}
 		m.mkt.State = types.MarketStateTradingTerminated


### PR DESCRIPTION
Send an update when using last traded price for mark price prior to final settlement.

Closes https://github.com/vegaprotocol/vega/issues/8718 