### PR TITLE
chore: migrate data when converting the stop_orders table to hypertable

### DIFF
--- a/datanode/sqlstore/migrations/0027_upgrade_tables_to_hypertables.sql
+++ b/datanode/sqlstore/migrations/0027_upgrade_tables_to_hypertables.sql
@@ -4,7 +4,7 @@
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = 'stop_orders') THEN
-        PERFORM create_hypertable('stop_orders', 'vega_time', chunk_time_interval => INTERVAL '1 day');
+        PERFORM create_hypertable('stop_orders', 'vega_time', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
     END IF;
 END $$;
 -- +goose StatementEnd


### PR DESCRIPTION
Add migrate_db flag to create_hypertable as stop_order table is already populated.