### PR TITLE
fix: estimate position can panic for perps

### DIFF
--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -2993,7 +2993,7 @@ func (t *TradingDataServiceV2) EstimatePosition(ctx context.Context, req *v2.Est
 		if err != nil {
 			return nil, formatE(fmt.Errorf("can't parse margin funding factor: %s", perp.MarginFundingFactor), err)
 		}
-		if !factor.IsZero() {
+		if !factor.IsZero() && mktData.ProductData != nil { // for perps it's possible that the product data is not available in the market data
 			if perpData := mktData.ProductData.GetPerpetualData(); perpData != nil {
 				fundingPayment, err := num.DecimalFromString(perpData.FundingPayment)
 				if err != nil {


### PR DESCRIPTION
The `ProductData` in the MarketData information can be nil for perps, but the estimate position function does not take this into consideration and can panic.