### PR TITLE
chore: encapsulate setting of twap period to avoid bugs

### DIFF
--- a/core/products/perpetual_test.go
+++ b/core/products/perpetual_test.go
@@ -368,7 +368,7 @@ func testOutOfOrderPointsBeforePeriodStart(t *testing.T) {
 	perp.perpetual.PromptSettlementCue(ctx, 1693398617000000000+int64(time.Hour))
 	assert.NotNil(t, fundingPayment)
 	assert.True(t, fundingPayment.IsInt())
-	assert.Equal(t, "100027778", fundingPayment.String())
+	assert.Equal(t, "100000000", fundingPayment.String())
 }
 
 func testRegisteredCallbacks(t *testing.T) {


### PR DESCRIPTION
Two little fixes.

First, incoming data-points can land before the start of the funding period, and we must add them but only count their contribution from the start of the funding period. I spotted a case where that might not happen so I've encapsulated all that nonsense with a sanity check panic.

Second, we were sending the internal TWAP as the external TWAP in the funding period event.