### PR TITLE
9113 only retry pending signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - [9038](https://github.com/vegaprotocol/vega/issues/9038) - New market proposals are no longer in both the active and enacted slices to prevent pointer sharing.
 - [8878](https://github.com/vegaprotocol/vega/issues/8878) - Fix amend to consider market decimals when checking for sufficient funds.
 - [8698](https://github.com/vegaprotocol/vega/issues/8698) - Final settlement rounding can be off by a 1 factor instead of just one.
+- [9113](https://github.com/vegaprotocol/vega/issues/9113) - Only add pending signatures to the retry list when the notary engine snapshot restores.
 - [8861](https://github.com/vegaprotocol/vega/issues/8861) - Fix successor proposals never leaving proposed state.
 - [9086](https://github.com/vegaprotocol/vega/issues/9086) - Set identifier generator during perpetual settlement for closed out orders.
 - [8884](https://github.com/vegaprotocol/vega/issues/8884) - Do not assume `\n` is present on the first read chunk of the input

--- a/core/notary/snapshot.go
+++ b/core/notary/snapshot.go
@@ -201,8 +201,7 @@ func (n *SnapshotNotary) restoreNotary(notary *types.Notary, p *types.Payload) e
 			n.log.Panic("invalid signature from snapshot", logging.Error(err))
 		}
 		ns := nodeSig{node: s.Node, sig: string(sig)}
-
-		if isValidator {
+		if isValidator && s.Pending {
 			signed := selfSigned[idK]
 			if !signed {
 				selfSigned[idK] = strings.EqualFold(s.Node, self)
@@ -225,6 +224,7 @@ func (n *SnapshotNotary) restoreNotary(notary *types.Notary, p *types.Payload) e
 	for resource, ok := range selfSigned {
 		if !ok {
 			// this is not signed, just add it to the retries list
+			n.log.Info("self-signature missing, adding to retry list", logging.String("id", resource.id))
 			retries.Add(resource, nil)
 		}
 	}

--- a/core/notary/snapshot.go
+++ b/core/notary/snapshot.go
@@ -141,8 +141,8 @@ func (n *SnapshotNotary) OfferSignatures(
 func (n *SnapshotNotary) serialiseNotary() ([]byte, error) {
 	sigs := make([]*types.NotarySigs, 0, len(n.sigs)) // it will likely be longer than this but we don't know yet
 	for ik, ns := range n.sigs {
+		_, pending := n.pendingSignatures[ik]
 		for _n := range ns {
-			_, pending := n.pendingSignatures[ik]
 			sigs = append(sigs,
 				&types.NotarySigs{
 					ID:      ik.id,
@@ -156,7 +156,7 @@ func (n *SnapshotNotary) serialiseNotary() ([]byte, error) {
 
 		// the case where aggregate has started but we have no node sigs
 		if len(ns) == 0 {
-			sigs = append(sigs, &types.NotarySigs{ID: ik.id, Kind: int32(ik.kind)})
+			sigs = append(sigs, &types.NotarySigs{ID: ik.id, Kind: int32(ik.kind), Pending: pending})
 		}
 	}
 


### PR DESCRIPTION
closes #9113 

Full details of the issue are on the ticket.

If we want to give the affected validator a hot-fix they should cherry-pick only this commit:
https://github.com/vegaprotocol/vega/commit/da8c4ab4379b2b65084d84606af0d07fe1a4c4ab

If they take the second commit they risk consensus issues later.

system test that flexes the issue working:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/94971/artifacts/
