### PR TITLE
feat: wire in internal time triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [8765](https://github.com/vegaprotocol/vega/issues/8765) - Implement snapshots state for `PERPS`.
 - [8918](https://github.com/vegaprotocol/vega/issues/8918) - Implement commands for team management.
 - [8960](https://github.com/vegaprotocol/vega/issues/8960) - Improve wiring perpetual markets through governance.
+- [8968](https://github.com/vegaprotocol/vega/issues/8968) - Improve wiring of internal time triggers for perpetual markets.
 - [8756](https://github.com/vegaprotocol/vega/issues/8756) - Settlement and margin implementation for `PERPS`.
 - [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the `nullchain` is used instead of `tendermint`
 - [8957](https://github.com/vegaprotocol/vega/issues/8957) - Oracle bindings for `PERPS`.

--- a/core/datasource/common/time_test.go
+++ b/core/datasource/common/time_test.go
@@ -168,4 +168,8 @@ func TestInternalTimeTriggersIsTriggered(t *testing.T) {
 	// Given time is after the next trigger
 	triggered = ttl.IsTriggered(nt.Add(time.Second * 15))
 	assert.Equal(t, true, triggered)
+
+	// check trigger time is progressed
+	triggered = ttl.IsTriggered(nt.Add(time.Second * 15))
+	assert.Equal(t, false, triggered)
 }

--- a/core/datasource/external/signedoracle/signedoracle_test.go
+++ b/core/datasource/external/signedoracle/signedoracle_test.go
@@ -145,3 +145,32 @@ func TestSpecConfigurationString(t *testing.T) {
 }
 
 func TestToDataSourceDefinitionProto(t *testing.T) {}
+
+func TestSpecConfigurationGetTimeTriggers(t *testing.T) {
+	ds := datasource.NewDefinitionWith(
+		signedoracle.SpecConfiguration{
+			Signers: []*common.Signer{
+				{},
+			},
+			Filters: []*common.SpecFilter{
+				{
+					Key: &common.SpecPropertyKey{
+						Name: "test-name",
+						Type: common.SpecPropertyKeyType(0),
+					},
+					Conditions: []*common.SpecCondition{
+						{
+							Operator: 8,
+							Value:    "12",
+						},
+					},
+				},
+			},
+		})
+
+	triggers := ds.GetTimeTriggers()
+	assert.NotNil(t, triggers)
+	assert.Equal(t, 1, len(triggers))
+	assert.IsType(t, &common.InternalTimeTrigger{}, triggers[0])
+	assert.Nil(t, triggers[0])
+}

--- a/core/datasource/spec/builtin.go
+++ b/core/datasource/spec/builtin.go
@@ -45,7 +45,8 @@ func (b *Builtin) OnTick(ctx context.Context, _ time.Time) {
 	data := common.Data{
 		Signers: nil,
 		Data: map[string]string{
-			BuiltinTimestamp: fmt.Sprintf("%d", b.engine.timeService.GetTimeNow().Unix()),
+			BuiltinTimestamp:   fmt.Sprintf("%d", b.engine.timeService.GetTimeNow().Unix()),
+			BuiltinTimeTrigger: fmt.Sprintf("%d", b.engine.timeService.GetTimeNow().Unix()),
 		},
 	}
 

--- a/core/products/perpetual_test.go
+++ b/core/products/perpetual_test.go
@@ -263,9 +263,9 @@ func testRegisteredCallbacks(t *testing.T) {
 	// register the callback
 	perpetual.NotifyOnSettlementData(marketSettle)
 
-	perpetual.OnLeaveOpeningAuction(ctx, 1000)
+	perpetual.OnLeaveOpeningAuction(ctx, scaleToNano(t, 1000))
 
-	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), 890))
+	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), scaleToNano(t, 890)))
 	// callback to receive settlement data
 	settle(ctx, dscommon.Data{
 		Data: map[string]string{
@@ -278,7 +278,7 @@ func testRegisteredCallbacks(t *testing.T) {
 
 	for _, p := range points {
 		// send in an external and a matching internal
-		require.NoError(t, perpetual.SubmitDataPoint(ctx, p.price, p.t))
+		require.NoError(t, perpetual.SubmitDataPoint(ctx, p.price, scaleToNano(t, p.t)))
 		settle(ctx, dscommon.Data{
 			Data: map[string]string{
 				perp.DataSourceSpecBinding.SettlementDataProperty: p.price.String(),
@@ -291,7 +291,7 @@ func testRegisteredCallbacks(t *testing.T) {
 
 	// add some data-points in the future from when we will cue the end of the funding period
 	// they should not affect the funding payment of this period
-	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), 2000))
+	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), scaleToNano(t, 2000)))
 	settle(ctx, dscommon.Data{
 		Data: map[string]string{
 			perp.DataSourceSpecBinding.SettlementDataProperty: "1",
@@ -354,9 +354,9 @@ func testRegisteredCallbacksWithDifferentData(t *testing.T) {
 	// register the callback
 	perpetual.NotifyOnSettlementData(marketSettle)
 
-	perpetual.OnLeaveOpeningAuction(ctx, 1000)
+	perpetual.OnLeaveOpeningAuction(ctx, scaleToNano(t, 1000))
 
-	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), 890))
+	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), scaleToNano(t, 890)))
 	// callback to receive settlement data
 	settle(ctx, dscommon.Data{
 		Data: map[string]string{
@@ -371,7 +371,7 @@ func testRegisteredCallbacksWithDifferentData(t *testing.T) {
 	for i, p := range points {
 		if i%2 == 0 {
 			ip := num.UintZero().Sub(p.price, num.UintOne())
-			require.NoError(t, perpetual.SubmitDataPoint(ctx, ip, p.t))
+			require.NoError(t, perpetual.SubmitDataPoint(ctx, ip, scaleToNano(t, p.t)))
 		}
 		settle(ctx, dscommon.Data{
 			Data: map[string]string{
@@ -385,7 +385,7 @@ func testRegisteredCallbacksWithDifferentData(t *testing.T) {
 
 	// add some data-points in the future from when we will cue the end of the funding period
 	// they should not affect the funding payment of this period
-	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), 2000))
+	require.NoError(t, perpetual.SubmitDataPoint(ctx, num.UintOne(), scaleToNano(t, 2000)))
 	settle(ctx, dscommon.Data{
 		Data: map[string]string{
 			perp.DataSourceSpecBinding.SettlementDataProperty: "1",
@@ -453,6 +453,11 @@ func getTestDataPoints(t *testing.T) []*testDataPoint {
 			t:     1030,
 		},
 	}
+}
+
+func scaleToNano(t *testing.T, secs int64) int64 {
+	t.Helper()
+	return secs * 1000000000
 }
 
 type tstPerp struct {


### PR DESCRIPTION
closes #8969  

Wires in the internal time trigger into the spec engine so that the cue's get broadcast time the perp product. There was also an issue where times received internally were in unixnano, but everything external is in seconds so for now I've scaled the external seconds to nanoseconds so that they are all at least all consistent. We might want to think a bit harder about this later.