### PR TITLE
feat: optionally print out last block in tendermint block store in sn…

### DIFF
--- a/cmd/vegatools/snapshot.go
+++ b/cmd/vegatools/snapshot.go
@@ -8,13 +8,35 @@ import (
 	"code.vegaprotocol.io/vega/core/config"
 	"code.vegaprotocol.io/vega/paths"
 	"code.vegaprotocol.io/vega/vegatools/snapshotdb"
+
+	"github.com/spf13/viper"
+	tmconfig "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/node"
+	"github.com/tendermint/tendermint/store"
 )
 
 type snapshotCmd struct {
 	config.OutputFlag
-	DBPath               string `description:"path to snapshot state data"                           long:"db-path"           short:"d"`
-	SnapshotContentsPath string `description:"path to file where to write the content of a snapshot" long:"snapshot-contents" short:"c"`
-	BlockHeight          uint64 `description:"block-height of requested snapshot"                    long:"block-height"      short:"b"`
+	DBPath               string `description:"path to snapshot state data"                                                  long:"db-path"           short:"d"`
+	SnapshotContentsPath string `description:"path to file where to write the content of a snapshot"                        long:"snapshot-contents" short:"c"`
+	BlockHeight          uint64 `description:"block-height of requested snapshot"                                           long:"block-height"      short:"b"`
+	TendermintHome       string `description:"tendermint home directory, if set will print the last processed block height" long:"tendermint-home"`
+}
+
+func getLastProcessedBlock(homeDir string) (int64, error) {
+	conf := tmconfig.DefaultConfig()
+	if err := viper.Unmarshal(conf); err != nil {
+		return 0, err
+	}
+	conf.SetRoot(homeDir)
+
+	// lets get the last processed block from tendermint
+	blockStoreDB, err := node.DefaultDBProvider(&node.DBContext{ID: "blockstore", Config: conf})
+	if err != nil {
+		return 0, err
+	}
+	blockStore := store.NewBlockStore(blockStoreDB)
+	return blockStore.Height(), nil
 }
 
 func (opts *snapshotCmd) Execute(_ []string) error {
@@ -42,13 +64,23 @@ func (opts *snapshotCmd) Execute(_ []string) error {
 	if err != nil {
 		return err
 	}
+
+	var lastProcessedBlock int64
+	if opts.TendermintHome != "" {
+		if lastProcessedBlock, err = getLastProcessedBlock(opts.TendermintHome); err != nil {
+			return err
+		}
+	}
+
 	if opts.Output.IsJSON() {
 		o := struct {
-			Snapshots []snapshotdb.Data `json:"snapshots"`
-			Invalid   []snapshotdb.Data `json:"invalidSnapshots,omitempty"`
+			Snapshots          []snapshotdb.Data `json:"snapshots"`
+			Invalid            []snapshotdb.Data `json:"invalidSnapshots,omitempty"`
+			LastProcessedBlock int64             `json:"lastProcessedBlock,omitempty"`
 		}{
-			Snapshots: snapshots,
-			Invalid:   invalid,
+			Snapshots:          snapshots,
+			Invalid:            invalid,
+			LastProcessedBlock: lastProcessedBlock,
 		}
 		b, err := json.Marshal(o)
 		if err != nil {
@@ -58,7 +90,11 @@ func (opts *snapshotCmd) Execute(_ []string) error {
 		return nil
 	}
 
-	fmt.Println("Snapshots available:", len(snapshots))
+	if lastProcessedBlock != 0 {
+		fmt.Printf("\nLast processed block: %d\n", lastProcessedBlock)
+	}
+
+	fmt.Println("\nSnapshots available:", len(snapshots))
 	for _, snap := range snapshots {
 		fmt.Printf("\tHeight: %d, Version: %d, Size %d, Hash: %s\n", snap.Height, snap.Version, snap.Size, snap.Hash)
 	}
@@ -66,10 +102,10 @@ func (opts *snapshotCmd) Execute(_ []string) error {
 	if len(invalid) == 0 {
 		return nil
 	}
-
 	fmt.Println("Invalid snapshots:", len(invalid))
 	for _, snap := range invalid {
 		fmt.Printf("\tVersion: %d, Size %d, Hash: %s\n", snap.Version, snap.Size, snap.Hash)
 	}
+
 	return nil
 }


### PR DESCRIPTION
relating to https://github.com/vegaprotocol/system-tests/issues/2621

The snapshot soak test script needs a way to know when its replayed to the end of the chain data it has _locally_ to know when to stop the vega processes (otherwise it stays alive trying to connect to the old network that no longer exists).

To do this I've added an option to `vega tools snapshot` that will read the from the tendermint block store and print out the last block-height processed.

Open for suggestions if there is a better idea for how to do this, or if a tool already exists to get the last processed block height.