### PR TITLE
Do not base recalc solely on the total vstake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 - [9198](https://github.com/vegaprotocol/vega/issues/9198) - Fix panic during LP amendment applications
 - [9196](https://github.com/vegaprotocol/vega/issues/9196) - `API` documentation should specify the time format.
 - [9203](https://github.com/vegaprotocol/vega/issues/9203) - Do not remove LPs from the parties map if they are an LP without an open position
+- [9202](https://github.com/vegaprotocol/vega/issues/9202) - Fix `ELS` not calculated when leaving opening auction.
 
 ## 0.72.1
 

--- a/core/execution/common/equity_shares.go
+++ b/core/execution/common/equity_shares.go
@@ -155,7 +155,7 @@ func (es *EquityShares) UpdateVStake() {
 			recalc = true
 		}
 	}
-	if total.Equal(es.totalVStake) {
+	if !total.Equal(es.totalVStake) {
 		// some vStake changed, force recalc of ELS values.
 		es.totalVStake = total
 		recalc = true
@@ -236,6 +236,8 @@ func (es *EquityShares) SetPartyStake(id string, newStakeU *num.Uint) {
 		v.stake = newStake
 		es.totalVStake = es.totalVStake.Add(v.vStake)
 		es.totalPStake = es.totalPStake.Add(v.stake)
+		// recalculate ELS for this party
+		v.share, _ = es.equity(id)
 		return
 	}
 

--- a/core/execution/common/equity_shares.go
+++ b/core/execution/common/equity_shares.go
@@ -139,6 +139,8 @@ func (es *EquityShares) OpeningAuctionEnded() {
 	}
 	es.openingAuctionEnded = true
 	es.r = num.DecimalZero()
+	// force recalc of vStake, ensuring ELS will be set properly
+	es.UpdateVStake()
 }
 
 func (es *EquityShares) UpdateVStake() {
@@ -147,20 +149,14 @@ func (es *EquityShares) UpdateVStake() {
 	}
 	total := num.DecimalZero()
 	factor := num.DecimalFromFloat(1.0).Add(es.r)
-	recalc := false
 	for _, v := range es.lps {
 		vStake := num.MaxD(v.stake, v.vStake.Mul(factor))
 		v.vStake = vStake
 		total = total.Add(vStake)
 	}
 	// some vStake changed, force recalc of ELS values.
-	if !es.totalVStake.Equals(total) {
-		recalc = true
-	}
 	es.totalVStake = total
-	if recalc {
-		es.updateAllELS()
-	}
+	es.updateAllELS()
 }
 
 func (es *EquityShares) GetTotalVStake() num.Decimal {

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -714,6 +714,10 @@ func (m *Market) CanLeaveOpeningAuction() bool {
 }
 
 func (m *Market) InheritParent(ctx context.Context, pstate *types.CPMarketState) {
+	// parent is in opening auction, do not inherit any state
+	if pstate.State == types.MarketStatePending {
+		return
+	}
 	// add the trade value from the parent
 	m.feeSplitter.SetTradeValue(pstate.LastTradeValue)
 	m.equityShares.InheritELS(pstate.Shares)
@@ -729,7 +733,7 @@ func (m *Market) RollbackInherit(ctx context.Context) {
 	// before the call to InheritParent was made. Market is still in opening auction, therefore
 	// feeSplitter trade value is zero, and equity shares are linear stake/vstake/ELS
 	// do make sure this call is not made when the market is active
-	if m.mkt.State == types.MarketStatePending {
+	if m.mkt.State == types.MarketStatePending || m.mkt.State == types.MarketStateProposed {
 		m.feeSplitter.SetTradeValue(num.UintZero())
 		m.equityShares.RollbackParentELS()
 	}

--- a/core/execution/future/market_checkpoint.go
+++ b/core/execution/future/market_checkpoint.go
@@ -6,8 +6,8 @@ import (
 )
 
 func (m *Market) GetCPState() *types.CPMarketState {
-	shares := m.equityShares.GetCPShares()
 	id := m.mkt.ID
+	shares := m.equityShares.GetCPShares()
 	// get all LP accounts, we don't have to sort this slice because we're fetching the balances
 	// in the same order as we got the ELS shares (which is already a deterministically sorted slice).
 	ipb, ok := m.collateral.GetInsurancePoolBalance(id, m.settlementAsset)
@@ -19,6 +19,7 @@ func (m *Market) GetCPState() *types.CPMarketState {
 		Shares:           shares,
 		InsuranceBalance: ipb,
 		LastTradeValue:   m.feeSplitter.TradeValue(),
+		State:            m.mkt.State,
 	}
 	// if the market was closed/settled, include the last valid market definition in the checkpoint
 	if m.mkt.State == types.MarketStateSettled || m.mkt.State == types.MarketStateClosed {

--- a/core/integration/features/successor-markets-ELS.feature
+++ b/core/integration/features/successor-markets-ELS.feature
@@ -191,8 +191,8 @@ Feature: Simple example of successor markets
     # this is from ETH/DEC19 market
     And the liquidity provider fee shares for the market "ETH/DEC20" should be:
       | party   | equity like share | average entry valuation |
-      | lpprov1 | 0.9               | 9000                    |
-      | lpprov2 | 0.1               | 10000                   |
+      | lpprov1 | 0.2               | 9000                    |
+      | lpprov2 | 0.8               | 10000                   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC20"
 
@@ -220,7 +220,7 @@ Feature: Simple example of successor markets
 
     And the liquidity provider fee shares for the market "ETH/DEC20" should be:
       | party   | equity like share  | average entry valuation |
-      | lpprov1 | 0.2727272727272727 | 9666.6666666666666      |
+      | lpprov1 | 0.2727272727272727 | 9666.6666666666666667   |
       | lpprov2 | 0.7272727272727273 | 10000                   |
     When the network moves ahead "1" blocks
     Then the insurance pool balance should be "0" for the market "ETH/DEC19"
@@ -329,9 +329,9 @@ Feature: Simple example of successor markets
 
 #this is from ETH/DEC19 market
     And the liquidity provider fee shares for the market "ETH/DEC20" should be:
-      | party   | equity like share | average entry valuation |
-      | lpprov1 | 0.9               | 9000                    |
-      | lpprov2 | 0.1               | 11750                   |
+      | party   | equity like share  | average entry valuation |
+      | lpprov1 | 0.3333333333333333 | 9000                    |
+      | lpprov2 | 0.6666666666666667 | 11750                   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC20"
 
@@ -442,8 +442,8 @@ Feature: Simple example of successor markets
     # this is from ETH/DEC19 market
     And the liquidity provider fee shares for the market "ETH/DEC20" should be:
       | party   | equity like share | average entry valuation |
-      | lpprov1 | 0.9               | 9000                    |
-      | lpprov2 | 0.1               | 10000                   |
+      | lpprov1 | 0.2               | 9000                    |
+      | lpprov2 | 0.8               | 10000                   |
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC20"
 
@@ -465,8 +465,8 @@ Feature: Simple example of successor markets
 
     And the liquidity provider fee shares for the market "ETH/DEC20" should be:
       | party   | equity like share | average entry valuation |
-      | lpprov1 | 0.9               | 9000                    |
-      | lpprov2 | 0.1               | 10000                   |
+      | lpprov1 | 0.2               | 9000                    |
+      | lpprov2 | 0.8               | 10000                   |
     When the network moves ahead "2" blocks
 
     And the parties submit the following liquidity provision:
@@ -477,8 +477,8 @@ Feature: Simple example of successor markets
 
     And the liquidity provider fee shares for the market "ETH/DEC20" should be:
       | party   | equity like share | average entry valuation |
-      | lpprov1 | 0.9               | 9000                    |
-      | lpprov2 | 0.1               | 10000                   |
+      | lpprov1 | 0.2               | 9000                    |
+      | lpprov2 | 0.8               | 10000                   |
     When the network moves ahead "1" blocks
     Then the insurance pool balance should be "0" for the market "ETH/DEC19"
     And the insurance pool balance should be "7983" for the market "ETH/DEC20"

--- a/core/types/checkpoint.go
+++ b/core/types/checkpoint.go
@@ -406,7 +406,8 @@ type CPMarketState struct {
 	LastTradeValue   *num.Uint
 	LastTradeVolume  *num.Uint
 	TTL              time.Time
-	Market           *Market // the full market object - needed in case the market has settled but a successor market is enacted during the successor window.
+	Market           *Market     // the full market object - needed in case the market has settled but a successor market is enacted during the successor window.
+	State            MarketState // only used during OnTick, indicating the parent is still in opening auction
 }
 
 func NewMarketStateFromProto(ms *checkpoint.MarketState) *CPMarketState {


### PR DESCRIPTION
Closes #9202 

Total Vstake will not change when leaving opening auction, and it is possible that due to growth, the existing VStake total decreases by the same amount as is committed by a new LP, keeping the total VStake the same, but still requiring the ELS to be recalculated.