### PR TITLE
feat: allow to specify runtime params when connecting to postgresql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [8846](https://github.com/vegaprotocol/vega/issues/8846) - Add support to transfer recurring transfers to metric based reward
 - [8857](https://github.com/vegaprotocol/vega/issues/8857) - Add a step for getting the balance of the liquidity provider liquidity fee account
 - [8847](https://github.com/vegaprotocol/vega/issues/8847) - Implement internal time trigger data source.
+- [8895](https://github.com/vegaprotocol/vega/issues/8895) - Allow to set runtime parameters in the SQL Store connection structure
 
 ### 🐛 Fixes
 

--- a/datanode/sqlstore/config.go
+++ b/datanode/sqlstore/config.go
@@ -56,6 +56,7 @@ type ConnectionConfig struct {
 	MaxConnLifetimeJitter encoding.Duration `long:"max-conn-lifetime-jitter"`
 	MaxConnPoolSize       int               `long:"max-conn-pool-size"`
 	MinConnPoolSize       int32             `long:"min-conn-pool-size"`
+	RuntimeParams         map[string]string `long:"runtime-params"`
 }
 
 type HypertableOverride interface {
@@ -129,6 +130,9 @@ func (conf ConnectionConfig) GetPoolConfig() (*pgxpool.Config, error) {
 	cfg.MaxConnLifetimeJitter = conf.MaxConnLifetimeJitter.Duration
 
 	cfg.ConnConfig.RuntimeParams["application_name"] = "Vega Data Node"
+	for paramKey, paramValue := range conf.RuntimeParams {
+		cfg.ConnConfig.RuntimeParams[paramKey] = paramValue
+	}
 	return cfg, nil
 }
 
@@ -143,6 +147,7 @@ func NewDefaultConfig() Config {
 			SocketDir:             "/tmp",
 			MaxConnLifetime:       encoding.Duration{Duration: time.Minute * 30},
 			MaxConnLifetimeJitter: encoding.Duration{Duration: time.Minute * 5},
+			RuntimeParams:         map[string]string{},
 		},
 		Level:            encoding.LogLevel{Level: logging.InfoLevel},
 		UseEmbedded:      false,


### PR DESCRIPTION
closes #8895


# Motivation of change.

We re-use the `sqlstore` package in our [monitoring tool](https://github.com/vegaprotocol/vega-monitoring). We re-import the package because We are adding more tables for monitoring purposes in the `data_node` database. However, We have to add new tables into a separated logic schema. To achieve it We MUST specify the runtime parameter called `search_patch` when connecting to the data-base.


# Breaking changes

No breaking change introduced

# Related PRs: 

- https://github.com/vegaprotocol/vega-monitoring/pull/6