### PR TITLE
fix: referral program APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - [8913](https://github.com/vegaprotocol/vega/issues/8913) - Add business logic for team management.
 - [8765](https://github.com/vegaprotocol/vega/issues/8765) - Implement snapshots state for `PERPS`.
 - [8918](https://github.com/vegaprotocol/vega/issues/8918) - Implement commands for team management.
-- [9401](https://github.com/vegaprotocol/vega/issues/9401) - Use boot strap peers when fetching initial network history segment 
+- [9401](https://github.com/vegaprotocol/vega/issues/9401) - Use boot strap peers when fetching initial network history segment
 - [8960](https://github.com/vegaprotocol/vega/issues/8960) - Improve wiring perpetual markets through governance.
 - [8969](https://github.com/vegaprotocol/vega/issues/8969) - Improve wiring of internal time triggers for perpetual markets.
 - [9001](https://github.com/vegaprotocol/vega/issues/9001) - Improve wiring of perpetual markets into the data node.
@@ -217,6 +217,9 @@
 - [9074](https://github.com/vegaprotocol/vega/issues/9074) - Fix error response for `CSV` exports.
 - [9512](https://github.com/vegaprotocol/vega/issues/9512) - Allow hysteresis period to be set to 0.
 - [8979](https://github.com/vegaprotocol/vega/issues/8979) - Add trusted proxy config and verification for `XFF` header.
+- [9530](https://github.com/vegaprotocol/vega/issues/9530) - Referral program end timestamp not correctly displaying in `GraphQL API`.
+- [9532](https://github.com/vegaprotocol/vega/issues/9532) - Data node crashes if referral program starts and ends in the same block.
+- [9540](https://github.com/vegaprotocol/vega/issues/9540) - Proposals connection errors for `UpdateReferralProgram`.
 
 ## 0.72.1
 

--- a/datanode/entities/referral_program.go
+++ b/datanode/entities/referral_program.go
@@ -22,10 +22,11 @@ type (
 		StakingTiers          []*vega.StakingTier
 		VegaTime              time.Time
 		EndedAt               *time.Time
+		SeqNum                uint64
 	}
 )
 
-func ReferralProgramFromProto(proto *vega.ReferralProgram, vegaTime time.Time) *ReferralProgram {
+func ReferralProgramFromProto(proto *vega.ReferralProgram, vegaTime time.Time, seqNum uint64) *ReferralProgram {
 	return &ReferralProgram{
 		ID:                    ReferralProgramID(proto.Id),
 		Version:               proto.Version,
@@ -34,6 +35,7 @@ func ReferralProgramFromProto(proto *vega.ReferralProgram, vegaTime time.Time) *
 		WindowLength:          proto.WindowLength,
 		StakingTiers:          proto.StakingTiers,
 		VegaTime:              vegaTime,
+		SeqNum:                seqNum,
 	}
 }
 
@@ -43,11 +45,14 @@ func (rp ReferralProgram) ToProto() *v2.ReferralProgram {
 		endedAt = ptr.From(rp.EndedAt.UnixNano())
 	}
 
+	// While the original referral program proto from core sends EndOfProgramTimestamp as a timestamp in unix seconds,
+	// For the data node API, we publish it as a unix timestamp in nanoseconds as the GraphQL API timestamp will incorrectly
+	// treat the timestamp as nanos.
 	return &v2.ReferralProgram{
 		Id:                    rp.ID.String(),
 		Version:               rp.Version,
 		BenefitTiers:          rp.BenefitTiers,
-		EndOfProgramTimestamp: rp.EndOfProgramTimestamp.Unix(),
+		EndOfProgramTimestamp: rp.EndOfProgramTimestamp.UnixNano(),
 		WindowLength:          rp.WindowLength,
 		StakingTiers:          rp.StakingTiers,
 		EndedAt:               endedAt,

--- a/datanode/gateway/graphql/proposal_terms_resolver.go
+++ b/datanode/gateway/graphql/proposal_terms_resolver.go
@@ -75,6 +75,10 @@ func (r *proposalTermsResolver) Change(ctx context.Context, obj *types.ProposalT
 		return obj.GetUpdateSpotMarket(), nil
 	case *types.ProposalTerms_UpdateMarketState:
 		return obj.GetUpdateMarketState(), nil
+	case *types.ProposalTerms_UpdateReferralProgram:
+		return obj.GetUpdateReferralProgram(), nil
+	case *types.ProposalTerms_UpdateVolumeDiscountProgram:
+		return obj.GetUpdateVolumeDiscountProgram(), nil
 	default:
 		return nil, ErrUnsupportedProposalTermsChanges
 	}

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -363,12 +363,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmVbN7EiVf5kRLLphJKPNAApbkd3XoZmJqgUvib1dZ7qQq", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmVTaSFvk1PYTqzQ1HvphN68xBTKYZtu3AwdewCYiHvHk7", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmdACcHZoBkSep3ki4E4tsczfJhm8cpfY4dMAHe7TGWJr7", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmVY88HRFhQYAkRtxwdfGoRAVCAztBQ2bfGJD4VB7Bk386", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmVqKdW2VkBVFowvGi1jfCWkyDQE8KPJLkBtK1XNSGQYKZ", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmSff9NikJpLUKGcEDNqaPpHrDQkRCZ6Rz63g3wwGhQmwY", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmfL8Wx3ad67gvBBMLBJ3B1oQYWXB9MWBboq7KUJvV1h3R", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmfKEQuDAddfyHmAmgJScRvaNK5R5vdSQDNneH8EkAtmMn", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmYDiPfN7SAd5Tf4BXqkDxMMGGiEj5cbV4vVeuaWJkBDBf", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmZPrSuvhgfmDFEBL5eZmtDETjhsBEuQbasrGBkxxFjr1S", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmdQNhiiACPzCZTqEAKuvNFYc6TsVTbfyfyowYuWiapyBX", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmPXtjX5zS2ayLEowFhYqpiEP5D3LsfVn4xKS2CjLVGvpy", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0041_referral_program_fix_9532.sql
+++ b/datanode/sqlstore/migrations/0041_referral_program_fix_9532.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+
+-- first drop the existing primary key
+alter table referral_programs drop constraint referral_programs_pkey;
+
+-- add the sequence number column to the table
+-- we can just set the default to 0 for any existing rows as previously it would only support
+-- one row per vega_time, but there is an edge case where it is possible for the program to start
+-- and end in the same block if it has been set up incorrectly, so we need to support this edge case
+-- and not fail
+alter table referral_programs add column if not exists seq_num bigint not null default 0;
+
+-- now add the new primary key to the table
+alter table referral_programs add constraint referral_programs_pkey primary key (vega_time, seq_num);
+
+-- update the current_referral_program view to correctly display the most recent referral program update
+
+-- make sure that it doesn't exist in case migrations have failed previously
+drop view if exists current_referral_program;
+
+-- simplify referral retrieval using a view that provides the latest referral information.
+create view current_referral_program as (
+    select *
+    from referral_programs
+    order by vega_time desc, seq_num desc
+    limit 1 -- there should only be 1 referral program running at any time, so just get the last record.
+);
+
+-- +goose Down
+
+-- make sure that it doesn't exist in case migrations have failed previously
+drop view if exists current_referral_program;
+
+alter table referral_programs drop constraint referral_programs_pkey;
+
+alter table referral_programs drop column seq_num;
+
+-- simplify referral retrieval using a view that provides the latest referral information.
+create view current_referral_program as (
+    select *
+    from referral_programs
+    order by vega_time desc limit 1 -- there should only be 1 referral program running at any time, so just get the last record.
+);
+
+alter table referral_programs add constraint referral_programs_pkey primary key (vega_time);

--- a/datanode/sqlsubscribers/referral_programs.go
+++ b/datanode/sqlsubscribers/referral_programs.go
@@ -28,7 +28,7 @@ type (
 	ReferralStore interface {
 		AddReferralProgram(ctx context.Context, referral *entities.ReferralProgram) error
 		UpdateReferralProgram(ctx context.Context, referral *entities.ReferralProgram) error
-		EndReferralProgram(ctx context.Context, referralID entities.ReferralProgramID, version uint64, vegaTime time.Time) error
+		EndReferralProgram(ctx context.Context, referralID entities.ReferralProgramID, version uint64, vegaTime time.Time, seqNum uint64) error
 	}
 
 	ReferralProgram struct {
@@ -65,16 +65,16 @@ func (rp *ReferralProgram) Push(ctx context.Context, evt events.Event) error {
 }
 
 func (rp *ReferralProgram) consumeReferralProgramStartedEvent(ctx context.Context, e ReferralProgramStartedEvent) error {
-	program := entities.ReferralProgramFromProto(e.GetReferralProgramStarted().GetProgram(), rp.vegaTime)
+	program := entities.ReferralProgramFromProto(e.GetReferralProgramStarted().GetProgram(), rp.vegaTime, e.Sequence())
 	return rp.store.AddReferralProgram(ctx, program)
 }
 
 func (rp *ReferralProgram) consumeReferralProgramUpdatedEvent(ctx context.Context, e ReferralProgramUpdatedEvent) error {
-	program := entities.ReferralProgramFromProto(e.GetReferralProgramUpdated().GetProgram(), rp.vegaTime)
+	program := entities.ReferralProgramFromProto(e.GetReferralProgramUpdated().GetProgram(), rp.vegaTime, e.Sequence())
 	return rp.store.UpdateReferralProgram(ctx, program)
 }
 
 func (rp *ReferralProgram) consumeReferralProgramEndedEvent(ctx context.Context, e ReferralProgramEndedEvent) error {
 	referralID := entities.ReferralProgramID(e.GetReferralProgramEnded().GetId())
-	return rp.store.EndReferralProgram(ctx, referralID, e.GetReferralProgramEnded().GetVersion(), rp.vegaTime)
+	return rp.store.EndReferralProgram(ctx, referralID, e.GetReferralProgramEnded().GetVersion(), rp.vegaTime, e.Sequence())
 }

--- a/protos/data-node/api/v2/trading_data.pb.go
+++ b/protos/data-node/api/v2/trading_data.pb.go
@@ -18604,8 +18604,8 @@ type ReferralProgram struct {
 	// Defined tiers in increasing order. First element will give Tier 1, second
 	// element will give Tier 2, and so on.
 	BenefitTiers []*vega.BenefitTier `protobuf:"bytes,3,rep,name=benefit_tiers,json=benefitTiers,proto3" json:"benefit_tiers,omitempty"`
-	// Timestamp as Unix time in seconds, after which when the current epoch ends, the
-	// programs status will become STATE_CLOSED and benefits will be disabled.
+	// Timestamp as Unix time in nanoseconds, after which when the current epoch ends, the
+	// programs will end and benefits will be disabled.
 	EndOfProgramTimestamp int64 `protobuf:"varint,4,opt,name=end_of_program_timestamp,json=endOfProgramTimestamp,proto3" json:"end_of_program_timestamp,omitempty"`
 	// Number of epochs over which to evaluate a referral set's running volume.
 	WindowLength uint64 `protobuf:"varint,5,opt,name=window_length,json=windowLength,proto3" json:"window_length,omitempty"`

--- a/protos/sources/data-node/api/v2/trading_data.proto
+++ b/protos/sources/data-node/api/v2/trading_data.proto
@@ -3586,8 +3586,8 @@ message ReferralProgram {
   // Defined tiers in increasing order. First element will give Tier 1, second
   // element will give Tier 2, and so on.
   repeated vega.BenefitTier benefit_tiers = 3;
-  // Timestamp as Unix time in seconds, after which when the current epoch ends, the
-  // programs status will become STATE_CLOSED and benefits will be disabled.
+  // Timestamp as Unix time in nanoseconds, after which when the current epoch ends, the
+  // programs will end and benefits will be disabled.
   int64 end_of_program_timestamp = 4;
   // Number of epochs over which to evaluate a referral set's running volume.
   uint64 window_length = 5;

--- a/protos/vega/vega.go
+++ b/protos/vega/vega.go
@@ -52,3 +52,5 @@ func (UpdateSpotMarketConfiguration_Simple) IsRiskModel()                 {}
 func (NewSpotMarketConfiguration_Simple) IsRiskModel()                    {}
 func (NewSpotMarketConfiguration_LogNormal) IsRiskModel()                 {}
 func (DataSourceSpecConfigurationTimeTrigger) IsInternalDataSourceKind()  {}
+func (UpdateReferralProgram) IsProposalChange()                           {}
+func (UpdateVolumeDiscountProgram) IsProposalChange()                     {}


### PR DESCRIPTION
Closes #9530 

GraphQL displays the end of program timestamp incorrectly as it expects the time in RFC3339Nano, but the API was publishing in RFC3339 as core publishes the time as Unix seconds. The data node API has been updated to publish time as Unix nano.

Closes #9532 

There is an edge case where a referral program can start and end in the same block if it is incorrectly configured and the proposal passes. Data node has been updated to handle this edge case.

Closes #9540 

The `UpdateReferralProgram` change type was not correctly handled by the GQL proposal resolver. Additionally, `UpdateVolumeDiscountProgram` proposal types was not added to the resolver so I have added that also.
