### PR TITLE
feat: reject call events with block time prior to the specifications initial time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 - [8749](https://github.com/vegaprotocol/vega/issues/8749) - Ensure stop order expiry is in the future
 - [9337](https://github.com/vegaprotocol/vega/issues/9337) - Non deterministic ordering of vesting ledger events
 - [8773](https://github.com/vegaprotocol/vega/issues/8773) - Fix panic with stop orders
+- [9343](https://github.com/vegaprotocol/vega/issues/9343) - Prevent malicious validator submitting Ethereum oracle chain event prior to initial start time 
 - [8792](https://github.com/vegaprotocol/vega/issues/8792) - Fix panic when starting null block chain node.
 - [8739](https://github.com/vegaprotocol/vega/issues/8739) - Cancel orders for rejected markets.
 - [9118](https://github.com/vegaprotocol/vega/issues/9118) - Improve list stop orders error message

--- a/commands/proposal_submission.go
+++ b/commands/proposal_submission.go
@@ -1362,9 +1362,8 @@ func checkDataSourceSpec(spec *vegapb.DataSourceDefinition, name string, parentP
 
 				if ethOracle.Trigger != nil &&
 					ethOracle.Trigger.GetTimeTrigger() != nil &&
-					(ethOracle.Trigger.GetTimeTrigger().Initial == nil || *ethOracle.Trigger.GetTimeTrigger().Initial == 0) &&
-					(ethOracle.Trigger.GetTimeTrigger().Every == nil || *ethOracle.Trigger.GetTimeTrigger().Every == 0) {
-					errs.AddForProperty(fmt.Sprintf("%s.%s.external.ethoracle.trigger.timetrigger.(initial|every)", parentProperty, name), ErrIsRequired)
+					(ethOracle.Trigger.GetTimeTrigger().Initial == nil || *ethOracle.Trigger.GetTimeTrigger().Initial == 0) {
+					errs.AddForProperty(fmt.Sprintf("%s.%s.external.ethoracle.trigger.timetrigger.initial", parentProperty, name), ErrIsRequired)
 				}
 			} else {
 				errs.AddForProperty(fmt.Sprintf("%s.%s.external.oracle", parentProperty, name), ErrIsRequired)

--- a/commands/proposal_submission.go
+++ b/commands/proposal_submission.go
@@ -145,11 +145,11 @@ func checkProposalChanges(terms *protoTypes.ProposalTerms) Errors {
 
 	switch c := terms.Change.(type) {
 	case *protoTypes.ProposalTerms_NewMarket:
-		errs.Merge(checkNewMarketChanges(c, terms.EnactmentTimestamp))
+		errs.Merge(checkNewMarketChanges(c))
 	case *protoTypes.ProposalTerms_UpdateMarket:
-		errs.Merge(checkUpdateMarketChanges(c, terms.EnactmentTimestamp))
+		errs.Merge(checkUpdateMarketChanges(c))
 	case *protoTypes.ProposalTerms_NewSpotMarket:
-		errs.Merge(checkNewSpotMarketChanges(c, terms.EnactmentTimestamp))
+		errs.Merge(checkNewSpotMarketChanges(c))
 	case *protoTypes.ProposalTerms_UpdateSpotMarket:
 		errs.Merge(checkUpdateSpotMarketChanges(c))
 	case *protoTypes.ProposalTerms_UpdateNetworkParameter:
@@ -725,7 +725,7 @@ func checkERC20UpdateAssetSource(s *protoTypes.AssetDetailsUpdate_Erc20) Errors 
 	return errs
 }
 
-func checkNewSpotMarketChanges(change *protoTypes.ProposalTerms_NewSpotMarket, enactmentTimestamp int64) Errors {
+func checkNewSpotMarketChanges(change *protoTypes.ProposalTerms_NewSpotMarket) Errors {
 	errs := NewErrors()
 
 	if change.NewSpotMarket == nil {
@@ -766,13 +766,13 @@ func checkNewSpotMarketChanges(change *protoTypes.ProposalTerms_NewSpotMarket, e
 	}
 	errs.Merge(checkPriceMonitoring(changes.PriceMonitoringParameters, "proposal_submission.terms.change.new_spot_market.changes"))
 	errs.Merge(checkTargetStakeParams(changes.TargetStakeParameters, "proposal_submission.terms.change.new_spot_market.changes"))
-	errs.Merge(checkNewInstrument(changes.Instrument, "proposal_submission.terms.change.new_spot_market.changes.instrument", enactmentTimestamp))
+	errs.Merge(checkNewInstrument(changes.Instrument, "proposal_submission.terms.change.new_spot_market.changes.instrument"))
 	errs.Merge(checkNewSpotRiskParameters(changes))
 	errs.Merge(checkSLAParams(changes.SlaParams, "proposal_submission.terms.change.new_spot_market.changes.sla_params"))
 	return errs
 }
 
-func checkNewMarketChanges(change *protoTypes.ProposalTerms_NewMarket, enactmentTimestamp int64) Errors {
+func checkNewMarketChanges(change *protoTypes.ProposalTerms_NewMarket) Errors {
 	errs := NewErrors()
 
 	if change.NewMarket == nil {
@@ -828,14 +828,14 @@ func checkNewMarketChanges(change *protoTypes.ProposalTerms_NewMarket, enactment
 
 	errs.Merge(checkPriceMonitoring(changes.PriceMonitoringParameters, "proposal_submission.terms.change.new_market.changes"))
 	errs.Merge(checkLiquidityMonitoring(changes.LiquidityMonitoringParameters, "proposal_submission.terms.change.new_market.changes"))
-	errs.Merge(checkNewInstrument(changes.Instrument, "proposal_submission.terms.change.new_market.changes.instrument", enactmentTimestamp))
+	errs.Merge(checkNewInstrument(changes.Instrument, "proposal_submission.terms.change.new_market.changes.instrument"))
 	errs.Merge(checkNewRiskParameters(changes))
 	errs.Merge(checkSLAParams(changes.LiquiditySlaParameters, "proposal_submission.terms.change.new_market.changes.sla_params"))
 
 	return errs
 }
 
-func checkUpdateMarketChanges(change *protoTypes.ProposalTerms_UpdateMarket, enactmentTimestamp int64) Errors {
+func checkUpdateMarketChanges(change *protoTypes.ProposalTerms_UpdateMarket) Errors {
 	errs := NewErrors()
 
 	if change.UpdateMarket == nil {
@@ -878,7 +878,7 @@ func checkUpdateMarketChanges(change *protoTypes.ProposalTerms_UpdateMarket, ena
 
 	errs.Merge(checkPriceMonitoring(changes.PriceMonitoringParameters, "proposal_submission.terms.change.update_market.changes"))
 	errs.Merge(checkLiquidityMonitoring(changes.LiquidityMonitoringParameters, "proposal_submission.terms.change.update_market.changes"))
-	errs.Merge(checkUpdateInstrument(changes.Instrument, enactmentTimestamp))
+	errs.Merge(checkUpdateInstrument(changes.Instrument))
 	errs.Merge(checkUpdateRiskParameters(changes))
 	errs.Merge(checkSLAParams(changes.LiquiditySlaParameters, "proposal_submission.terms.change.update_market.changes.sla_params"))
 
@@ -999,7 +999,7 @@ func checkTargetStakeParams(targetStakeParameters *protoTypes.TargetStakeParamet
 	return errs
 }
 
-func checkNewInstrument(instrument *protoTypes.InstrumentConfiguration, parent string, enactmentTimestamp int64) Errors {
+func checkNewInstrument(instrument *protoTypes.InstrumentConfiguration, parent string) Errors {
 	errs := NewErrors()
 
 	if instrument == nil {
@@ -1019,9 +1019,9 @@ func checkNewInstrument(instrument *protoTypes.InstrumentConfiguration, parent s
 
 	switch product := instrument.Product.(type) {
 	case *protoTypes.InstrumentConfiguration_Future:
-		errs.Merge(checkNewFuture(product.Future, enactmentTimestamp))
+		errs.Merge(checkNewFuture(product.Future))
 	case *protoTypes.InstrumentConfiguration_Perpetual:
-		errs.Merge(checkNewPerps(product.Perpetual, enactmentTimestamp))
+		errs.Merge(checkNewPerps(product.Perpetual))
 	case *protoTypes.InstrumentConfiguration_Spot:
 		errs.Merge(checkNewSpot(product.Spot))
 	default:
@@ -1031,7 +1031,7 @@ func checkNewInstrument(instrument *protoTypes.InstrumentConfiguration, parent s
 	return errs
 }
 
-func checkUpdateInstrument(instrument *protoTypes.UpdateInstrumentConfiguration, enactmentTimestamp int64) Errors {
+func checkUpdateInstrument(instrument *protoTypes.UpdateInstrumentConfiguration) Errors {
 	errs := NewErrors()
 
 	if instrument == nil {
@@ -1048,9 +1048,9 @@ func checkUpdateInstrument(instrument *protoTypes.UpdateInstrumentConfiguration,
 
 	switch product := instrument.Product.(type) {
 	case *protoTypes.UpdateInstrumentConfiguration_Future:
-		errs.Merge(checkUpdateFuture(product.Future, enactmentTimestamp))
+		errs.Merge(checkUpdateFuture(product.Future))
 	case *protoTypes.UpdateInstrumentConfiguration_Perpetual:
-		errs.Merge(checkUpdatePerps(product.Perpetual, enactmentTimestamp))
+		errs.Merge(checkUpdatePerps(product.Perpetual))
 	default:
 		return errs.FinalAddForProperty("proposal_submission.terms.change.update_market.changes.instrument.product", ErrIsNotValid)
 	}
@@ -1058,7 +1058,7 @@ func checkUpdateInstrument(instrument *protoTypes.UpdateInstrumentConfiguration,
 	return errs
 }
 
-func checkNewFuture(future *protoTypes.FutureProduct, enactmentTimestamp int64) Errors {
+func checkNewFuture(future *protoTypes.FutureProduct) Errors {
 	errs := NewErrors()
 
 	if future == nil {
@@ -1072,14 +1072,14 @@ func checkNewFuture(future *protoTypes.FutureProduct, enactmentTimestamp int64) 
 		errs.AddForProperty("proposal_submission.terms.change.new_market.changes.instrument.product.future.quote_name", ErrIsRequired)
 	}
 
-	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.new_market.changes.instrument.product.future", true, enactmentTimestamp))
-	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForTradingTermination, "data_source_spec_for_trading_termination", "proposal_submission.terms.change.new_market.changes.instrument.product.future", false, enactmentTimestamp))
+	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.new_market.changes.instrument.product.future", true))
+	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForTradingTermination, "data_source_spec_for_trading_termination", "proposal_submission.terms.change.new_market.changes.instrument.product.future", false))
 	errs.Merge(checkNewOracleBinding(future))
 
 	return errs
 }
 
-func checkNewPerps(perps *protoTypes.PerpetualProduct, enactmentTimestamp int64) Errors {
+func checkNewPerps(perps *protoTypes.PerpetualProduct) Errors {
 	errs := NewErrors()
 
 	if perps == nil {
@@ -1151,8 +1151,8 @@ func checkNewPerps(perps *protoTypes.PerpetualProduct, enactmentTimestamp int64)
 		errs.AddForProperty("proposal_submission.terms.change.new_market.changes.instrument.product.perps.clamp_upper_bound", ErrMustBeGTEClampLowerBound)
 	}
 
-	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.new_market.changes.instrument.product.perps", true, enactmentTimestamp))
-	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementSchedule, "data_source_spec_for_settlement_schedule", "proposal_submission.terms.change.new_market.changes.instrument.product.perps", true, enactmentTimestamp))
+	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.new_market.changes.instrument.product.perps", true))
+	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementSchedule, "data_source_spec_for_settlement_schedule", "proposal_submission.terms.change.new_market.changes.instrument.product.perps", true))
 	errs.Merge(checkNewPerpsOracleBinding(perps))
 
 	return errs
@@ -1180,7 +1180,7 @@ func checkNewSpot(spot *protoTypes.SpotProduct) Errors {
 	return errs
 }
 
-func checkUpdateFuture(future *protoTypes.UpdateFutureProduct, enactmentTimestamp int64) Errors {
+func checkUpdateFuture(future *protoTypes.UpdateFutureProduct) Errors {
 	errs := NewErrors()
 
 	if future == nil {
@@ -1191,14 +1191,14 @@ func checkUpdateFuture(future *protoTypes.UpdateFutureProduct, enactmentTimestam
 		errs.AddForProperty("proposal_submission.terms.change.update_market.changes.instrument.product.future.quote_name", ErrIsRequired)
 	}
 
-	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.update_market.changes.instrument.product.future", true, enactmentTimestamp))
-	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForTradingTermination, "data_source_spec_for_trading_termination", "proposal_submission.terms.change.update_market.changes.instrument.product.future", false, enactmentTimestamp))
+	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.update_market.changes.instrument.product.future", true))
+	errs.Merge(checkDataSourceSpec(future.DataSourceSpecForTradingTermination, "data_source_spec_for_trading_termination", "proposal_submission.terms.change.update_market.changes.instrument.product.future", false))
 	errs.Merge(checkUpdateOracleBinding(future))
 
 	return errs
 }
 
-func checkUpdatePerps(perps *protoTypes.UpdatePerpetualProduct, enactmentTimestamp int64) Errors {
+func checkUpdatePerps(perps *protoTypes.UpdatePerpetualProduct) Errors {
 	errs := NewErrors()
 
 	if perps == nil {
@@ -1209,15 +1209,14 @@ func checkUpdatePerps(perps *protoTypes.UpdatePerpetualProduct, enactmentTimesta
 		errs.AddForProperty("proposal_submission.terms.change.update_market.changes.instrument.product.future.quote_name", ErrIsRequired)
 	}
 
-	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.update_market.changes.instrument.product.future", true, enactmentTimestamp))
-	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementSchedule, "data_source_spec_for_settlement_schedule", "proposal_submission.terms.change.new_market.changes.instrument.product.perps", true, enactmentTimestamp))
+	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementData, "data_source_spec_for_settlement_data", "proposal_submission.terms.change.update_market.changes.instrument.product.future", true))
+	errs.Merge(checkDataSourceSpec(perps.DataSourceSpecForSettlementSchedule, "data_source_spec_for_settlement_schedule", "proposal_submission.terms.change.new_market.changes.instrument.product.perps", true))
 	errs.Merge(checkUpdatePerpsOracleBinding(perps))
 
 	return errs
 }
 
 func checkDataSourceSpec(spec *vegapb.DataSourceDefinition, name string, parentProperty string, tryToSettle bool,
-	enactmentTimestamp int64,
 ) Errors {
 	errs := NewErrors()
 	if spec == nil {
@@ -1360,13 +1359,6 @@ func checkDataSourceSpec(spec *vegapb.DataSourceDefinition, name string, parentP
 
 				if ethOracle.Trigger == nil {
 					errs.AddForProperty(fmt.Sprintf("%s.%s.external.ethoracle.trigger", parentProperty, name), ErrIsRequired)
-				}
-
-				if ethOracle.Trigger != nil &&
-					ethOracle.Trigger.GetTimeTrigger() != nil &&
-					(ethOracle.Trigger.GetTimeTrigger().Initial == nil || *ethOracle.Trigger.GetTimeTrigger().Initial == 0) {
-					defaultTriggerInitialTime := uint64(enactmentTimestamp)
-					ethOracle.Trigger.GetTimeTrigger().Initial = &defaultTriggerInitialTime
 				}
 			} else {
 				errs.AddForProperty(fmt.Sprintf("%s.%s.external.oracle", parentProperty, name), ErrIsRequired)

--- a/core/datasource/definition/definition.go
+++ b/core/datasource/definition/definition.go
@@ -232,6 +232,18 @@ func (s *Definition) GetEthCallSpec() ethcallcommon.Spec {
 	return ethcallcommon.Spec{}
 }
 
+func (s *Definition) IsEthCallSpec() bool {
+	data := s.Content()
+	if data != nil {
+		switch data.(type) {
+		case ethcallcommon.Spec:
+			return true
+		}
+	}
+
+	return false
+}
+
 // Definition is also a `Timer`.
 func (s *Definition) GetTimeTriggers() common.InternalTimeTriggers {
 	data := s.Content()

--- a/core/datasource/external/ethcall/call.go
+++ b/core/datasource/external/ethcall/call.go
@@ -121,3 +121,11 @@ func (c Call) triggered(prevEthBlock blockish, currentEthBlock blockish) bool {
 	}
 	return false
 }
+
+func (c Call) initialTime() uint64 {
+	switch trigger := c.spec.Trigger.(type) {
+	case ethcallcommon.TimeTrigger:
+		return trigger.Initial
+	}
+	return 0
+}

--- a/core/datasource/external/ethcall/engine.go
+++ b/core/datasource/external/ethcall/engine.go
@@ -161,6 +161,18 @@ func (e *Engine) GetRequiredConfirmations(id string) (uint64, error) {
 	return call.spec.RequiredConfirmations, nil
 }
 
+func (e *Engine) GetInitialTriggerTime(id string) (uint64, error) {
+	e.mu.Lock()
+	call, ok := e.calls[id]
+	if !ok {
+		e.mu.Unlock()
+		return 0, fmt.Errorf("no such specification: %v", id)
+	}
+	e.mu.Unlock()
+
+	return call.initialTime(), nil
+}
+
 func (e *Engine) OnSpecActivated(ctx context.Context, spec datasource.Spec) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/core/datasource/external/ethverifier/mocks/ethcallengine_mock.go
+++ b/core/datasource/external/ethverifier/mocks/ethcallengine_mock.go
@@ -50,6 +50,21 @@ func (mr *MockEthCallEngineMockRecorder) CallSpec(arg0, arg1, arg2 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallSpec", reflect.TypeOf((*MockEthCallEngine)(nil).CallSpec), arg0, arg1, arg2)
 }
 
+// GetInitialTriggerTime mocks base method.
+func (m *MockEthCallEngine) GetInitialTriggerTime(arg0 string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInitialTriggerTime", arg0)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInitialTriggerTime indicates an expected call of GetInitialTriggerTime.
+func (mr *MockEthCallEngineMockRecorder) GetInitialTriggerTime(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInitialTriggerTime", reflect.TypeOf((*MockEthCallEngine)(nil).GetInitialTriggerTime), arg0)
+}
+
 // GetRequiredConfirmations mocks base method.
 func (m *MockEthCallEngine) GetRequiredConfirmations(arg0 string) (uint64, error) {
 	m.ctrl.T.Helper()

--- a/core/datasource/external/ethverifier/verifier_snapshot_test.go
+++ b/core/datasource/external/ethverifier/verifier_snapshot_test.go
@@ -79,6 +79,7 @@ func TestEthereumOracleVerifierWithPendingQueryResults(t *testing.T) {
 	result := okResult()
 
 	eov.ethCallEngine.EXPECT().CallSpec(gomock.Any(), "testspec", uint64(5)).Return(result, nil)
+	eov.ethCallEngine.EXPECT().GetInitialTriggerTime("testspec").Return(uint64(90), nil)
 	eov.ethCallEngine.EXPECT().GetRequiredConfirmations("testspec").Return(uint64(5), nil)
 
 	eov.ts.EXPECT().GetTimeNow().Times(1)

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -77,6 +77,7 @@ type EthCallEngine interface {
 	MakeResult(specID string, bytes []byte) (ethcall.Result, error)
 	CallSpec(ctx context.Context, id string, atBlock uint64) (ethcall.Result, error)
 	GetRequiredConfirmations(id string) (uint64, error)
+	GetInitialTriggerTime(id string) (uint64, error)
 	OnSpecActivated(ctx context.Context, spec datasource.Spec) error
 	OnSpecDeactivated(ctx context.Context, spec datasource.Spec)
 }


### PR DESCRIPTION
closes #9343.  This change also modifies the behaviour of the of an eth oracle spec trigger that has an 'every' period and no 'inital' time so that the every period is now relative to the enactment time, previously the trigger would fire when Mod(period, ethereum time) == 0 which could be an arbitrary interval after enactment.