### PR TITLE
fix: eth call spec not deactivating after market settles

### DIFF
--- a/core/datasource/external/ethcall/engine.go
+++ b/core/datasource/external/ethcall/engine.go
@@ -187,7 +187,7 @@ func (e *Engine) OnSpecDeactivated(ctx context.Context, spec datasource.Spec) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	switch spec.Data.Content().(type) {
-	case *common.Spec:
+	case common.Spec:
 		id := spec.ID
 		delete(e.calls, id)
 	}

--- a/core/datasource/external/ethcall/engine_test.go
+++ b/core/datasource/external/ethcall/engine_test.go
@@ -109,6 +109,13 @@ func TestEngine(t *testing.T) {
 	})
 
 	e.Poll(ctx, time.Now())
+
+	// Now deactivate the spec and make sure we don't get called again
+	tc.client.Commit()
+	tc.client.Commit()
+
+	e.OnSpecDeactivated(context.Background(), oracleSpec)
+	e.Poll(ctx, time.Now())
 }
 
 func TestEngineWithErrorSpec(t *testing.T) {


### PR DESCRIPTION
closes #8804 