### PR TITLE
fix: team events not being persisted to the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@
 - [9466](https://github.com/vegaprotocol/vega/issues/9466) - `ListReferralSets` returns error when there are no stats available.
 - [9341](https://github.com/vegaprotocol/vega/issues/9341) - Fix checkpoint loading
 - [9472](https://github.com/vegaprotocol/vega/issues/9472) - `ListTeams` returns error when filtering by referrer or team.
+- [9477](https://github.com/vegaprotocol/vega/issues/947y) - Teams data not persisted to the database.
 
 ## 0.72.1
 

--- a/cmd/data-node/commands/start/sqlsubscribers.go
+++ b/cmd/data-node/commands/start/sqlsubscribers.go
@@ -187,6 +187,7 @@ func (s *SQLSubscribers) GetSQLSubscribers() []broker.SQLBrokerSubscriber {
 		s.partyActivityStreakSub,
 		s.referralProgramSub,
 		s.referralSetsSub,
+		s.teamsSub,
 	}
 }
 

--- a/core/events/team.go
+++ b/core/events/team.go
@@ -22,6 +22,10 @@ func (t TeamCreated) StreamMessage() *eventspb.BusEvent {
 	return busEvent
 }
 
+func (t TeamCreated) TeamCreated() *eventspb.TeamCreated {
+	return &t.e
+}
+
 func NewTeamCreatedEvent(ctx context.Context, epoch uint64, t *types.Team) *TeamCreated {
 	return &TeamCreated{
 		Base: newBase(ctx, TeamCreatedEvent),
@@ -59,6 +63,10 @@ func (t TeamUpdated) StreamMessage() *eventspb.BusEvent {
 	return busEvent
 }
 
+func (t TeamUpdated) TeamUpdated() *eventspb.TeamUpdated {
+	return &t.e
+}
+
 func NewTeamUpdatedEvent(ctx context.Context, t *types.Team) *TeamUpdated {
 	return &TeamUpdated{
 		Base: newBase(ctx, TeamUpdatedEvent),
@@ -93,6 +101,10 @@ func (t RefereeSwitchedTeam) StreamMessage() *eventspb.BusEvent {
 	return busEvent
 }
 
+func (t RefereeSwitchedTeam) RefereeSwitchedTeam() *eventspb.RefereeSwitchedTeam {
+	return &t.e
+}
+
 func NewRefereeSwitchedTeamEvent(ctx context.Context, from, to types.TeamID, membership *types.Membership) *RefereeSwitchedTeam {
 	return &RefereeSwitchedTeam{
 		Base: newBase(ctx, RefereeSwitchedTeamEvent),
@@ -125,6 +137,10 @@ func (t RefereeJoinedTeam) StreamMessage() *eventspb.BusEvent {
 	}
 
 	return busEvent
+}
+
+func (t RefereeJoinedTeam) RefereeJoinedTeam() *eventspb.RefereeJoinedTeam {
+	return &t.e
 }
 
 func NewRefereeJoinedTeamEvent(ctx context.Context, teamID types.TeamID, membership *types.Membership) *RefereeJoinedTeam {

--- a/datanode/sqlsubscribers/teams.go
+++ b/datanode/sqlsubscribers/teams.go
@@ -12,22 +12,22 @@ import (
 type (
 	TeamCreatedEvent interface {
 		events.Event
-		TeamCreated() eventspb.TeamCreated
+		TeamCreated() *eventspb.TeamCreated
 	}
 
 	TeamUpdateEvent interface {
 		events.Event
-		TeamUpdated() eventspb.TeamUpdated
+		TeamUpdated() *eventspb.TeamUpdated
 	}
 
 	RefereeJoinedTeam interface {
 		events.Event
-		RefereeJoinedTeam() eventspb.RefereeJoinedTeam
+		RefereeJoinedTeam() *eventspb.RefereeJoinedTeam
 	}
 
 	RefereeSwitchedTeam interface {
 		events.Event
-		RefereeSwitchedTeam() eventspb.RefereeSwitchedTeam
+		RefereeSwitchedTeam() *eventspb.RefereeSwitchedTeam
 	}
 
 	TeamStore interface {
@@ -75,24 +75,24 @@ func (t *Teams) Push(ctx context.Context, evt events.Event) error {
 
 func (t *Teams) consumeTeamCreatedEvent(ctx context.Context, e TeamCreatedEvent) error {
 	createdEvt := e.TeamCreated()
-	created := entities.TeamCreatedFromProto(&createdEvt, t.vegaTime)
+	created := entities.TeamCreatedFromProto(createdEvt, t.vegaTime)
 	return errors.Wrap(t.store.AddTeam(ctx, created), "adding team")
 }
 
 func (t *Teams) consumeTeamUpdateEvent(ctx context.Context, e TeamUpdateEvent) error {
 	updatedEvt := e.TeamUpdated()
-	updated := entities.TeamUpdatedFromProto(&updatedEvt, t.vegaTime)
+	updated := entities.TeamUpdatedFromProto(updatedEvt, t.vegaTime)
 	return errors.Wrap(t.store.UpdateTeam(ctx, updated), "updating team")
 }
 
 func (t *Teams) consumeRefereeJoinedTeamEvent(ctx context.Context, e RefereeJoinedTeam) error {
 	joinedEvt := e.RefereeJoinedTeam()
-	referee := entities.TeamRefereeFromProto(&joinedEvt, t.vegaTime)
+	referee := entities.TeamRefereeFromProto(joinedEvt, t.vegaTime)
 	return errors.Wrap(t.store.RefereeJoinedTeam(ctx, referee), "adding referee to team")
 }
 
 func (t *Teams) consumeRefereeSwitchedTeamEvent(ctx context.Context, e RefereeSwitchedTeam) error {
 	switchedEvt := e.RefereeSwitchedTeam()
-	switched := entities.TeamRefereeHistoryFromProto(&switchedEvt, t.vegaTime)
+	switched := entities.TeamRefereeHistoryFromProto(switchedEvt, t.vegaTime)
 	return errors.Wrap(t.store.RefereeSwitchedTeam(ctx, switched), "updating referee history")
 }


### PR DESCRIPTION
Closes #9477 

The teams events did not implement the interfaces that allowed them to be recognised by the data node. Additionally the teams subscriber was not added to the list of subscribers.
