### PR TITLE
fix: fetch referral sets returns error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@
 - [9374](https://github.com/vegaprotocol/vega/issues/9374) - `ListGovernanceData` returns an error instead of results.
 - [9461](https://github.com/vegaprotocol/vega/issues/9461) - Do not make SLA related transfers for 0 amount.
 - [9462](https://github.com/vegaprotocol/vega/issues/9462) - Add missing proposal error `enum` values to the database.
+- [9466](https://github.com/vegaprotocol/vega/issues/9466) - `ListReferralSets` returns error when there are no stats available.
 
 ## 0.72.1
 

--- a/datanode/entities/referral_set_stats.go
+++ b/datanode/entities/referral_set_stats.go
@@ -51,6 +51,10 @@ func ReferralSetStatsFromProto(protos *eventspb.ReferralSetStatsUpdated, vegaTim
 }
 
 func (rss *ReferralSetStats) ToProto() *v2.ReferralSetStats {
+	if rss == nil {
+		return nil
+	}
+
 	return &v2.ReferralSetStats{
 		SetId:                                 rss.SetID.String(),
 		AtEpoch:                               rss.AtEpoch,

--- a/datanode/gateway/graphql/generated.go
+++ b/datanode/gateway/graphql/generated.go
@@ -65623,14 +65623,11 @@ func (ec *executionContext) _ReferralSet_stats(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*v2.ReferralSetStats)
 	fc.Result = res
-	return ec.marshalNReferralSetStats2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐReferralSetStats(ctx, field.Selections, res)
+	return ec.marshalOReferralSetStats2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐReferralSetStats(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ReferralSet_stats(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -100769,9 +100766,6 @@ func (ec *executionContext) _ReferralSet(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._ReferralSet_stats(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			}
 
@@ -109268,20 +109262,6 @@ func (ec *executionContext) marshalNReferralSetRefereeEdge2ᚕᚖcodeᚗvegaprot
 	return ret
 }
 
-func (ec *executionContext) marshalNReferralSetStats2codeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐReferralSetStats(ctx context.Context, sel ast.SelectionSet, v v2.ReferralSetStats) graphql.Marshaler {
-	return ec._ReferralSetStats(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNReferralSetStats2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐReferralSetStats(ctx context.Context, sel ast.SelectionSet, v *v2.ReferralSetStats) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._ReferralSetStats(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNReward2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋvegaᚐReward(ctx context.Context, sel ast.SelectionSet, v *vega.Reward) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -114594,6 +114574,13 @@ func (ec *executionContext) marshalOReferralSetRefereeEdge2ᚖcodeᚗvegaprotoco
 		return graphql.Null
 	}
 	return ec._ReferralSetRefereeEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOReferralSetStats2ᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋdataᚑnodeᚋapiᚋv2ᚐReferralSetStats(ctx context.Context, sel ast.SelectionSet, v *v2.ReferralSetStats) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ReferralSetStats(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOReward2ᚕᚖcodeᚗvegaprotocolᚗioᚋvegaᚋprotosᚋvegaᚐReward(ctx context.Context, sel ast.SelectionSet, v []*vega.Reward) graphql.Marshaler {

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -5875,7 +5875,7 @@ type ReferralSet {
   Referral set statistics for the latest or specific epoch.
   If provided the results can be filtered for a specific referee
   """
-  stats(epoch: Int, referee: ID): ReferralSetStats!
+  stats(epoch: Int, referee: ID): ReferralSetStats
 }
 
 "Edge type containing the referral set and cursor information returned by a ReferralSetConnection"

--- a/datanode/sqlstore/referral_sets_test.go
+++ b/datanode/sqlstore/referral_sets_test.go
@@ -609,7 +609,8 @@ func TestReferralSets_GetReferralSetStats(t *testing.T) {
 		want := testStats[0]
 		got, err := rs.GetReferralSetStats(ctx, set.ID, nil, nil)
 		require.NoError(t, err)
-		assert.Equal(t, want, got)
+		require.NotNil(t, got)
+		assert.Equal(t, want, *got)
 	})
 
 	t.Run("Should return the stats for the specified epoch if an epoch is provided", func(t *testing.T) {
@@ -619,7 +620,8 @@ func TestReferralSets_GetReferralSetStats(t *testing.T) {
 
 		got, err := rs.GetReferralSetStats(ctx, set.ID, &wantEpoch, nil)
 		require.NoError(t, err)
-		assert.Equal(t, want, got)
+		require.NotNil(t, got)
+		assert.Equal(t, want, *got)
 	})
 
 	t.Run("Should return the stats for the most current and referee if no epoch and a referee is provided", func(t *testing.T) {
@@ -637,7 +639,8 @@ func TestReferralSets_GetReferralSetStats(t *testing.T) {
 		}
 		got, err := rs.GetReferralSetStats(ctx, set.ID, nil, &referee)
 		require.NoError(t, err)
-		assert.Equal(t, want, got)
+		require.NotNil(t, got)
+		assert.Equal(t, want, *got)
 	})
 
 	t.Run("Should return the stats for the specified epoch and referee if they are provided", func(t *testing.T) {
@@ -655,6 +658,7 @@ func TestReferralSets_GetReferralSetStats(t *testing.T) {
 		}
 		got, err := rs.GetReferralSetStats(ctx, set.ID, &want.AtEpoch, &referee)
 		require.NoError(t, err)
-		assert.Equal(t, want, got)
+		require.NotNil(t, got)
+		assert.Equal(t, want, *got)
 	})
 }


### PR DESCRIPTION
Closes #9466 

This was caused when there are no stats for the referral set, which might be possible if the query is made before the first set of statistics are published. I've made the data nullable so that it doesn't error.