### PR TITLE
chore: remove obsolete network parameters from snapshots

### DIFF
--- a/core/netparams/snapshot.go
+++ b/core/netparams/snapshot.go
@@ -131,7 +131,7 @@ func (s *Store) LoadState(ctx context.Context, pl *types.Payload) ([]types.State
 	}
 
 	for _, kv := range np.NetParams.Params {
-		if err := s.UpdateOptionalValidation(ctx, kv.Key, kv.Value, false); err != nil {
+		if err := s.UpdateOptionalValidation(ctx, kv.Key, kv.Value, false, false); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
close #9287  