### PR TITLE
chore: integration test for 0053-PERP-005

### DIFF
--- a/core/integration/features/settlement/mark_to_market_perpetual.feature
+++ b/core/integration/features/settlement/mark_to_market_perpetual.feature
@@ -1,0 +1,154 @@
+Feature: Test mark to market settlement with periodicity, takes the first scenario from mark_to_market_settlement_neg_pdp
+
+  Background:
+
+    And the perpetual oracles from "0xCAFECAFE1":
+      | name        | asset | settlement property | settlement type | schedule property | schedule type  | margin funding factor | interest rate | clamp lower bound | clamp upper bound | quote name | settlement decimals |
+      | perp-oracle | ETH   | perp.ETH.value      | TYPE_INTEGER    | perp.funding.cue  | TYPE_TIMESTAMP | 0                     | 0             | 0                 | 0                 | ETH        | 18                  |
+    And the liquidity sla params named "SLA":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1.0         | 0.5                          | 1                             | 1.0                    |
+
+    And the markets:
+      | id        | quote name | asset | risk model                  | margin calculator         | auction duration | fees         | price monitoring | data source config | linear slippage factor | quadratic slippage factor | position decimal places | market type | sla params |
+      | ETH/DEC19 | ETH        | ETH   | default-simple-risk-model-3 | default-margin-calculator | 1                | default-none | default-none     | perp-oracle        | 1e6                    | 1e6                         | -3                       | perp        | default-futures |
+
+    And the following network parameters are set:
+      | name                           | value |
+      | market.auction.minimumDuration | 1     |
+      | limits.markets.maxPeggedOrders | 2     |
+
+  @Perpetual
+  Scenario: (0053-PERP-005) Mark to market settlement works correctly with a predefined frequency irrespective of the behaviour of any of the oracles specified for the market.
+    Given the following network parameters are set:
+      | name                                    | value |
+      | network.markPriceUpdateMaximumFrequency | 5s    |
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset | amount    |
+      | party1 | ETH   | 10000000  |
+      | party2 | ETH   | 10000000  |
+      | party3 | ETH   | 10000000  |
+      | aux    | ETH   | 100000000 |
+      | aux2   | ETH   | 100000000 |
+      | lpprov | ETH   | 100000000 |
+
+    When the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | lp type    |
+      | lp1 | lpprov | ETH/DEC19 | 10000000          | 0.001 | submission |
+      | lp1 | lpprov | ETH/DEC19 | 10000000          | 0.001 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party  | market id | peak size | minimum visible size | side | pegged reference | volume     | offset |
+      | lpprov | ETH/DEC19 | 2         | 1                    | buy  | BID              | 50         | 1      |
+      | lpprov | ETH/DEC19 | 2         | 1                    | sell | ASK              | 50         | 1      |
+ 
+    # place auxiliary orders so we always have best bid and best offer as to not trigger the liquidity auction
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux   | ETH/DEC19 | buy  | 1      | 49    | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 5001  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC19 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux   | ETH/DEC19 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    And the market data for the market "ETH/DEC19" should be:
+      | target stake | supplied stake |
+      | 1100000      | 10000000       |
+    Then the opening auction period ends for market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the settlement account should have a balance of "0" for the market "ETH/DEC19"
+
+    # back sure we end the block so we're in a new one after opening auction
+    When the network moves ahead "1" blocks
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC19 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC19 | buy  | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin | general |
+      | party1 | ETH   | ETH/DEC19 | 120000 | 9880000 |
+      | party2 | ETH   | ETH/DEC19 | 132000 | 9867000 |
+
+    And the settlement account should have a balance of "0" for the market "ETH/DEC19"
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC19 | sell | 1      | 2000  | 0                | TYPE_LIMIT | TIF_GTC |
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 5041200 | 4958800 |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party3 | ETH/DEC19 | buy  | 1      | 2000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 5041200 | 4958800 |
+      | party3 | ETH   | ETH/DEC19 | 132000  | 9866000 |
+      | party2 | ETH   | ETH/DEC19 | 132000  | 9867000 |
+
+
+    # send in external data to the perpetual market, it should not change anything and a MTM should not happen
+    When the network moves ahead "1" blocks
+    When the oracles broadcast data with block time signed with "0xCAFECAFE1":
+      | name             | value                   | time offset |
+      | perp.ETH.value   | 2100000000000000000000  | 0s         |
+      | perp.funding.cue | 1511924180              | 0s          |
+    
+    # move to the block before we should MTM and check for no changes
+    When the network moves ahead "3" blocks
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 5041200 | 4958800 |
+      | party3 | ETH   | ETH/DEC19 | 132000  | 9866000 |
+      | party2 | ETH   | ETH/DEC19 | 132000  | 9867000 |
+
+    ## Now take us past the MTM frequency time
+    When the network moves ahead "1" blocks
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 7682400 | 1317600 |
+      | party3 | ETH   | ETH/DEC19 | 2605200 | 7392800 |
+      | party2 | ETH   | ETH/DEC19 | 2605200 | 8393800 |
+    And the following transfers should happen:
+      | from   | to     | from account        | to account              | market id | amount  | asset |
+      | party1 | market | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC19 | 1000000 | ETH   |
+    And the cumulated balance for all accounts should be worth "330000000"
+    And the settlement account should have a balance of "0" for the market "ETH/DEC19"
+
+    When the network moves ahead "1" blocks
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux   | ETH/DEC19 | sell | 1      | 2001  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC19 | buy  | 1      | 2001  | 1                | TYPE_LIMIT | TIF_GTC |
+
+    When the oracles broadcast data with block time signed with "0xCAFECAFE1":
+      | name             | value      | time offset |
+      | perp.funding.cue | 1575072009 | 0s          |
+
+    # funding payment is -100, funding-rate ~-0.05,
+    # party 1 loses 200000, party 2/3 gain 10000 in their margin account
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 7482400 | 1317600 |
+      | party3 | ETH   | ETH/DEC19 | 2705200 | 7392800 |
+      | party2 | ETH   | ETH/DEC19 | 2705200 | 8393800 |
+
+    # move to the block before the next MTM should be no changes
+    When the network moves ahead "3" blocks
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 7482400 | 1317600 |
+      | party3 | ETH   | ETH/DEC19 | 2705200 | 7392800 |
+      | party2 | ETH   | ETH/DEC19 | 2705200 | 8393800 |
+
+    ## Now take us past the MTM frequency time and things should change
+    When the network moves ahead "1" blocks
+    Then the parties should have the following account balances:
+      | party  | asset | market id | margin  | general |
+      | party1 | ETH   | ETH/DEC19 | 7480400 | 1317600 |
+      | party3 | ETH   | ETH/DEC19 | 2706200 | 7392800 |
+      | party2 | ETH   | ETH/DEC19 | 2706200 | 8393800 |
+    And the following transfers should happen:
+      | from   | to     | from account        | to account              | market id | amount  | asset |
+      | party1 | market | ACCOUNT_TYPE_MARGIN | ACCOUNT_TYPE_SETTLEMENT | ETH/DEC19 | 200000 | ETH   |
+    And the cumulated balance for all accounts should be worth "330000000"
+    And the settlement account should have a balance of "0" for the market "ETH/DEC19"

--- a/core/integration/steps/oracles_broadcast_data_signed_with_keys.go
+++ b/core/integration/steps/oracles_broadcast_data_signed_with_keys.go
@@ -42,7 +42,7 @@ func OraclesBroadcastDataSignedWithKeys(
 		return err
 	}
 	meta := map[string]string{
-		"eth-block-time": row.metaTime(timesvc),
+		"eth-block-time": row.metaTimeSeconds(timesvc),
 	}
 
 	// we need a traceID here in case of final MTM settlement -> an idgen is required
@@ -81,7 +81,7 @@ func OraclesBroadcastDataWithBlockTimeSignedWithKeys(
 				Signers: pubKeysSigners,
 				Data:    map[string]string{},
 				MetaData: map[string]string{
-					"eth-block-time": time,
+					"eth-block-time": row.metaTimeSeconds(timesvc),
 				},
 			}
 		}
@@ -167,4 +167,12 @@ func (r oracleDataPropertyRow) metaTime(timeSvc *stubs.TimeStub) string {
 	}
 	tm := timeSvc.GetTimeNow().Add(r.timeOffset())
 	return fmt.Sprintf("%d", tm.UnixNano())
+}
+
+func (r oracleDataPropertyRow) metaTimeSeconds(timeSvc *stubs.TimeStub) string {
+	if r.row.HasColumn("eth-block-time") {
+		return r.row.MustStr("eth-block-time")
+	}
+	tm := timeSvc.GetTimeNow().Add(r.timeOffset())
+	return fmt.Sprintf("%d", tm.Unix())
 }


### PR DESCRIPTION
close https://github.com/vegaprotocol/OctoberACs/issues/54

AC
"(0053-PERP-005) Mark to market settlement works correctly with a predefined frequency irrespective of the behaviour of any of the oracles specified for the market."

Feature test summary:
- make perps market with 5s MTM frequence
- leaves opening auction
- sends some perp data-sources
- checks no account balance change because we've not at MTM time AND we have no internal data point to do periodic funding
- step foward the MTM frequency point, watch MTM happen
- step forward one block, and send in more perp data-sources
- funding-payments happen BUT NOT MTM because we're not at the time yet
- step forward until the MTM time, watch it happen again