### PR TITLE
Avoid panic when closing a market

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -322,7 +322,7 @@ func NewMarket(
 func (m *Market) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 	if epoch.Action == vega.EpochAction_EPOCH_ACTION_START {
 		m.liquidity.OnEpochStart(ctx, m.timeService.GetTimeNow(), m.markPrice, m.midPrice(), m.getTargetStake(), m.positionFactor)
-	} else if epoch.Action == vega.EpochAction_EPOCH_ACTION_END {
+	} else if epoch.Action == vega.EpochAction_EPOCH_ACTION_END && !m.finalFeesDistributed {
 		m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow())
 	}
 


### PR DESCRIPTION
If accounts have already been cleared (final distribution of LP fees already done), the regular "OnEpochEnd" call at block end will trigger panic when attempting to distribute again from the (now deleted) accounts.

Closes #8928 