### PR TITLE
fix: list teams API returns an error when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@
 - [9462](https://github.com/vegaprotocol/vega/issues/9462) - Add missing proposal error `enum` values to the database.
 - [9466](https://github.com/vegaprotocol/vega/issues/9466) - `ListReferralSets` returns error when there are no stats available.
 - [9341](https://github.com/vegaprotocol/vega/issues/9341) - Fix checkpoint loading
+- [9472](https://github.com/vegaprotocol/vega/issues/9472) - `ListTeams` returns error when filtering by referrer or team.
 
 ## 0.72.1
 

--- a/datanode/sqlstore/teams.go
+++ b/datanode/sqlstore/teams.go
@@ -121,13 +121,13 @@ func (t *Teams) RefereeSwitchedTeam(ctx context.Context, referee *entities.Refer
 	return err
 }
 
-func (t *Teams) GetTeam(ctx context.Context, teamID entities.TeamID, partyID entities.PartyID) (entities.Team, error) {
+func (t *Teams) GetTeam(ctx context.Context, teamID entities.TeamID, partyID entities.PartyID) (*entities.Team, error) {
 	defer metrics.StartSQLQuery("Teams", "GetTeam")()
 
 	var team entities.Team
 
 	if teamID == "" && partyID == "" {
-		return team, fmt.Errorf("either teamID or partyID must be provided")
+		return nil, fmt.Errorf("either teamID or partyID must be provided")
 	}
 
 	var args []interface{}
@@ -141,10 +141,10 @@ func (t *Teams) GetTeam(ctx context.Context, teamID entities.TeamID, partyID ent
 	}
 
 	if err := pgxscan.Get(ctx, t.Connection, &team, query, args...); err != nil {
-		return team, err
+		return nil, err
 	}
 
-	return team, nil
+	return &team, nil
 }
 
 func (t *Teams) ListTeams(ctx context.Context, pagination entities.CursorPagination) ([]entities.Team, entities.PageInfo, error) {

--- a/datanode/sqlstore/teams_test.go
+++ b/datanode/sqlstore/teams_test.go
@@ -304,7 +304,8 @@ func testShouldReturnTeamIfTeamIDProvided(t *testing.T) {
 	want := teams[rand.Intn(len(teams))]
 	got, err := ts.GetTeam(ctx, want.ID, "")
 	require.NoError(t, err)
-	assert.Equal(t, want, got)
+	require.NotNil(t, got)
+	assert.Equal(t, want, *got)
 }
 
 func testShouldReturnTeamIfReferrerPartyIDProvided(t *testing.T) {
@@ -317,7 +318,8 @@ func testShouldReturnTeamIfReferrerPartyIDProvided(t *testing.T) {
 
 	got, err := ts.GetTeam(ctx, "", want.Referrer)
 	require.NoError(t, err)
-	assert.Equal(t, want, got)
+	require.NotNil(t, got)
+	assert.Equal(t, want, *got)
 }
 
 func testShouldReturnTeamIfRefereePartyIDProvided(t *testing.T) {
@@ -333,7 +335,8 @@ func testShouldReturnTeamIfRefereePartyIDProvided(t *testing.T) {
 
 	got, err := ts.GetTeam(ctx, "", wantMember.PartyID)
 	require.NoError(t, err)
-	assert.Equal(t, wantTeam, got)
+	require.NotNil(t, got)
+	assert.Equal(t, wantTeam, *got)
 }
 
 func testShouldReturnErrorIfNoTeamIDOrPartyIDProvided(t *testing.T) {


### PR DESCRIPTION
Closes #9472 

The ListTeams API leverages the GetTeam API call when filtering for a specific team ID or party ID as there should only be 1 result. When calling with an ID that doesn't exist, the GetTeam API correct returns a not found error, but the ListTeams API did not take this into account and should actually return an empty slice instead of the error.
