### PR TITLE
fix: non deterministic ordering of vesting ledger events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - [8545](https://github.com/vegaprotocol/vega/issues/8545) - Block Explorer pagination does not order correctly.
 - [8748](https://github.com/vegaprotocol/vega/issues/8748) - `ListSuccessorMarkets` does not return results.
 - [8749](https://github.com/vegaprotocol/vega/issues/8749) - Ensure stop order expiry is in the future
+- [9337](https://github.com/vegaprotocol/vega/issues/9337) - Non deterministic ordering of vesting ledger events 
 - [8773](https://github.com/vegaprotocol/vega/issues/8773) - Fix panic with stop orders
 - [8792](https://github.com/vegaprotocol/vega/issues/8792) - Fix panic when starting null block chain node.
 - [8739](https://github.com/vegaprotocol/vega/issues/8739) - Cancel orders for rejected markets.

--- a/core/vesting/vesting.go
+++ b/core/vesting/vesting.go
@@ -251,9 +251,11 @@ func (e *Engine) moveLocked() {
 func (e *Engine) distributeVested(ctx context.Context) {
 	transfers := []*types.Transfer{}
 	parties := maps.Keys(e.state)
+	sort.Strings(parties)
 	for _, party := range parties {
 		rewards := e.state[party]
 		assets := maps.Keys(rewards.Vesting)
+		sort.Strings(assets)
 		for _, asset := range assets {
 			balance := rewards.Vesting[asset]
 			transfer := e.makeTransfer(


### PR DESCRIPTION
closes #9337 
Iteration over non sorted keys of maps in vesting logic causing non-deterministic event order