### PR TITLE
fix: clear insurance pools in a determinisitc order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - [8874](https://github.com/vegaprotocol/vega/issues/8874) - Database migration can fail when rolling back and migrating up again.
 - [8855](https://github.com/vegaprotocol/vega/issues/8855) - Preserve reference to parent market when restoring checkpoint data
 - [8909](https://github.com/vegaprotocol/vega/issues/8909) - initialise id generator for all branches of market state update
+- [9004](https://github.com/vegaprotocol/vega/issues/9004) - Clear insurance pools in a deterministic order in successor markets.
 - [8908](https://github.com/vegaprotocol/vega/issues/8908) - A rejected parent market should result in all successors getting rejected, too.
 - [8953](https://github.com/vegaprotocol/vega/issues/8953) - Fix reward distribution when validator delegate to other validators
 - [8898](https://github.com/vegaprotocol/vega/issues/8898) - Fix auction uncrossing handling for spots

--- a/core/execution/engine.go
+++ b/core/execution/engine.go
@@ -1330,9 +1330,20 @@ func (e *Engine) OnTick(ctx context.Context, t time.Time) {
 		}
 		e.removeMarket(id)
 	}
+
+	// sort the marketCPStates by ID since the order we clear insurance pools
+	// changes the division when we split it across remaining markets and
+	// who the remainder ends up with if it doesn't divide equally.
+	allIDs := []string{}
+	for id := range e.marketCPStates {
+		allIDs = append(allIDs, id)
+	}
+	sort.Strings(allIDs)
+
 	// find state that should expire
-	for id, cpm := range e.marketCPStates {
+	for _, id := range allIDs {
 		// market field will be nil if the market is still current (ie not closed/settled)
+		cpm := e.marketCPStates[id]
 		if !cpm.TTL.Before(t) {
 			// CP data has not expired yet
 			continue


### PR DESCRIPTION
closes #9004 

We have two markets that are getting their insurance pools cleared during an OnTick:
`market1` has balance `0`
`market2` has balance `432400000000000000000`
there are 8 other markets not being cleared but will receive the cleared balance split equally.

If we process `market1` first:
- `market1` has balance `0` and is removed
- `market2`then has its balance split between 8
- each other market gets `54050000000000000000`

If we process `market2` first:
- `market2`'s balance is split between 9, including `market1`
- each get `48044444444444444444`
- then we process `market1` which now has a balance of `48044444444444444444`
- this is split between 8 and each get `6005555555555555555`

The end result is the same, except that because it one case we have to divide twice, we have to handle the remainer twice and the crumbs end up in with different markets.

