### PR TITLE
feat: nullchain changes for snapshot-compatibility pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [8765](https://github.com/vegaprotocol/vega/issues/8765) - Implement snapshots state for `PERPS`.
 - [8918](https://github.com/vegaprotocol/vega/issues/8918) - Implement commands for team management.
 - [8756](https://github.com/vegaprotocol/vega/issues/8756) - Settlement and margin implementation for `PERPS`.
+- [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the nullchain is used instead of tendermint
 
 ### 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,9 @@
 - [8758](https://github.com/vegaprotocol/vega/issues/8758) - Internal recurring time trigger for `PERPS`.
 - [8913](https://github.com/vegaprotocol/vega/issues/8913) - Add business logic for team management.
 - [8765](https://github.com/vegaprotocol/vega/issues/8765) - Implement snapshots state for `PERPS`.
-<<<<<<< HEAD
 - [8918](https://github.com/vegaprotocol/vega/issues/8918) - Implement commands for team management.
 - [8756](https://github.com/vegaprotocol/vega/issues/8756) - Settlement and margin implementation for `PERPS`.
-- [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the nullchain is used instead of tendermint
-=======
 - [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the `nullchain` is used instead of `tendermint`
->>>>>>> d0ab9968e (fix: fix linter issue for CHANGELOG)
 
 ### 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,13 @@
 - [8758](https://github.com/vegaprotocol/vega/issues/8758) - Internal recurring time trigger for `PERPS`.
 - [8913](https://github.com/vegaprotocol/vega/issues/8913) - Add business logic for team management.
 - [8765](https://github.com/vegaprotocol/vega/issues/8765) - Implement snapshots state for `PERPS`.
+<<<<<<< HEAD
 - [8918](https://github.com/vegaprotocol/vega/issues/8918) - Implement commands for team management.
 - [8756](https://github.com/vegaprotocol/vega/issues/8756) - Settlement and margin implementation for `PERPS`.
 - [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the nullchain is used instead of tendermint
+=======
+- [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the `nullchain` is used instead of `tendermint`
+>>>>>>> d0ab9968e (fix: fix linter issue for CHANGELOG)
 
 ### 🐛 Fixes
 

--- a/cmd/vega/commands/node/node.go
+++ b/cmd/vega/commands/node/node.go
@@ -445,7 +445,7 @@ func (n *Command) startBlockchainClients() error {
 	// We may not need ethereum client initialized when we have not
 	// provided the ethereum endpoint. We skip creating client here
 	// when RPCEnpoint is empty and the nullchain present.
-	if n.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain && len(n.conf.Ethereum.RPCEndpoint) < 1 {
+	if len(n.conf.Ethereum.RPCEndpoint) < 1 {
 		return nil
 	}
 

--- a/cmd/vega/commands/node/node.go
+++ b/cmd/vega/commands/node/node.go
@@ -442,6 +442,13 @@ func (n *Command) startBlockchainClients() error {
 		return nil
 	}
 
+	// We may not need ethereum client initialized when we have not
+	// provided the ethereum endpoint. We skip creating client here
+	// when RPCEnpoint is empty and the nullchain present.
+	if n.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain && len(n.conf.Ethereum.RPCEndpoint) < 1 {
+		return nil
+	}
+
 	var err error
 	n.ethClient, err = ethclient.Dial(n.ctx, n.conf.Ethereum)
 	if err != nil {

--- a/cmd/vega/commands/node/node.go
+++ b/cmd/vega/commands/node/node.go
@@ -442,14 +442,12 @@ func (n *Command) startBlockchainClients() error {
 		return nil
 	}
 
-	// if n.conf.Blockchain.ChainProvider != blockchain.ProviderNullChain {
 	var err error
 	n.ethClient, err = ethclient.Dial(n.ctx, n.conf.Ethereum)
 	if err != nil {
 		return fmt.Errorf("could not instantiate ethereum client: %w", err)
 	}
 	n.ethConfirmations = ethclient.NewEthereumConfirmations(n.conf.Ethereum, n.ethClient, nil)
-	// }
 
 	return nil
 }

--- a/cmd/vega/commands/node/node.go
+++ b/cmd/vega/commands/node/node.go
@@ -442,14 +442,14 @@ func (n *Command) startBlockchainClients() error {
 		return nil
 	}
 
-	if n.conf.Blockchain.ChainProvider != blockchain.ProviderNullChain {
-		var err error
-		n.ethClient, err = ethclient.Dial(n.ctx, n.conf.Ethereum)
-		if err != nil {
-			return fmt.Errorf("could not instantiate ethereum client: %w", err)
-		}
-		n.ethConfirmations = ethclient.NewEthereumConfirmations(n.conf.Ethereum, n.ethClient, nil)
+	// if n.conf.Blockchain.ChainProvider != blockchain.ProviderNullChain {
+	var err error
+	n.ethClient, err = ethclient.Dial(n.ctx, n.conf.Ethereum)
+	if err != nil {
+		return fmt.Errorf("could not instantiate ethereum client: %w", err)
 	}
+	n.ethConfirmations = ethclient.NewEthereumConfirmations(n.conf.Ethereum, n.ethClient, nil)
+	// }
 
 	return nil
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -165,9 +165,6 @@ func (c Config) GetMaxMemoryFactor() (float64, error) {
 }
 
 func (c Config) HaveEthClient() bool {
-	// if c.Blockchain.ChainProvider == blockchain.ProviderNullChain {
-	// 	return false
-	// }
 	return c.IsValidator()
 }
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -165,6 +165,10 @@ func (c Config) GetMaxMemoryFactor() (float64, error) {
 }
 
 func (c Config) HaveEthClient() bool {
+	if c.Blockchain.ChainProvider == blockchain.ProviderNullChain {
+		return c.IsValidator() && len(c.Ethereum.RPCEndpoint) > 0
+	}
+
 	return c.IsValidator()
 }
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -165,9 +165,9 @@ func (c Config) GetMaxMemoryFactor() (float64, error) {
 }
 
 func (c Config) HaveEthClient() bool {
-	if c.Blockchain.ChainProvider == blockchain.ProviderNullChain {
-		return false
-	}
+	// if c.Blockchain.ChainProvider == blockchain.ProviderNullChain {
+	// 	return false
+	// }
 	return c.IsValidator()
 }
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -165,11 +165,7 @@ func (c Config) GetMaxMemoryFactor() (float64, error) {
 }
 
 func (c Config) HaveEthClient() bool {
-	if c.Blockchain.ChainProvider == blockchain.ProviderNullChain {
-		return c.IsValidator() && len(c.Ethereum.RPCEndpoint) > 0
-	}
-
-	return c.IsValidator()
+	return c.IsValidator() && len(c.Ethereum.RPCEndpoint) > 0
 }
 
 type Loader struct {

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -412,7 +412,8 @@ func NewApp(
 
 	app.time.NotifyOnTick(app.onTick)
 
-	app.nilPow = app.pow == nil || reflect.ValueOf(app.pow).IsNil()
+	app.nilPow = app.pow == nil ||
+		reflect.ValueOf(app.pow).IsNil()
 	app.nilSpam = app.spam == nil || reflect.ValueOf(app.spam).IsNil()
 	app.ensureConfig()
 	return app

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -412,8 +412,7 @@ func NewApp(
 
 	app.time.NotifyOnTick(app.onTick)
 
-	app.nilPow = app.pow == nil ||
-		reflect.ValueOf(app.pow).IsNil()
+	app.nilPow = app.pow == nil || reflect.ValueOf(app.pow).IsNil()
 	app.nilSpam = app.spam == nil || reflect.ValueOf(app.spam).IsNil()
 	app.ensureConfig()
 	return app

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -332,15 +332,11 @@ func newServices(
 	if svcs.spam != nil {
 		svcs.snapshotEngine.AddProviders(svcs.spam)
 	}
-	powWatchers := []netparams.WatchParam{}
 
-	// if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
-	// 	svcs.pow = pow.NewNoop()
-	// } else {
 	pow := pow.New(svcs.log, svcs.conf.PoW, svcs.timeService)
 	svcs.pow = pow
 	svcs.snapshotEngine.AddProviders(pow)
-	powWatchers = []netparams.WatchParam{
+	powWatchers := []netparams.WatchParam{
 		{
 			Param:   netparams.SpamPoWNumberOfPastBlocks,
 			Watcher: pow.UpdateSpamPoWNumberOfPastBlocks,
@@ -366,7 +362,6 @@ func newServices(
 			Watcher: pow.OnEpochDurationChanged,
 		},
 	}
-	// }
 
 	// setup config reloads for all engines / services /etc
 	svcs.registerConfigWatchers()

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -274,6 +274,7 @@ func newServices(
 		// Use staking-loop to pretend a dummy builtin assets deposited with the faucet was staked
 		svcs.codec = &processor.NullBlockchainTxCodec{}
 		stakingLoop := nullchain.NewStakingLoop(svcs.collateral, svcs.assets)
+		svcs.spam = spam.New(svcs.log, svcs.conf.Spam, svcs.epochService, svcs.stakingAccounts)
 		svcs.governance = governance.NewEngine(svcs.log, svcs.conf.Governance, stakingLoop, svcs.timeService, svcs.broker, svcs.assets, svcs.witness, svcs.executionEngine, svcs.netParams, svcs.banking)
 		svcs.delegation = delegation.New(svcs.log, svcs.conf.Delegation, svcs.broker, svcs.topology, stakingLoop, svcs.epochService, svcs.timeService)
 	} else {
@@ -333,39 +334,39 @@ func newServices(
 	}
 	powWatchers := []netparams.WatchParam{}
 
-	if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
-		svcs.pow = pow.NewNoop()
-	} else {
-		pow := pow.New(svcs.log, svcs.conf.PoW, svcs.timeService)
-		svcs.pow = pow
-		svcs.snapshotEngine.AddProviders(pow)
-		powWatchers = []netparams.WatchParam{
-			{
-				Param:   netparams.SpamPoWNumberOfPastBlocks,
-				Watcher: pow.UpdateSpamPoWNumberOfPastBlocks,
-			},
-			{
-				Param:   netparams.SpamPoWDifficulty,
-				Watcher: pow.UpdateSpamPoWDifficulty,
-			},
-			{
-				Param:   netparams.SpamPoWHashFunction,
-				Watcher: pow.UpdateSpamPoWHashFunction,
-			},
-			{
-				Param:   netparams.SpamPoWIncreasingDifficulty,
-				Watcher: pow.UpdateSpamPoWIncreasingDifficulty,
-			},
-			{
-				Param:   netparams.SpamPoWNumberOfTxPerBlock,
-				Watcher: pow.UpdateSpamPoWNumberOfTxPerBlock,
-			},
-			{
-				Param:   netparams.ValidatorsEpochLength,
-				Watcher: pow.OnEpochDurationChanged,
-			},
-		}
+	// if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
+	// 	svcs.pow = pow.NewNoop()
+	// } else {
+	pow := pow.New(svcs.log, svcs.conf.PoW, svcs.timeService)
+	svcs.pow = pow
+	svcs.snapshotEngine.AddProviders(pow)
+	powWatchers = []netparams.WatchParam{
+		{
+			Param:   netparams.SpamPoWNumberOfPastBlocks,
+			Watcher: pow.UpdateSpamPoWNumberOfPastBlocks,
+		},
+		{
+			Param:   netparams.SpamPoWDifficulty,
+			Watcher: pow.UpdateSpamPoWDifficulty,
+		},
+		{
+			Param:   netparams.SpamPoWHashFunction,
+			Watcher: pow.UpdateSpamPoWHashFunction,
+		},
+		{
+			Param:   netparams.SpamPoWIncreasingDifficulty,
+			Watcher: pow.UpdateSpamPoWIncreasingDifficulty,
+		},
+		{
+			Param:   netparams.SpamPoWNumberOfTxPerBlock,
+			Watcher: pow.UpdateSpamPoWNumberOfTxPerBlock,
+		},
+		{
+			Param:   netparams.ValidatorsEpochLength,
+			Watcher: pow.OnEpochDurationChanged,
+		},
 	}
+	// }
 
 	// setup config reloads for all engines / services /etc
 	svcs.registerConfigWatchers()

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -334,6 +334,10 @@ func newServices(
 	}
 
 	pow := pow.New(svcs.log, svcs.conf.PoW, svcs.timeService)
+	if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
+		pow.DisableVerification()
+	}
+
 	svcs.pow = pow
 	svcs.snapshotEngine.AddProviders(pow)
 	powWatchers := []netparams.WatchParam{

--- a/core/protocol/upon_genesis.go
+++ b/core/protocol/upon_genesis.go
@@ -75,10 +75,6 @@ func (svcs *allServices) loadAsset(
 		return fmt.Errorf("unable to get asset %v", err)
 	}
 
-	// if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain && asset.IsERC20() {
-	// 	return ErrERC20AssetWithNullChain
-	// }
-
 	// the validation is required only for validators
 	if svcs.conf.IsValidator() {
 		// just a simple backoff here

--- a/core/protocol/upon_genesis.go
+++ b/core/protocol/upon_genesis.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"code.vegaprotocol.io/vega/core/assets"
-	"code.vegaprotocol.io/vega/core/blockchain"
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/logging"
 	proto "code.vegaprotocol.io/vega/protos/vega"
@@ -76,9 +75,9 @@ func (svcs *allServices) loadAsset(
 		return fmt.Errorf("unable to get asset %v", err)
 	}
 
-	if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain && asset.IsERC20() {
-		return ErrERC20AssetWithNullChain
-	}
+	// if svcs.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain && asset.IsERC20() {
+	// 	return ErrERC20AssetWithNullChain
+	// }
 
 	// the validation is required only for validators
 	if svcs.conf.IsValidator() {

--- a/core/spam/engine.go
+++ b/core/spam/engine.go
@@ -63,7 +63,7 @@ type Engine struct {
 	hashKeys                []string
 	banDuration             time.Duration
 
-	noSpamProtection bool // flag that disables chesk for the spam policies, that is usefull for the nullchain
+	noSpamProtection bool // flag that disables chesk for the spam policies, that is useful for the nullchain
 }
 
 type Policy interface {


### PR DESCRIPTION
close vegaprotocol/devops-infra#1531 .

# Changes

Vega code disables some functionalities when we use null chain it causes an inability to use genesis where We have the ERC20 tokens - this means We cannot use the mainnet genesis. A very similar situation was with some of the snapshot items. Vega loads snapshots differently when We want to use the null chain.

I have removed branches for the null chain and now the null chain should behave in the same way as tendermint.


# Triggered runs:

- https://jenkins.ops.vega.xyz/job/common/job/vega-market-sim/2605/
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/52/



# Related PRs

- https://github.com/vegaprotocol/vega-market-sim/pull/471
- https://github.com/vegaprotocol/system-tests/pull/2323