### PR TITLE
fix: release extension trigger when market is resumed via governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@
 - [9472](https://github.com/vegaprotocol/vega/issues/9472) - `ListTeams` returns error when filtering by referrer or team.
 - [9477](https://github.com/vegaprotocol/vega/issues/947y) - Teams data not persisted to the database.
 - [9412](https://github.com/vegaprotocol/vega/issues/9412) - Use vote close time for opening auction start time.
+- [9487](https://github.com/vegaprotocol/vega/issues/9487) - Reset auction trigger appropriately when market is resumed via governance.
 
 ## 0.72.1
 

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1233,6 +1233,7 @@ func (m *Market) UpdateMarketState(ctx context.Context, changes *types.MarketSta
 			m.as.EndGovernanceSuspensionAuction()
 			m.leaveAuction(ctx, m.timeService.GetTimeNow())
 		} else {
+			m.as.EndGovernanceSuspensionAuction()
 			if m.as.GetState().Trigger == types.AuctionTriggerOpening {
 				m.mkt.State = types.MarketStatePending
 				m.mkt.TradingMode = types.MarketTradingModeOpeningAuction

--- a/core/monitor/auction.go
+++ b/core/monitor/auction.go
@@ -111,12 +111,26 @@ func (a *AuctionState) StartGovernanceSuspensionAuction(t time.Time) {
 }
 
 func (a *AuctionState) EndGovernanceSuspensionAuction() {
-	a.mode = types.MarketTradingModeContinuous
-	a.trigger = types.AuctionTriggerUnspecified
-	a.start = false
-	a.stop = true
-	a.begin = nil
-	a.end = nil
+	if a.trigger == types.AuctionTriggerGovernanceSuspension {
+		// if there governance was the trigger and there is no extension, reset the state.
+		if a.extension == nil {
+			a.mode = types.MarketTradingModeContinuous
+			a.trigger = types.AuctionTriggerUnspecified
+			a.start = false
+			a.stop = true
+			a.begin = nil
+			a.end = nil
+		} else {
+			// if we're leaving the governance auction which was the trigger but there was an extension trigger -
+			// make the extension trigger the trigger and set the mode to monitoring auction.
+			a.mode = types.MarketTradingModeMonitoringAuction
+			a.trigger = *a.extension
+			a.extension = nil
+		}
+	} else if a.ExtensionTrigger() == types.AuctionTriggerGovernanceSuspension {
+		// if governance suspension was the extension trigger - just reset it.
+		a.extension = nil
+	}
 }
 
 // StartOpeningAuction - set the state to start an opening auction (used for testing)


### PR DESCRIPTION
Closes #9487 

With the fix: https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/11952/pipeline/

