### PR TITLE
Orders divergence map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -258,6 +258,7 @@ require (
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	github.com/wk8/go-ordered-map v1.0.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMd
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
+github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
@@ -85,15 +87,18 @@ github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
+github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
+github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/Workiva/go-datastructures v1.0.53 h1:J6Y/52yX10Xc5JjXmGtWoSSxs3mZnGSaq37xZZh7Yig=
 github.com/Workiva/go-datastructures v1.0.53/go.mod h1:1yZL+zfsztete+ePzZz/Zb1/t5BnDuE2Ya2MMGhzP6A=
 github.com/adlio/schema v1.3.3 h1:oBJn8I02PyTB466pZO1UZEn1TV5XLlifBSyMrmHl/1I=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
@@ -171,6 +176,7 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -201,6 +207,7 @@ github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoG
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811/go.mod h1:Nb5lgvnQ2+oGlE/EyZy4+2/CxRh9KfvCXnag1vtpxVM=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
+github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
@@ -287,6 +294,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
+github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
@@ -339,6 +348,7 @@ github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzP
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
+github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
@@ -554,6 +564,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
+github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -683,6 +694,7 @@ github.com/ipfs/go-ds-leveldb v0.5.0 h1:s++MEBbD3ZKc9/8/njrn4flZLnCuY9I79v94gBUN
 github.com/ipfs/go-ds-leveldb v0.5.0/go.mod h1:d3XG9RUDzQ6V4SHi8+Xgj9j1XuEk1z82lquxrVbml/Q=
 github.com/ipfs/go-ds-measure v0.2.0 h1:sG4goQe0KDTccHMyT45CY1XyUbxe5VwTKpg2LjApYyQ=
 github.com/ipfs/go-ds-measure v0.2.0/go.mod h1:SEUD/rE2PwRa4IQEC5FuNAmjJCyYObZr9UvVh8V3JxE=
+github.com/ipfs/go-fetcher v1.6.1/go.mod h1:27d/xMV8bodjVs9pugh/RCjjK2OZ68UgAMspMdingNo=
 github.com/ipfs/go-fs-lock v0.0.7 h1:6BR3dajORFrFTkb5EpCUFIAypsoxpGpDSVUdFwzgL9U=
 github.com/ipfs/go-fs-lock v0.0.7/go.mod h1:Js8ka+FNYmgQRLrRXzU3CB/+Csr1BwrRilEcvYrHhhc=
 github.com/ipfs/go-graphsync v0.14.4 h1:ysazATpwsIjYtYEZH5CdD/HRaonCJd4pASUtnzESewk=
@@ -690,6 +702,7 @@ github.com/ipfs/go-graphsync v0.14.4/go.mod h1:yT0AfjFgicOoWdAlUJ96tQ5AkuGI4r1ta
 github.com/ipfs/go-ipfs-blockstore v1.3.0 h1:m2EXaWgwTzAfsmt5UdJ7Is6l4gJcaM/A12XwJyvYvMM=
 github.com/ipfs/go-ipfs-blockstore v1.3.0/go.mod h1:KgtZyc9fq+P2xJUiCAzbRdhhqJHvsw8u2Dlqy2MyRTE=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
+github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
 github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7NapWLY8=
 github.com/ipfs/go-ipfs-cmds v0.9.0 h1:K0VcXg1l1k6aY6sHnoxYcyimyJQbcV1ueXuWgThmK9Q=
 github.com/ipfs/go-ipfs-cmds v0.9.0/go.mod h1:SBFHK8WNwC416QWH9Vz1Ql42SSMAOqKpaHUMBu3jpLo=
@@ -703,6 +716,7 @@ github.com/ipfs/go-ipfs-exchange-offline v0.3.0 h1:c/Dg8GDPzixGd0MC8Jh6mjOwU57uY
 github.com/ipfs/go-ipfs-files v0.3.0 h1:fallckyc5PYjuMEitPNrjRfpwl7YFt69heCOUhsbGxQ=
 github.com/ipfs/go-ipfs-files v0.3.0/go.mod h1:xAUtYMwB+iu/dtf6+muHNSFQCJG2dSiStR2P6sn9tIM=
 github.com/ipfs/go-ipfs-posinfo v0.0.1 h1:Esoxj+1JgSjX0+ylc0hUmJCOv6V2vFoZiETLR6OtpRs=
+github.com/ipfs/go-ipfs-posinfo v0.0.1/go.mod h1:SwyeVP+jCwiDu0C313l/8jg6ZxM0qqtlt2a0vILTc1A=
 github.com/ipfs/go-ipfs-pq v0.0.3 h1:YpoHVJB+jzK15mr/xsWC574tyDLkezVrDNeaalQBsTE=
 github.com/ipfs/go-ipfs-pq v0.0.3/go.mod h1:btNw5hsHBpRcSSgZtiNm/SLj5gYIZ18AKtv3kERkRb4=
 github.com/ipfs/go-ipfs-redirects-file v0.1.1 h1:Io++k0Vf/wK+tfnhEh63Yte1oQK5VGT2hIEYpD0Rzx8=
@@ -1172,6 +1186,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
+github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
 github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
@@ -1355,6 +1370,7 @@ github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
@@ -1484,6 +1500,8 @@ github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1 h1:ctS9An
 github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1/go.mod h1:tKH72zYNt/exx6/5IQO6L9LoQ0rEjd5SbbWaDTs9Zso=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
+github.com/wk8/go-ordered-map v1.0.0 h1:BV7z+2PaK8LTSd/mWgY12HyMAo5CEgkHqbkVq2thqr8=
+github.com/wk8/go-ordered-map v1.0.0/go.mod h1:9ZIbRunKbuvfPKyBP1SIKLcXNlv74YCOZ3t3VTS6gRk=
 github.com/wk8/go-ordered-map/v2 v2.0.0 h1:jWOAU/F5AkYb8jr/rkVPe418g7nf2CZBzyfOR4Y7Q1w=
 github.com/wk8/go-ordered-map/v2 v2.0.0/go.mod h1:fGIuB3GmY3JZP6L3t5riKtaSH9u13IYVYvar5Ee+9lM=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
@@ -2135,6 +2153,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
@@ -2155,6 +2174,7 @@ gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVY
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/libs/temp_ordered_map_benchmarks_test.go
+++ b/libs/temp_ordered_map_benchmarks_test.go
@@ -8,11 +8,11 @@ import (
 
 /*
 BenchmarkMapIteration
-iterations: 1000
-iterations: 100000
-iterations: 10000000
-iterations: 139970000
-BenchmarkMapIteration-16    	  139970	      8536 ns/op
+values length: 8890
+values length: 889000
+values length: 88900000
+values length: 1262157750
+BenchmarkMapIteration-16    	  141975	      8371 ns/op
 */
 func BenchmarkMapIteration(b *testing.B) {
 
@@ -21,25 +21,27 @@ func BenchmarkMapIteration(b *testing.B) {
 	for c := 0; c < 1000; c++ {
 		m[fmt.Sprintf("%d-key", c)] = fmt.Sprintf("%d-value", c)
 	}
+
+	lengthOfAllValues := 0
+
 	b.ResetTimer()
 
-	i := 0
 	for n := 0; n < b.N; n++ {
-		for _, _ = range m {
-			i++
+		for _, v := range m {
+			lengthOfAllValues += len(v)
 		}
 	}
 
-	fmt.Printf("iterations: %d\n", i)
+	fmt.Printf("values length: %d\n", lengthOfAllValues)
 }
 
 /*
 BenchmarkOrderedMapIteration
-iterations: 1000
-iterations: 100000
-iterations: 10000000
-iterations: 411097000
-BenchmarkOrderedMapIteration-16    	  411097	      2811 ns/op
+values length: 8890
+values length: 889000
+values length: 88900000
+values length: 3754478140
+BenchmarkOrderedMapIteration-16    	  422326	      2811 ns/op
 */
 func BenchmarkOrderedMapIteration(b *testing.B) {
 
@@ -47,16 +49,17 @@ func BenchmarkOrderedMapIteration(b *testing.B) {
 	for c := 0; c < 1000; c++ {
 		m.Set(fmt.Sprintf("%d-key", c), fmt.Sprintf("%d-value", c))
 	}
+
+	lengthOfAllValues := 0
 	b.ResetTimer()
 
-	i := 0
 	for n := 0; n < b.N; n++ {
 		for p := m.Oldest(); p != nil; p = p.Next() {
-			i++
+			lengthOfAllValues += len(p.Value)
 		}
 	}
 
-	fmt.Printf("iterations: %d\n", i)
+	fmt.Printf("values length: %d\n", lengthOfAllValues)
 }
 
 /*

--- a/libs/temp_ordered_map_benchmarks_test.go
+++ b/libs/temp_ordered_map_benchmarks_test.go
@@ -199,7 +199,7 @@ length: 0
 length: 0
 length: 0
 length: 0
-BenchmarkMapDelete-16    	  651661	      1799 ns/op
+BenchmarkMapDelete-16    	    6439	    182624 ns/op
 */
 func BenchmarkMapDelete(b *testing.B) {
 
@@ -207,12 +207,12 @@ func BenchmarkMapDelete(b *testing.B) {
 
 	var keys []string
 	var values []string
-	for c := 0; c < 1000; c++ {
+	for c := 0; c < 100000; c++ {
 		keys = append(keys, fmt.Sprintf("%d-key", c))
 		values = append(values, fmt.Sprintf("%d-value", c))
 	}
 
-	for c := 0; c < 1000; c++ {
+	for c := 0; c < 100000; c++ {
 		m[keys[c]] = values[c]
 	}
 
@@ -220,7 +220,7 @@ func BenchmarkMapDelete(b *testing.B) {
 
 	i := 0
 	for n := 0; n < b.N; n++ {
-		for c := 999; c >= 0; c-- {
+		for c := 99999; c >= 0; c-- {
 			delete(m, keys[c])
 			i++
 		}
@@ -235,7 +235,7 @@ length: 0
 length: 0
 length: 0
 length: 0
-BenchmarkOrderedMapDelete-16    	  577935	      2049 ns/op
+BenchmarkOrderedMapDelete-16    	    5668	    210437 ns/op
 */
 func BenchmarkOrderedMapDelete(b *testing.B) {
 
@@ -243,12 +243,12 @@ func BenchmarkOrderedMapDelete(b *testing.B) {
 
 	var keys []string
 	var values []string
-	for c := 0; c < 1000; c++ {
+	for c := 0; c < 100000; c++ {
 		keys = append(keys, fmt.Sprintf("%d-key", c))
 		values = append(values, fmt.Sprintf("%d-value", c))
 	}
 
-	for c := 0; c < 1000; c++ {
+	for c := 0; c < 100000; c++ {
 		m.Set(keys[c], values[c])
 	}
 
@@ -256,7 +256,7 @@ func BenchmarkOrderedMapDelete(b *testing.B) {
 
 	i := 0
 	for n := 0; n < b.N; n++ {
-		for c := 999; c >= 0; c-- {
+		for c := 99999; c >= 0; c-- {
 			_, _ = m.Delete(keys[c])
 			i++
 		}

--- a/libs/temp_ordered_map_benchmarks_test.go
+++ b/libs/temp_ordered_map_benchmarks_test.go
@@ -1,0 +1,266 @@
+package libs
+
+import (
+	"fmt"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"testing"
+)
+
+/*
+BenchmarkMapIteration
+iterations: 1000
+iterations: 100000
+iterations: 10000000
+iterations: 139970000
+BenchmarkMapIteration-16    	  139970	      8536 ns/op
+*/
+func BenchmarkMapIteration(b *testing.B) {
+
+	m := make(map[string]string)
+
+	for c := 0; c < 1000; c++ {
+		m[fmt.Sprintf("%d-key", c)] = fmt.Sprintf("%d-value", c)
+	}
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for _, _ = range m {
+			i++
+		}
+	}
+
+	fmt.Printf("iterations: %d\n", i)
+}
+
+/*
+BenchmarkOrderedMapIteration
+iterations: 1000
+iterations: 100000
+iterations: 10000000
+iterations: 411097000
+BenchmarkOrderedMapIteration-16    	  411097	      2811 ns/op
+*/
+func BenchmarkOrderedMapIteration(b *testing.B) {
+
+	m := orderedmap.New[string, string]()
+	for c := 0; c < 1000; c++ {
+		m.Set(fmt.Sprintf("%d-key", c), fmt.Sprintf("%d-value", c))
+	}
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for p := m.Oldest(); p != nil; p = p.Next() {
+			i++
+		}
+	}
+
+	fmt.Printf("iterations: %d\n", i)
+}
+
+/*
+BenchmarkMapAdd
+iterations: 1000
+iterations: 100000
+iterations: 10000000
+iterations: 82893000
+BenchmarkMapAdd-16    	   82893	     14207 ns/op
+*/
+func BenchmarkMapAdd(b *testing.B) {
+
+	m := make(map[string]string)
+
+	var keys []string
+	var values []string
+	for c := 0; c < 1000; c++ {
+		keys = append(keys, fmt.Sprintf("%d-key", c))
+		values = append(values, fmt.Sprintf("%d-value", c))
+	}
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for c := 0; c < 1000; c++ {
+			m[keys[c]] = values[c]
+			i++
+		}
+	}
+
+	fmt.Printf("iterations: %d\n", i)
+}
+
+/*
+BenchmarkOrderedMapAdd
+iterations: 1000
+iterations: 100000
+iterations: 10000000
+iterations: 89872000
+BenchmarkOrderedMapAdd-16    	   89872	     12770 ns/op
+*/
+func BenchmarkOrderedMapAdd(b *testing.B) {
+
+	m := orderedmap.New[string, string]()
+
+	var keys []string
+	var values []string
+	for c := 0; c < 1000; c++ {
+		keys = append(keys, fmt.Sprintf("%d-key", c))
+		values = append(values, fmt.Sprintf("%d-value", c))
+	}
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for c := 0; c < 1000; c++ {
+			m.Set(keys[c], values[c])
+			i++
+		}
+	}
+
+	fmt.Printf("iterations: %d\n", i)
+}
+
+/*
+BenchmarkMapGet
+iterations: 1000
+iterations: 100000
+iterations: 10000000
+iterations: 146986000
+BenchmarkMapGet-16    	  146986	      7892 ns/op
+*/
+func BenchmarkMapGet(b *testing.B) {
+
+	m := make(map[string]string)
+
+	var keys []string
+	var values []string
+	for c := 0; c < 1000; c++ {
+		keys = append(keys, fmt.Sprintf("%d-key", c))
+		values = append(values, fmt.Sprintf("%d-value", c))
+	}
+
+	for c := 0; c < 1000; c++ {
+		m[keys[c]] = values[c]
+	}
+
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for c := 0; c < 1000; c++ {
+			_ = m[keys[c]]
+			i++
+		}
+	}
+
+	fmt.Printf("iterations: %d\n", i)
+}
+
+/*
+BenchmarkOrderedMapGet
+iterations: 1000
+iterations: 100000
+iterations: 10000000
+iterations: 139746000
+BenchmarkOrderedMapGet-16    	  139746	      8157 ns/op
+*/
+func BenchmarkOrderedMapGet(b *testing.B) {
+
+	m := orderedmap.New[string, string]()
+
+	var keys []string
+	var values []string
+	for c := 0; c < 1000; c++ {
+		keys = append(keys, fmt.Sprintf("%d-key", c))
+		values = append(values, fmt.Sprintf("%d-value", c))
+	}
+
+	for c := 0; c < 1000; c++ {
+		m.Set(keys[c], values[c])
+	}
+
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for c := 0; c < 1000; c++ {
+			_, _ = m.Get(keys[c])
+			i++
+		}
+	}
+
+	fmt.Printf("iterations: %d\n", i)
+}
+
+/*
+BenchmarkMapDelete
+length: 0
+length: 0
+length: 0
+length: 0
+BenchmarkMapDelete-16    	  651661	      1799 ns/op
+*/
+func BenchmarkMapDelete(b *testing.B) {
+
+	m := make(map[string]string)
+
+	var keys []string
+	var values []string
+	for c := 0; c < 1000; c++ {
+		keys = append(keys, fmt.Sprintf("%d-key", c))
+		values = append(values, fmt.Sprintf("%d-value", c))
+	}
+
+	for c := 0; c < 1000; c++ {
+		m[keys[c]] = values[c]
+	}
+
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for c := 999; c >= 0; c-- {
+			delete(m, keys[c])
+			i++
+		}
+	}
+
+	fmt.Printf("length: %d\n", len(m))
+}
+
+/*
+BenchmarkOrderedMapDelete
+length: 0
+length: 0
+length: 0
+length: 0
+BenchmarkOrderedMapDelete-16    	  577935	      2049 ns/op
+*/
+func BenchmarkOrderedMapDelete(b *testing.B) {
+
+	m := orderedmap.New[string, string]()
+
+	var keys []string
+	var values []string
+	for c := 0; c < 1000; c++ {
+		keys = append(keys, fmt.Sprintf("%d-key", c))
+		values = append(values, fmt.Sprintf("%d-value", c))
+	}
+
+	for c := 0; c < 1000; c++ {
+		m.Set(keys[c], values[c])
+	}
+
+	b.ResetTimer()
+
+	i := 0
+	for n := 0; n < b.N; n++ {
+		for c := 999; c >= 0; c-- {
+			_, _ = m.Delete(keys[c])
+			i++
+		}
+	}
+
+	fmt.Printf("length: %d\n", m.Len())
+}


### PR DESCRIPTION
Experiment to gauge the impact of using an a generics based ordered map instead of the built in map to try and reduce the number of occurrences of non-deterministic event ordering.   This may not solve all ordering issues, but maybe its the braces of a belt and braces approach, the belt being the current sorts peppered in the code.

Syntactically it works well, theres is little to no inconvenience (arguagly iteration is a bit more verbose).

Performance wise (see the `temp_ordered_map_benchmarks_test`), it performs surprisingly well,  iteration, of all things seems to be quicker(!) - unless there is some issue with the benchmark test, I can't see it.
