### PR TITLE
fix: add stop-order instructions to empty batch check

### DIFF
--- a/commands/batch_market_instructions.go
+++ b/commands/batch_market_instructions.go
@@ -17,7 +17,11 @@ func checkBatchMarketInstructions(cmd *commandspb.BatchMarketInstructions) Error
 
 	// there's very little to verify here, only if the batch is not empty
 	// all transaction verification is done when processing then.
-	if len(cmd.Cancellations)+len(cmd.Amendments)+len(cmd.Submissions) == 0 {
+	if len(cmd.Cancellations)+
+		len(cmd.Amendments)+
+		len(cmd.Submissions)+
+		len(cmd.StopOrdersSubmission)+
+		len(cmd.StopOrdersCancellation) == 0 {
 		return errs.FinalAddForProperty("batch_market_instructions", ErrEmptyBatchMarketInstructions)
 	}
 


### PR DESCRIPTION
We were missing the new stop order submission/cancellation instructions in the "is the batch instruction empty" check.

This means if you sent a batch instruction with only stop order related instructions, it would be rejected at checkTx.