### PR TITLE
fix: restore stats in referral engine when loading from a snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@
 - [9140](https://github.com/vegaprotocol/vega/issues/9140) - Stop orders table should be a `hypertable` with retention policy.
 - [9153](https://github.com/vegaprotocol/vega/issues/9153) - `MTM` win transfers can be less than one.
 - [9227](https://github.com/vegaprotocol/vega/issues/9227) - Do not allow market updates that change the product type.
+- [9535](https://github.com/vegaprotocol/vega/issues/9535) - Populate referral statistics when loading from a snapshot.
 - [9178](https://github.com/vegaprotocol/vega/issues/9178) - Fix LP amendment panic
 - [9329](https://github.com/vegaprotocol/vega/issues/9329) - Roll next trigger time forward until after the time that triggered it.
 - [9053](https://github.com/vegaprotocol/vega/issues/9053) - Handle settle market events in core positions plug-in.

--- a/core/referral/engine.go
+++ b/core/referral/engine.go
@@ -310,7 +310,7 @@ func (e *Engine) OnEpoch(ctx context.Context, ep types.Epoch) {
 		e.currentEpoch = ep.Seq
 		e.applyProgramUpdate(ctx, ep.StartTime)
 	case vegapb.EpochAction_EPOCH_ACTION_END:
-		e.computeReferralSetsStats(ctx, ep, false)
+		e.computeReferralSetsStats(ctx, ep)
 	}
 }
 
@@ -453,7 +453,7 @@ func (e *Engine) loadReferralSetsFromSnapshot(setsProto *snapshotpb.ReferralSets
 	}
 }
 
-func (e *Engine) computeReferralSetsStats(ctx context.Context, epoch types.Epoch, fromSnapshot bool) {
+func (e *Engine) computeReferralSetsStats(ctx context.Context, epoch types.Epoch) {
 	priorEpoch := uint64(0)
 	if epoch.Seq > MaximumWindowLength {
 		priorEpoch = epoch.Seq - MaximumWindowLength
@@ -462,18 +462,14 @@ func (e *Engine) computeReferralSetsStats(ctx context.Context, epoch types.Epoch
 
 	for partyID, setID := range e.referrers {
 		volumeForEpoch := e.marketActivityTracker.NotionalTakerVolumeForParty(string(partyID))
-		if !fromSnapshot {
-			e.referralSetsNotionalVolumes.Add(epoch.Seq, setID, volumeForEpoch)
-		}
+		e.referralSetsNotionalVolumes.Add(epoch.Seq, setID, volumeForEpoch)
 	}
 
 	partiesTakerVolume := map[types.PartyID]*num.Uint{}
 
 	for partyID, setID := range e.referees {
 		volumeForEpoch := e.marketActivityTracker.NotionalTakerVolumeForParty(string(partyID))
-		if !fromSnapshot {
-			e.referralSetsNotionalVolumes.Add(epoch.Seq, setID, volumeForEpoch)
-		}
+		e.referralSetsNotionalVolumes.Add(epoch.Seq, setID, volumeForEpoch)
 		partiesTakerVolume[partyID] = volumeForEpoch
 	}
 

--- a/core/referral/snapshot.go
+++ b/core/referral/snapshot.go
@@ -216,6 +216,12 @@ func (e *SnapshottedEngine) buildHashKeys() {
 	e.hashKeys = append([]string{}, e.currentProgramKey, e.newProgramKey, e.referralSetsKey)
 }
 
+func (e *Engine) OnStateLoaded(ctx context.Context) error {
+	// we need to regenerate the statistics based on the restored state
+	e.computeReferralSetsStats(ctx, types.Epoch{Seq: e.currentEpoch}, true)
+	return nil
+}
+
 func NewSnapshottedEngine(broker Broker, timeSvc TimeService, mat MarketActivityTracker, staking StakingBalances) *SnapshottedEngine {
 	se := &SnapshottedEngine{
 		Engine:  NewEngine(broker, timeSvc, mat, staking),

--- a/core/referral/snapshot_test.go
+++ b/core/referral/snapshot_test.go
@@ -189,10 +189,6 @@ func TestTakingAndRestoringSnapshotSucceeds(t *testing.T) {
 	require.NoError(t, te2.engine.OnReferralProgramMaxPartyNotionalVolumeByQuantumPerEpochUpdate(ctx, maxVolumeParams))
 
 	// OnStateLoaded will recalculate referrer stats and send out all these events
-	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer1)).Return(num.UintFromUint64(100)).Times(1)
-	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer2)).Return(num.UintFromUint64(100)).Times(1)
-	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer3)).Return(num.UintFromUint64(100)).Times(1)
-	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer4)).Return(num.UintFromUint64(100)).Times(1)
 	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee1)).Return(num.UintFromUint64(100)).Times(1)
 	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee2)).Return(num.UintFromUint64(100)).Times(1)
 	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee3)).Return(num.UintFromUint64(100)).Times(1)

--- a/core/referral/snapshot_test.go
+++ b/core/referral/snapshot_test.go
@@ -175,7 +175,6 @@ func TestTakingAndRestoringSnapshotSucceeds(t *testing.T) {
 	closeSnapshotEngine1()
 
 	// Reload the engine using the previous snapshot.
-
 	te2 := newEngine(t)
 	snapshotEngine2 := newSnapshotEngine(t, vegaPath, now, te2.engine)
 	defer snapshotEngine2.Close()
@@ -189,6 +188,21 @@ func TestTakingAndRestoringSnapshotSucceeds(t *testing.T) {
 	// Simulate restoration of the network parameter at the time of the snapshot
 	require.NoError(t, te2.engine.OnReferralProgramMaxPartyNotionalVolumeByQuantumPerEpochUpdate(ctx, maxVolumeParams))
 
+	// OnStateLoaded will recalculate referrer stats and send out all these events
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer1)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer2)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer3)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referrer4)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee1)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee2)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee3)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee4)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee5)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee6)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee7)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee8)).Return(num.UintFromUint64(100)).Times(1)
+	te2.marketActivityTracker.EXPECT().NotionalTakerVolumeForParty(string(referee9)).Return(num.UintFromUint64(100)).Times(1)
+	expectReferralSetStatsUpdatedEvent(t, te2, 4)
 	// This triggers the state restoration from the local snapshot.
 	require.NoError(t, snapshotEngine2.Start(ctx))
 


### PR DESCRIPTION
closes #9535