### PR TITLE
feat: add clamped interest rates to funding rate calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [8969](https://github.com/vegaprotocol/vega/issues/8969) - Improve wiring of internal time triggers for perpetual markets.
 - [9001](https://github.com/vegaprotocol/vega/issues/9001) - Improve wiring of perpetual markets into the data node.
 - [8985](https://github.com/vegaprotocol/vega/issues/8985) - Improve snapshot restore of internal time triggers for perpetual markets.
+- [8817](https://github.com/vegaprotocol/vega/issues/8817) - Add interest term to perpetual funding payment calculation.
 - [8756](https://github.com/vegaprotocol/vega/issues/8756) - Settlement and margin implementation for `PERPS`.
 - [8887](https://github.com/vegaprotocol/vega/pull/8887) - Remove differences for snapshot loading when the `nullchain` is used instead of `tendermint`
 - [8973](https://github.com/vegaprotocol/vega/issues/8973) - Do some more validation on Ethereum call specifications, add explicit error types to improve reporting

--- a/libs/num/int.go
+++ b/libs/num/int.go
@@ -74,6 +74,15 @@ func IntFromBig(b *big.Int) (*Int, bool) {
 	}, false
 }
 
+// IntFromDecimal returns the Int part of a decimal.
+func IntFromDecimal(d Decimal) (*Int, bool) {
+	u, ok := d.Uint()
+	return &Int{
+		U: &Uint{*u},
+		s: d.IsPositive(),
+	}, ok
+}
+
 // IsNegative tests if the stored value is negative
 // true if < 0
 // false if >= 0.


### PR DESCRIPTION
closes #8817 

Just adding the interest rate term as described here:
https://github.com/vegaprotocol/specs/blob/cosmicelevator/protocol/0053-PERP-product_builtin_perpetual_future.md#funding-payment-calculation

And a lot of shuffling around of the tests so that the time-delta between the data-points are a little more realistive and larger than a few nanoseconds.