### PR TITLE
test: add test tool for json comparison of requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ integration.test
 .testCoverage.txt
 *.tmp
 tmp/
+cmd/vegatools/testdata/*
 
 # Exclude files related to proto
 proto/*-re

--- a/cmd/vegatools/checktx.go
+++ b/cmd/vegatools/checktx.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"fmt"
+
+	inspecttx2 "code.vegaprotocol.io/vega/vegatools/inspecttx"
+
+	"github.com/sirupsen/logrus"
+
+	"code.vegaprotocol.io/vega/core/config"
+)
+
+var (
+	transactionDiffs     int
+	transactionsAnalysed int
+	transactionsPassed   int
+)
+
+type checkTxCmd struct {
+	config.OutputFlag
+	Diffs        string `description:"The output directory for detailed reporting on diffs" long:"diffs"        short:"d"`
+	Transactions string `description:"Path to the transaction json files"                   long:"transactions" required:"true" short:"t"`
+}
+
+func (opts *checkTxCmd) Execute(_ []string) error {
+	transactionsAnalysed = 0
+	transactionsPassed = 0
+	transactionDiffs = 0
+
+	transactionFiles, err := inspecttx2.GetFilesInDirectory(opts.Transactions)
+	if err != nil {
+		return fmt.Errorf("error when attempting to get files in the given directory. \nerr: %v", err)
+	}
+
+	for _, file := range transactionFiles {
+		transactionData, err := inspecttx2.GetTransactionDataFromFile(file)
+		if err != nil {
+			return fmt.Errorf("error reading transaction file '%s'\nerr: %v", file, err)
+		}
+
+		logrus.Infof("inspecting transaction in '%s'", file)
+		result, err := inspecttx2.TransactionMatch(transactionData)
+		if err != nil {
+			return fmt.Errorf("error when attempting to inspect transaction in file '%s' \nerr: %v", file, err)
+		}
+
+		if result.Match {
+			transactionsPassed += 1
+		} else {
+			transactionDiffs += 1
+			inspecttx2.WriteDiffsToFile(file, opts.Diffs, result)
+		}
+		transactionsAnalysed += 1
+	}
+
+	logrus.Infof("transactions analysed: %d, transactions passed: %d, transactions failed: %d", transactionsAnalysed, transactionsPassed, transactionDiffs)
+	if transactionDiffs != 0 {
+		return fmt.Errorf("there were diffs in the transactions sent from your application vs the marshalled equivalents from core, check your protos are up to date. Diffs can be found in '%s'\nnumber of transactions with diffs: %d", opts.Diffs, transactionDiffs)
+	}
+
+	return nil
+}

--- a/cmd/vegatools/checktx_test.go
+++ b/cmd/vegatools/checktx_test.go
@@ -1,0 +1,115 @@
+package tools
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"code.vegaprotocol.io/vega/vegatools/inspecttx"
+
+	"code.vegaprotocol.io/vega/libs/proto"
+
+	v1 "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+
+	"code.vegaprotocol.io/vega/commands"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testFiles = "./testdata/transactionfiles"
+	diffFiles = "./testdata/diffs"
+)
+
+var testInputData = v1.InputData{Nonce: 123, BlockHeight: 456, Command: &v1.InputData_Transfer{Transfer: &v1.Transfer{
+	FromAccountType: 1,
+	To:              "dave",
+	ToAccountType:   2,
+	Asset:           "test asset",
+	Amount:          "123",
+	Reference:       "test ref",
+	Kind:            nil,
+}}}
+
+func setUpTestData(t *testing.T) inspecttx.TransactionData {
+	t.Helper()
+	marshalledInputData, err := commands.MarshalInputData(&testInputData)
+	assert.NoErrorf(t, err, "error occurred when attempting to marshal test input data\nerr: %v", err)
+	testTransaction := commands.NewTransaction("mykey", marshalledInputData, commands.NewSignature([]byte("testSig"), "testAlgo", 3))
+
+	transactionJson, err := inspecttx.MarshalToJSONWithOneOf(testTransaction)
+	assert.NoErrorf(t, err, "error occurred when attempting to marshal raw transaction to json: %v", err)
+	inputDataJson, err := inspecttx.MarshalToJSONWithOneOf(&testInputData)
+	assert.NoErrorf(t, err, "error occurred when attempting to marshal raw input data to json: %v", err)
+	protoToEncode, err := proto.Marshal(testTransaction)
+	assert.NoErrorf(t, err, "error occurred when attempting to encode the transaction proto %v", err)
+	encodedData := base64.StdEncoding.EncodeToString(protoToEncode)
+
+	testData := inspecttx.TransactionData{Transaction: json.RawMessage(transactionJson), InputData: json.RawMessage(inputDataJson), EncodedData: encodedData}
+	return testData
+}
+
+func writeTestDataToFile(t *testing.T, testData inspecttx.TransactionData, testFileName string) {
+	t.Helper()
+	transactionData, err := json.Marshal(testData)
+	assert.NoErrorf(t, err, "error occurred when attempting to marshal the test data")
+	err = os.MkdirAll(testFiles, 0o755)
+	assert.NoErrorf(t, err, "error occurred when attempting to make a directory for the valid test data")
+	filePath := path.Join(testFiles, testFileName)
+
+	err = os.WriteFile(filePath, transactionData, 0o644)
+	assert.NoErrorf(t, err, "error when creating transaction.json file.\nerr: %v", err)
+
+	err = os.MkdirAll(diffFiles, 0o755)
+	assert.NoErrorf(t, err, "error occurred when attempting to make a directory for test diffs")
+}
+
+func clearTestData(t *testing.T) {
+	t.Helper()
+	err := os.RemoveAll(testFiles)
+	assert.NoErrorf(t, err, "error occurred when attempting to clean valid test data dir")
+}
+
+func TestInspectTxsInDirectoryCmd_ReturnsNoErrorWhenAllTransactionsMatch(t *testing.T) {
+	clearTestData(t)
+	writeTestDataToFile(t, setUpTestData(t), "transaction1.json")
+	writeTestDataToFile(t, setUpTestData(t), "transaction2.json")
+	cmd := checkTxCmd{
+		Transactions: testFiles,
+		Diffs:        diffFiles,
+	}
+
+	err := cmd.Execute(nil)
+	assert.NoErrorf(t, err, "expected inspectTxsInDirectoryCmd to run without error, however one was thrown: \nERR: %v", err)
+	assert.Equalf(t, 0, transactionDiffs, "expected there to be no comparison failures, instead there was %d", transactionDiffs)
+	assert.Equalf(t, 2, transactionsPassed, "expected there to be 1 passing transaction, instead there was %d", transactionsPassed)
+	assert.Equalf(t, 2, transactionsAnalysed, "expected there to be 1 analysed transaction, instead there was %d", transactionsAnalysed)
+}
+
+func TestInspectTxsInDirectoryCmd_ErrReturnedAfterInspectingAllFilesIfNoMatch(t *testing.T) {
+	clearTestData(t)
+	data := setUpTestData(t)
+	var jsonMap map[string]interface{}
+	err := json.Unmarshal(data.Transaction, &jsonMap)
+	assert.NoErrorf(t, err, "error occurred when attempting to unmarshal transaction to map when prepping sad path test data")
+
+	jsonMap["version"] = "this will cause a diff"
+	jsonForCausingDiff, err := json.Marshal(jsonMap)
+	assert.NoErrorf(t, err, "error occurred when attempting to marshal sad path data to json")
+	data.Transaction = jsonForCausingDiff
+
+	writeTestDataToFile(t, data, "transaction.json")
+	writeTestDataToFile(t, setUpTestData(t), "transaction1.json")
+	cmd := checkTxCmd{
+		Transactions: testFiles,
+		Diffs:        diffFiles,
+	}
+
+	err = cmd.Execute(nil)
+	assert.Error(t, err, "inspectTxsInDirectoryCmd was expected to fail, however the command did not throw any error")
+	assert.Equalf(t, 1, transactionDiffs, "expected there to be 1 failure, instead there was %d", transactionDiffs)
+	assert.Equalf(t, 1, transactionsPassed, "expected there to be 1 passing transaction, instead there was %d", transactionsPassed)
+	assert.Equalf(t, 2, transactionsAnalysed, "expected there to be 2 analysed transactions, instead there was %d", transactionsAnalysed)
+}

--- a/cmd/vegatools/root.go
+++ b/cmd/vegatools/root.go
@@ -16,6 +16,7 @@ type RootCmd struct {
 	Snapshot   snapshotCmd   `command:"snapshot"   description:"Display information about saved snapshots"`
 	Checkpoint checkpointCmd `command:"checkpoint" description:"Make checkpoint human-readable, or generate checkpoint from human readable format"`
 	Stream     streamCmd     `command:"stream"     description:"Stream events from vega node"`
+	CheckTx    checkTxCmd    `command:"check-tx"   description:"Decode transactions created from a dependent app, check vega's decoded transaction matches your apps transaction"`
 }
 
 var rootCmd RootCmd
@@ -25,6 +26,7 @@ func VegaTools(ctx context.Context, parser *flags.Parser) error {
 		Snapshot:   snapshotCmd{},
 		Checkpoint: checkpointCmd{},
 		Stream:     streamCmd{},
+		CheckTx:    checkTxCmd{},
 	}
 
 	var (

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/google/go-github/v50 v50.0.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.9.0
+	github.com/iancoleman/strcase v0.3.0
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/ipfs/boxo v0.8.1
 	github.com/ipfs/go-cid v0.4.1
@@ -78,9 +79,11 @@ require (
 	github.com/muesli/cancelreader v0.2.2
 	github.com/muesli/termenv v0.11.0
 	github.com/multiformats/go-multiaddr v0.9.0
+	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220317090546-adb2f9614b17
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pressly/goose/v3 v3.6.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/soheilhy/cmux v0.1.4
 	github.com/tendermint/tendermint v0.35.9
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75
@@ -247,7 +250,6 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/samber/lo v1.36.0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ github.com/huin/goupnp v1.1.0 h1:gEe0Dp/lZmPZiDFzJJaOfUpOvv2MKUkoBX8lDrn9vKU=
 github.com/huin/goupnp v1.1.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
@@ -1147,6 +1149,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
+github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 h1:dOYG7LS/WK00RWZc8XGgcUTlTxpp3mKhdR2Q9z9HbXM=
+github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/vegatools/inspecttx/file.go
+++ b/vegatools/inspecttx/file.go
@@ -1,0 +1,125 @@
+package inspecttx
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type TransactionData struct {
+	Transaction json.RawMessage
+	InputData   json.RawMessage
+	EncodedData string
+}
+
+type DiffType string
+
+const (
+	InputData   DiffType = "InputData"
+	Transaction DiffType = "Transaction"
+)
+
+func GetFilesInDirectory(directory string) ([]string, error) {
+	files, err := os.Open(directory)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred when attempting to open the given directory '%s'. \nerr: %w", directory, err)
+	}
+	defer func(files *os.File) {
+		err := files.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(files)
+
+	fileInfo, err := files.Readdir(-1)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred when attempting to read files in the given directory. \nerr: %w", err)
+	}
+
+	transactionFiles := make([]string, 0, len(fileInfo))
+	for _, info := range fileInfo {
+		dir := filepath.Join(directory, info.Name())
+		transactionFiles = append(transactionFiles, dir)
+	}
+
+	return transactionFiles, nil
+}
+
+func GetTransactionDataFromFile(filePath string) (TransactionData, error) {
+	fileContents, err := os.ReadFile(filePath)
+	if err != nil {
+		return TransactionData{}, fmt.Errorf("error reading file at %s. \nerr: %w", filePath, err)
+	}
+
+	transactionData := TransactionData{}
+	err = json.Unmarshal(fileContents, &transactionData)
+	if err != nil {
+		return TransactionData{}, fmt.Errorf("error unmarshalling the json in file '%s'. \nerr: %v", filePath, err)
+	}
+
+	return transactionData, nil
+}
+
+func trimExtensionFromFileName(file string) string {
+	dotIndex := strings.Index(file, ".")
+	lastSlashIndex := strings.LastIndex(file, "/")
+	trimmedFileName := file
+	if dotIndex != -1 {
+		trimmedFileName = file[lastSlashIndex+1 : dotIndex]
+	}
+
+	return trimmedFileName
+}
+
+func writeToFile(filePath string, data []byte, fileMode os.FileMode) error {
+	err := os.WriteFile(filePath, data, fileMode)
+	if err != nil {
+		return fmt.Errorf("error writing file '%s': %w", filePath, err)
+	}
+	return nil
+}
+
+func WriteDiffsToFile(currentTransactionFile string, diffOutputDir string, result Result) error {
+	if result.Match {
+		return fmt.Errorf("result data shows results match. should not need to write diffs to file")
+	}
+
+	if result.TransactionJson.CoreJson != nil {
+		return writeDiffToFile(currentTransactionFile, diffOutputDir, result.TransactionJson, result.TransactionHtmlDiff)
+	}
+
+	if result.InputDataJson.CoreJson != nil {
+		return writeDiffToFile(currentTransactionFile, diffOutputDir, result.InputDataJson, result.InputDataHtmlDiff)
+	}
+
+	return fmt.Errorf("did not write any diffs to file, check the result struct is being set correctly")
+}
+
+func writeDiffToFile(currentTransactionFile string, diffOutputDir string, coreVsOriginalJson ComparableJson, htmlDiff string) error {
+	marshalledDiffData, err := json.MarshalIndent(coreVsOriginalJson, " ", "	")
+	if err != nil {
+		return fmt.Errorf("error marshalling diffs to json when preparing to write diffs to file. \nerr: %v", err)
+	}
+
+	folderName := trimExtensionFromFileName(currentTransactionFile)
+	filePath := path.Join(diffOutputDir, folderName)
+
+	if err := os.MkdirAll(filePath, 0o755); err != nil {
+		return fmt.Errorf("error creating directory for diff files. \nerr: %v", err)
+	}
+
+	jsonFileName := fmt.Sprintf("%s-tocompare.json", string(coreVsOriginalJson.DiffType))
+	if err := writeToFile(path.Join(filePath, jsonFileName), marshalledDiffData, 0o644); err != nil {
+		return fmt.Errorf("error when attempting to write diffs to JSON file.\nerr: %v", err)
+	}
+
+	htmlFileName := fmt.Sprintf("%s-diff.html", string(coreVsOriginalJson.DiffType))
+	if err := writeToFile(path.Join(filePath, htmlFileName), []byte(htmlDiff), 0o644); err != nil {
+		return fmt.Errorf("error when attempting to write diffs to HTML file.\nerr: %v", err)
+	}
+
+	return nil
+}

--- a/vegatools/inspecttx/file_test.go
+++ b/vegatools/inspecttx/file_test.go
@@ -1,0 +1,63 @@
+package inspecttx
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFilesInDirectoryRetrievesAllFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFiles := []string{"file1.json", "file2.json", "file3.json"}
+	filePaths := make([]string, 0, len(testFiles))
+
+	for _, file := range testFiles {
+		filePath := filepath.Join(tmpDir, file)
+		if _, err := os.Create(filePath); err != nil {
+			t.Fatalf("failed to create test file %s: %v", filePath, err)
+		}
+		filePaths = append(filePaths, filePath)
+	}
+
+	retrievedFiles, err := GetFilesInDirectory(tmpDir)
+	assert.NoError(t, err, "GetFilesInDirectory failed")
+	assert.Len(t, retrievedFiles, len(testFiles), "GetFilesInDirectory returned incorrect number of files")
+
+	for _, filePath := range filePaths {
+		assert.Contains(t, retrievedFiles, filePath, "GetFilesInDirectory did not return expected file")
+	}
+}
+
+func TestGetTransactionDataFromFileReturnsValidTransactionData(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-transaction-*.json")
+	assert.NoErrorf(t, err, "failed to create temporary test file: %v", err)
+	defer os.Remove(tmpFile.Name())
+
+	testData := `{"Transaction": {"field1": "value1"}, "InputData": {"field2": "value2"}, "EncodedData": "base64data"}`
+	_, err = tmpFile.WriteString(testData)
+	assert.NoErrorf(t, err, "failed to write test data to file: %v", err)
+	err = tmpFile.Close()
+	assert.NoErrorf(t, err, "error occurred when closing file: %v", err)
+
+	transactionData, err := GetTransactionDataFromFile(tmpFile.Name())
+	assert.NoError(t, err, "GetTransactionDataFromFile failed")
+
+	var expectedData TransactionData
+	err = json.Unmarshal([]byte(testData), &expectedData)
+	assert.NoError(t, err, "failed to unmarshal expected data")
+
+	assert.Equal(t, string(expectedData.Transaction), string(transactionData.Transaction), "GetTransactionDataFromFile returned incorrect Transaction data")
+	assert.Equal(t, string(expectedData.InputData), string(transactionData.InputData), "GetTransactionDataFromFile returned incorrect InputData")
+	assert.Equal(t, expectedData.EncodedData, transactionData.EncodedData, "GetTransactionDataFromFile returned incorrect EncodedData")
+}
+
+func TestTrimExtensionFromCurrentFileName(t *testing.T) {
+	file := "/path/to/somefile.json"
+	trimmedFileName := trimExtensionFromFileName(file)
+
+	expectedTrimmedFileName := "somefile"
+	assert.Equal(t, expectedTrimmedFileName, trimmedFileName, "trimExtensionFromCurrentFileName returned incorrect trimmed file name")
+}

--- a/vegatools/inspecttx/inspect_tx.go
+++ b/vegatools/inspecttx/inspect_tx.go
@@ -1,0 +1,71 @@
+package inspecttx
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/nsf/jsondiff"
+)
+
+type Result struct {
+	Match               bool
+	TransactionJson     ComparableJson
+	InputDataJson       ComparableJson
+	TransactionHtmlDiff string
+	InputDataHtmlDiff   string
+}
+
+func TransactionMatch(transactionData TransactionData) (Result, error) {
+	comparisonData := Result{}
+	decodedBytes, err := base64.StdEncoding.DecodeString(transactionData.EncodedData)
+	if err != nil {
+		return comparisonData, fmt.Errorf("error occurred when decoding the transaction encoded data.\nerr: %v", err)
+	}
+
+	unmarshalledTransaction, unmarshalledInputData, err := unmarshalTransaction(decodedBytes)
+	if err != nil {
+		return comparisonData, fmt.Errorf("an error occurred when attempting to unmarshal the decoded transaction byte array. \nerr: %v", err)
+	}
+
+	marshalledTransaction, marshalledInputData, err := marshalTransactionAndInputDataToString(unmarshalledTransaction, unmarshalledInputData)
+	if err != nil {
+		return comparisonData, fmt.Errorf("an error occurred when attempting to marshal the structs back to a json string. \nerr: %v", err)
+	}
+
+	transactionCompareResult, transactionHtmlDiff := compareJson(transactionData.Transaction, []byte(marshalledTransaction))
+	inputDataCompareResult, inputDataHtmlDiff := compareJson(transactionData.InputData, []byte(marshalledInputData))
+
+	if transactionCompareResult == jsondiff.NoMatch || inputDataCompareResult == jsondiff.NoMatch {
+		comparisonData.Match = false
+		if transactionCompareResult == jsondiff.NoMatch {
+			comparableTransactionJson := ComparableJson{
+				OriginalJson: transactionData.Transaction,
+				CoreJson:     json.RawMessage(marshalledTransaction),
+				DiffType:     Transaction,
+			}
+
+			logrus.Errorf("transaction data did not match")
+			comparisonData.TransactionJson = comparableTransactionJson
+			comparisonData.TransactionHtmlDiff = transactionHtmlDiff
+		}
+
+		if inputDataCompareResult == jsondiff.NoMatch {
+			comparableInputDataJson := ComparableJson{
+				OriginalJson: transactionData.InputData,
+				CoreJson:     json.RawMessage(marshalledInputData),
+				DiffType:     InputData,
+			}
+
+			logrus.Errorf("input data did not match")
+			comparisonData.InputDataJson = comparableInputDataJson
+			comparisonData.InputDataHtmlDiff = inputDataHtmlDiff
+		}
+		return comparisonData, nil
+	}
+
+	comparisonData.Match = true
+	return comparisonData, nil
+}

--- a/vegatools/inspecttx/json.go
+++ b/vegatools/inspecttx/json.go
@@ -1,0 +1,138 @@
+package inspecttx
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/iancoleman/strcase"
+
+	proto2 "github.com/golang/protobuf/proto"
+
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+
+	"github.com/golang/protobuf/jsonpb"
+
+	"code.vegaprotocol.io/vega/commands"
+	"code.vegaprotocol.io/vega/libs/proto"
+
+	"github.com/nsf/jsondiff"
+)
+
+var JsonMarshaller = jsonpb.Marshaler{
+	Indent:      "   ",
+	EnumsAsInts: false,
+}
+
+// ComparableJson used to contain json data for comparison.
+type ComparableJson struct {
+	OriginalJson json.RawMessage
+	CoreJson     json.RawMessage
+	DiffType     DiffType
+}
+
+func marshalTransactionAndInputDataToString(transaction *commandspb.Transaction, inputData *commandspb.InputData) (string, string, error) {
+	marshalledTransaction, err := MarshalToJSONWithOneOf(transaction)
+	if err != nil {
+		return "", "", fmt.Errorf("couldn't marshal transaction: %w", err)
+	}
+
+	marshalledInputData, err := MarshalToJSONWithOneOf(inputData)
+	if err != nil {
+		return "", "", fmt.Errorf("couldn't marshal input data: %w", err)
+	}
+
+	return marshalledTransaction, marshalledInputData, nil
+}
+
+// MarshalToJSONWithOneOf this method exists to accommodate to marshalling proto fields with a 'oneof' tag. These are ignored in marshalling unless explicitly handled.
+func MarshalToJSONWithOneOf(pb proto2.Message) (string, error) {
+	marshalledTransaction, err := JsonMarshaller.MarshalToString(pb)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling the proto message to a string\nerr: %d", err)
+	}
+
+	transactionValsWithoutOneOfFields := map[string]interface{}{}
+	oneOfValues := map[string]interface{}{}
+	err = json.Unmarshal([]byte(marshalledTransaction), &transactionValsWithoutOneOfFields)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling transaction struct to a map.\nerr: %v", err)
+	}
+
+	pbType := reflect.TypeOf(pb).Elem()
+	pbValue := reflect.ValueOf(pb).Elem()
+
+	for i := 0; i < pbType.NumField(); i++ {
+		field := pbType.Field(i)
+
+		if field.Tag.Get("protobuf_oneof") != "" {
+			oneOfFieldName := field.Tag.Get("protobuf_oneof")
+			oneOfField := pbValue.FieldByName(field.Name)
+
+			if oneOfField.IsValid() && !oneOfField.IsNil() {
+				oneOfValue := getInterfaceValue(oneOfField)
+				if oneOfValue != nil {
+					oneOfSelectedType := reflect.TypeOf(oneOfValue)
+					oneOfSelectedValue := reflect.ValueOf(oneOfValue).Elem().Field(0).Interface()
+
+					jsonKey := strcase.ToLowerCamel(oneOfSelectedType.Elem().Field(0).Name)
+					oneOfData := map[string]interface{}{jsonKey: oneOfSelectedValue}
+					oneOfValues[oneOfFieldName] = oneOfData
+					delete(transactionValsWithoutOneOfFields, jsonKey)
+				}
+			}
+		}
+	}
+
+	combinedWithOneOfVals := make(map[string]interface{})
+	for key, value := range transactionValsWithoutOneOfFields {
+		combinedWithOneOfVals[key] = value
+	}
+
+	for key, value := range oneOfValues {
+		combinedWithOneOfVals[key] = value
+	}
+
+	mergedJson, err := json.Marshal(combinedWithOneOfVals)
+	if err != nil {
+		return "", fmt.Errorf("Error merging original json vals with 'oneof' fields to JSON:\nerr: %v", err)
+	}
+
+	return string(mergedJson), nil
+}
+
+func getInterfaceValue(v reflect.Value) interface{} {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		return getInterfaceValue(v.Elem())
+	}
+
+	if v.Kind() == reflect.Interface {
+		return v.Interface()
+	}
+
+	return nil
+}
+
+func unmarshalTransaction(decodedTransactionBytes []byte) (*commandspb.Transaction, *commandspb.InputData, error) {
+	unmarshalledTransaction := &commandspb.Transaction{}
+	unmarshalledInputData := &commandspb.InputData{}
+	if err := proto.Unmarshal(decodedTransactionBytes, unmarshalledTransaction); err != nil {
+		return unmarshalledTransaction, unmarshalledInputData, fmt.Errorf("unable to unmarshal transaction: %w", err)
+	}
+
+	inputData, err := commands.UnmarshalInputData(unmarshalledTransaction.InputData)
+	if err != nil {
+		return unmarshalledTransaction, unmarshalledInputData, fmt.Errorf("unable to unmarshal input data: %w", err)
+	}
+
+	return unmarshalledTransaction, inputData, nil
+}
+
+func compareJson(firstJson []byte, secondJson []byte) (jsondiff.Difference, string) {
+	options := jsondiff.DefaultHTMLOptions()
+	result, diffHtml := jsondiff.Compare(firstJson, secondJson, &options)
+	return result, diffHtml
+}

--- a/vegatools/inspecttx/json_test.go
+++ b/vegatools/inspecttx/json_test.go
@@ -1,0 +1,124 @@
+package inspecttx
+
+import (
+	"testing"
+
+	proto2 "github.com/golang/protobuf/proto"
+
+	"github.com/stretchr/testify/assert"
+
+	"code.vegaprotocol.io/vega/libs/proto"
+
+	"github.com/nsf/jsondiff"
+
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+)
+
+func TestMarshalTransactionAndInputDataToString(t *testing.T) {
+	transaction := &commandspb.Transaction{}
+	inputData := &commandspb.InputData{}
+
+	marshalledTransaction, marshalledInputData, err := marshalTransactionAndInputDataToString(transaction, inputData)
+
+	assert.NoErrorf(t, err, "Error marshalling transaction and input data: %v", err)
+	assert.NotZero(t, len(marshalledTransaction), "Marshalled transaction is empty")
+	assert.NotZero(t, len(marshalledInputData), "Marshalled input data is empty")
+}
+
+func TestUnmarshalTransactionReturnsValidTransactionAndInputData(t *testing.T) {
+	transaction := &commandspb.Transaction{}
+
+	encodedTransaction, err := proto.Marshal(transaction)
+	assert.NoErrorf(t, err, "Error marshalling transaction: %v", err)
+
+	unmarshalledTransaction, inputData, err := unmarshalTransaction(encodedTransaction)
+	assert.NoErrorf(t, err, "Error unmarshalling transaction: %v", err)
+	assert.NotNil(t, unmarshalledTransaction, "Unmarshalled transaction is nil")
+	assert.NotNil(t, inputData, "Unmarshalled input data is nil")
+}
+
+type CompareJsonTestCase struct {
+	Name         string
+	FirstJson    []byte
+	SecondJson   []byte
+	ExpectedDiff jsondiff.Difference
+}
+
+func TestCompareJson(t *testing.T) {
+	testCases := []CompareJsonTestCase{
+		{
+			Name:         "Same JSON",
+			FirstJson:    []byte(`{"name": "John", "age": 30}`),
+			SecondJson:   []byte(`{"name": "John", "age": 30}`),
+			ExpectedDiff: jsondiff.FullMatch,
+		},
+		{
+			Name:         "Different age",
+			FirstJson:    []byte(`{"name": "John", "age": 30}`),
+			SecondJson:   []byte(`{"name": "John", "age": 300}`),
+			ExpectedDiff: jsondiff.NoMatch,
+		},
+		{
+			Name:         "Different casing in name",
+			FirstJson:    []byte(`{"name": "John", "age": 30}`),
+			SecondJson:   []byte(`{"name": "john", "age": 300}`),
+			ExpectedDiff: jsondiff.NoMatch,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			result, diffHtml := compareJson(testCase.FirstJson, testCase.SecondJson)
+
+			assert.Equalf(t, testCase.ExpectedDiff, result, "Expected JSONs to have a difference of %v, but got: %v", testCase.ExpectedDiff, result)
+			assert.NotZero(t, len(diffHtml), "Diff HTML is empty")
+		})
+	}
+}
+
+func TestJsonMarshalsCorrectlyWithOneOfHandling(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          proto2.Message
+		expectedOutput string
+	}{
+		{
+			name: "OneOfTagInTransaction",
+			input: &commandspb.Transaction{
+				From:    &commandspb.Transaction_PubKey{PubKey: "pubkey"},
+				Version: 1,
+			},
+			expectedOutput: "{\"from\":{\"pubKey\":\"pubkey\"},\"version\":1}",
+		},
+		{
+			name: "NoOneOfTag",
+			input: &commandspb.Transaction{
+				Version: 1,
+				Signature: &commandspb.Signature{
+					Value:   "sig",
+					Algo:    "alg",
+					Version: 1,
+				},
+			},
+			expectedOutput: "{\"signature\":{\"algo\":\"alg\",\"value\":\"sig\",\"version\":1},\"version\":1}",
+		},
+		{
+			name: "OneOfTagInInputData",
+			input: &commandspb.InputData{
+				BlockHeight: 1,
+				Command: &commandspb.InputData_ProposalSubmission{ProposalSubmission: &commandspb.ProposalSubmission{
+					Reference: "myref",
+				}},
+			},
+			expectedOutput: "{\"blockHeight\":\"1\",\"command\":{\"proposalSubmission\":{\"reference\":\"myref\"}}}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonString, err := MarshalToJSONWithOneOf(tc.input)
+			assert.NoErrorf(t, err, "error occurred, marshalling was expected to be successful.\nerr: %v", err)
+			assert.Equal(t, tc.expectedOutput, jsonString)
+		})
+	}
+}


### PR DESCRIPTION
Test tool for testing if an external application can communicate with vega proto definitions without needing a system integration test. The idea is if we can 'generate' a contract via unit tests or a script (it could also be hand cranked) in the consuming apps repo (in this instance it will be browser wallet) we can then replay them against this test tool to check the data sent will retain all information once decoded by vega. This will ensure we are crafting our requests correctly and that our protos remain up to date. This means we can test our interactions with vega in seconds instead of test runs that take an hour or so and it is much more scalable

**Transaction files:**
The tool currently accepts a directory of transaction.json files (will scale this back so we can just fire a decoded string at it too in another PR) the traction json should have the below top level keys:

**Transaction:** Raw json generated by the consuming application (e.g browser wallet), this is for comparison against the decoded json
**InputData:** Raw input data json generated by the consuming application, this is for comparison against the decoded json
**EncodedData:** Encoded data generated by the consuming application, this is for the test tool to decode using vega protos and used to create json to compare against the Transaction and InputData keys above.

Here is an example transaction.json:

`{
  "Transaction": {
    "from": {
      "pubKey": "mykey"
    },
    "inputData": "CHsQyAOiPyUIARIEZGF2ZRgCIgp0ZXN0IGFzc2V0KgMxMjMyCHRlc3QgcmVm",
    "signature": {
      "algo": "testAlgo",
      "value": "74657374536967",
      "version": 3
    },
    "version": "this will cause a diff"
  },
  "InputData": {
    "blockHeight": "456",
    "command": {
      "transfer": {
        "from_account_type": 1,
        "to": "dave",
        "to_account_type": 2,
        "asset": "test asset",
        "amount": "123",
        "reference": "test ref",
        "Kind": null
      }
    },
    "nonce": "123"
  },
  "EncodedData": "Ci0IexDIA6I/JQgBEgRkYXZlGAIiCnRlc3QgYXNzZXQqAzEyMzIIdGVzdCByZWYSHAoONzQ2NTczNzQ1MzY5NjcSCHRlc3RBbGdvGAOAfQPSPgVteWtleQ=="
}`

example command:
`vega tools check-tx --transactions=/your/dir/with/transaction/files.json --diffs=/your/dir/for/diffs`

results should be outputted in the diff directory. You will see an html diff that will render like this
![image](https://github.com/vegaprotocol/vega/assets/37066267/5534654e-d5af-4e50-95a5-364e9f1f59ff)
there is also a json file outputted to compare core json vs your json in full.

