### PR TITLE
feat: disable long lines for project_management

### DIFF
--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -1,3 +1,5 @@
+# yamllint disable rule:line-length
+
 # ---
 
 


### PR DESCRIPTION
# Changes

Ignores the yaml linter for the project management GH action