### PR TITLE
fix: 8748 ListSuccessorMarkets not returning all results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [8721](https://github.com/vegaprotocol/vega/issues/8721) - Fix panic with triggered OCO expiring
 - [8729](https://github.com/vegaprotocol/vega/issues/8729) - Stop order direction not set in datanode
 - [8545](https://github.com/vegaprotocol/vega/issues/8545) - Block Explorer pagination does not order correctly.
+- [8748](https://github.com/vegaprotocol/vega/issues/8748) - `ListSuccessorMarkets` does not return results.
 
 
 ## 0.72.1

--- a/datanode/sqlstore/markets.go
+++ b/datanode/sqlstore/markets.go
@@ -340,5 +340,20 @@ left join lineage s on l.successor_market_id = s.parent_id
 		edges = append(edges, edge)
 	}
 
+	if len(markets) == 0 {
+		// We do not have any markets in the given succession line, so we need to return the market
+		// associated with the given market ID, which should be the parent market.
+		market, err := m.GetByID(ctx, marketID)
+		if err != nil {
+			return nil, entities.PageInfo{}, err
+		}
+
+		edge := entities.SuccessorMarket{
+			Market: market,
+		}
+
+		edges = append(edges, edge)
+	}
+
 	return edges, pageInfo, nil
 }

--- a/datanode/sqlstore/markets_test.go
+++ b/datanode/sqlstore/markets_test.go
@@ -1173,6 +1173,17 @@ func testListSuccessorMarkets(t *testing.T) {
 			EndCursor:       wantEndCursor,
 		}, pageInfo)
 	})
+
+	t.Run("should list the parent market even if it has not entered continuous trading and has no successors", func(t *testing.T) {
+		got, _, err := md.ListSuccessorMarkets(ctx, "deadbeef04", false, entities.CursorPagination{})
+		require.NoError(t, err)
+		want := []entities.SuccessorMarket{
+			{
+				Market: markets[10],
+			},
+		}
+		assert.Equal(t, want, got)
+	})
 }
 
 func testGetMarketWithParentAndSuccessor(t *testing.T) {
@@ -1236,6 +1247,14 @@ func setupSuccessorMarkets(t *testing.T, ctx context.Context) (*sqlstore.Markets
 			TradableInstrument: &vega.TradableInstrument{},
 		},
 		ParentMarketID: successorMarketA.ID,
+	}
+
+	parentMarket2 := entities.Market{
+		ID:           entities.MarketID("deadbeef04"),
+		InstrumentID: "deadbeef04",
+		TradableInstrument: entities.TradableInstrument{
+			TradableInstrument: &vega.TradableInstrument{},
+		},
 	}
 
 	successorMarketA.SuccessorMarketID = successorMarketB.ID
@@ -1399,6 +1418,11 @@ func setupSuccessorMarkets(t *testing.T, ctx context.Context) (*sqlstore.Markets
 			market:      successorMarketB,
 			state:       entities.MarketStateActive,
 			tradingMode: entities.MarketTradingModeContinuous,
+		},
+		{
+			market:      parentMarket2,
+			state:       entities.MarketStatePending,
+			tradingMode: entities.MarketTradingModeOpeningAuction,
 		},
 	}
 


### PR DESCRIPTION
Closes #8748 

This fixes ListSuccessorMarkets so that it will display a market even if the market has not entered continuous trading and has no successors.

The market typically only enters the lineage when a successor leaves auction and enters continuous trading. In the case of a market that doesn't have any successors (i.e. a parent market) we want to list it regardless as the only market in the succession line.