### PR TITLE
feat: add FTs to cover SLA performance ACs

### DIFF
--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -487,7 +487,7 @@ Feature: Test liquidity provider reward distribution
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
   @FeeRound
-  Scenario: 005, 2 LPs joining at start, unequal commitments, 1 LP lp3 joining later, and 4 LPs lp4/5/6/7 with large commitment and low/high fee joins later
+  Scenario: 005, 2 LPs joining at start, unequal commitments, 1 LP lp3 joining later, and 4 LPs lp4/5/6/7 with large commitment and low/high fee joins later (0042-LIQF-032)
 
     And the following network parameters are set:
       | name                    | value |

--- a/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
+++ b/core/integration/features/fees/setting-fee-and-rewarding-lps.feature
@@ -7,14 +7,14 @@ Feature: Test liquidity provider reward distribution
       | long | short | max move up | min move down | probability of trading |
       | 0.1  | 0.1   | 500         | 500           | 0.1                    |
     And the following network parameters are set:
-      | name                                               | value |
-      | market.value.windowLength                          | 1h    |
-      | market.stake.target.timeWindow                     | 24h   |
-      | market.stake.target.scalingFactor                  | 1     |
-      | market.liquidity.targetstake.triggering.ratio      | 0     |
-      | network.markPriceUpdateMaximumFrequency            | 1s    |
-      | network.markPriceUpdateMaximumFrequency            | 0s    |
-      | limits.markets.maxPeggedOrders                     | 612   |
+      | name                                          | value |
+      | market.value.windowLength                     | 1h    |
+      | market.stake.target.timeWindow                | 24h   |
+      | market.stake.target.scalingFactor             | 1     |
+      | market.liquidity.targetstake.triggering.ratio | 0     |
+      | network.markPriceUpdateMaximumFrequency       | 1s    |
+      | network.markPriceUpdateMaximumFrequency       | 0s    |
+      | limits.markets.maxPeggedOrders                | 612   |
     And the log normal risk model named "lognormal-risk-model-1":
       | risk aversion | tau  | mu | r   | sigma |
       | 0.001         | 0.01 | 0  | 0.0 | 1.2   |
@@ -43,447 +43,448 @@ Feature: Test liquidity provider reward distribution
       | ETH/DEC21 | ETH        | ETH   | simple-risk-model-1    | default-margin-calculator | 2                | fees-config-1 | price-monitoring-1 | ethDec21Oracle     | 1e0                    | 1e0                       | SLA        |
       | ETH/DEC22 | ETH        | ETH   | lognormal-risk-model-1 | default-margin-calculator | 2                | fees-config-1 | price-monitoring-2 | ethDec21Oracle     | 1e0                    | 1e0                       | SLA        |
     And the following network parameters are set:
-      | name                                               | value |
+      | name                                             | value |
       | market.liquidity.providersFeeCalculationTimeStep | 600s  |
     And the average block duration is "1"
 
-#   Scenario: 001, 1 LP joining at start, checking liquidity rewards over 3 periods, 1 period with no trades
-#     # setup accounts
-#     Given the parties deposit on asset's general account the following amount:
-#       | party  | asset | amount     |
-#       | lp1    | ETH   | 1000000000 |
-#       | party1 | ETH   | 100000000  |
-#       | party2 | ETH   | 100000000  |
-
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | submission |
-#       | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | amendment  |
-#       | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | amendment  |
-#       | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | amendment  |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp1   | ETH/DEC21 | 15        | 10                   | buy  | BID              | 30     | 2      |
-#       | lp1   | ETH/DEC21 | 15        | 10                   | buy  | MID              | 30     | 1      |
-#       | lp1   | ETH/DEC21 | 15        | 10                   | sell | ASK              | 30     | 2      |
-#       | lp1   | ETH/DEC21 | 15        | 10                   | sell | MID              | 30     | 1      |
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-#     Then the opening auction period ends for market "ETH/DEC21"
-
-#     And the following trades should be executed:
-#       | buyer  | price | size | seller |
-#       | party1 | 1000  | 10   | party2 |
-
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     And the mark price should be "1000" for the market "ETH/DEC21"
-#     And the open interest should be "10" for the market "ETH/DEC21"
-#     And the target stake should be "1000" for the market "ETH/DEC21"
-#     And the supplied stake should be "10000" for the market "ETH/DEC21"
-
-#     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
-#       | party | equity like share | average entry valuation |
-#       | lp1   | 1                 | 10000                   |
-
-#     Then the network moves ahead "1" blocks
-
-#     And the price monitoring bounds for the market "ETH/DEC21" should be:
-#       | min bound | max bound |
-#       | 500       | 1500      |
-
-#     And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
-
-#     Then the parties place the following orders with ticks:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-#       | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
-#       | party2 | ETH/DEC21 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-buy  |
-
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
-
-#     # opening auction + time window
-#     Then time is updated to "2019-11-30T00:10:05Z"
-#     Then debug transfers
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 20     | ETH   |
-
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
-
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     Then time is updated to "2019-11-30T00:20:05Z"
-
-#     When the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
-#       | party1 | ETH/DEC21 | buy  | 8      | 1100  | 1                | TYPE_LIMIT | TIF_GTC | party1-buy |
-#     #   | party2 | ETH/DEC21 | sell | 40     | 1100  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell |
-
-#     Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-
-#     # this is slightly different than expected, as the trades happen against the LP,
-#     # which is probably not what you expected initially
-#     And the accumulated liquidity fees should be "8" for the market "ETH/DEC21"
-
-#     # opening auction + time window
-#     Then time is updated to "2019-11-30T00:30:05Z"
-
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 8      | ETH   |
-
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
-
-
-#   Scenario: 002, 2 LPs joining at start, equal commitments
-
-#     Given the parties deposit on asset's general account the following amount:
-#       | party  | asset | amount     |
-#       | lp1    | ETH   | 1000000000 |
-#       | lp2    | ETH   | 1000000000 |
-#       | party1 | ETH   | 100000000  |
-#       | party2 | ETH   | 100000000  |
-
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | submission |
-#       | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | amendment  |
-#       | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | amendment  |
-#       | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | amendment  |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp1   | ETH/DEC21 | 20        | 15                   | buy  | BID              | 100    | 2      |
-#       | lp1   | ETH/DEC21 | 20        | 15                   | buy  | MID              | 200    | 1      |
-#       | lp1   | ETH/DEC21 | 20        | 15                   | sell | ASK              | 100    | 2      |
-#       | lp1   | ETH/DEC21 | 20        | 15                   | sell | MID              | 100    | 1      |
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | submission |
-#       | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | amendment  |
-#       | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | amendment  |
-#       | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | amendment  |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp2   | ETH/DEC21 | 20        | 15                   | buy  | BID              | 100    | 2      |
-#       | lp2   | ETH/DEC21 | 20        | 15                   | buy  | MID              | 100    | 1      |
-#       | lp2   | ETH/DEC21 | 20        | 15                   | sell | ASK              | 100    | 2      |
-#       | lp2   | ETH/DEC21 | 20        | 15                   | sell | MID              | 100    | 1      |
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC21 | buy  | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-#     Then the opening auction period ends for market "ETH/DEC21"
-
-#     And the following trades should be executed:
-#       | buyer  | price | size | seller |
-#       | party1 | 1000  | 90   | party2 |
-
-#     And debug all events
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     And the mark price should be "1000" for the market "ETH/DEC21"
-#     And the open interest should be "90" for the market "ETH/DEC21"
-#     And the target stake should be "9000" for the market "ETH/DEC21"
-#     And the supplied stake should be "10000" for the market "ETH/DEC21"
-
-#     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
-#       | party | equity like share | average entry valuation |
-#       | lp1   | 0.5               | 5000                    |
-#       | lp2   | 0.5               | 10000                   |
-
-#     And the price monitoring bounds for the market "ETH/DEC21" should be:
-#       | min bound | max bound |
-#       | 500       | 1500      |
-
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
-
-#     # no fees in auction
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
-
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-#       | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
-#       | party2 | ETH/DEC21 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-buy  |
-
-#     And the accumulated liquidity fees should be "39" for the market "ETH/DEC21"
-
-#     # opening auction + time window
-#     Then time is updated to "2019-11-30T00:10:05Z"
-
-#     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 19     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 19     | ETH   |
-
-
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-#       | party1 | ETH/DEC21 | buy  | 40     | 1100  | 2                | TYPE_LIMIT | TIF_GTC | party1-buy  |
-#       | party2 | ETH/DEC21 | sell | 40     | 1100  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell |
-
-#     And the accumulated liquidity fees should be "79" for the market "ETH/DEC21"
-
-#     # opening auction + time window
-#     Then time is updated to "2019-11-30T00:20:08Z"
-
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 39     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 39     | ETH   |
-
-#   @FeeRound
-#   Scenario: 003, 2 LPs joining at start, equal commitments, unequal offsets
-#     Given the following network parameters are set:
-#       | name                           | value |
-#       | limits.markets.maxPeggedOrders | 10    |
-#     And the liquidity sla params named "updated-SLA":
-#       | price range | commitment min time fraction | providers fee calculation time step | performance hysteresis epochs | sla competition factor |
-#       | 1.0         | 0.5                          | 5                                   | 1                             | 1.0                    |
-#     And the markets are updated:
-#       | id        | sla params  | linear slippage factor | quadratic slippage factor |
-#       | ETH/DEC22 | updated-SLA | 1e0                    | 1e0                       |
-#     And the parties deposit on asset's general account the following amount:
-#       | party  | asset | amount       |
-#       | lp1    | ETH   | 100000000000 |
-#       | lp2    | ETH   | 100000000000 |
-#       | party1 | ETH   | 100000000    |
-#       | party2 | ETH   | 100000000    |
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp1 | lp1   | ETH/DEC22 | 40000             | 0.001 | submission |
-#       | lp1 | lp1   | ETH/DEC22 | 40000             | 0.001 |            |
-#       | lp2 | lp2   | ETH/DEC22 | 40000             | 0.002 | submission |
-#       | lp2 | lp2   | ETH/DEC22 | 40000             | 0.002 |            |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference  |
-#       | lp1   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 32     | lp1-bids-1 |
-#       | lp1   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 32     | lp1-asks-1 |
-#       | lp2   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 102    | lp2-bids-1 |
-#       | lp2   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 102    | lp2-asks-1 |
-#     When the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC22 | buy  | 1      | 995   | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC22 | buy  | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC22 | sell | 1      | 1005  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC22 | sell | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#     And the opening auction period ends for market "ETH/DEC22"
-#     Then the market data for the market "ETH/DEC22" should be:
-#       | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest | best static bid price | static mid price | best static offer price |
-#       | 1000       | TRADING_MODE_CONTINUOUS | 10000   | 893       | 1120      | 43908        | 80000          | 90            | 995                   | 1000             | 1005                    |
-#     And the following trades should be executed:
-#       | buyer  | price | size | seller |
-#       | party1 | 1000  | 90   | party2 |
-#     And the liquidity provider fee shares for the market "ETH/DEC22" should be:
-#       | party | equity like share | average entry valuation |
-#       | lp1   | 0.5               | 40000                   |
-#       | lp2   | 0.5               | 80000                   |
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC22"
-#     # no fees in auction
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC22"
-
-#     When the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC22 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC22 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
-#     Then the accumulated liquidity fees should be "40" for the market "ETH/DEC22"
-
-#     When the network moves ahead "6" blocks
-
-#     Then the accumulated liquidity fees should be "1" for the market "ETH/DEC22"
-
-#     Then debug transfers
-#     # observe that lp2 gets lower share of the fees despite the same commitment amount (that is due to their orders being much wider than those of lp1)
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 26     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 13     | ETH   |
-
-#     # modify lp2 orders so that they fall outside the price monitoring bounds
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference  |
-#       | lp2   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 116    | lp2-bids-2 |
-#       | lp2   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 116    | lp2-asks-2 |
-#     And the parties cancel the following orders:
-#       | party | reference  |
-#       | lp2   | lp2-bids-1 |
-#       | lp2   | lp2-asks-1 |
-#     And the market data for the market "ETH/DEC22" should be:
-#       | mark price | trading mode            | horizon | min bound | max bound | best static bid price | static mid price | best static offer price |
-#       | 1000       | TRADING_MODE_CONTINUOUS | 10000   | 893       | 1120      | 995                   | 1000             | 1005                    |
-#     And the accumulated liquidity fees should be "1" for the market "ETH/DEC22"
-
-#     Then debug transfers
-
-#     And the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
-#     Then the accumulated liquidity fees should be "41" for the market "ETH/DEC22"
-
-#     When the network moves ahead "6" blocks
-#     Then debug transfers
-#     # all the fees go to lp2
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 41     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 0      | ETH   |
-
-#     # lp2 manually adds some limit orders within PM range, observe automatically deployed orders go down and fee share go up
-#     When clear all events
-#     And the parties place the following orders:
-#       | party | market id | side | volume | price | resulting trades | type       | tif     |
-#       | lp2   | ETH/DEC22 | buy  | 100    | 995   | 0                | TYPE_LIMIT | TIF_GTC |
-#       | lp2   | ETH/DEC22 | sell | 100    | 1005  | 0                | TYPE_LIMIT | TIF_GTC |
-
-
-#     When the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
-#     Then the accumulated liquidity fees should be "40" for the market "ETH/DEC22"
-
-#     When the network moves ahead "6" blocks
-#     # lp2 has increased their liquidity score by placing limit orders closer to the mid (and within price monitoring bounds),
-#     # hence their fee share is larger (and no longer 0) now.
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 24     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 15     | ETH   |
-
-#     # lp2 manually adds some pegged orders within PM range, liquidity obligation is now fullfiled by limit and pegged orders so no automatic order deployment takes place
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference  |
-#       | lp2   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 1      | lp2-bids-3 |
-#       | lp2   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 1      | lp2-asks-3 |
-
-#     When the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
-#     Then the accumulated liquidity fees should be "41" for the market "ETH/DEC22"
-
-#     When the network moves ahead "6" blocks
-#     # lp2 has increased their liquidity score by placing pegged orders closer to the mid (and within price monitoring bounds),
-#     # hence their fee share is larger now.
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 22     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 18     | ETH   |
-
-#   @FeeRound
-#   Scenario: 004, 2 LPs joining at start, unequal commitments
-
-#     Given the parties deposit on asset's general account the following amount:
-#       | party  | asset | amount     |
-#       | lp1    | ETH   | 1000000000 |
-#       | lp2    | ETH   | 1000000000 |
-#       | party1 | ETH   | 100000000  |
-#       | party2 | ETH   | 100000000  |
-
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
-#       | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
-#       | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
-#       | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp1   | ETH/DEC21 | 100       | 1                    | buy  | BID              | 200    | 2      |
-#       | lp1   | ETH/DEC21 | 100       | 1                    | sell | ASK              | 200    | 2      |
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
-#       | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
-#       | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
-#       | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp2   | ETH/DEC21 | 100       | 1                    | buy  | BID              | 200    | 2      |
-#       | lp2   | ETH/DEC21 | 100       | 1                    | sell | ASK              | 200    | 2      |
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC21 | buy  | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-
-#     Then the opening auction period ends for market "ETH/DEC21"
-
-#     And the following trades should be executed:
-#       | buyer  | price | size | seller |
-#       | party1 | 1000  | 60   | party2 |
-
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     And the mark price should be "1000" for the market "ETH/DEC21"
-#     And the open interest should be "60" for the market "ETH/DEC21"
-#     And the target stake should be "6000" for the market "ETH/DEC21"
-#     And the supplied stake should be "10000" for the market "ETH/DEC21"
-
-#     And the liquidity provider fee shares for the market "ETH/DEC21" should be:
-#       | party | equity like share | average entry valuation |
-#       | lp1   | 0.8               | 8000                    |
-#       | lp2   | 0.2               | 10000                   |
-
-#     And the price monitoring bounds for the market "ETH/DEC21" should be:
-#       | min bound | max bound |
-#       | 500       | 1500      |
-
-#     And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
-
-#     # no fees in auction
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
-
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-#       | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
-#       | party2 | ETH/DEC21 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-buy  |
-
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-
-#     And the following trades should be executed:
-#       | buyer  | price | size | seller |
-#       | party2 | 1000  | 20   | party1 |
-
-#     And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
-#     # opening auction + time window
-#     Then time is updated to "2019-11-30T00:10:05Z"
-
-#     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 16     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 4      | ETH   |
-
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
-
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
-#       | party1 | ETH/DEC21 | buy  | 40     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-buy  |
-#       | party2 | ETH/DEC21 | sell | 40     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-sell |
-
-#     And the following trades should be executed:
-#       | buyer  | price | size | seller |
-#       | party1 | 1000  | 40   | party2 |
-
-#     And the accumulated liquidity fees should be "40" for the market "ETH/DEC21"
-
-#     # opening auction + time window
-#     Then time is updated to "2019-11-30T00:20:06Z"
-
-#     # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
-#     Then the following transfers should happen:
-#       | from   | to  | from account                | to account                     | market id | amount | asset |
-#       | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 32     | ETH   |
-#       | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 8      | ETH   |
-
-#     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+  Scenario: 001, 1 LP joining at start, checking liquidity rewards over 3 periods, 1 period with no trades
+    # setup accounts
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
+
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | submission |
+      | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | amendment  |
+      | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | amendment  |
+      | lp1 | lp1   | ETH/DEC21 | 10000             | 0.001 | amendment  |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp1   | ETH/DEC21 | 15        | 10                   | buy  | BID              | 30     | 2      |
+      | lp1   | ETH/DEC21 | 15        | 10                   | buy  | MID              | 30     | 1      |
+      | lp1   | ETH/DEC21 | 15        | 10                   | sell | ASK              | 30     | 2      |
+      | lp1   | ETH/DEC21 | 15        | 10                   | sell | MID              | 30     | 1      |
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the opening auction period ends for market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 1000  | 10   | party2 |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the open interest should be "10" for the market "ETH/DEC21"
+    And the target stake should be "1000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+
+    And the liquidity provider fee shares for the market "ETH/DEC21" should be:
+      | party | equity like share | average entry valuation |
+      | lp1   | 1                 | 10000                   |
+
+    Then the network moves ahead "1" blocks
+
+    And the price monitoring bounds for the market "ETH/DEC21" should be:
+      | min bound | max bound |
+      | 500       | 1500      |
+
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
+
+    Then the parties place the following orders with ticks:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
+
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:10:05Z"
+    Then debug transfers
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 20     | ETH   |
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    Then time is updated to "2019-11-30T00:20:05Z"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference  |
+      | party1 | ETH/DEC21 | buy  | 8      | 1100  | 1                | TYPE_LIMIT | TIF_GTC | party1-buy |
+    #   | party2 | ETH/DEC21 | sell | 40     | 1100  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell |
+
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+
+    # this is slightly different than expected, as the trades happen against the LP,
+    # which is probably not what you expected initially
+    And the accumulated liquidity fees should be "8" for the market "ETH/DEC21"
+
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:30:05Z"
+
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 8      | ETH   |
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+
+  Scenario: 002, 2 LPs joining at start, equal commitments
+
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | ETH   | 1000000000 |
+      | lp2    | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
+
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | submission |
+      | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | amendment  |
+      | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | amendment  |
+      | lp1 | lp1   | ETH/DEC21 | 5000              | 0.001 | amendment  |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp1   | ETH/DEC21 | 20        | 15                   | buy  | BID              | 100    | 2      |
+      | lp1   | ETH/DEC21 | 20        | 15                   | buy  | MID              | 200    | 1      |
+      | lp1   | ETH/DEC21 | 20        | 15                   | sell | ASK              | 100    | 2      |
+      | lp1   | ETH/DEC21 | 20        | 15                   | sell | MID              | 100    | 1      |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | submission |
+      | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | amendment  |
+      | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | amendment  |
+      | lp2 | lp2   | ETH/DEC21 | 5000              | 0.002 | amendment  |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp2   | ETH/DEC21 | 20        | 15                   | buy  | BID              | 100    | 2      |
+      | lp2   | ETH/DEC21 | 20        | 15                   | buy  | MID              | 100    | 1      |
+      | lp2   | ETH/DEC21 | 20        | 15                   | sell | ASK              | 100    | 2      |
+      | lp2   | ETH/DEC21 | 20        | 15                   | sell | MID              | 100    | 1      |
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the opening auction period ends for market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 1000  | 90   | party2 |
+
+    And debug all events
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the open interest should be "90" for the market "ETH/DEC21"
+    And the target stake should be "9000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+
+    And the liquidity provider fee shares for the market "ETH/DEC21" should be:
+      | party | equity like share | average entry valuation |
+      | lp1   | 0.5               | 5000                    |
+      | lp2   | 0.5               | 10000                   |
+
+    And the price monitoring bounds for the market "ETH/DEC21" should be:
+      | min bound | max bound |
+      | 500       | 1500      |
+
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+
+    # no fees in auction
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+
+    And the accumulated liquidity fees should be "39" for the market "ETH/DEC21"
+
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:10:05Z"
+
+    # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 19     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 19     | ETH   |
+
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | buy  | 40     | 1100  | 2                | TYPE_LIMIT | TIF_GTC | party1-buy  |
+      | party2 | ETH/DEC21 | sell | 40     | 1100  | 0                | TYPE_LIMIT | TIF_GTC | party2-sell |
+
+    And the accumulated liquidity fees should be "79" for the market "ETH/DEC21"
+
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:20:08Z"
+
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 39     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 39     | ETH   |
+
+  @FeeRound
+  Scenario: 003, 2 LPs joining at start, equal commitments, unequal offsets
+    Given the following network parameters are set:
+      | name                                             | value |
+      | limits.markets.maxPeggedOrders                   | 10    |
+      | market.liquidity.providersFeeCalculationTimeStep | 5s    |
+    And the liquidity sla params named "updated-SLA":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1.0         | 0.5                          | 1                             | 1.0                    |
+    And the markets are updated:
+      | id        | sla params  | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC22 | updated-SLA | 1e0                    | 1e0                       |
+    And the parties deposit on asset's general account the following amount:
+      | party  | asset | amount       |
+      | lp1    | ETH   | 100000000000 |
+      | lp2    | ETH   | 100000000000 |
+      | party1 | ETH   | 100000000    |
+      | party2 | ETH   | 100000000    |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp1 | lp1   | ETH/DEC22 | 40000             | 0.001 | submission |
+      | lp1 | lp1   | ETH/DEC22 | 40000             | 0.001 |            |
+      | lp2 | lp2   | ETH/DEC22 | 40000             | 0.002 | submission |
+      | lp2 | lp2   | ETH/DEC22 | 40000             | 0.002 |            |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference  |
+      | lp1   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 32     | lp1-bids-1 |
+      | lp1   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 32     | lp1-asks-1 |
+      | lp2   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 102    | lp2-bids-1 |
+      | lp2   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 102    | lp2-asks-1 |
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC22 | buy  | 1      | 995   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC22 | buy  | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC22 | sell | 1      | 1005  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC22 | sell | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC22"
+    Then the market data for the market "ETH/DEC22" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest | best static bid price | static mid price | best static offer price |
+      | 1000       | TRADING_MODE_CONTINUOUS | 10000   | 893       | 1120      | 43908        | 80000          | 90            | 995                   | 1000             | 1005                    |
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 1000  | 90   | party2 |
+    And the liquidity provider fee shares for the market "ETH/DEC22" should be:
+      | party | equity like share | average entry valuation |
+      | lp1   | 0.5               | 40000                   |
+      | lp2   | 0.5               | 80000                   |
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC22"
+    # no fees in auction
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC22"
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC22 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC22 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
+    Then the accumulated liquidity fees should be "40" for the market "ETH/DEC22"
+
+    When the network moves ahead "6" blocks
+
+    Then the accumulated liquidity fees should be "1" for the market "ETH/DEC22"
+
+    Then debug transfers
+    # observe that lp2 gets lower share of the fees despite the same commitment amount (that is due to their orders being much wider than those of lp1)
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 26     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 13     | ETH   |
+
+    # modify lp2 orders so that they fall outside the price monitoring bounds
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference  |
+      | lp2   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 116    | lp2-bids-2 |
+      | lp2   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 116    | lp2-asks-2 |
+    And the parties cancel the following orders:
+      | party | reference  |
+      | lp2   | lp2-bids-1 |
+      | lp2   | lp2-asks-1 |
+    And the market data for the market "ETH/DEC22" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | best static bid price | static mid price | best static offer price |
+      | 1000       | TRADING_MODE_CONTINUOUS | 10000   | 893       | 1120      | 995                   | 1000             | 1005                    |
+    And the accumulated liquidity fees should be "1" for the market "ETH/DEC22"
+
+    Then debug transfers
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
+    Then the accumulated liquidity fees should be "41" for the market "ETH/DEC22"
+
+    When the network moves ahead "6" blocks
+    Then debug transfers
+    # all the fees go to lp2
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 41     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 0      | ETH   |
+
+    # lp2 manually adds some limit orders within PM range, observe automatically deployed orders go down and fee share go up
+    When clear all events
+    And the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | lp2   | ETH/DEC22 | buy  | 100    | 995   | 0                | TYPE_LIMIT | TIF_GTC |
+      | lp2   | ETH/DEC22 | sell | 100    | 1005  | 0                | TYPE_LIMIT | TIF_GTC |
+
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
+    Then the accumulated liquidity fees should be "40" for the market "ETH/DEC22"
+
+    When the network moves ahead "6" blocks
+    # lp2 has increased their liquidity score by placing limit orders closer to the mid (and within price monitoring bounds),
+    # hence their fee share is larger (and no longer 0) now.
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 24     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 15     | ETH   |
+
+    # lp2 manually adds some pegged orders within PM range, liquidity obligation is now fullfiled by limit and pegged orders so no automatic order deployment takes place
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference  |
+      | lp2   | ETH/DEC22 | 100       | 50                   | buy  | BID              | 100    | 1      | lp2-bids-3 |
+      | lp2   | ETH/DEC22 | 100       | 50                   | sell | ASK              | 100    | 1      | lp2-asks-3 |
+
+    When the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party2 | ETH/DEC22 | buy  | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC22 | sell | 20     | 1000  | 1                | TYPE_LIMIT | TIF_FOK |
+    Then the accumulated liquidity fees should be "41" for the market "ETH/DEC22"
+
+    When the network moves ahead "6" blocks
+    # lp2 has increased their liquidity score by placing pegged orders closer to the mid (and within price monitoring bounds),
+    # hence their fee share is larger now.
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 22     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC22 | 18     | ETH   |
+
+  @FeeRound
+  Scenario: 004, 2 LPs joining at start, unequal commitments
+
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | ETH   | 1000000000 |
+      | lp2    | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
+
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.001 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp1   | ETH/DEC21 | 100       | 1                    | buy  | BID              | 200    | 2      |
+      | lp1   | ETH/DEC21 | 100       | 1                    | sell | ASK              | 200    | 2      |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.002 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp2   | ETH/DEC21 | 100       | 1                    | buy  | BID              | 200    | 2      |
+      | lp2   | ETH/DEC21 | 100       | 1                    | sell | ASK              | 200    | 2      |
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 60     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    Then the opening auction period ends for market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 1000  | 60   | party2 |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the mark price should be "1000" for the market "ETH/DEC21"
+    And the open interest should be "60" for the market "ETH/DEC21"
+    And the target stake should be "6000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+
+    And the liquidity provider fee shares for the market "ETH/DEC21" should be:
+      | party | equity like share | average entry valuation |
+      | lp1   | 0.8               | 8000                    |
+      | lp2   | 0.2               | 10000                   |
+
+    And the price monitoring bounds for the market "ETH/DEC21" should be:
+      | min bound | max bound |
+      | 500       | 1500      |
+
+    And the liquidity fee factor should be "0.001" for the market "ETH/DEC21"
+
+    # no fees in auction
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | sell | 20     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-sell |
+      | party2 | ETH/DEC21 | buy  | 20     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-buy  |
+
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party2 | 1000  | 20   | party1 |
+
+    And the accumulated liquidity fees should be "20" for the market "ETH/DEC21"
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:10:05Z"
+
+    # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 16     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 4      | ETH   |
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
+
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference   |
+      | party1 | ETH/DEC21 | buy  | 40     | 1000  | 0                | TYPE_LIMIT | TIF_GTC | party1-buy  |
+      | party2 | ETH/DEC21 | sell | 40     | 1000  | 1                | TYPE_LIMIT | TIF_GTC | party2-sell |
+
+    And the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 1000  | 40   | party2 |
+
+    And the accumulated liquidity fees should be "40" for the market "ETH/DEC21"
+
+    # opening auction + time window
+    Then time is updated to "2019-11-30T00:20:06Z"
+
+    # these are different from the tests, but again, we end up with a 2/3 vs 1/3 fee share here.
+    Then the following transfers should happen:
+      | from   | to  | from account                | to account                     | market id | amount | asset |
+      | market | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 32     | ETH   |
+      | market | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC21 | 8      | ETH   |
+
+    And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
   @FeeRound
   Scenario: 005, 2 LPs joining at start, unequal commitments, 1 LP lp3 joining later, and 4 LPs lp4/5/6/7 with large commitment and low/high fee joins later
@@ -866,213 +867,207 @@ Feature: Test liquidity provider reward distribution
 
     And the accumulated liquidity fees should be "0" for the market "ETH/DEC21"
 
-#   Scenario: 008, 2 LPs joining at start, unequal commitments, 1 LP joins later , and 1 LP leave
+  Scenario: 008, 2 LPs joining at start, unequal commitments, 1 LP joins later , and 1 LP leave
 
-#     Given the liquidity sla params named "updated-SLA":
-#       | price range | commitment min time fraction | providers fee calculation time step | performance hysteresis epochs | sla competition factor |
-#       | 1.0         | 0.5                          | 0                                   | 1                             | 1.0                    |
-#     And the markets are updated:
-#       | id        | sla params  | linear slippage factor | quadratic slippage factor |
-#       | ETH/DEC22 | updated-SLA | 1e0                    | 1e0                       |
+    Given the following network parameters are set:
+      | name                                             | value |
+      | limits.markets.maxPeggedOrders                   | 10    |
+      | market.liquidity.providersFeeCalculationTimeStep | 1s    |
+      | limits.markets.maxPeggedOrders                   | 612   |
+    #   | validators.epoch.length                          | 1s    |
 
-#     Given the parties deposit on asset's general account the following amount:
-#       | party  | asset | amount     |
-#       | lp1    | ETH   | 1000000000 |
-#       | lp2    | ETH   | 1000000000 |
-#       | lp3    | ETH   | 1000000000 |
-#       | lp4    | ETH   | 1000000000 |
-#       | lp5    | ETH   | 1000000000 |
-#       | party1 | ETH   | 100000000  |
-#       | party2 | ETH   | 100000000  |
+    Given the liquidity sla params named "updated-SLA":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1.0         | 0.0                          | 1                             | 0.0                    |
+    And the markets are updated:
+      | id        | sla params  | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC22 | updated-SLA | 1e0                    | 1e0                       |
 
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp1 | lp1   | ETH/DEC21 | 8000              | 0.002 | submission |
-#       | lp1 | lp1   | ETH/DEC21 | 8000              | 0.002 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp1   | ETH/DEC21 | 200       | 1                    | buy  | BID              | 200    | 1      |
-#       | lp1   | ETH/DEC21 | 200       | 1                    | sell | ASK              | 200    | 1      |
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp2 | lp2   | ETH/DEC21 | 2000              | 0.001 | submission |
-#       | lp2 | lp2   | ETH/DEC21 | 2000              | 0.001 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp2   | ETH/DEC21 | 200       | 1                    | buy  | BID              | 200    | 1      |
-#       | lp2   | ETH/DEC21 | 200       | 1                    | sell | ASK              | 200    | 1      |
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party1 | ETH/DEC21 | buy  | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | ETH   | 1000000000 |
+      | lp2    | ETH   | 1000000000 |
+      | lp3    | ETH   | 1000000000 |
+      | lp4    | ETH   | 1000000000 |
+      | lp5    | ETH   | 1000000000 |
+      | party1 | ETH   | 100000000  |
+      | party2 | ETH   | 100000000  |
 
-#     Then the opening auction period ends for market "ETH/DEC21"
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     And the target stake should be "9000" for the market "ETH/DEC21"
-#     And the supplied stake should be "10000" for the market "ETH/DEC21"
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.002 | submission |
+      | lp1 | lp1   | ETH/DEC21 | 8000              | 0.002 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp1   | ETH/DEC21 | 200       | 1                    | buy  | BID              | 200    | 1      |
+      | lp1   | ETH/DEC21 | 200       | 1                    | sell | ASK              | 200    | 1      |
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.001 | submission |
+      | lp2 | lp2   | ETH/DEC21 | 2000              | 0.001 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp2   | ETH/DEC21 | 200       | 1                    | buy  | BID              | 200    | 1      |
+      | lp2   | ETH/DEC21 | 200       | 1                    | sell | ASK              | 200    | 1      |
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 1      | 900   | 0                | TYPE_LIMIT | TIF_GTC |
+      | party1 | ETH/DEC21 | buy  | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 90     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
 
-#     And the network moves ahead "1" blocks
+    Then the opening auction period ends for market "ETH/DEC21"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the target stake should be "9000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
 
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type    |
-#       | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | submission |
-#       | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp3   | ETH/DEC21 | 200       | 1                    | buy  | BID              | 200    | 4      |
-#       | lp3   | ETH/DEC21 | 200       | 1                    | sell | ASK              | 200    | 4      |
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type      |
-#       | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | cancellation |
-#     And the network moves ahead "1" blocks
-#     And the liquidity fee factor should be "0.0015" for the market "ETH/DEC21"
-#     And the network moves ahead "10" blocks
+    And the network moves ahead "1" blocks
 
-#     And the target stake should be "9000" for the market "ETH/DEC21"
-#     And the supplied stake should be "19000" for the market "ETH/DEC21"
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type    |
+      | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | submission |
+      | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp3   | ETH/DEC21 | 200       | 1                    | buy  | BID              | 200    | 4      |
+      | lp3   | ETH/DEC21 | 200       | 1                    | sell | ASK              | 200    | 4      |
+    And the network moves ahead "1" blocks
+    And the liquidity fee factor should be "0.0015" for the market "ETH/DEC21"
+    And the network moves ahead "10" blocks
 
-#     #AC 0042-LIQF-025: lp3 leaves a market that is above target stake when their fee bid is currently being used: fee changes to fee bid by the LP who takes their place in the bidding order
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type      |
-#       | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | cancellation |
-#       | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | cancellation |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp3   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp3   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     Then the liquidity provisions should have the following states:
-#       | id  | party | market    | commitment amount | status           |
-#       | lp3 | lp3   | ETH/DEC21 | 9000              | STATUS_CANCELLED |
-#     And the network moves ahead "10" blocks
-#     And the target stake should be "9000" for the market "ETH/DEC21"
-#     And the supplied stake should be "10000" for the market "ETH/DEC21"
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+    And the target stake should be "9000" for the market "ETH/DEC21"
+    And the supplied stake should be "19000" for the market "ETH/DEC21"
 
-#     Then the parties place the following orders:
-#       | party  | market id | side | volume | price | resulting trades | type       | tif     |
-#       | party1 | ETH/DEC21 | buy  | 30     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-#       | party2 | ETH/DEC21 | sell | 30     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    #AC 0042-LIQF-025: lp3 leaves a market that is above target stake when their fee bid is currently being used: fee changes to fee bid by the LP who takes their place in the bidding order
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type      |
+      | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | cancellation |
+      | lp3 | lp3   | ETH/DEC21 | 9000              | 0.0015 | cancellation |
+    And the network moves ahead "10" blocks
+    And the target stake should be "9000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
 
-#     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "10000" for the market "ETH/DEC21"
-#     #AC 0042-LIQF-020: lp3 joining a market that is below the target stake with a lower fee bid than the current fee: fee doesn't change
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type    |
-#       | lp3 | lp3   | ETH/DEC21 | 1000              | 0.0001 | submission |
-#       | lp3 | lp3   | ETH/DEC21 | 1000              | 0.0001 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp3   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp3   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "11000" for the market "ETH/DEC21"
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC21 | buy  | 30     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC21 | sell | 30     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
 
-#     #AC 0042-LIQF-019: lp3 joining a market that is below the target stake with a higher fee bid than the current fee: their fee is used
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type   |
-#       | lp3 | lp3   | ETH/DEC21 | 2000              | 0.003 | amendment |
-#       | lp3 | lp3   | ETH/DEC21 | 2000              | 0.003 | amendment |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp3   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp3   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "12000" for the market "ETH/DEC21"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC21"
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+    And the network moves ahead "1" blocks
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "10000" for the market "ETH/DEC21"
+    #AC 0042-LIQF-020: lp3 joining a market that is below the target stake with a lower fee bid than the current fee: fee doesn't change
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type    |
+      | lp3 | lp3   | ETH/DEC21 | 1000              | 0.0001 | submission |
+      | lp3 | lp3   | ETH/DEC21 | 1000              | 0.0001 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp3   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
+      | lp3   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+    And the network moves ahead "1" blocks
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "11000" for the market "ETH/DEC21"
 
-#     #lp4 join when market is below target stake with a large commitment
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | submission |
-#       | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp4   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp4   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
+    #AC 0042-LIQF-019: lp3 joining a market that is below the target stake with a higher fee bid than the current fee: their fee is used
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type   |
+      | lp3 | lp3   | ETH/DEC21 | 2000              | 0.003 | amendment |
+      | lp3 | lp3   | ETH/DEC21 | 2000              | 0.003 | amendment |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp3   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
+      | lp3   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
+    And the network moves ahead "2" blocks
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "12000" for the market "ETH/DEC21"
 
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "22000" for the market "ETH/DEC21"
+    #lp4 join when market is below target stake with a large commitment
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | submission |
+      | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp4   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
+      | lp4   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the network moves ahead "1" blocks
 
-#     # AC 0042-LIQF-028: lp4 leaves a market that is above target stake when their fee bid is higher than the one currently being used: fee doesn't change
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type      |
-#       | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | cancellation |
-#       | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | cancellation |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp4   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp4   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "12000" for the market "ETH/DEC21"
-#     # lp4 join when market is above target stake with a large commitment
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee   | lp type    |
-#       | lp4 | lp4   | ETH/DEC21 | 4000              | 0.004 | submission |
-#       | lp4 | lp4   | ETH/DEC21 | 4000              | 0.004 | submission |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "16000" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "22000" for the market "ETH/DEC21"
 
-#     # AC 0042-LIQF-023: An LP joining a market that is above the target stake with a commitment large enough to push one of two higher bids above the target stake, and a lower fee bid than the current fee: the fee changes to the other lower bid
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type    |
-#       | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | submission |
-#       | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp5   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp5   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "22000" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
+    # AC 0042-LIQF-028: lp4 leaves a market that is above target stake when their fee bid is higher than the one currently being used: fee doesn't change
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type      |
+      | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | cancellation |
+      | lp4 | lp4   | ETH/DEC21 | 10000             | 0.004 | cancellation |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp4   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
+      | lp4   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
+    And the network moves ahead "1" blocks
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "12000" for the market "ETH/DEC21"
+    # lp4 join when market is above target stake with a large commitment
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee   | lp type    |
+      | lp4 | lp4   | ETH/DEC21 | 4000              | 0.004 | submission |
+      | lp4 | lp4   | ETH/DEC21 | 4000              | 0.004 | submission |
+    And the network moves ahead "1" blocks
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "16000" for the market "ETH/DEC21"
 
-#     #AC 0042-LIQF-026: An LP leaves a market that is above target stake when their fee bid is lower than the one currently being used and their commitment size changes the LP that meets the target stake: fee changes to fee bid by the LP that is now at the place in the bid order to provide the target stake
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type      |
-#       | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | cancellation |
-#       | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | cancellation |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp5   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp5   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "16000" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
+    # AC 0042-LIQF-023: An LP joining a market that is above the target stake with a commitment large enough to push one of two higher bids above the target stake, and a lower fee bid than the current fee: the fee changes to the other lower bid
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type    |
+      | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | submission |
+      | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp5   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
+      | lp5   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
+    And the network moves ahead "1" blocks
+    And the liquidity fee factor should be "0.002" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "22000" for the market "ETH/DEC21"
 
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | lp type    |
-#       | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | submission |
-#       | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | submission |
-#     And the parties place the following pegged iceberg orders:
-#       | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
-#       | lp5   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
-#       | lp5   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "17000" for the market "ETH/DEC21"
-#     And the network moves ahead "1" blocks
+    #AC 0042-LIQF-026: An LP leaves a market that is above target stake when their fee bid is lower than the one currently being used and their commitment size changes the LP that meets the target stake: fee changes to fee bid by the LP that is now at the place in the bid order to provide the target stake
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type      |
+      | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | cancellation |
+      | lp5 | lp5   | ETH/DEC21 | 6000              | 0.0015 | cancellation |
+    And the network moves ahead "2" blocks
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "16000" for the market "ETH/DEC21"
 
-#     #AC 0042-LIQF-027: An LP leaves a market that is above target stake when their fee bid is lower than the one currently being used and their commitment size doesn't change the LP that meets the target stake: fee doesn't change
-#     And the parties submit the following liquidity provision:
-#       | id  | party | market id | commitment amount | fee    | side | pegged reference | volume | offset | lp type      |
-#       | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | buy  | BID              | 1      | 4      | cancellation |
-#       | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | sell | ASK              | 1      | 4      | cancellation |
-#     And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
-#     And the target stake should be "12000" for the market "ETH/DEC21"
-#     And the supplied stake should be "16000" for the market "ETH/DEC21"
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type    |
+      | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | submission |
+      | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lp5   | ETH/DEC21 | 2         | 1                    | buy  | BID              | 1      | 4      |
+      | lp5   | ETH/DEC21 | 2         | 1                    | sell | ASK              | 1      | 4      |
+    And the network moves ahead "1" blocks
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "17000" for the market "ETH/DEC21"
+
+    #AC 0042-LIQF-027: An LP leaves a market that is above target stake when their fee bid is lower than the one currently being used and their commitment size doesn't change the LP that meets the target stake: fee doesn't change
+    And the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee    | lp type      |
+      | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | cancellation |
+      | lp5 | lp5   | ETH/DEC21 | 1000              | 0.0015 | cancellation |
+    And the network moves ahead "1" blocks
+    And the liquidity fee factor should be "0.003" for the market "ETH/DEC21"
+    And the target stake should be "12000" for the market "ETH/DEC21"
+    And the supplied stake should be "16000" for the market "ETH/DEC21"

--- a/core/integration/features/verified/0042-LIQF-SLA.feature
+++ b/core/integration/features/verified/0042-LIQF-SLA.feature
@@ -24,7 +24,7 @@ Feature: Calculating SLA Performance
       | party2 | USD   | 1000000000 |
 
 
-  Scenario: LP fulfills the mininum time fraction but only provides liquidity at the start of the epoch (0042-LIQF-037)
+  Scenario: LP fulfills the mininum time fraction but only provides liquidity at the start of the epoch (0042-LIQF-037)(0042-LIQF-043)(0042-LIQF-046)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -67,12 +67,13 @@ Feature: Calculating SLA Performance
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
       | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
       | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction but only provides liquidity scattered throughout the epoch (0042-LIQF-038)
+  Scenario: LP fulfills the mininum time fraction but only provides liquidity scattered throughout the epoch (0042-LIQF-038)(0042-LIQF-043)(0042-LIQF-046)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -140,12 +141,13 @@ Feature: Calculating SLA Performance
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
       | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
       | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction but is not always on the book when the sla competition factor is zero. (0042-LIQF-041)
+  Scenario: LP fulfills the mininum time fraction but is not always on the book when the sla competition factor is zero. (0042-LIQF-041)(0042-LIQF-043)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -187,11 +189,12 @@ Feature: Calculating SLA Performance
       | lp1   | lp1-ice-sell-1 |
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
-      | from | to  | from account                   | to account           | market id | amount | asset |
-      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
+      | from | to  | from account                   | to account                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC23 | 100    | USD   |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL           | ETH/DEC23 | 100    | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction but is not always on the book when the sla competition factor is non-zero. (0042-LIQF-042)
+  Scenario: LP fulfills the mininum time fraction but is not always on the book when the sla competition factor is non-zero. (0042-LIQF-042)(0042-LIQF-043)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -234,12 +237,13 @@ Feature: Calculating SLA Performance
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
       | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 75     | USD   |
       | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 25     | USD   |
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 25     | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction and provides liquidity throughout the epoch when performance hysteresis epochs is 1. (0042-LIQF-035)
+  Scenario: LP fulfills the mininum time fraction and provides liquidity throughout the epoch when performance hysteresis epochs is 1. (0042-LIQF-035)(0042-LIQF-043)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -280,7 +284,7 @@ Feature: Calculating SLA Performance
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
 
 
-  Scenario: LP does not fulfill the mininum time fraction when performance hysteresis epochs is 1. (0042-LIQF-049)
+  Scenario: LP does not fulfill the mininum time fraction when performance hysteresis epochs is 1. (0042-LIQF-043)(0042-LIQF-049)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -322,11 +326,12 @@ Feature: Calculating SLA Performance
       | lp1   | lp1-ice-sell-1 |
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
-      | from | to | from account                   | to account             | market id | amount | asset |
-      | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
+      | from | to  | from account                   | to account                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC23 | 100    | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/DEC23 | 100    | USD   |
 
 
-  Scenario: LPs previous failures to meet the minimum time fraction if the markets performance hysteresis epochs is increased. (0042-LIQF-053)
+  Scenario: LPs previous failures to meet the minimum time fraction if the markets performance hysteresis epochs is increased. (0042-LIQF-043)(0042-LIQF-053)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -389,11 +394,12 @@ Feature: Calculating SLA Performance
       | ETH/DEC23 | updated-sla-params | 1e-3                   | 0                         |
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
-      | from | to  | from account                   | to account           | market id | amount | asset |
-      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
+      | from | to  | from account                   | to account                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC23 | 100    | USD   |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL           | ETH/DEC23 | 100    | USD   |
 
 
-  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-047)
+  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-043)(0042-LIQF-047)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -452,12 +458,13 @@ Feature: Calculating SLA Performance
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
       | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 75     | USD   |
       | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 25     | USD   |
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 25     | USD   |
 
 
-  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-039)
+  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-039)(0042-LIQF-043)(0042-LIQF-046)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -514,15 +521,15 @@ Feature: Calculating SLA Performance
     Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
 
     When the network moves ahead "1" epochs
-    Then debug transfers
     Then the following transfers should happen:
       | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
       | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
 
 
-  Scenario: LPs average penalty over the last N epochs is better then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-040)
+  Scenario: LPs average penalty over the last N epochs is better then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-040)(0042-LIQF-043)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -576,5 +583,189 @@ Feature: Calculating SLA Performance
 
     When the network moves ahead "1" epochs
     Then the following transfers should happen:
-      | from | to | from account                   | to account             | market id | amount | asset |
-      | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
+      | from | to  | from account                   | to account                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/DEC23 | 100    | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/DEC23 | 100    | USD   |
+
+
+  Scenario: 2 LPs fulfill the mininum time fraction but have different SLA performance when the sla competition factor is non-zero.(0042-LIQF-043)(0042-LIQF-044)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    And the following network parameters are set:
+      | name                    | value |
+      | validators.epoch.length | 1m58s |
+
+    # Setup the market with 2 LPs who are initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+      | lp2 | lp2   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+      | lp2   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp2-ice-buy-1  |
+      | lp2   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp2-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 2      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 2      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "200" for the market "ETH/DEC23"
+
+    # Ensure LP1s average timeBookFraction ~0.75 and penalties will be ~0.5 in the next epoch
+    Given the network moves ahead "90" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    # Ensure LP2s average timeBookFraction ~0.875 and penalties will be ~0.75 in the next epoch
+    Given the network moves ahead "15" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp2   | lp2-ice-buy-1  |
+      | lp2   | lp2-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
+      |      | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
+      | lp2  | lp2 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 75     | USD   |
+      | lp2  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 25     | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 30     | USD   |
+      |      | lp2 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 45     | USD   |
+
+
+  Scenario: 2 LPs fulfill the mininum time fraction but have different SLA performance when the sla competition factor is non-zero. (0042-LIQF-043)(0042-LIQF-044)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    And the following network parameters are set:
+      | name                    | value |
+      | validators.epoch.length | 1m58s |
+
+    # Setup the market with 1 LP who is initially meeting their commitment and 1 LP who isn't
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+      | lp2 | lp2   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+      | lp2   | ETH/DEC23 | 9         | 9                    | buy  | BID              | 1      | 1      | lp1-ice-buy-1  |
+      | lp2   | ETH/DEC23 | 9         | 9                    | sell | ASK              | 1      | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 2      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 2      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "200" for the market "ETH/DEC23"
+
+    # Ensure LP1s average timeBookFraction ~0.75 and penalties will be ~0.5 in the next epoch
+    Given the network moves ahead "90" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
+      |      | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
+      | lp2  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 100    | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 150    | USD   |
+
+
+  Scenario: 2 LPs fulfill the mininum time fraction but have different SLA performance when the sla competition factor is non-zero. (0042-LIQF-043)(0042-LIQF-044)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    And the following network parameters are set:
+      | name                    | value |
+      | validators.epoch.length | 1m58s |
+
+    # Setup the market with 1 LP who is initially meeting their commitment and 1 LP who isn't
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+      | lp2 | lp2   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+      | lp2   | ETH/DEC23 | 9         | 9                    | buy  | BID              | 1      | 1      | lp1-ice-buy-1  |
+      | lp2   | ETH/DEC23 | 9         | 9                    | sell | ASK              | 1      | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 2      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 2      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "200" for the market "ETH/DEC23"
+
+    # Ensure LP1s average timeBookFraction ~0.75 and penalties will be ~0.5 in the next epoch
+    Given the network moves ahead "90" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      |      | lp1 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
+      |      | lp2 | ACCOUNT_TYPE_FEES_LIQUIDITY                    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/DEC23 | 100    | USD   |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
+      | lp2  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 100    | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 150    | USD   |
+

--- a/core/integration/features/verified/0042-LIQF-SLA.feature
+++ b/core/integration/features/verified/0042-LIQF-SLA.feature
@@ -1,0 +1,658 @@
+Feature: Calculating SLA Performance
+
+  Background:
+    
+    Given the markets:
+      | id        | quote name | asset | risk model                    | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params    |
+      | ETH/DEC23 | ETH        | USD   | default-log-normal-risk-model | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e-3                   | 0                         | default-basic |
+    And the following network parameters are set:
+      | name                                             | value |
+      | limits.markets.maxPeggedOrders                   | 2     |
+      | network.markPriceUpdateMaximumFrequency          | 0s    |
+      | market.liquidity.providersFeeCalculationTimeStep | 1s    |
+      | validators.epoch.length                          | 58s   |
+      | market.liquidity.stakeToCcyVolume                | 1     |
+    And the average block duration is "1"
+
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount     |
+      | lp1    | USD   | 1000000000 |
+      | lp2    | USD   | 1000000000 |
+      | aux1   | USD   | 1000000000 |
+      | aux2   | USD   | 1000000000 |
+      | party1 | USD   | 1000000000 |
+      | party2 | USD   | 1000000000 |
+
+
+  Scenario: LP fulfills the mininum time fraction but only provides liquidity at the start of the epoch (0042-LIQF-037)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 0                             | 1.0                    |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Ensure LPs timeBookFraction ~=0.75, then check ~0.5 fees are penalised (then returned as a bonus as they are the only LP)
+    Given the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction but only provides liquidity scattered throughout the epoch (0042-LIQF-038)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 0                             | 1.0                    |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Ensure LPs timeBookFraction ~=0.75, then check ~0.5 fees are penalised (then returned as a bonus as they are the only LP)
+    Given the network moves ahead "10" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "5" blocks
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
+    And the network moves ahead "10" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-2  |
+      | lp1   | lp1-ice-sell-2 |
+    And the network moves ahead "5" blocks
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-3  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-3 |
+    And the network moves ahead "10" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-3  |
+      | lp1   | lp1-ice-sell-3 |
+    And the network moves ahead "5" blocks
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-4  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-4 |
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction but is not always on the book when the sla competition factor is zero. (0042-LIQF-041)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 0                             | 0                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Ensure LPs timeBookFraction ~=0.75, then check ~0.0 fees are penalised
+    Given the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                   | to account           | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction but is not always on the book when the sla competition factor is non-zero. (0042-LIQF-042)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 0                             | 0.5                    |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Ensure LPs timeBookFraction ~=0.75, then check ~0.25 fees are penalised (then returned as a bonus as they are the only LP)
+    Given the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 75     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 25     | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 25     | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction and provides liquidity throughout the epoch when performance hysteresis epochs is 1. (0042-LIQF-035)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 1                            | 1                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Ensure LPs timeBookFraction ~=1.00, then check ~0.0 fees are penalised
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                   | to account           | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
+
+
+  Scenario: LP does not fulfill the mininum time fraction when performance hysteresis epochs is 1. (0042-LIQF-049)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 1                            | 1                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Ensure LPs timeBookFraction <1.00, then check ~1.0 fees are penalised
+    Given the network moves ahead "1" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to | from account                   | to account             | market id | amount | asset |
+      | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
+
+
+  Scenario: LPs previous failures to meet the minimum time fraction if the markets performance hysteresis epochs is increased. (0042-LIQF-053)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 1.0                          | 0                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+
+    # Ensure LPs average timeBookFraction ~0.75 over the last 2 epochs, and will be ~1.0 in the next epoch
+    Given the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
+    And the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-2  |
+      | lp1   | lp1-ice-sell-2 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-3  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-3 |
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    # Update the market by increasing 'performance hysteresis epochs'. No penalty should be applied.
+    Given the liquidity sla params named "updated-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.5                          | 2                             | 1                      |
+    And the markets are updated:
+      | id        | sla params         | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | updated-sla-params | 1e-3                   | 0                         |
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                   | to account           | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-047)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.0                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Ensure LPs average timeBookFraction ~0.75 over the last 2 epochs, and will be ~1.0 in the next epoch
+    Given the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
+    And the network moves ahead "45" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-2  |
+      | lp1   | lp1-ice-sell-2 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-3  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-3 |
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 75     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 25     | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 25     | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-039)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.0                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Ensure LPs average timeBookFraction ~0.50 over the last 2 epochs, and will be ~1.0 in the next epoch
+    Given the network moves ahead "30" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
+    And the network moves ahead "30" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-2  |
+      | lp1   | lp1-ice-sell-2 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-3  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-3 |
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    When the network moves ahead "1" epochs
+    Then debug transfers
+    Then the following transfers should happen:
+      | from | to  | from account                                   | to account                                     | market id | amount | asset |
+      | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+      | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/DEC23 | 50     | USD   |
+      |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-040)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.0                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Ensure LPs average timeBookFraction ~0.50 over the last 2 epochs, and will be ~1.0 in the next epoch
+    Given the network moves ahead "30" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
+    And the network moves ahead "30" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-2  |
+      | lp1   | lp1-ice-sell-2 |
+    And the network moves ahead "1" epochs
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to | from account                   | to account             | market id | amount | asset |
+      | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
+
+
+  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-052)
+
+    # Initialise the market with the required parameters
+    Given the liquidity sla params named "scenario-sla-params":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 1           | 0.0                          | 3                             | 1                      |
+    And the markets are updated:
+      | id        | sla params          | linear slippage factor | quadratic slippage factor |
+      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
+
+    # Setup the market with 1 LP who is initially meeting their commitment
+    Given the parties submit the following liquidity provision:
+      | id  | party | market id | commitment amount | fee | lp type    |
+      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
+    When the parties place the following orders:
+      | party | market id | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/DEC23"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
+
+    # Ensure LPs average timeBookFraction ~0.50 over the last 2 epochs, and will be ~1.0 in the next epoch
+    Given the network moves ahead "30" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-1  |
+      | lp1   | lp1-ice-sell-1 |
+    And the network moves ahead "1" epochs
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
+      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
+      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
+    And the network moves ahead "30" blocks
+    And the parties cancel the following orders:
+      | party | reference      |
+      | lp1   | lp1-ice-buy-2  |
+      | lp1   | lp1-ice-sell-2 |
+    And the network moves ahead "1" epochs
+
+    # Generate liquidity fees to be allocated to the LP
+    Given the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     |
+      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
+
+    When the network moves ahead "1" epochs
+    Then the following transfers should happen:
+      | from | to | from account                   | to account             | market id | amount | asset |
+      | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
+
+
+
+
+
+
+
+    
+
+
+
+ 
+
+    
+
+
+
+
+
+

--- a/core/integration/features/verified/0042-LIQF-SLA.feature
+++ b/core/integration/features/verified/0042-LIQF-SLA.feature
@@ -393,7 +393,7 @@ Feature: Calculating SLA Performance
       | lp1  | lp1 | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_GENERAL | ETH/DEC23 | 100    | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-047)
+  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-047)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -457,7 +457,7 @@ Feature: Calculating SLA Performance
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 25     | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-039)
+  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-039)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -522,7 +522,7 @@ Feature: Calculating SLA Performance
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | ETH/DEC23 | 50     | USD   |
 
 
-  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-040)
+  Scenario: LPs average penalty over the last N epochs is better then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-040)
 
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
@@ -578,81 +578,3 @@ Feature: Calculating SLA Performance
     Then the following transfers should happen:
       | from | to | from account                   | to account             | market id | amount | asset |
       | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
-
-
-  Scenario: LP fulfills the mininum time fraction when performance hysteresis epochs is > 1. (0042-LIQF-052)
-
-    # Initialise the market with the required parameters
-    Given the liquidity sla params named "scenario-sla-params":
-      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
-      | 1           | 0.0                          | 3                             | 1                      |
-    And the markets are updated:
-      | id        | sla params          | linear slippage factor | quadratic slippage factor |
-      | ETH/DEC23 | scenario-sla-params | 1e-3                   | 0                         |
-
-    # Setup the market with 1 LP who is initially meeting their commitment
-    Given the parties submit the following liquidity provision:
-      | id  | party | market id | commitment amount | fee | lp type    |
-      | lp1 | lp1   | ETH/DEC23 | 10000             | 0.1 | submission |
-    And the parties place the following pegged iceberg orders:
-      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
-      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-1  |
-      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-1 |
-    When the parties place the following orders:
-      | party | market id | side | volume | price | resulting trades | type       | tif     |
-      | aux1  | ETH/DEC23 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
-      | aux2  | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | aux1  | ETH/DEC23 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | aux2  | ETH/DEC23 | sell | 1      | 1010  | 0                | TYPE_LIMIT | TIF_GTC |
-    And the opening auction period ends for market "ETH/DEC23"
-    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC23"
-
-    # Ensure LPs average timeBookFraction ~0.50 over the last 2 epochs, and will be ~1.0 in the next epoch
-    Given the network moves ahead "30" blocks
-    And the parties cancel the following orders:
-      | party | reference      |
-      | lp1   | lp1-ice-buy-1  |
-      | lp1   | lp1-ice-sell-1 |
-    And the network moves ahead "1" epochs
-    And the parties place the following pegged iceberg orders:
-      | party | market id | peak size | minimum visible size | side | pegged reference | volume | offset | reference      |
-      | lp1   | ETH/DEC23 | 200       | 120                  | buy  | BID              | 1000   | 1      | lp1-ice-buy-2  |
-      | lp1   | ETH/DEC23 | 200       | 120                  | sell | ASK              | 1000   | 1      | lp1-ice-sell-2 |
-    And the network moves ahead "30" blocks
-    And the parties cancel the following orders:
-      | party | reference      |
-      | lp1   | lp1-ice-buy-2  |
-      | lp1   | lp1-ice-sell-2 |
-    And the network moves ahead "1" epochs
-
-    # Generate liquidity fees to be allocated to the LP
-    Given the parties place the following orders:
-      | party  | market id | side | volume | price | resulting trades | type       | tif     |
-      | party1 | ETH/DEC23 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | party2 | ETH/DEC23 | sell | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
-    Then the accumulated liquidity fees should be "100" for the market "ETH/DEC23"
-
-    When the network moves ahead "1" epochs
-    Then the following transfers should happen:
-      | from | to | from account                   | to account             | market id | amount | asset |
-      | lp1  |    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE | ETH/DEC23 | 100    | USD   |
-
-
-
-
-
-
-
-    
-
-
-
- 
-
-    
-
-
-
-
-
-


### PR DESCRIPTION
PR adds a new file containing tests for 0042-LIQF ACs related to SLA performance. PR also reintroduces legacy 0042-LIQF tests accidentally commented out during the SLA fixes (and uses an existing test to cover one of the ACs).

closes https://github.com/vegaprotocol/OctoberACs/issues/154
closes https://github.com/vegaprotocol/OctoberACs/issues/158
closes https://github.com/vegaprotocol/OctoberACs/issues/159
closes https://github.com/vegaprotocol/OctoberACs/issues/160
closes https://github.com/vegaprotocol/OctoberACs/issues/161
closes https://github.com/vegaprotocol/OctoberACs/issues/162
closes https://github.com/vegaprotocol/OctoberACs/issues/163
closes https://github.com/vegaprotocol/OctoberACs/issues/164
closes https://github.com/vegaprotocol/OctoberACs/issues/165
closes https://github.com/vegaprotocol/OctoberACs/issues/166
closes https://github.com/vegaprotocol/OctoberACs/issues/167
closes https://github.com/vegaprotocol/OctoberACs/issues/168
closes https://github.com/vegaprotocol/OctoberACs/issues/169
closes https://github.com/vegaprotocol/OctoberACs/issues/170
closes https://github.com/vegaprotocol/OctoberACs/issues/265

