### PR TITLE
fix: 8737 GetStopOrders errors when a stop order has had a state change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [8713](https://github.com/vegaprotocol/vega/issues/8713) - Wallet name with upper-case letter is allowed, again
 - [8698](https://github.com/vegaprotocol/vega/issues/8698) - Always set the `ToAccount` field when clearing fees.
 - [8711](https://github.com/vegaprotocol/vega/issues/8711) - Fix market lineage trigger.
+- [8737](https://github.com/vegaprotocol/vega/issues/8737) - Fix `GetStopOrder` errors when order has a state change.
 
 
 ## 0.72.0

--- a/datanode/sqlstore/stop_orders.go
+++ b/datanode/sqlstore/stop_orders.go
@@ -66,7 +66,7 @@ func (so *StopOrders) GetStopOrder(ctx context.Context, orderID string) (entitie
 	order := entities.StopOrder{}
 	id := entities.StopOrderID(orderID)
 	defer metrics.StartSQLQuery("StopOrders", "GetStopOrder")()
-	query := `select * from stop_orders where id=$1`
+	query := `select * from stop_orders_current_desc where id=$1`
 	err = pgxscan.Get(ctx, so.Connection, &order, query, id)
 
 	return order, so.wrapE(err)

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/adrg/xdg v0.4.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.2.0
+	github.com/cometbft/cometbft-db v0.7.0
 	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
@@ -112,7 +113,6 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 // indirect
 	github.com/cockroachdb/redact v1.1.3 // indirect
-	github.com/cometbft/cometbft-db v0.7.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d // indirect


### PR DESCRIPTION
Closes #8737 

This bug was caused by a bad query which should have selected from the appropriate view rather than directly from the stop order table.