### PR TITLE
chore: share data-source spec resolver with perps and futures

### DIFF
--- a/datanode/gateway/graphql/data_source_resolver.go
+++ b/datanode/gateway/graphql/data_source_resolver.go
@@ -58,6 +58,10 @@ func (di myDataSourceDefinitionInternalResolver) SourceType(_ context.Context, o
 				if tp.Time != nil {
 					return tp.Time, nil
 				}
+			case *vegapb.DataSourceDefinitionInternal_TimeTrigger:
+				if tp.TimeTrigger != nil {
+					return tp.TimeTrigger, nil
+				}
 			}
 		}
 	}

--- a/datanode/gateway/graphql/oracles_resolver.go
+++ b/datanode/gateway/graphql/oracles_resolver.go
@@ -139,6 +139,14 @@ func resolveDataSourceDefinition(d *vegapb.DataSourceDefinition) (ds *vegapb.Dat
 					},
 				},
 			}
+		case *vegapb.DataSourceSpecConfigurationTimeTrigger:
+			ds.SourceType = &vegapb.DataSourceDefinition_Internal{
+				Internal: &vegapb.DataSourceDefinitionInternal{
+					SourceType: &vegapb.DataSourceDefinitionInternal_TimeTrigger{
+						TimeTrigger: tp,
+					},
+				},
+			}
 		}
 	}
 

--- a/datanode/gateway/graphql/perps_resolver.go
+++ b/datanode/gateway/graphql/perps_resolver.go
@@ -2,9 +2,9 @@ package gql
 
 import (
 	"context"
-	"fmt"
 
 	"code.vegaprotocol.io/vega/protos/vega"
+	vegapb "code.vegaprotocol.io/vega/protos/vega"
 )
 
 type perpetualResolver VegaResolverRoot
@@ -14,45 +14,11 @@ func (r *perpetualResolver) SettlementAsset(ctx context.Context, obj *vega.Perpe
 }
 
 func (r *perpetualResolver) DataSourceSpecForSettlementSchedule(ctx context.Context, obj *vega.Perpetual) (*DataSourceSpec, error) {
-	var status DataSourceSpecStatus
-
-	switch obj.DataSourceSpecForSettlementSchedule.Status {
-	case vega.DataSourceSpec_STATUS_ACTIVE:
-		status = DataSourceSpecStatusStatusActive
-	case vega.DataSourceSpec_STATUS_DEACTIVATED:
-		status = DataSourceSpecStatusStatusDeactivated
-	default:
-		return nil, fmt.Errorf("unknown status: %v", obj.DataSourceSpecForSettlementSchedule.Status)
-	}
-
-	return &DataSourceSpec{
-		ID:        obj.DataSourceSpecForSettlementSchedule.Id,
-		CreatedAt: obj.DataSourceSpecForSettlementSchedule.CreatedAt,
-		UpdatedAt: &obj.DataSourceSpecForSettlementSchedule.UpdatedAt,
-		Data:      obj.DataSourceSpecForSettlementSchedule.Data,
-		Status:    status,
-	}, nil
+	return resolveDataSourceSpec(obj.DataSourceSpecForSettlementSchedule), nil
 }
 
 func (r *perpetualResolver) DataSourceSpecForSettlementData(ctx context.Context, obj *vega.Perpetual) (*DataSourceSpec, error) {
-	var status DataSourceSpecStatus
-
-	switch obj.DataSourceSpecForSettlementData.Status {
-	case vega.DataSourceSpec_STATUS_ACTIVE:
-		status = DataSourceSpecStatusStatusActive
-	case vega.DataSourceSpec_STATUS_DEACTIVATED:
-		status = DataSourceSpecStatusStatusDeactivated
-	default:
-		return nil, fmt.Errorf("unknown status: %v", obj.DataSourceSpecForSettlementData.Status)
-	}
-
-	return &DataSourceSpec{
-		ID:        obj.DataSourceSpecForSettlementData.Id,
-		CreatedAt: obj.DataSourceSpecForSettlementData.CreatedAt,
-		UpdatedAt: &obj.DataSourceSpecForSettlementData.UpdatedAt,
-		Data:      obj.DataSourceSpecForSettlementData.Data,
-		Status:    status,
-	}, nil
+	return resolveDataSourceSpec(obj.DataSourceSpecForSettlementData), nil
 }
 
 func (r *perpetualResolver) DataSourceSpecBinding(ctx context.Context, obj *vega.Perpetual) (*DataSourceSpecPerpetualBinding, error) {
@@ -73,4 +39,18 @@ func (r *perpetualProductResolver) DataSourceSpecBinding(ctx context.Context, ob
 		SettlementDataProperty:     obj.DataSourceSpecBinding.SettlementDataProperty,
 		SettlementScheduleProperty: obj.DataSourceSpecBinding.SettlementScheduleProperty,
 	}, nil
+}
+
+func (r *perpetualProductResolver) DataSourceSpecForSettlementData(_ context.Context, obj *vegapb.PerpetualProduct) (*vegapb.DataSourceDefinition, error) {
+	if obj.DataSourceSpecForSettlementData == nil {
+		return nil, nil
+	}
+	return resolveDataSourceDefinition(obj.DataSourceSpecForSettlementData), nil
+}
+
+func (r *perpetualProductResolver) DataSourceSpecForSettlementSchedule(_ context.Context, obj *vegapb.PerpetualProduct) (*vegapb.DataSourceDefinition, error) {
+	if obj.DataSourceSpecForSettlementSchedule == nil {
+		return nil, nil
+	}
+	return resolveDataSourceDefinition(obj.DataSourceSpecForSettlementSchedule), nil
 }


### PR DESCRIPTION
The perpetual resolver now uses the same code path as futures for converting the data source specs and things:
<img width="1726" alt="image" src="https://github.com/vegaprotocol/vega/assets/1857660/17be201c-f785-4714-84b3-8aa9c023b933">
