### PR TITLE
fix: stop orders api always returns null for expiresAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [8417](https://github.com/vegaprotocol/vega/issues/8417) - Fix normalisation of Ethereum calls that return structures
 - [8719](https://github.com/vegaprotocol/vega/issues/8719) - Do not try to resolve iceberg order if it's not set
 - [8721](https://github.com/vegaprotocol/vega/issues/8721) - Fix panic with triggered OCO expiring
-- [8751](https://github.com/vegaprotocol/vega/issues/8751) - Fix Ethereum oracle data error event sent with incorrect sequence number  
+- [8751](https://github.com/vegaprotocol/vega/issues/8751) - Fix Ethereum oracle data error event sent with incorrect sequence number
 - [8729](https://github.com/vegaprotocol/vega/issues/8729) - Stop order direction not set in datanode
 - [8545](https://github.com/vegaprotocol/vega/issues/8545) - Block Explorer pagination does not order correctly.
 - [8748](https://github.com/vegaprotocol/vega/issues/8748) - `ListSuccessorMarkets` does not return results.
@@ -31,6 +31,7 @@
 - [8773](https://github.com/vegaprotocol/vega/issues/8773) - Fix panic with stop orders
 - [8792](https://github.com/vegaprotocol/vega/issues/8792) - Fix panic when starting null block chain node.
 - [8739](https://github.com/vegaprotocol/vega/issues/8739) - Cancel orders for rejected markets.
+- [8800](https://github.com/vegaprotocol/vega/issues/8800) - `expiresAt` is always null in the Stop Orders `API`.
 
 
 ## 0.72.1

--- a/datanode/entities/stop_orders.go
+++ b/datanode/entities/stop_orders.go
@@ -172,6 +172,10 @@ func StopOrderFromProto(so *pbevents.StopOrderEvent, vegaTime time.Time, seqNum 
 		ocoLinkID = StopOrderID(*so.StopOrder.OcoLinkId)
 	}
 
+	if so.StopOrder.ExpiresAt != nil {
+		expiresAt = ptr.From(NanosToPostgresTimestamp(*so.StopOrder.ExpiresAt))
+	}
+
 	if so.StopOrder.ExpiryStrategy != nil {
 		expiryStrategy = StopOrderExpiryStrategy(*so.StopOrder.ExpiryStrategy)
 	}

--- a/datanode/entities/stop_orders_test.go
+++ b/datanode/entities/stop_orders_test.go
@@ -1,0 +1,77 @@
+package entities_test
+
+import (
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/libs/ptr"
+
+	"code.vegaprotocol.io/vega/datanode/entities"
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandpb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+	pbevents "code.vegaprotocol.io/vega/protos/vega/events/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopOrderFromProto(t *testing.T) {
+	t.Run("Should set ExpiresAt if ExpiryStrategy is set", func(t *testing.T) {
+		createdAt := time.Now().Round(time.Microsecond)
+		expiresAt := createdAt.Add(time.Minute)
+		sop := vega.StopOrder{
+			Id:               "deadbeef",
+			ExpiresAt:        ptr.From(expiresAt.UnixNano()),
+			ExpiryStrategy:   ptr.From(vega.StopOrder_EXPIRY_STRATEGY_CANCELS),
+			TriggerDirection: vega.StopOrder_TRIGGER_DIRECTION_RISES_ABOVE,
+			Status:           vega.StopOrder_STATUS_PENDING,
+			CreatedAt:        createdAt.UnixNano(),
+			UpdatedAt:        nil,
+			OrderId:          "deadbeef",
+			PartyId:          "deadbaad",
+			MarketId:         "dead2bad",
+			Trigger: &vega.StopOrder_Price{
+				Price: "100",
+			},
+		}
+		sub := commandpb.OrderSubmission{
+			MarketId:    "dead2bad",
+			Price:       "100",
+			Size:        100,
+			Side:        vega.Side_SIDE_BUY,
+			TimeInForce: vega.Order_TIME_IN_FORCE_GTC,
+			Reference:   "some-reference",
+		}
+		soEvent := pbevents.StopOrderEvent{
+			Submission: &sub,
+			StopOrder:  &sop,
+		}
+
+		vegaTime := time.Now().Round(time.Microsecond)
+		seqNum := uint64(0)
+		txHash := entities.TxHash(`deadbaad`)
+
+		got, err := entities.StopOrderFromProto(&soEvent, vegaTime, seqNum, txHash)
+		require.NoError(t, err)
+
+		want := entities.StopOrder{
+			ID:                   entities.StopOrderID("deadbeef"),
+			ExpiresAt:            ptr.From(expiresAt),
+			ExpiryStrategy:       entities.StopOrderExpiryStrategyCancels,
+			TriggerDirection:     entities.StopOrderTriggerDirectionRisesAbove,
+			Status:               entities.StopOrderStatusPending,
+			CreatedAt:            createdAt,
+			UpdatedAt:            nil,
+			OrderID:              "deadbeef",
+			TriggerPrice:         ptr.From("100"),
+			TriggerPercentOffset: nil,
+			PartyID:              "deadbaad",
+			MarketID:             "dead2bad",
+			VegaTime:             vegaTime,
+			SeqNum:               0,
+			TxHash:               entities.TxHash(`deadbaad`),
+			Submission:           &sub,
+		}
+
+		assert.Equal(t, want, got)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 require (
 	github.com/99designs/gqlgen v0.17.20
 	github.com/BurntSushi/toml v1.2.1
+	github.com/PaesslerAG/gval v1.0.0
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/adrg/xdg v0.4.0
 	github.com/blang/semver/v4 v4.0.0
@@ -101,7 +102,6 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
 	github.com/DataDog/zstd v1.5.2 // indirect
-	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect


### PR DESCRIPTION
Closes #8800 

This was caused by the parsing of the event from the event bus before being inserted into the database. The value of expiresAt was not checked and updated if it isn't null, so it was always being inserted into the database as null.