### PR TITLE
Eth leave infinite retry if cancelled

### DIFF
--- a/core/evtforward/ethereum/filterer.go
+++ b/core/evtforward/ethereum/filterer.go
@@ -163,7 +163,7 @@ func NewLogFilterer(
 func (f *LogFilterer) CurrentHeight(ctx context.Context) uint64 {
 	currentHeight := new(uint64)
 
-	infiniteRetry(func() error {
+	infiniteRetry(ctx, func() error {
 		height, err := f.client.CurrentHeight(ctx)
 		if err != nil {
 			return fmt.Errorf("couldn't get the current height of Ethereum blockchain: %e", err)
@@ -248,7 +248,7 @@ func (f *LogFilterer) FilterMultisigControlEvents(ctx context.Context, startAt, 
 func (f *LogFilterer) filterLogs(ctx context.Context, query eth.FilterQuery) []ethtypes.Log {
 	var logs []ethtypes.Log
 
-	infiniteRetry(func() error {
+	infiniteRetry(ctx, func() error {
 		l, err := f.client.FilterLogs(ctx, query)
 		if err != nil {
 			fromBlock := big.NewInt(0)
@@ -853,7 +853,7 @@ func (f *blockTimeFetcher) TimeForBlock(ctx context.Context, blockNumber uint64)
 
 func (f *blockTimeFetcher) fetchTimeByBlock(ctx context.Context, blockNumber uint64) uint64 {
 	var header *ethtypes.Header
-	infiniteRetry(func() error {
+	infiniteRetry(ctx, func() error {
 		h, err := f.client.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
 		if err != nil {
 			f.log.Error("Couldn't retrieve the block header for given number on the staking bridge",
@@ -870,8 +870,9 @@ func (f *blockTimeFetcher) fetchTimeByBlock(ctx context.Context, blockNumber uin
 
 // We are retrying infinitely, on purpose, as we don't want the Ethereum
 // Forwarder to exit, and this under any circumstances. Failure is not an option.
-func infiniteRetry(fn backoff.Operation, durationBetweenTwoRetry time.Duration) {
+func infiniteRetry(ctx context.Context, fn backoff.Operation, durationBetweenTwoRetry time.Duration) {
 	// No need to retrieve the error, as we are waiting indefinitely for a
 	// success.
-	_ = backoff.Retry(fn, backoff.NewConstantBackOff(durationBetweenTwoRetry))
+	bo := backoff.WithContext(backoff.NewConstantBackOff(durationBetweenTwoRetry), ctx)
+	_ = backoff.Retry(fn, bo)
 }


### PR DESCRIPTION
In the eth-forwarder if the context is cancelled we would never break out of the infitnite retry.

When the network starts from genesis, or a snapshot we bounce the eth-forward engine when the network parameters with the contract address are read and _sometimes_ we can get to the part where we were make the first call to ethereum before we stop-cancel-start. The result is that we get stuck in the infinite loop backoff return, and loads and loads of log messages end up in the system tests that look like:
```
ethereum/filterer.go:262	Couldn't subscribe to the Ethereum log filterer	{"from-block": "168", "to-block": "169", "addresses": ["0xdEcdA30fd3449718304eA201A8f220eBdE25dd1E"], "error": "Post \"http://127.0.0.1:8545/\": context canceled"}
```
example: https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/95869/artifact/testnet/logs/testnet-nodeset-validators-2-validator/visor-2-with-vega.stdout-2023-08-21T09%3A15%3A46Z.log

its not a problem, but it is a bit distracting (and can be a red-herring) when trying to debug issues.
