### PR TITLE
Make oracle_data oracle_data_oracle_specs into hypertables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - [9536](https://github.com/vegaprotocol/vega/issues/9536) - Feature tests for average position metric transfers and reward
 - [8764](https://github.com/vegaprotocol/vega/issues/8764) - Include funding payment in margin and liquidation price estimates for `PERPS`.
 - [9519](https://github.com/vegaprotocol/vega/issues/9519) - Fix `oracle_specs` data in the `database` that was inadvertently removed during an earlier database migration
+- [9475](https://github.com/vegaprotocol/vega/issues/9475) - Make `oracle_data` and `oracle_data_oracle_specs` into `hypertables`
 - [9478](https://github.com/vegaprotocol/vega/issues/8764) - Add SLA statistics to market data and liquidity provision APIs.
 
 ### 🐛 Fixes

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -363,12 +363,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmfL8Wx3ad67gvBBMLBJ3B1oQYWXB9MWBboq7KUJvV1h3R", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmfKEQuDAddfyHmAmgJScRvaNK5R5vdSQDNneH8EkAtmMn", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmYDiPfN7SAd5Tf4BXqkDxMMGGiEj5cbV4vVeuaWJkBDBf", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmZPrSuvhgfmDFEBL5eZmtDETjhsBEuQbasrGBkxxFjr1S", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmdQNhiiACPzCZTqEAKuvNFYc6TsVTbfyfyowYuWiapyBX", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmPXtjX5zS2ayLEowFhYqpiEP5D3LsfVn4xKS2CjLVGvpy", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmWH8qtmaVuJWaxkCPtUf2XKkX6s2ZcmHtkhutcAfcXiuU", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmX8zxd1NZuqTfZzusq7QSV7goLTADQRLenu7PYc1miQbv", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmSCuDbj16gedfLvMRYwhUsMCK16DvZeqg1hHixSJGbxPN", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmbfmEmz8vWiuwP87ybYbLxKpwyX21kHqm8bL77P42Hqf6", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmaBYRiPSWUg4HN7uxvZLiwCLtMF1Fnb8DqUxuE6ZbgYU2", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmUDCsV74Rj9uEaM9G9yUut6AMGhARCnxu7EwbnTRBjnJg", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0042_oracle_data_hypertables.sql
+++ b/datanode/sqlstore/migrations/0042_oracle_data_hypertables.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+-- So because I think of some obscure bug in timescaledb, we can't simply 
+-- create_hypertable ('oracle_data', ...), because in the past it had a previous
+-- column, 'matched_spec_ids'. When you drop a column in postgres, I don't think
+-- it actually goes away, it just gets flagged as 'removed' and the CSV import
+-- doesn't work, complaining about 
+-- - attribute 6 of type _timescaledb_internal._hyper_184_47_chunk has wrong type
+-- - 'Table has type bigint, but query expects timestamp with time zone.'
+-- So we have to create a new table, copy the data in, drop the old table, and rename.
+   CREATE TABLE oracle_data_temp (LIKE oracle_data INCLUDING ALL);
+
+   INSERT INTO oracle_data_temp
+   SELECT *
+     FROM oracle_data;
+
+     DROP TABLE oracle_data;
+
+    ALTER TABLE oracle_data_temp
+RENAME TO oracle_data;
+
+   SELECT create_hypertable ('oracle_data', 'vega_time', chunk_time_interval => INTERVAL '1 day', migrate_data => TRUE);
+
+-- oracle_data_oracle_specs is fine though we don't have to faff around with it because we never dropped any columns
+   SELECT create_hypertable ('oracle_data_oracle_specs', 'vega_time', chunk_time_interval => INTERVAL '1 day', migrate_data => TRUE);
+
+-- +goose Down
+-- to de-hypertable ourselves we have to make a new table and copy stuff in
+-- It would be nice to create the new table like this but it confuses timescaledb
+   CREATE TABLE oracle_data_temp (LIKE oracle_data INCLUDING ALL);
+
+   INSERT INTO oracle_data_temp
+   SELECT *
+     FROM oracle_data;
+
+     DROP TABLE oracle_data;
+
+    ALTER TABLE oracle_data_temp
+RENAME TO oracle_data;
+
+-- same for the join table to specs
+   CREATE TABLE oracle_data_oracle_specs_temp (LIKE oracle_data_oracle_specs INCLUDING ALL);
+
+   INSERT INTO oracle_data_oracle_specs_temp
+   SELECT *
+     FROM oracle_data_oracle_specs;
+
+     DROP TABLE oracle_data_oracle_specs;
+
+    ALTER TABLE oracle_data_oracle_specs_temp
+RENAME TO oracle_data_oracle_specs;

--- a/datanode/sqlstore/sqlstore.go
+++ b/datanode/sqlstore/sqlstore.go
@@ -81,6 +81,8 @@ var defaultRetentionPolicies = map[RetentionPeriod][]RetentionPolicy{
 		{HypertableOrCaggName: "party_activity_streaks", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "referral_programs", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "referral_set_stats", DataRetentionPeriod: "1 year"},
+		{HypertableOrCaggName: "oracle_data", DataRetentionPeriod: "1 year"},
+		{HypertableOrCaggName: "oracle_data_oracle_specs", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "vesting_stats", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "volume_discount_stats", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "referral_set_stats", DataRetentionPeriod: "1 year"},


### PR DESCRIPTION
While working around a weird postgres/timescale bug triggered by trying to COPY into a table that has had a column dropped from it in the past. Closes #9475 