### PR TITLE
ci: add option to trigger docs release manually

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -6,6 +6,14 @@ name: "Release Documentation"
     tags:
       - '**'
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git Tag to build and publish'
+        required: false
+        type: string
+        default: ''
+
 jobs:
   gen-docs:
     runs-on: ubuntu-latest
@@ -16,6 +24,7 @@ jobs:
         with:
           path: 'vega'
           fetch-depth: '0'
+          ref: ${{ inputs.tag }}
       -
         name: Check out docs code
         uses: actions/checkout@v3


### PR DESCRIPTION
closes vegaprotocol/devops-infra#1986