### PR TITLE
fix: preserve internal state when updating a product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 - [8944](https://github.com/vegaprotocol/vega/issues/8944) - Fix ignoring of asset `ID` in ledger export, and make it optional.
 - [8971](https://github.com/vegaprotocol/vega/issues/8971) - Record the epoch start time even in opening auction
 - [8992](https://github.com/vegaprotocol/vega/issues/8992) - allow for 0 time step for `SLA` fee calculation
+- [9266](https://github.com/vegaprotocol/vega/issues/9266) - Preserve perpetual state when updating product
 - [8988](https://github.com/vegaprotocol/vega/issues/8988) - allow amend/cancel of pending liquidity provision
 - [8993](https://github.com/vegaprotocol/vega/issues/8993) - handle the case where commitment min time fraction is 1
 - [9252](https://github.com/vegaprotocol/vega/issues/9252) - Preserve the order of pegged orders in snapshots.

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -480,11 +480,6 @@ func (m *Market) Update(ctx context.Context, config *types.Market, oracleEngine 
 	assets, _ := config.GetAssets()
 	m.settlementAsset = assets[0]
 
-	if m.mkt.State == types.MarketStateTradingTerminated {
-		m.tradableInstrument.Instrument.UnsubscribeSettlementData(ctx)
-	} else {
-		m.tradableInstrument.Instrument.Unsubscribe(ctx)
-	}
 	if err := m.tradableInstrument.UpdateInstrument(ctx, m.log, m.mkt.TradableInstrument, m.GetID(), oracleEngine, m.broker); err != nil {
 		return err
 	}

--- a/core/products/products.go
+++ b/core/products/products.go
@@ -56,6 +56,7 @@ type Product interface {
 	ScaleSettlementDataToDecimalPlaces(price *num.Numeric, dp uint32) (*num.Uint, error)
 	NotifyOnTradingTerminated(listener func(context.Context, bool))
 	NotifyOnSettlementData(listener func(context.Context, *num.Numeric))
+	Update(ctx context.Context, pp interface{}, oe OracleEngine) error
 	UnsubscribeTradingTerminated(ctx context.Context)
 	UnsubscribeSettlementData(ctx context.Context)
 	RestoreSettlementData(*num.Numeric)


### PR DESCRIPTION
closes #9266 

Previously when we did a market update and came to update the product, we would just create a fresh instance which was fine for a future beacuse it doesn't do anything.

Now with perpetuals there is state in the product relating to funding periods that we do not want to lose when during a market update. So we now do so via an `Update()` call on the product and handle the update explicitly.

existing market-update tests still passing:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/3670/tests