### PR TITLE
feat: rework data node mode options and make the default archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [8679](https://github.com/vegaprotocol/vega/issues/8679) - Snapshot configuration `load-from-block-height` no longer accept `-1` as value. To reload from the latest snapshot, it should be valued `0`.
 - [8679](https://github.com/vegaprotocol/vega/issues/8679) - Snapshot configuration `snapshot-keep-recent` only accept values from `1` (included) to `10` (included) .
 - [8944](https://github.com/vegaprotocol/vega/issues/8944) - Asset ID field on the `ExportLedgerEntriesRequest gRPC API` for exporting ledger entries has changed type to make it optional.
+- [9562](https://github.com/vegaprotocol/vega/issues/9562) - `--lite` and `--archive` options to data node have been replaced with `--mode=[archive|lite|standard]` with default mode as archive.
 
 ### 🗑️ Deprecation
 

--- a/cmd/data-node/commands/init.go
+++ b/cmd/data-node/commands/init.go
@@ -30,9 +30,8 @@ import (
 type InitCmd struct {
 	config.VegaHomeFlag
 
-	Force   bool `description:"Erase exiting vega configuration at the specified path"                           long:"force"   short:"f"`
-	Archive bool `description:"Disable database retention policies. Keeps data and network history indefinitely" long:"archive" short:"a"`
-	Lite    bool `description:"Set all database retention policies to one day only"                              long:"lite"    short:"l"`
+	Force bool   `description:"Erase exiting vega configuration at the specified path" long:"force"  short:"f"`
+	Mode  string `choice:"archive"                                                     choice:"lite" choice:"standard" default:"archive" description:"Set which mode to initialise the data node with, will affect retention policies" long:"mode" short:"m"`
 }
 
 var initCmd InitCmd
@@ -73,19 +72,14 @@ func (opts *InitCmd) Execute(args []string) error {
 
 	cfg := config.NewDefaultConfig()
 
-	if opts.Archive && opts.Lite {
-		return fmt.Errorf("specify either archive mode, lite mode - not both")
-	}
-
-	if opts.Archive {
+	if opts.Mode == "archive" {
 		cfg.NetworkHistory.Store.HistoryRetentionBlockSpan = math.MaxInt64
 		cfg.SQLStore.RetentionPeriod = sqlstore.RetentionPeriodArchive
 	}
 
-	if opts.Lite {
+	if opts.Mode == "lite" {
 		cfg.SQLStore.RetentionPeriod = sqlstore.RetentionPeriodLite
 	}
-
 	cfg.ChainID = chainID
 
 	if err := cfgLoader.Save(&cfg); err != nil {


### PR DESCRIPTION
closes #9562 

I've removed the `--archive` and `--lite` options in favour of a single `--mode=[archive|lite|standard]`. Makes things a bit cleaner.

```
wwestgarth@wwestgarth-macbook ~/work/vega -  (9562-make-archival-default) $ vega datanode init --help
Usage:
  datanode [OPTIONS] init <ChainID> [options]

Generate the minimal configuration required for a vega data-node to start. The Chain ID is required.

Help Options:
  -h, --help                             Show this help message

[init command options]
          --home=                        Path to the custom home for vega
      -f, --force                        Erase exiting vega configuration at the specified path
          --mode=[archive|lite|standard] Set which mode to initialise the data node with, will affect retention policies (default: archive)
```