### PR TITLE
fix: set market ID generator when doing perps funding settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - [8878](https://github.com/vegaprotocol/vega/issues/8878) - Fix amend to consider market decimals when checking for sufficient funds.
 - [8698](https://github.com/vegaprotocol/vega/issues/8698) - Final settlement rounding can be off by a 1 factor instead of just one.
 - [8861](https://github.com/vegaprotocol/vega/issues/8861) - Fix successor proposals never leaving proposed state.
+- [9086](https://github.com/vegaprotocol/vega/issues/9086) - Set identifier generator during perpetual settlement for closed out orders.
 - [8884](https://github.com/vegaprotocol/vega/issues/8884) - Do not assume `\n` is present on the first read chunk of the input
 - [8477](https://github.com/vegaprotocol/vega/issues/8477) - Do not allow opening auction duration of 0
 - [8891](https://github.com/vegaprotocol/vega/issues/8891) - Emit market update event when resuming via governance

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -3750,6 +3750,13 @@ func (m *Market) settlementData(ctx context.Context, settlementData *num.Numeric
 func (m *Market) settlementDataPerp(ctx context.Context, settlementData *num.Numeric) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	_, blockHash := vegacontext.TraceIDFromContext(ctx)
+	m.idgen = idgeneration.New(blockHash + crypto.HashStrToHex("perpsettlement"+m.GetID()))
+	defer func() {
+		m.idgen = nil
+	}()
+
 	// take all positions, get funding transfers
 	sdi := settlementData.Int()
 	if !settlementData.IsInt() && settlementData.Decimal() != nil {


### PR DESCRIPTION
closes #9086 

Trying to close out parties (I'm guessing because of the wild funding rate being calculated due to the decimal point differences) and we weren't initialising an id generator.