### PR TITLE
fix: validate settlement price when market-state changing a perp

### DIFF
--- a/core/execution/engine.go
+++ b/core/execution/engine.go
@@ -545,7 +545,7 @@ func (e *Engine) UpdateSpotMarket(ctx context.Context, marketConfig *types.Marke
 func (e *Engine) VerifyUpdateMarketState(changes *types.MarketStateUpdateConfiguration) error {
 	// futures or perps market
 	if market, ok := e.futureMarkets[changes.MarketID]; ok {
-		if changes.SettlementPrice == nil && changes.UpdateType == types.MarketStateUpdateTypeTerminate && !market.IsPerp() {
+		if changes.SettlementPrice == nil && changes.UpdateType == types.MarketStateUpdateTypeTerminate {
 			return fmt.Errorf("missing settlement price for governance initiated futures market termination")
 		}
 		state := market.GetMarketState()


### PR DESCRIPTION
A full system tests run with all markets set to be perpetuals instead of the classic fixed-expiry future threw a panic during a negative tests case where trying to terminate the market via governance without specifying a settlement price.

This fixes it by not skipping the validation.