### PR TITLE
feat: rename datanode mode to retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [8679](https://github.com/vegaprotocol/vega/issues/8679) - Snapshot configuration `load-from-block-height` no longer accept `-1` as value. To reload from the latest snapshot, it should be valued `0`.
 - [8679](https://github.com/vegaprotocol/vega/issues/8679) - Snapshot configuration `snapshot-keep-recent` only accept values from `1` (included) to `10` (included) .
 - [8944](https://github.com/vegaprotocol/vega/issues/8944) - Asset ID field on the `ExportLedgerEntriesRequest gRPC API` for exporting ledger entries has changed type to make it optional.
-- [9562](https://github.com/vegaprotocol/vega/issues/9562) - `--lite` and `--archive` options to data node have been replaced with `--mode=[archive|lite|standard]` with default mode as archive.
+- [9562](https://github.com/vegaprotocol/vega/issues/9562) - `--lite` and `--archive` options to data node have been replaced with `--retention-profile=[archive|conservative|minimal]` with default mode as archive.
 
 ### 🗑️ Deprecation
 

--- a/cmd/data-node/commands/init.go
+++ b/cmd/data-node/commands/init.go
@@ -33,8 +33,8 @@ import (
 type InitCmd struct {
 	config.VegaHomeFlag
 
-	Force bool   `description:"Erase exiting vega configuration at the specified path" long:"force"  short:"f"`
-	Mode  string `choice:"archive"                                                     choice:"lite" choice:"standard" default:"archive" description:"Set which mode to initialise the data node with, will affect retention policies" long:"mode" short:"m"`
+	Force            bool   `description:"Erase exiting vega configuration at the specified path" long:"force"     short:"f"`
+	RetentionProfile string `choice:"archive"                                                     choice:"minimal" choice:"conservative" default:"archive" description:"Set which mode to initialise the data node with, will affect retention policies" long:"retention-profile" short:"r"`
 }
 
 var initCmd InitCmd
@@ -75,14 +75,14 @@ func (opts *InitCmd) Execute(args []string) error {
 
 	cfg := config.NewDefaultConfig()
 
-	if opts.Mode == "archive" {
+	if opts.RetentionProfile == "archive" {
 		cfg.NetworkHistory.Store.HistoryRetentionBlockSpan = math.MaxInt64
 		cfg.SQLStore.RetentionPeriod = sqlstore.RetentionPeriodArchive
 		cfg.NetworkHistory.Initialise.TimeOut = encoding.Duration{Duration: 96 * time.Hour}
 		cfg.NetworkHistory.Initialise.MinimumBlockCount = -1
 	}
 
-	if opts.Mode == "lite" {
+	if opts.RetentionProfile == "minimal" {
 		cfg.SQLStore.RetentionPeriod = sqlstore.RetentionPeriodLite
 		cfg.NetworkHistory.Initialise.TimeOut = encoding.Duration{Duration: 1 * time.Minute}
 		cfg.NetworkHistory.Initialise.MinimumBlockCount = 1


### PR DESCRIPTION
When trying to update the docs to so that `standard` wasn't the default it turned out it was hard to describe what `standard` actually was. And also the word "standard" didn't make much sense when it wasn't the default anymore, and isn't the retention policy we want people to set.

So I've changed the `--mode -> --retention-profile` with options `archive|conservative|minimal` and will spin the non-archival ones in the docs to be aimed more for people withd custom private data node.

more conversation here: https://vegaprotocol.slack.com/archives/C02KVKMAE82/p1695902059592879
