### PR TITLE
fix: migration for oracle_specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - [5176](https://github.com/vegaprotocol/vega/issues/5176) - Check for duplicate asset registration in integration tests.
 - [9496](https://github.com/vegaprotocol/vega/issues/9496) - Added support for new dispatch strategy fields in feature tests
 - [8764](https://github.com/vegaprotocol/vega/issues/8764) - Include funding payment in margin and liquidation price estimates for `PERPS`.
+- [9519](https://github.com/vegaprotocol/vega/issues/9519) - Fix `oracle_specs` data in the `database` that was inadvertently removed during an earlier database migration 
 
 ### 🐛 Fixes
 

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -363,12 +363,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmZDgxeeZk7zj8spVfLHgbMEbMVoKdnjB8zi8Zhpkajswi", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmUXkPRHc3q1d36kSJrMJZyc4ueBqC4C9MyRPZQF7uMYg7", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmdeoFTZWLxQvvXLTc84YNGq7RTYUdXCKykXqwuvigjNmD", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmbJnRvjYJZNBBwgbkXPLN8HzDtPyBLMVDAtHnbzhBLYvd", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmQNuQYz1Cgv6x5coZjF7F49bHSEXgHPy4hz5wuZrnT6du", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmTLuWKMKGzXhU1kvhD6WFbMH6D8SfbnBkVAeFAPE9w9nx", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmeVB1RxKB2QcnXgZMWPaDLSioL8qnRzHdWaa5sC26sEPZ", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmXBVcL8fAvG4qeQdFvaZb1YWrzUsL3eGv16cWxfiJDGQz", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmNfoBVRihN8ykM3BKbmEQf7izEmy8jjDw9wZhBKcsUkBc", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmYkxWEkt4wJ8c6rkHmnWgg7KFLgUaiSt9ZYTWrUruM5XB", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmRi868TzrTZGY6nw9maWWYrNm5HxVrvwJwhssKw7pF2Nb", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmQtBdKBhXiYKtX5G3pmSkYq26BtViwvZFHDNe1gyybcLc", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0038_oracle_data_broken.sql
+++ b/datanode/sqlstore/migrations/0038_oracle_data_broken.sql
@@ -1,0 +1,101 @@
+-- An earlier migration (0004_oracle_specs) changed the schema the oracle_specs so that instead of having two columns
+-- for signers and filters, we have a single column 'data', which is a JSONB object; in order to support more diverse
+-- sorts of data (e.g. from ethereum oracles)
+--
+-- Unforunately, we neglected to preseve the existing data in those columns, so they were left with NULL values in data.
+-- A recent API change meant that this has started to cause issues on the front end.
+--
+-- Thankfully this information is actually redundantly stored inside the 'tradable_instument' field of the market table,
+-- so we are able to recreate it; which is what this migration does.
+--
+-- We found a couple of cases where there the data was missing in the market table, so for those we simply delete the
+-- rows; they are not critical and new ones will be written when the oracle changes state.
+-- Fish out the relevant stuff from our markets
+-- +goose Up
+     WITH instruments AS (
+             SELECT tradable_instrument -> 'instrument' AS instrument
+               FROM markets_current
+          ),
+          futures AS (
+             SELECT instrument -> 'future' AS future
+               FROM instruments
+              WHERE instrument ? 'future'
+          ),
+          futures_settlement AS (
+             SELECT future -> 'dataSourceSpecForSettlementData' AS spec
+               FROM futures
+              WHERE future ? 'dataSourceSpecForSettlementData'
+          ),
+          futures_termination AS (
+             SELECT future -> 'dataSourceSpecForTradingTermination' AS spec
+               FROM futures
+              WHERE future ? 'dataSourceSpecForTradingTermination'
+          ),
+          perpetuals AS (
+             SELECT instrument -> 'perpetual' AS perpetual
+               FROM instruments
+              WHERE instrument ? 'perpetual'
+          ),
+          perpetuals_settlement AS (
+             SELECT perpetual -> 'dataSourceSpecForSettlementData' AS spec
+               FROM perpetuals
+              WHERE perpetual ? 'dataSourceSpecForSettlementData'
+          ),
+          perpetuals_schedule AS (
+             SELECT perpetual -> 'dataSourceSpecForSettlementSchedule' AS spec
+               FROM perpetuals
+              WHERE perpetual ? 'dataSourceSpecForSettlementSchedule'
+          ),
+          all_specs AS (
+             SELECT *
+               FROM futures_settlement
+          UNION ALL
+             SELECT *
+               FROM futures_termination
+          UNION ALL
+             SELECT *
+               FROM perpetuals_settlement
+          UNION ALL
+             SELECT *
+               FROM perpetuals_schedule
+          ),
+          nice_specs AS (
+             SELECT DECODE(spec ->> 'id', 'hex') AS id,
+                    spec -> 'data'               AS DATA
+               FROM all_specs
+          ),
+          unique_specs AS (
+             SELECT DISTINCT ON (id) *
+               FROM nice_specs
+          ),
+          changes AS (
+             SELECT              os.id,
+                    os.vega_time,
+                    os.data      AS old_data,
+                    us.data      AS new_data
+               FROM oracle_specs os
+          LEFT JOIN unique_specs us ON os.id = us.id
+              WHERE os.data IS NULL
+                AND us.data IS NOT NULL
+           ORDER BY os.id,
+                    os.vega_time
+          )
+   UPDATE oracle_specs os
+      SET DATA = changes.new_data
+     FROM changes
+    WHERE os.id = changes.id
+      AND os.vega_time = changes.vega_time;
+
+-- Finally remove any straggelers 
+   DELETE FROM oracle_specs
+    WHERE DATA IS NULL;
+
+-- And lets make sure it can't happen again
+    ALTER TABLE oracle_specs
+    ALTER COLUMN DATA
+      SET NOT NULL;
+
+-- +goose Down
+    ALTER TABLE oracle_specs
+    ALTER COLUMN DATA
+     DROP NOT NULL;


### PR DESCRIPTION
closes #9519 

Would appreciate some SQL friendly eyes on this and perhaps a bit of a test; seems to work on my machine but it makes me a tad nervous that we might accidentally write a bunch of crap on validators databases!