### PR TITLE
fix: return correct error for too many staking tiers in referral prop…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - [9475](https://github.com/vegaprotocol/vega/issues/9475) - Make `oracle_data` and `oracle_data_oracle_specs` into `hypertables`
 - [9478](https://github.com/vegaprotocol/vega/issues/8764) - Add SLA statistics to market data and liquidity provision APIs.
 - [9558](https://github.com/vegaprotocol/vega/issues/9558) - Feature tests for relative return metric transfers and reward
+- [9564](https://github.com/vegaprotocol/vega/issues/9564) - Fix error message for too many staking tiers. 
 
 ### 🐛 Fixes
 

--- a/core/governance/referral_program.go
+++ b/core/governance/referral_program.go
@@ -10,11 +10,11 @@ import (
 func validateUpdateReferralProgram(netp NetParams, p *types.UpdateReferralProgram) (types.ProposalError, error) {
 	maxReferralTiers, _ := netp.GetUint(netparams.ReferralProgramMaxReferralTiers)
 	if len(p.Changes.BenefitTiers) > int(maxReferralTiers.Uint64()) {
-		return types.ProposalErrorInvalidReferralProgram, fmt.Errorf("the number of tiers in the proposal is higher than the maximum allowed by the network parameter %q: maximum is %s, but got %d", netparams.ReferralProgramMaxReferralTiers, maxReferralTiers.String(), len(p.Changes.BenefitTiers))
+		return types.ProposalErrorInvalidReferralProgram, fmt.Errorf("the number of benefit tiers in the proposal is higher than the maximum allowed by the network parameter %q: maximum is %s, but got %d", netparams.ReferralProgramMaxReferralTiers, maxReferralTiers.String(), len(p.Changes.BenefitTiers))
 	}
 
 	if len(p.Changes.StakingTiers) > int(maxReferralTiers.Uint64()) {
-		return types.ProposalErrorInvalidReferralProgram, fmt.Errorf("the number of tiers in the proposal is higher than the maximum allowed by the network parameter %q: maximum is %s, but got %d", netparams.ReferralProgramMaxReferralTiers, maxReferralTiers.String(), len(p.Changes.BenefitTiers))
+		return types.ProposalErrorInvalidReferralProgram, fmt.Errorf("the number of staking tiers in the proposal is higher than the maximum allowed by the network parameter %q: maximum is %s, but got %d", netparams.ReferralProgramMaxReferralTiers, maxReferralTiers.String(), len(p.Changes.StakingTiers))
 	}
 
 	maxRewardFactor, _ := netp.GetDecimal(netparams.ReferralProgramMaxReferralRewardFactor)


### PR DESCRIPTION
…osal

Closes #9564 

The error is misleading and incorrect. In the ticket the proposal contains 3 tiers for staking. With correct number of staking layers the test passes. 