### PR TITLE
feat: optimise network history by removing staged segments as we go a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - [5176](https://github.com/vegaprotocol/vega/issues/5176) - Check for duplicate asset registration in integration tests.
 - [9496](https://github.com/vegaprotocol/vega/issues/9496) - Added support for new dispatch strategy fields in feature tests
 - [9536](https://github.com/vegaprotocol/vega/issues/9536) - Feature tests for average position metric transfers and reward
+- [9547](https://github.com/vegaprotocol/vega/issues/9547) - Less disk space is now needed to initialise a data node from network history.
 - [8764](https://github.com/vegaprotocol/vega/issues/8764) - Include funding payment in margin and liquidation price estimates for `PERPS`.
 - [9519](https://github.com/vegaprotocol/vega/issues/9519) - Fix `oracle_specs` data in the `database` that was inadvertently removed during an earlier database migration
 - [9475](https://github.com/vegaprotocol/vega/issues/9475) - Make `oracle_data` and `oracle_data_oracle_specs` into `hypertables`

--- a/cmd/data-node/commands/networkhistory/load.go
+++ b/cmd/data-node/commands/networkhistory/load.go
@@ -205,7 +205,13 @@ func (cmd *loadCmd) Execute(args []string) error {
 }
 
 func createNetworkHistoryService(ctx context.Context, log *logging.Logger, vegaConfig config.Config, connPool *pgxpool.Pool, vegaPaths paths.Paths) (*networkhistory.Service, error) {
-	snapshotService, err := snapshot.NewSnapshotService(log, vegaConfig.NetworkHistory.Snapshot, connPool,
+	networkHistoryStore, err := store.New(ctx, log, vegaConfig.ChainID, vegaConfig.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
+		vegaConfig.MaxMemoryPercent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create network history store: %w", err)
+	}
+
+	snapshotService, err := snapshot.NewSnapshotService(log, vegaConfig.NetworkHistory.Snapshot, connPool, networkHistoryStore,
 		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo), func(version int64) error {
 			if err := sqlstore.MigrateUpToSchemaVersion(log, vegaConfig.SQLStore, version, sqlstore.EmbedMigrations); err != nil {
 				return fmt.Errorf("failed to migrate to schema version %d: %w", version, err)
@@ -222,13 +228,7 @@ func createNetworkHistoryService(ctx context.Context, log *logging.Logger, vegaC
 		return nil, fmt.Errorf("failed to create snapshot service: %w", err)
 	}
 
-	networkHistoryStore, err := store.New(ctx, log, vegaConfig.ChainID, vegaConfig.NetworkHistory.Store, vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome),
-		vegaConfig.MaxMemoryPercent)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create network history store:%w", err)
-	}
-
-	networkHistoryService, err := networkhistory.NewWithStore(ctx, log, vegaConfig.ChainID, vegaConfig.NetworkHistory,
+	networkHistoryService, err := networkhistory.New(ctx, log, vegaConfig.ChainID, vegaConfig.NetworkHistory,
 		connPool, snapshotService, networkHistoryStore, vegaConfig.API.Port,
 		vegaPaths.StatePathFor(paths.DataNodeNetworkHistorySnapshotCopyTo))
 	if err != nil {
@@ -264,4 +264,8 @@ func (l *loadLog) Infof(s string, args ...interface{}) {
 
 func (l *loadLog) Info(msg string, fields ...zap.Field) {
 	l.log.Info(msg, fields...)
+}
+
+func (l *loadLog) Error(msg string, fields ...zap.Field) {
+	l.log.Error(msg, fields...)
 }

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -312,7 +312,7 @@ func TestMain(t *testing.M) {
 		datanodeConfig := config2.NewDefaultConfig()
 		cfg := networkhistory.NewDefaultConfig()
 
-		_, err = networkhistory.NewWithStore(outerCtx, log, chainID, cfg, networkHistoryConnPool, snapshotService,
+		_, err = networkhistory.New(outerCtx, log, chainID, cfg, networkHistoryConnPool, snapshotService,
 			networkHistoryStore, datanodeConfig.API.Port, snapshotCopyToPath)
 
 		if err != nil {
@@ -1207,7 +1207,7 @@ func setupNetworkHistoryService(ctx context.Context, log *logging.Logger, inputS
 
 	datanodeConfig := config2.NewDefaultConfig()
 
-	networkHistoryService, err := networkhistory.NewWithStore(ctx, log, chainID, cfg, networkHistoryConnPool,
+	networkHistoryService, err := networkhistory.New(ctx, log, chainID, cfg, networkHistoryConnPool,
 		inputSnapshotService, store, datanodeConfig.API.Port, snapshotCopyToPath)
 	if err != nil {
 		panic(err)
@@ -1276,7 +1276,7 @@ func assertIntervalHistoryIsEmpty(t *testing.T, historyTableDelta []map[string]t
 func setupSnapshotService(snapshotCopyToPath string) *snapshot.Service {
 	snapshotServiceCfg := snapshot.NewDefaultConfig()
 	snapshotService, err := snapshot.NewSnapshotService(logging.NewTestLogger(), snapshotServiceCfg,
-		networkHistoryConnPool, snapshotCopyToPath, migrateUpToDatabaseVersion,
+		networkHistoryConnPool, networkHistoryStore, snapshotCopyToPath, migrateUpToDatabaseVersion,
 		migrateDownToDatabaseVersion)
 	if err != nil {
 		panic(err)

--- a/datanode/networkhistory/snapshot/service_create_snapshot_test.go
+++ b/datanode/networkhistory/snapshot/service_create_snapshot_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetHistorySnapshots(t *testing.T) {
 	snapshotsDir := t.TempDir()
-	service, err := snapshot.NewSnapshotService(logging.NewTestLogger(), snapshot.NewDefaultConfig(), nil, snapshotsDir, nil, nil)
+	service, err := snapshot.NewSnapshotService(logging.NewTestLogger(), snapshot.NewDefaultConfig(), nil, nil, snapshotsDir, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/datanode/networkhistory/store/store.go
+++ b/datanode/networkhistory/store/store.go
@@ -107,7 +107,7 @@ func New(ctx context.Context, log *logging.Logger, chainID string, cfg Config, n
 	storePath := filepath.Join(networkHistoryHome, "store")
 
 	p := &Store{
-		log:        log,
+		log:        log.Named("store"),
 		cfg:        cfg,
 		indexPath:  filepath.Join(storePath, "index"),
 		stagingDir: filepath.Join(storePath, "staging"),
@@ -143,7 +143,7 @@ func New(ctx context.Context, log *logging.Logger, chainID string, cfg Config, n
 		PrivKey: cfg.PrivKey,
 	}
 
-	log.Infof("starting network history store with ipfs Peer Id:%s", p.identity.PeerID)
+	p.log.Infof("starting network history store with ipfs Peer Id:%s", p.identity.PeerID)
 
 	if plugins == nil {
 		plugins, err = loadPlugins(p.ipfsPath)
@@ -152,11 +152,11 @@ func New(ctx context.Context, log *logging.Logger, chainID string, cfg Config, n
 		}
 	}
 
-	log.Debugf("ipfs swarm port:%d", cfg.SwarmPort)
+	p.log.Debugf("ipfs swarm port:%d", cfg.SwarmPort)
 	ipfsCfg, err := createIpfsNodeConfiguration(p.log, p.identity, cfg.BootstrapPeers,
 		cfg.SwarmPort)
 
-	log.Debugf("ipfs bootstrap peers:%v", ipfsCfg.Bootstrap)
+	p.log.Debugf("ipfs bootstrap peers:%v", ipfsCfg.Bootstrap)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ipfs node configuration:%w", err)
@@ -676,6 +676,7 @@ func (p *Store) FetchHistorySegment(ctx context.Context, historySegmentID string
 }
 
 func (p *Store) StagedSegment(ctx context.Context, s segment.Full) (segment.Staged, error) {
+	p.log.Info("staging full-segment", logging.String("segment", s.ZipFileName()))
 	ss := segment.Staged{
 		Full:      s,
 		Directory: p.stagingDir,


### PR DESCRIPTION
closes #9547 

Before the flow was:
- fetch all segments
- load all segments into the database
- accidently forget to delete staged segments

Now it goes:
- fetch 1 segments
- load into database
- delete the staged segments
- move onto the next segment...

logs from locally auto-initialising network history from fairground:
```
INFO	datanode.networkHistory.service.store	store/store.go:679	staging full-segment	{"segment": "vega-fairground-202305051805-37-15278159-15279158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:355	copying into database	{"segment": "vega-fairground-202305051805-37-15278159-15279158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:361	copy complete	{"rows": 69534, "segment": "vega-fairground-202305051805-37-15278159-15279158.zip", "took": "1.151436311s"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:364	removing staged segment	{"path": "/Users/wwestgarth/basic_home/state/data-node/networkhistory/store/staging/vega-fairground-202305051805-37-15278159-15279158.zip"}
INFO	datanode.networkHistory.service.store	store/store.go:679	staging full-segment	{"segment": "vega-fairground-202305051805-37-15279159-15280158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:355	copying into database	{"segment": "vega-fairground-202305051805-37-15279159-15280158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:361	copy complete	{"rows": 71023, "segment": "vega-fairground-202305051805-37-15279159-15280158.zip", "took": "1.087890895s"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:364	removing staged segment	{"path": "/Users/wwestgarth/basic_home/state/data-node/networkhistory/store/staging/vega-fairground-202305051805-37-15279159-15280158.zip"}
INFO	datanode.networkHistory.service.store	store/store.go:679	staging full-segment	{"segment": "vega-fairground-202305051805-37-15280159-15281158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:355	copying into database	{"segment": "vega-fairground-202305051805-37-15280159-15281158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:361	copy complete	{"rows": 68972, "segment": "vega-fairground-202305051805-37-15280159-15281158.zip", "took": "1.105160871s"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:364	removing staged segment	{"path": "/Users/wwestgarth/basic_home/state/data-node/networkhistory/store/staging/vega-fairground-202305051805-37-15280159-15281158.zip"}
INFO	datanode.networkHistory.service.store	store/store.go:679	staging full-segment	{"segment": "vega-fairground-202305051805-37-15281159-15282158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:355	copying into database	{"segment": "vega-fairground-202305051805-37-15281159-15282158.zip"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:361	copy complete	{"rows": 68848, "segment": "vega-fairground-202305051805-37-15281159-15282158.zip", "took": "1.057671679s"}
INFO	datanode.networkHistory.service	snapshot/service_load_snapshot.go:364	removing staged segment	{"path": "/Users/wwestgarth/basic_home/state/data-node/networkhistory/store/staging/vega-fairground-202305051805-37-15281159-15282158.zip"}
```


system tests running the network history tests passing:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/16221/pipeline/

except for one, which was a timing issue when the test wanted to assert a lot of things happened within the epoch. Running the test again and it passed:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/16333/pipeline