### PR TITLE
fix: only download the minimum block count when loading from history

### DIFF
--- a/datanode/networkhistory/initialise.go
+++ b/datanode/networkhistory/initialise.go
@@ -64,7 +64,11 @@ func InitialiseDatanodeFromNetworkHistory(ctx context.Context, cfg Initializatio
 
 				blocksToFetch = mostRecentHistorySegment.ToHeight - currentSpan.ToHeight
 			} else {
-				blocksToFetch = -1
+				// check if goes < 0
+				blocksToFetch = cfg.MinimumBlockCount
+				if mostRecentHistorySegment.ToHeight-cfg.MinimumBlockCount < 0 {
+					blocksToFetch = -1
+				}
 			}
 
 			err = loadSegments(ctxWithTimeout, log, connCfg, networkHistoryService, currentSpan,


### PR DESCRIPTION
When loading network history from the tip of the chain, and there's no currentSpan from the database, then we can download up to N segment to the tip of the chain as setup in the configuration.