### PR TITLE
chore: update default network parameter values for new SLA params

### DIFF
--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -92,10 +92,10 @@ func defaultNetParams() map[string]value {
 		RewardMarketCreationQuantumMultiple:       NewDecimal(gteD1, DecimalLT(num.MustDecimalFromString("1e20"))).Mutable(true).MustUpdate("10000000"),
 
 		MarketLiquidityBondPenaltyParameter:              NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("0.1"),
-		MarketLiquidityEarlyExitPenalty:                  NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("0.1"),
+		MarketLiquidityEarlyExitPenalty:                  NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("0.05"),
 		MarketLiquidityMaximumLiquidityFeeFactorLevel:    NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("1"),
-		MarketLiquiditySLANonPerformanceBondPenaltyMax:   NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0.5"),
-		MarketLiquiditySLANonPerformanceBondPenaltySlope: NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("2"),
+		MarketLiquiditySLANonPerformanceBondPenaltyMax:   NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0.05"),
+		MarketLiquiditySLANonPerformanceBondPenaltySlope: NewDecimal(gteD0, lteD1000).Mutable(true).MustUpdate("1"),
 		MarketLiquidityStakeToCCYVolume:                  NewDecimal(gteD0, lteD100).Mutable(true).MustUpdate("1"),
 
 		// @TODO karel add validation


### PR DESCRIPTION
closes #9468 

The issue was in some code that was trying to set default values for the new SLA network parameters when we restored from a snapshot. It wasn't propagating them on restore, and only at the next epoch, which meant whenever a new node join from a snapshot it would get the defaults in `defaults.go` and not the hardcoded ones until the next epoch.

This PR https://github.com/vegaprotocol/vega/pull/9465 actually indirectly fixed it by pulling out the code meaning during a protocol upgrade, we set the new SLA network parameters to whatever they were in `defaults.go`.

The missing bit was getting an answer to what those values should be:
https://vegaprotocol.slack.com/archives/CAHA5EX0F/p1695132771096889?thread_ts=1695130815.025419&cid=CAHA5EX0F