### PR TITLE
feat: updates for liquidity test fixes

### DIFF
--- a/core/integration/steps/the_liquidity_provider_fee_shares_for_the_market_should_be.go
+++ b/core/integration/steps/the_liquidity_provider_fee_shares_for_the_market_should_be.go
@@ -41,6 +41,17 @@ func TheLiquidityProviderFeeSharesForTheMarketShouldBe(engine Execution, marketI
 				v.AverageEntryValuation == expected.AverageEntryValuation {
 				found = true
 			}
+			if row.HasColumn("average score") &&
+				v.AverageScore != row.MustStr("average score") {
+				found = false
+			}
+			if row.HasColumn("virtual stake") &&
+				v.VirtualStake != row.MustStr("virtual stake") {
+				found = false
+			}
+			if found {
+				break // No need to continue checking once a match is found
+			}
 		}
 
 		if !found {
@@ -60,5 +71,8 @@ func parseLiquidityFeeSharesTable(table *godog.Table) []RowWrapper {
 		"party",
 		"equity like share",
 		"average entry valuation",
-	}, []string{})
+	}, []string{
+		"average score",
+		"virtual stake",
+	})
 }


### PR DESCRIPTION
Previously this test used changes in ELS as a proxy to check the virtual stakes were being updated correctly between market periods.

Since original test, virtual stake has been added as a field to the `LiquidityProviderFeeShare` type. PR adds optional average score and virtual stake checks to the liquidity fee shares step and condenses the test removing now un-needed steps.