### PR TITLE
fix: allow updating a market when it is in opening auction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,7 @@
 - [8466](https://github.com/vegaprotocol/vega/issues/8466) - Add stop orders protobufs and domain types
 - [8467](https://github.com/vegaprotocol/vega/issues/8467) - Add stop orders data structures
 - [8516](https://github.com/vegaprotocol/vega/issues/8516) - Add stop orders network parameter
+- [9509](https://github.com/vegaprotocol/vega/issues/9509) - Markets can now be updated when they are in an opening auction.
 - [8470](https://github.com/vegaprotocol/vega/issues/8470) - Stop orders snapshots
 - [8548](https://github.com/vegaprotocol/vega/issues/8548) - Use default for tendermint `RPC` address and better validation for `semver`
 - [8472](https://github.com/vegaprotocol/vega/issues/8472) - Add support for stop orders with batch market instructions

--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -36,7 +36,7 @@ var (
 	ErrProposalDoesNotExist                      = errors.New("proposal does not exist")
 	ErrMarketDoesNotExist                        = errors.New("market does not exist")
 	ErrMarketStateUpdateNotAllowed               = errors.New("market state does not allow for state update")
-	ErrMarketNotEnactedYet                       = errors.New("market has been enacted yet")
+	ErrMarketProposalStillOpen                   = errors.New("original market proposal is still open")
 	ErrProposalNotOpenForVotes                   = errors.New("proposal is not open for votes")
 	ErrProposalIsDuplicate                       = errors.New("proposal with given ID already exists")
 	ErrVoterInsufficientTokensAndEquityLikeShare = errors.New("vote requires tokens or equity-like share")
@@ -905,8 +905,8 @@ func (e *Engine) validateMarketUpdate(ID, marketID, party string, params *Propos
 		return types.ProposalErrorInvalidMarket, ErrMarketDoesNotExist
 	}
 	for _, p := range e.activeProposals {
-		if p.ID == marketID {
-			return types.ProposalErrorInvalidMarket, ErrMarketNotEnactedYet
+		if p.ID == marketID && p.IsOpen() {
+			return types.ProposalErrorInvalidMarket, ErrMarketProposalStillOpen
 		}
 	}
 
@@ -935,8 +935,8 @@ func (e *Engine) validateSpotMarketUpdate(proposal *types.Proposal, params *Prop
 		return types.ProposalErrorInvalidMarket, ErrMarketDoesNotExist
 	}
 	for _, p := range e.activeProposals {
-		if p.ID == updateMarket.MarketID {
-			return types.ProposalErrorInvalidMarket, ErrMarketNotEnactedYet
+		if p.ID == updateMarket.MarketID && p.IsOpen() {
+			return types.ProposalErrorInvalidMarket, ErrMarketProposalStillOpen
 		}
 	}
 

--- a/core/governance/engine_update_spot_market_test.go
+++ b/core/governance/engine_update_spot_market_test.go
@@ -126,7 +126,7 @@ func testSubmittingProposalForSpotMarketUpdateForNotEnactedMarketFails(t *testin
 	toSubmit, err = eng.submitProposal(t, updateMarketProposal)
 
 	// then
-	require.ErrorIs(t, governance.ErrMarketNotEnactedYet, err)
+	require.ErrorIs(t, governance.ErrMarketProposalStillOpen, err)
 	require.Nil(t, toSubmit)
 }
 


### PR DESCRIPTION
closes #9509

This AC says that we should be allowed to enact an UpdateMarket proposal before the market is enacted provided it has passed the vote and is in opening auction:
```
0028-GOVE-070
    A market change proposal that's to modify any parameters on a market in pending state
    (i.e. voting has successfully completed and the market is in the opening auction) will
    be accepted and if it's the enactment time happens to be before the opening
    auction ends then the proposed modification is enacted.
```

but the check in core was too strict.

system-test passing:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/12344/tests