### PR TITLE
fix: new market proposals can no longer be in both active and enacted…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - [8962](https://github.com/vegaprotocol/vega/issues/8962) - Refreshed pegged iceberg orders remain tracked as pegged orders.
 - [8837](https://github.com/vegaprotocol/vega/issues/8837) - Remove successor entries from snapshot if they will be removed next tick.
 - [8868](https://github.com/vegaprotocol/vega/issues/8868) - Fix `oracle_specs` table null value error.
+- [9038](https://github.com/vegaprotocol/vega/issues/9038) - New market proposals are no longer in both the active and enacted slices to prevent pointer sharing.
 - [8878](https://github.com/vegaprotocol/vega/issues/8878) - Fix amend to consider market decimals when checking for sufficient funds.
 - [8698](https://github.com/vegaprotocol/vega/issues/8698) - Final settlement rounding can be off by a 1 factor instead of just one.
 - [8861](https://github.com/vegaprotocol/vega/issues/8861) - Fix successor proposals never leaving proposed state.

--- a/core/governance/checkpoint_test.go
+++ b/core/governance/checkpoint_test.go
@@ -186,10 +186,10 @@ func TestCheckpointSavingAndLoadingWithDroppedMarkets(t *testing.T) {
 		proposals = append(proposals, enactNewProposal(t, eng))
 	}
 
-	// market 1 has already been dropped of the execution engine
+	// market 1 has already been dropped of the execution engine, so it is removed from active and not added to enacted
 	// market 2 has trading terminated
 	// market 3 is there and should be saved to the checkpoint
-	eng.markets.EXPECT().GetMarketState(proposals[0].ID).Times(2).Return(types.MarketStateUnspecified, types.ErrInvalidMarketID)
+	eng.markets.EXPECT().GetMarketState(proposals[0].ID).Times(1).Return(types.MarketStateUnspecified, types.ErrInvalidMarketID)
 	eng.markets.EXPECT().GetMarketState(proposals[1].ID).Times(2).Return(types.MarketStateTradingTerminated, nil)
 	eng.markets.EXPECT().GetMarketState(proposals[2].ID).Times(2).Return(types.MarketStateActive, nil)
 
@@ -211,7 +211,6 @@ func TestCheckpointSavingAndLoadingWithDroppedMarkets(t *testing.T) {
 	data, err := eng.Checkpoint()
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-
 	eng2 := getTestEngine(t, time.Now())
 	defer eng2.ctrl.Finish()
 

--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -48,8 +48,8 @@ var (
 	ErrErc20AddressAlreadyInUse                  = errors.New("erc20 address already in use")
 	ErrSpotsNotEnabled                           = errors.New("spot trading not enabled")
 	ErrParentMarketDoesNotExist                  = errors.New("market to succeed does not exist")
-	ErrParentMarketAlreadySucceeded              = errors.New("the market was already succeeded by a prior proposal")
-	ErrInvalidSuccessor                          = errors.New("the successor is no longer valid")
+	ErrParentMarketAlreadySucceeded              = errors.New("the parent market was already succeeded by a prior proposal")
+	ErrParentMarketSucceededByCompeting          = errors.New("the parent market has been succeeded by a competing propsal")
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/mocks.go -package mocks code.vegaprotocol.io/vega/core/governance Markets,StakingAccounts,Assets,TimeService,Witness,NetParams,Banking
@@ -297,11 +297,8 @@ func (e *Engine) preVoteClosedProposal(p *proposal) *VoteClosed {
 		startAuction := true
 		if p.State != types.ProposalStatePassed {
 			startAuction = false
-		} else {
-			// this proposal needs to be included in the checkpoint but we don't need to copy
-			// the proposal here, as it may reach the enacted state shortly
-			e.enactedProposals = append(e.enactedProposals, p)
 		}
+
 		vc.m = &NewMarketVoteClosed{
 			startAuction: startAuction,
 		}
@@ -343,7 +340,7 @@ func (e *Engine) OnTick(ctx context.Context, t time.Time) ([]*ToEnact, []*VoteCl
 		// check if the market for successor proposals still exists, if not, reject the proposal
 		if nm := proposal.Terms.GetNewMarket(); nm != nil && nm.Successor() != nil {
 			if _, err := e.markets.GetMarketState(proposal.ID); err != nil {
-				proposal.RejectWithErr(types.ProposalErrorInvalidSuccessorMarket, ErrInvalidSuccessor)
+				proposal.RejectWithErr(types.ProposalErrorInvalidSuccessorMarket, ErrParentMarketSucceededByCompeting)
 				e.broker.Send(events.NewProposalEvent(ctx, *proposal.Proposal))
 				toBeRemoved = append(toBeRemoved, proposal.ID)
 				continue
@@ -414,31 +411,15 @@ func (e *Engine) OnTick(ctx context.Context, t time.Time) ([]*ToEnact, []*VoteCl
 			// to another successor leaving opening auction
 			if _, err := e.markets.GetMarketState(id); err != nil {
 				if nm := prop.Terms.GetNewMarket(); nm != nil && nm.Successor() != nil {
-					prop.Reject(types.ProposalErrorInvalidSuccessorMarket)
+					prop.RejectWithErr(types.ProposalErrorInvalidSuccessorMarket, ErrParentMarketSucceededByCompeting)
 					e.broker.Send(events.NewProposalEvent(ctx, *prop.Proposal))
-					toBeRemoved = append(toBeRemoved, prop.ID)
 					continue
 				}
 				e.log.Error("could not get state of market %s", logging.String("market-id", id))
 				continue
 			}
 		}
-		// just in case the proposal wasn't added for whatever reason (shouldn't be possible)
-		found := false
-		for i, p := range e.enactedProposals {
-			if p.ID == prop.ID {
-				e.enactedProposals[i] = &prop // replace with pointer to copy
-				found = true
-				break
-			}
-		}
-		// no need to append
-		if found {
-			toBeEnacted = append(toBeEnacted, preparedToEnact[i])
-			continue
-		}
 
-		// take a copy in the state just before the proposal was enacted
 		e.enactedProposals = append(e.enactedProposals, &prop)
 		toBeEnacted = append(toBeEnacted, preparedToEnact[i])
 	}


### PR DESCRIPTION
closes #9038 

The issue was that for a new market proposal that _hasn't_ reached enactment time, it would exist in both the `activeProposal` slice and the `enactedProposal` slice. This is so that fresh markets in opening auctions would be included in the checkpoints.

The problem this caused is that the same pointer was in each slice, but when we restored from a snapshot we restore the two slices independently and so have distinct proposals. This caused differences if a successor market was rejected between passing and its enactment because in a restored node the proposal in the enacted slice would not have its state updated.

The fix is to just not have a proposal in both the active and enacted slices anymore. Its a confusing internal state to have that no one is expecting, [and has caused confusion in the past](https://vegaprotocol.slack.com/archives/C9E6XA8GK/p1668789917100529), so lets just not do it.

Modified successor market test that would previously fail the snapshot soak tests now passing:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/92145/pipeline