### PR TITLE
fix: pass marketID through to product and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [8918](https://github.com/vegaprotocol/vega/issues/8918) - Implement commands for team management.
 - [8960](https://github.com/vegaprotocol/vega/issues/8960) - Improve wiring perpetual markets through governance.
 - [8969](https://github.com/vegaprotocol/vega/issues/8969) - Improve wiring of internal time triggers for perpetual markets.
+- [9001](https://github.com/vegaprotocol/vega/issues/9001) - Improve wiring of perpetual markets into the data node.
 - [8985](https://github.com/vegaprotocol/vega/issues/8985) - Improve snapshot restore of internal time triggers for perpetual markets.
 - [8756](https://github.com/vegaprotocol/vega/issues/8756) - Settlement and margin implementation for `PERPS`.
 - [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the `nullchain` is used instead of `tendermint`

--- a/cmd/data-node/commands/start/sqlsubscribers.go
+++ b/cmd/data-node/commands/start/sqlsubscribers.go
@@ -129,6 +129,7 @@ type SQLSubscribers struct {
 	pupSub                  *sqlsubscribers.ProtocolUpgrade
 	snapSub                 *sqlsubscribers.SnapshotData
 	stopOrdersSub           *sqlsubscribers.StopOrder
+	fundingPeriodSub        *sqlsubscribers.FundingPeriod
 }
 
 func (s *SQLSubscribers) GetSQLSubscribers() []broker.SQLBrokerSubscriber {
@@ -170,6 +171,7 @@ func (s *SQLSubscribers) GetSQLSubscribers() []broker.SQLBrokerSubscriber {
 		s.pupSub,
 		s.snapSub,
 		s.stopOrdersSub,
+		s.fundingPeriodSub,
 	}
 }
 
@@ -309,4 +311,5 @@ func (s *SQLSubscribers) SetupSQLSubscribers() {
 	s.pupSub = sqlsubscribers.NewProtocolUpgrade(s.protocolUpgradeService)
 	s.snapSub = sqlsubscribers.NewSnapshotData(s.coreSnapshotService)
 	s.stopOrdersSub = sqlsubscribers.NewStopOrder(s.stopOrderService)
+	s.fundingPeriodSub = sqlsubscribers.NewFundingPeriod(s.fundingPeriodService)
 }

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -180,7 +180,7 @@ func NewMarket(
 	assetDecimals := assetDetails.DecimalPlaces()
 	positionFactor := num.DecimalFromFloat(10).Pow(num.DecimalFromInt64(mkt.PositionDecimalPlaces))
 
-	tradableInstrument, err := markets.NewTradableInstrument(ctx, log, mkt.TradableInstrument, oracleEngine, broker, uint32(assetDecimals))
+	tradableInstrument, err := markets.NewTradableInstrument(ctx, log, mkt.TradableInstrument, mkt.ID, oracleEngine, broker, uint32(assetDecimals))
 	if err != nil {
 		return nil, fmt.Errorf("unable to instantiate a new market: %w", err)
 	}
@@ -385,7 +385,7 @@ func (m *Market) Update(ctx context.Context, config *types.Market, oracleEngine 
 	} else {
 		m.tradableInstrument.Instrument.Unsubscribe(ctx)
 	}
-	if err := m.tradableInstrument.UpdateInstrument(ctx, m.log, m.mkt.TradableInstrument, oracleEngine, m.broker); err != nil {
+	if err := m.tradableInstrument.UpdateInstrument(ctx, m.log, m.mkt.TradableInstrument, m.GetID(), oracleEngine, m.broker); err != nil {
 		return err
 	}
 	m.risk.UpdateModel(m.stateVarEngine, m.tradableInstrument.MarginCalculator, m.tradableInstrument.RiskModel)

--- a/core/execution/future/market_snapshot.go
+++ b/core/execution/future/market_snapshot.go
@@ -65,7 +65,7 @@ func NewMarketFromSnapshot(
 	}
 
 	assetDecimals := assetDetails.DecimalPlaces()
-	tradableInstrument, err := markets.NewTradableInstrumentFromSnapshot(ctx, log, mkt.TradableInstrument,
+	tradableInstrument, err := markets.NewTradableInstrumentFromSnapshot(ctx, log, mkt.TradableInstrument, em.Market.ID,
 		oracleEngine, broker, em.Product, uint32(assetDecimals), timeService.GetTimeNow())
 	if err != nil {
 		return nil, fmt.Errorf("unable to instantiate a new market: %w", err)

--- a/core/markets/instrument.go
+++ b/core/markets/instrument.go
@@ -32,8 +32,8 @@ type TradableInstrument struct {
 
 // NewTradableInstrument will instantiate a new tradable instrument
 // using a market framework configuration for a tradable instrument.
-func NewTradableInstrument(ctx context.Context, log *logging.Logger, pti *types.TradableInstrument, oe products.OracleEngine, broker products.Broker, assetDP uint32) (*TradableInstrument, error) {
-	instrument, err := NewInstrument(ctx, log, pti.Instrument, oe, broker, assetDP)
+func NewTradableInstrument(ctx context.Context, log *logging.Logger, pti *types.TradableInstrument, marketID string, oe products.OracleEngine, broker products.Broker, assetDP uint32) (*TradableInstrument, error) {
+	instrument, err := NewInstrument(ctx, log, pti.Instrument, marketID, oe, broker, assetDP)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +50,8 @@ func NewTradableInstrument(ctx context.Context, log *logging.Logger, pti *types.
 	}, nil
 }
 
-func (i *TradableInstrument) UpdateInstrument(ctx context.Context, log *logging.Logger, ti *types.TradableInstrument, oe products.OracleEngine, broker products.Broker) error {
-	instrument, err := NewInstrument(ctx, log, ti.Instrument, oe, broker, i.assetDP)
+func (i *TradableInstrument) UpdateInstrument(ctx context.Context, log *logging.Logger, ti *types.TradableInstrument, marketID string, oe products.OracleEngine, broker products.Broker) error {
+	instrument, err := NewInstrument(ctx, log, ti.Instrument, marketID, oe, broker, i.assetDP)
 	if err != nil {
 		return err
 	}
@@ -82,8 +82,8 @@ type Instrument struct {
 
 // NewInstrument will instantiate a new instrument
 // using a market framework configuration for a instrument.
-func NewInstrument(ctx context.Context, log *logging.Logger, pi *types.Instrument, oe products.OracleEngine, broker products.Broker, assetDP uint32) (*Instrument, error) {
-	product, err := products.New(ctx, log, pi.Product, oe, broker, assetDP)
+func NewInstrument(ctx context.Context, log *logging.Logger, pi *types.Instrument, marketID string, oe products.OracleEngine, broker products.Broker, assetDP uint32) (*Instrument, error) {
+	product, err := products.New(ctx, log, pi.Product, marketID, oe, broker, assetDP)
 	if err != nil {
 		return nil, fmt.Errorf("unable to instantiate product from instrument configuration: %w", err)
 	}

--- a/core/markets/instrument_snapshot.go
+++ b/core/markets/instrument_snapshot.go
@@ -30,13 +30,14 @@ func NewInstrumentFromSnapshot(
 	ctx context.Context,
 	log *logging.Logger,
 	pi *types.Instrument,
+	marketID string,
 	oe products.OracleEngine,
 	broker products.Broker,
 	productState *snapshotpb.Product,
 	assetDP uint32,
 	tm time.Time,
 ) (*Instrument, error) {
-	product, err := products.NewFromSnapshot(ctx, log, pi.Product, oe, broker, productState, assetDP, tm)
+	product, err := products.NewFromSnapshot(ctx, log, pi.Product, marketID, oe, broker, productState, assetDP, tm)
 	if err != nil {
 		return nil, fmt.Errorf("unable to instantiate product from instrument configuration: %w", err)
 	}
@@ -55,13 +56,14 @@ func NewTradableInstrumentFromSnapshot(
 	ctx context.Context,
 	log *logging.Logger,
 	pti *types.TradableInstrument,
+	marketID string,
 	oe products.OracleEngine,
 	broker products.Broker,
 	productState *snapshotpb.Product,
 	assetDP uint32,
 	tm time.Time,
 ) (*TradableInstrument, error) {
-	instrument, err := NewInstrumentFromSnapshot(ctx, log, pti.Instrument, oe, broker, productState, assetDP, tm)
+	instrument, err := NewInstrumentFromSnapshot(ctx, log, pti.Instrument, marketID, oe, broker, productState, assetDP, tm)
 	if err != nil {
 		return nil, err
 	}

--- a/core/markets/instrument_test.go
+++ b/core/markets/instrument_test.go
@@ -37,7 +37,7 @@ import (
 func TestInstrument(t *testing.T) {
 	t.Run("Create a valid new instrument", func(t *testing.T) {
 		pinst := getValidInstrumentProto()
-		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
+		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, "", newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
 		assert.NotNil(t, inst)
 		assert.Nil(t, err)
 	})
@@ -45,7 +45,7 @@ func TestInstrument(t *testing.T) {
 	t.Run("nil product", func(t *testing.T) {
 		pinst := getValidInstrumentProto()
 		pinst.Product = nil
-		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
+		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, "", newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
 		assert.Nil(t, inst)
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Error(), "unable to instantiate product from instrument configuration: nil product")
@@ -64,7 +64,7 @@ func TestInstrument(t *testing.T) {
 				},
 			},
 		}
-		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
+		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, "", newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
 		require.NotNil(t, err)
 		assert.Nil(t, inst)
 		assert.Equal(t, "unable to instantiate product from instrument configuration: a data source spec and spec binding are required", err.Error())
@@ -114,7 +114,7 @@ func TestInstrument(t *testing.T) {
 				DataSourceSpecBinding: nil,
 			},
 		}
-		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
+		inst, err := markets.NewInstrument(context.Background(), logging.NewTestLogger(), pinst, "", newOracleEngine(t), mocks.NewMockBroker(gomock.NewController(t)), 1)
 		require.NotNil(t, err)
 		assert.Nil(t, inst)
 		assert.Equal(t, "unable to instantiate product from instrument configuration: a data source spec and spec binding are required", err.Error())

--- a/core/products/perpetual.go
+++ b/core/products/perpetual.go
@@ -74,7 +74,7 @@ type Perpetual struct {
 	assetDP uint32
 }
 
-func NewPerpetual(ctx context.Context, log *logging.Logger, p *types.Perps, oe OracleEngine, broker Broker, assetDP uint32) (*Perpetual, error) {
+func NewPerpetual(ctx context.Context, log *logging.Logger, p *types.Perps, marketID string, oe OracleEngine, broker Broker, assetDP uint32) (*Perpetual, error) {
 	// make sure we have all we need
 	if p.DataSourceSpecForSettlementData == nil || p.DataSourceSpecForSettlementSchedule == nil || p.DataSourceSpecBinding == nil {
 		return nil, ErrDataSourceSpecAndBindingAreRequired
@@ -87,6 +87,7 @@ func NewPerpetual(ctx context.Context, log *logging.Logger, p *types.Perps, oe O
 	// check decimal places for settlement data
 	perp := &Perpetual{
 		p:       p,
+		id:      marketID,
 		log:     log,
 		broker:  broker,
 		assetDP: assetDP,

--- a/core/products/perpetual_snapshot.go
+++ b/core/products/perpetual_snapshot.go
@@ -26,6 +26,7 @@ func NewPerpetualFromSnapshot(
 	ctx context.Context,
 	log *logging.Logger,
 	p *types.Perps,
+	marketID string,
 	oe OracleEngine,
 	broker Broker,
 	state *snapshotpb.Perps,
@@ -34,9 +35,9 @@ func NewPerpetualFromSnapshot(
 ) (*Perpetual, error) {
 	// set next trigger from the settlement cue, it'll roll forward from `initial` to the next trigger time after `now`
 	tt := p.DataSourceSpecForSettlementSchedule.Data.GetInternalTimeTriggerSpecConfiguration()
-	tt.SetNextTrigger(tm)
+	tt.SetNextTrigger(tm.Truncate(time.Second))
 
-	perps, err := NewPerpetual(ctx, log, p, oe, broker, assetDP)
+	perps, err := NewPerpetual(ctx, log, p, marketID, oe, broker, assetDP)
 	if err != nil {
 		return nil, err
 	}

--- a/core/products/perpetual_test.go
+++ b/core/products/perpetual_test.go
@@ -259,7 +259,7 @@ func testRegisteredCallbacks(t *testing.T) {
 	broker.EXPECT().Send(gomock.Any()).AnyTimes()
 	broker.EXPECT().SendBatch(gomock.Any()).AnyTimes()
 	perp := getTestPerpProd(t)
-	perpetual, err := products.NewPerpetual(context.Background(), log, perp, oe, broker, 1)
+	perpetual, err := products.NewPerpetual(context.Background(), log, perp, "", oe, broker, 1)
 	require.NoError(t, err)
 	require.NotNil(t, settle)
 	require.NotNil(t, period)
@@ -350,7 +350,7 @@ func testRegisteredCallbacksWithDifferentData(t *testing.T) {
 	broker.EXPECT().Send(gomock.Any()).AnyTimes()
 	broker.EXPECT().SendBatch(gomock.Any()).AnyTimes()
 	perp := getTestPerpProd(t)
-	perpetual, err := products.NewPerpetual(context.Background(), log, perp, oe, broker, 1)
+	perpetual, err := products.NewPerpetual(context.Background(), log, perp, "", oe, broker, 1)
 	require.NoError(t, err)
 	require.NotNil(t, settle)
 	require.NotNil(t, period)
@@ -481,7 +481,7 @@ func testPerpetual(t *testing.T) *tstPerp {
 	oe.EXPECT().Subscribe(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(spec.SubscriptionID(1), func(_ context.Context, _ spec.SubscriptionID) {}, nil)
 	perp := getTestPerpProd(t)
 
-	perpetual, err := products.NewPerpetual(context.Background(), log, perp, oe, broker, 1)
+	perpetual, err := products.NewPerpetual(context.Background(), log, perp, "", oe, broker, 1)
 	if err != nil {
 		t.Fatalf("couldn't create a perp for testing: %v", err)
 	}

--- a/core/products/products.go
+++ b/core/products/products.go
@@ -70,7 +70,7 @@ type Product interface {
 }
 
 // New instance a new product from a Market framework product configuration.
-func New(ctx context.Context, log *logging.Logger, pp interface{}, oe OracleEngine, broker Broker, assetDP uint32) (Product, error) {
+func New(ctx context.Context, log *logging.Logger, pp interface{}, marketID string, oe OracleEngine, broker Broker, assetDP uint32) (Product, error) {
 	if pp == nil {
 		return nil, ErrNilProduct
 	}
@@ -79,7 +79,7 @@ func New(ctx context.Context, log *logging.Logger, pp interface{}, oe OracleEngi
 	case *types.InstrumentFuture:
 		return NewFuture(ctx, log, p.Future, oe, assetDP)
 	case *types.InstrumentPerps:
-		return NewPerpetual(ctx, log, p.Perps, oe, broker, assetDP)
+		return NewPerpetual(ctx, log, p.Perps, marketID, oe, broker, assetDP)
 	default:
 		return nil, ErrUnimplementedProduct
 	}

--- a/core/products/products_snapshot.go
+++ b/core/products/products_snapshot.go
@@ -29,6 +29,7 @@ func NewFromSnapshot(
 	ctx context.Context,
 	log *logging.Logger,
 	pp interface{},
+	marketID string,
 	oe OracleEngine,
 	broker Broker,
 	state *snapshotpb.Product,
@@ -47,7 +48,7 @@ func NewFromSnapshot(
 		if perpsState == nil {
 			return nil, ErrNoStateProvidedForPerpsWithSnapshot
 		}
-		return NewPerpetualFromSnapshot(ctx, log, p.Perps, oe, broker, perpsState, assetDP, tm)
+		return NewPerpetualFromSnapshot(ctx, log, p.Perps, marketID, oe, broker, perpsState, assetDP, tm)
 	default:
 		return nil, ErrUnimplementedProduct
 	}

--- a/core/products/products_test.go
+++ b/core/products/products_test.go
@@ -116,7 +116,7 @@ func TestFutureSettlement(t *testing.T) {
 
 	prodSpec := proto.Product
 	require.NotNil(t, prodSpec)
-	prod, err := products.New(ctx, logging.NewTestLogger(), prodSpec, oe, broker, 1)
+	prod, err := products.New(ctx, logging.NewTestLogger(), prodSpec, "", oe, broker, 1)
 
 	// Cast back into a future so we can call future specific functions
 	f, ok := prod.(*products.Future)

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -3907,10 +3907,20 @@ func stopOrderExpiryStrategyFromProto(strategies []vega.StopOrder_ExpiryStrategy
 
 func (t *TradingDataServiceV2) ListFundingPeriods(ctx context.Context, req *v2.ListFundingPeriodsRequest) (*v2.ListFundingPeriodsResponse, error) {
 	defer metrics.StartAPIRequestAndTimeGRPC("ListFundingPeriods")()
+
+	if len(req.MarketId) == 0 {
+		return nil, formatE(ErrEmptyMissingMarketID)
+	}
+
+	if !crypto.IsValidVegaID(req.MarketId) {
+		return nil, formatE(ErrInvalidMarketID)
+	}
+
 	pagination, err := entities.CursorPaginationFromProto(req.Pagination)
 	if err != nil {
 		return nil, formatE(ErrInvalidPagination, err)
 	}
+
 	dateRange := entities.DateRangeFromProto(req.DateRange)
 	periods, pageInfo, err := t.fundingPeriodService.ListFundingPeriods(ctx, entities.MarketID(req.MarketId), dateRange, pagination)
 	if err != nil {
@@ -3936,6 +3946,15 @@ func (t *TradingDataServiceV2) ListFundingPeriodDataPoints(ctx context.Context, 
 	*v2.ListFundingPeriodDataPointsResponse, error,
 ) {
 	defer metrics.StartAPIRequestAndTimeGRPC("ListFundingPeriodDataPoints")()
+
+	if len(req.MarketId) == 0 {
+		return nil, formatE(ErrEmptyMissingMarketID)
+	}
+
+	if !crypto.IsValidVegaID(req.MarketId) {
+		return nil, formatE(ErrInvalidMarketID)
+	}
+
 	pagination, err := entities.CursorPaginationFromProto(req.Pagination)
 	if err != nil {
 		return nil, formatE(ErrInvalidPagination, err)

--- a/datanode/entities/enums.go
+++ b/datanode/entities/enums.go
@@ -534,6 +534,7 @@ const (
 	ProposalErrorInvalidStateUpdate               = ProposalError(vega.ProposalError_PROPOSAL_ERROR_INVALID_MARKET_STATE_UPDATE)
 	ProposalErrorInvalidSLAParams                 = ProposalError(vega.ProposalError_PROPOSAL_ERROR_INVALID_SLA_PARAMS)
 	ProposalErrorMissingSLAParams                 = ProposalError(vega.ProposalError_PROPOSAL_ERROR_MISSING_SLA_PARAMS)
+	ProposalInvalidPerpetualProduct               = ProposalError(vega.ProposalError_PROPOSAL_ERROR_INVALID_PERPETUAL_PRODUCT)
 )
 
 func (s ProposalError) EncodeText(_ *pgtype.ConnInfo, buf []byte) ([]byte, error) {

--- a/datanode/entities/funding_period.go
+++ b/datanode/entities/funding_period.go
@@ -28,55 +28,51 @@ type FundingPeriod struct {
 }
 
 func NewFundingPeriodFromProto(fp *events.FundingPeriod, txHash TxHash, vegaTime time.Time) (*FundingPeriod, error) {
-	var (
-		endTime        *time.Time
-		fundingPayment *num.Decimal
-		fundingRate    *num.Decimal
-		externalTwap   *num.Decimal
-		internalTwap   *num.Decimal
-		err            error
-	)
-
-	if fp.End != nil {
-		endTime = ptr.From(NanosToPostgresTimestamp(*fp.End))
-	}
-
-	if fp.FundingPayment != nil {
-		if *fundingPayment, err = num.DecimalFromString(*fp.FundingPayment); err != nil {
-			return nil, err
-		}
-	}
-
-	if fp.FundingRate != nil {
-		if *fundingRate, err = num.DecimalFromString(*fp.FundingRate); err != nil {
-			return nil, err
-		}
-	}
-
-	if fp.ExternalTwap != nil {
-		if *externalTwap, err = num.DecimalFromString(*fp.ExternalTwap); err != nil {
-			return nil, err
-		}
-	}
-
-	if fp.InternalTwap != nil {
-		if *internalTwap, err = num.DecimalFromString(*fp.InternalTwap); err != nil {
-			return nil, err
-		}
-	}
-
-	return &FundingPeriod{
+	fundingPeriod := &FundingPeriod{
 		MarketID:         MarketID(fp.MarketId),
 		FundingPeriodSeq: fp.Seq,
 		StartTime:        NanosToPostgresTimestamp(fp.Start),
-		EndTime:          endTime,
-		FundingPayment:   fundingPayment,
-		FundingRate:      fundingRate,
-		ExternalTwap:     externalTwap,
-		InternalTwap:     internalTwap,
 		VegaTime:         vegaTime,
 		TxHash:           txHash,
-	}, err
+	}
+
+	if fp.End != nil {
+		fundingPeriod.EndTime = ptr.From(NanosToPostgresTimestamp(*fp.End))
+	}
+
+	if fp.FundingPayment != nil {
+		fundingPayment, err := num.DecimalFromString(*fp.FundingPayment)
+		if err != nil {
+			return nil, err
+		}
+		fundingPeriod.FundingPayment = &fundingPayment
+	}
+
+	if fp.FundingRate != nil {
+		fundingRate, err := num.DecimalFromString(*fp.FundingRate)
+		if err != nil {
+			return nil, err
+		}
+		fundingPeriod.FundingRate = &fundingRate
+	}
+
+	if fp.ExternalTwap != nil {
+		externalTwap, err := num.DecimalFromString(*fp.ExternalTwap)
+		if err != nil {
+			return nil, err
+		}
+		fundingPeriod.ExternalTwap = &externalTwap
+	}
+
+	if fp.InternalTwap != nil {
+		internalTwap, err := num.DecimalFromString(*fp.InternalTwap)
+		if err != nil {
+			return nil, err
+		}
+		fundingPeriod.InternalTwap = &internalTwap
+	}
+
+	return fundingPeriod, nil
 }
 
 func (fp FundingPeriod) ToProto() *events.FundingPeriod {

--- a/datanode/entities/ledgerentry.go
+++ b/datanode/entities/ledgerentry.go
@@ -129,6 +129,8 @@ const (
 	LedgerMovementTypeTransferFundsSend       = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_SEND)
 	LedgerMovementTypeTransferFundsDistribute = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_DISTRIBUTE)
 	LedgerMovementTypeClearAccount            = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_CLEAR_ACCOUNT)
+	LedgerMovementTypePerpFundingWin          = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_PERP_FUNDING_WIN)
+	LedgerMovementTypePerpFundingLoss         = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_PERP_FUNDING_LOSS)
 )
 
 func (l LedgerMovementType) EncodeText(_ *pgtype.ConnInfo, buf []byte) ([]byte, error) {

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -3215,6 +3215,8 @@ enum ProposalRejectionReason {
   PROPOSAL_ERROR_MISSING_SLA_PARAMS
   "Mandatory liquidity provision SLA parameters are missing from the proposal"
   PROPOSAL_ERROR_INVALID_SLA_PARAMS
+  "Perpetual market proposal contained invalid product definition"
+  PROPOSAL_ERROR_INVALID_PERPETUAL_PRODUCT
 }
 
 "Why the order was rejected by the core node"

--- a/datanode/sqlstore/migrations/0023_periodic_settlement_data.sql
+++ b/datanode/sqlstore/migrations/0023_periodic_settlement_data.sql
@@ -1,4 +1,7 @@
 -- +goose Up
+
+ALTER TYPE proposal_error ADD VALUE IF NOT EXISTS 'PROPOSAL_ERROR_INVALID_PERPETUAL_PRODUCT';
+
 CREATE TABLE IF NOT EXISTS funding_period (
     market_id BYTEA NOT NULL,
     funding_period_seq BIGINT NOT NULL,

--- a/datanode/sqlstore/proposals_test.go
+++ b/datanode/sqlstore/proposals_test.go
@@ -60,7 +60,7 @@ func addTestProposal(
 		RequiredLPParticipation: nil,
 		TxHash:                  generateTxHash(),
 	}
-	ps.Add(ctx, p)
+	assert.NoError(t, ps.Add(ctx, p))
 	return p
 }
 
@@ -160,6 +160,14 @@ func TestProposals(t *testing.T) {
 		actual, _, err := propStore.Get(ctx, nil, nil, propType, entities.CursorPagination{})
 		require.NoError(t, err)
 		assertProposalsMatch(t, expected, actual)
+	})
+
+	t.Run("Add with proposal error", func(t *testing.T) {
+		propError := entities.ProposalInvalidPerpetualProduct
+		expected := addTestProposal(t, ctx, propStore, helpers.GenerateID(), party1, reference1, block1, entities.ProposalStateEnacted, rationale1, terms1, propError)
+		actual, err := propStore.GetByID(ctx, string(expected.ID))
+		require.NoError(t, err)
+		assert.Equal(t, expected.Reason, actual.Reason)
 	})
 }
 


### PR DESCRIPTION
closes #9001 

I created a perpetual's market and had a play with the new data-node endpoints. There were a few niggles:
- core wasn't sending a market ID with the funding period events, so we couldn't query them
- some edge case when restoring from a snapshot came up due to the fact the oracles use precision seconds but we'd restore a trigger with nano-seconds
- data node was missing knowledge of a few new types for proposals/transfers that were added to the protos
- some other general plumbing issues with the new data subscriber for the funding events