### PR TITLE
fix: ListLedgerEntries tranfers type filter works as expected with op…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 - [9178](https://github.com/vegaprotocol/vega/issues/9178) - Fix LP amendment panic
 - [9053](https://github.com/vegaprotocol/vega/issues/9053) - Handle settle market events in core positions plug-in.
 - [9189](https://github.com/vegaprotocol/vega/issues/9189) - Fix stop orders snapshots
+- [9313](https://github.com/vegaprotocol/vega/issues/9313) - `ListLedgerEntries` transfers type filter works as expected with open to and from filters.
 - [9198](https://github.com/vegaprotocol/vega/issues/9198) - Fix panic during LP amendment applications
 - [9196](https://github.com/vegaprotocol/vega/issues/9196) - `API` documentation should specify the time format.
 - [9203](https://github.com/vegaprotocol/vega/issues/9203) - Do not remove LPs from the parties map if they are an LP without an open position

--- a/datanode/sqlstore/ledger.go
+++ b/datanode/sqlstore/ledger.go
@@ -398,7 +398,7 @@ func createDynamicQuery(filterQueries [3]string, closeOnAccountFilters entities.
 				whereClause = fmt.Sprintf("WHERE (%s) AND (%s)", filterQueries[0], filterQueries[1])
 			} else {
 				tableName = tableNameOpenOnFilterQuery
-				whereClause = fmt.Sprintf("WHERE (%s) OR (%s)", filterQueries[0], filterQueries[1])
+				whereClause = fmt.Sprintf("WHERE ((%s) OR (%s))", filterQueries[0], filterQueries[1])
 			}
 		}
 	} else {

--- a/datanode/sqlstore/ledger_test.go
+++ b/datanode/sqlstore/ledger_test.go
@@ -728,7 +728,7 @@ func TestLedger(t *testing.T) {
 			assert.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
-			assert.Equal(t, 4, len(*entries))
+			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
 					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
@@ -748,19 +748,6 @@ func TestLedger(t *testing.T) {
 					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
 					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
-				}
-
-				if e.Quantity.Abs().String() == strconv.Itoa(25) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[2].ID)
-
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[3].ID)
-					assert.Equal(t, strconv.Itoa(1700), e.FromAccountBalance.Abs().String())
-					assert.Equal(t, strconv.Itoa(2590), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
@@ -846,7 +833,7 @@ func TestLedger(t *testing.T) {
 			assert.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
-			assert.Equal(t, 4, len(*entries))
+			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
 					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
@@ -866,19 +853,6 @@ func TestLedger(t *testing.T) {
 					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
 					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
-				}
-
-				if e.Quantity.Abs().String() == strconv.Itoa(25) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[2].ID)
-
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[3].ID)
-					assert.Equal(t, strconv.Itoa(1700), e.FromAccountBalance.Abs().String())
-					assert.Equal(t, strconv.Itoa(2590), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
@@ -1047,7 +1021,7 @@ func TestLedger(t *testing.T) {
 			assert.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
-			assert.Equal(t, 4, len(*entries))
+			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
 					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
@@ -1067,19 +1041,6 @@ func TestLedger(t *testing.T) {
 					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
 					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
-				}
-
-				if e.Quantity.Abs().String() == strconv.Itoa(25) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[2].ID)
-
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[3].ID)
-					assert.Equal(t, strconv.Itoa(1700), e.FromAccountBalance.Abs().String())
-					assert.Equal(t, strconv.Itoa(2590), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {


### PR DESCRIPTION
closes #9313 

We were doing a `$x OR $y AND $z` which ends up as `$x OR ($y AND $z)` when it should have been `($x OR $y) AND $z`