### PR TITLE
fix: spot snapshot fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [8711](https://github.com/vegaprotocol/vega/issues/8711) - Fix market lineage trigger.
 - [8737](https://github.com/vegaprotocol/vega/issues/8737) - Fix `GetStopOrder` errors when order has a state change.
 - [8727](https://github.com/vegaprotocol/vega/issues/8727) - Clear parent market on checkpoint restore if the parent market was already succeeded.
+- [8835](https://github.com/vegaprotocol/vega/issues/8835) - Spot snapshot fixes
 
 
 ## 0.72.0

--- a/core/execution/common/interfaces.go
+++ b/core/execution/common/interfaces.go
@@ -300,4 +300,6 @@ type CommonMarket interface {
 	CancelAllStopOrders(context.Context, string) error
 	CancelStopOrder(context.Context, string, string) error
 	SubmitStopOrdersWithIDGeneratorAndOrderIDs(context.Context, *types.StopOrdersSubmission, string, IDGenerator, *string, *string) (*types.OrderConfirmation, error)
+
+	PostRestore(context.Context) error
 }

--- a/core/execution/engine_snapshot.go
+++ b/core/execution/engine_snapshot.go
@@ -382,7 +382,7 @@ func (e *Engine) restoreSuccessorMaps(successors []*types.Successors) {
 }
 
 func (e *Engine) OnStateLoaded(ctx context.Context) error {
-	for _, m := range e.futureMarkets {
+	for _, m := range e.allMarkets {
 		if err := m.PostRestore(ctx); err != nil {
 			return err
 		}

--- a/core/execution/spot/market_snapshot.go
+++ b/core/execution/spot/market_snapshot.go
@@ -95,7 +95,7 @@ func NewMarketFromSnapshot(
 	if err != nil {
 		return nil, fmt.Errorf("unable to instantiate risk model: %w", err)
 	}
-	pMonitor, err := price.NewMonitor(quoteAsset, mkt.ID, riskModel, as, mkt.PriceMonitoringSettings, stateVarEngine, log)
+	pMonitor, err := price.NewMonitorFromSnapshot(mkt.ID, quoteAsset, em.PriceMonitor, mkt.PriceMonitoringSettings, riskModel, as, stateVarEngine, log)
 	if err != nil {
 		return nil, fmt.Errorf("unable to instantiate price monitoring engine: %w", err)
 	}

--- a/core/liquidity/target/spot/snapshot.go
+++ b/core/liquidity/target/spot/snapshot.go
@@ -49,8 +49,8 @@ func NewSnapshotEngine(
 	marketID string,
 	positionFactor num.Decimal,
 ) *SnapshotEngine {
-	key := (&types.PayloadLiquidityTarget{
-		Target: &snapshot.LiquidityTarget{MarketId: marketID},
+	key := (&types.PayloadSpotLiquidityTarget{
+		Target: &snapshot.SpotLiquidityTarget{MarketId: marketID},
 	}).Key()
 
 	return &SnapshotEngine{


### PR DESCRIPTION
Closes #8835

fixes:
1. calls post restore on spot market to have the orders restore correctly with their prices
2. restore price monitor snapshot correctly
3. use correct payload for liquidity target