### PR TITLE
fix: market proto ext does not support new asset types

### DIFF
--- a/protos/vega/market_ext.go
+++ b/protos/vega/market_ext.go
@@ -27,6 +27,8 @@ func (m *Market) GetAsset() (string, error) {
 	switch pimpl := m.TradableInstrument.Instrument.Product.(type) {
 	case *Instrument_Future:
 		return pimpl.Future.SettlementAsset, nil
+	case *Instrument_Perpetual:
+		return pimpl.Perpetual.SettlementAsset, nil
 	default:
 		return "", ErrUnknownAsset
 	}


### PR DESCRIPTION
Market assets not resolving causing API failures for Estimate Position API when requesting Perps and Spots.