### PR TITLE
feat: run vega-core pipeline in the office servers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,8 +232,8 @@ pipeline {
                 stage('core/integration perps tests') {
                     steps {
                         dir('vega/core/integration') {
-                            // sh 'go test -v  . -perps --godog.format=junit:core-integration-perps-report.xml'
-                            // junit checksName: 'Core Integration Perps Tests', testResults: 'core-integration-perps-report.xml'
+                            sh 'go test . -timeout 30m -perps --godog.format=junit:core-integration-perps-report.xml'
+                            junit checksName: 'Core Integration Perps Tests', testResults: 'core-integration-perps-report.xml'
                         }
                     }
                 }
@@ -326,11 +326,11 @@ pipeline {
                     }
                 }
                 stage('protos') {
-                    // environment {
-                    //     GOPATH = "${env.WORKSPACE}/GOPATH"
-                    //     GOBIN = "${env.GOPATH}/bin"
-                    //     PATH = "${env.GOBIN}:${env.PATH}"
-                    // }
+                    environment {
+                        GOPATH = "${env.WORKSPACE}/GOPATH"
+                        GOBIN = "${env.GOPATH}/bin"
+                        PATH = "${env.GOBIN}:${env.PATH}"
+                    }
                     stages {
                         stage('Install dependencies') {
                             // We are using specific tools versions

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def commitHash = 'UNKNOWN'
 
 pipeline {
     agent {
-        label "core-build"
+        label params.NODE_LABEL
     }
     options {
         skipDefaultCheckout true
@@ -170,14 +170,6 @@ pipeline {
         //
         // End LINTERS
         //
-
-        stage('Cache go packages') {
-            steps {
-                script {
-                    sh "whoami"
-                }
-            }
-        }
 
         //
         // Begin TESTS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def commitHash = 'UNKNOWN'
 
 pipeline {
     agent {
-        label params.NODE_LABEL
+        label "core-build"
     }
     options {
         skipDefaultCheckout true
@@ -45,6 +45,9 @@ pipeline {
         CGO_ENABLED = 0
         GO111MODULE = 'on'
         BUILD_UID="${BUILD_NUMBER}-${EXECUTOR_NUMBER}"
+        GOPATH = "/jenkins/GOPATH"
+        GOBIN = "${env.GOPATH}/bin"
+        PATH = "${env.GOBIN}:${env.PATH}"
     }
 
     stages {
@@ -167,6 +170,14 @@ pipeline {
         //
         // End LINTERS
         //
+
+        stage('Cache go packages') {
+            steps {
+                script {
+                    sh "whoami"
+                }
+            }
+        }
 
         //
         // Begin TESTS
@@ -315,11 +326,11 @@ pipeline {
                     }
                 }
                 stage('protos') {
-                    environment {
-                        GOPATH = "${env.WORKSPACE}/GOPATH"
-                        GOBIN = "${env.GOPATH}/bin"
-                        PATH = "${env.GOBIN}:${env.PATH}"
-                    }
+                    // environment {
+                    //     GOPATH = "${env.WORKSPACE}/GOPATH"
+                    //     GOBIN = "${env.GOPATH}/bin"
+                    //     PATH = "${env.GOBIN}:${env.PATH}"
+                    // }
                     stages {
                         stage('Install dependencies') {
                             // We are using specific tools versions

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                 description: 'Git branch, tag or hash of the vegaprotocol/vega-market-sim repository')
         string( name: 'JENKINS_SHARED_LIB_BRANCH', defaultValue: 'main',
                 description: 'Git branch, tag or hash of the vegaprotocol/jenkins-shared-library repository')
-        string( name: 'NODE_LABEL', defaultValue: 's-4vcpu-8gb',
+        string( name: 'NODE_LABEL', defaultValue: 'core-build',
                 description: 'Label on which vega build should be run, if empty any any node is used')
     }
     environment {


### PR DESCRIPTION
# Changes

- Move the vega-core pipeline to the office
- Enable perps tests

# Underlying change:

1. The build has been running on DO (4vCPU|8GB) - shared server
2. In the office We have dedicated 6 cores | 8 GB for the build.
3. It took about `20 minutes` to complete `golang tests` on the DO agents. 
4. After moving the pipeline to the office computers it takes about `5 minutes` to complete `golang tests`.
5. The pipeline will run on digital ocan 4vCPU 8GB when there is no idle server in the office

But anyway, the system tests take 20 minutes to finish, so there is no need for more cores for unit-tests

Tested in the following pipeline: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/vega/detail/PR-9069/28/pipeline/220


# Related change:
- [feat: add core-build labels to more office based servers + cloud fallback 4vCPU|8GB](https://github.com/vegaprotocol/jenkins-shared-library/commit/243e20264c721a51f45fbd5095586d65f95d7f40)