### PR TITLE
fix: collateral engine snapshot fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,7 @@
 - [8727](https://github.com/vegaprotocol/vega/issues/8727) - Clear parent market on checkpoint restore if the parent market was already succeeded.
 - [8835](https://github.com/vegaprotocol/vega/issues/8835) - Spot snapshot fixes
 - [9651](https://github.com/vegaprotocol/vega/issues/9651) - Park pegged orders if they lose their peg
+- [9666]()(https://github.com/vegaprotocol/vega/issues/9666) - Fix balance cache refresh snapshot issue
 
 ## 0.72.0
 

--- a/core/collateral/engine.go
+++ b/core/collateral/engine.go
@@ -181,6 +181,9 @@ func (e *Engine) snapshotBalances() {
 	m := make(map[string]*num.Uint, len(e.partiesAccs))
 	quantums := map[string]*num.Uint{}
 	for k, v := range e.partiesAccs {
+		if k == "*" {
+			continue
+		}
 		total := num.UintZero()
 		for _, a := range v {
 			asset := a.Asset
@@ -206,6 +209,7 @@ func (e *Engine) updateNextBalanceSnapshot(t time.Time) {
 func (e *Engine) OnBalanceSnapshotFrequencyUpdated(ctx context.Context, d time.Duration) error {
 	if e.activeRestore {
 		e.balanceSnapshotFrequency = d
+		e.activeRestore = false
 		return nil
 	}
 	if !e.nextBalancesSnapshot.IsZero() {

--- a/core/collateral/snapshot.go
+++ b/core/collateral/snapshot.go
@@ -113,11 +113,6 @@ func (e *Engine) restoreAccounts(ctx context.Context, accs *types.CollateralAcco
 	return err
 }
 
-func (e *Engine) PostRestore(ctx context.Context) error {
-	e.activeRestore = false
-	return nil
-}
-
 func (e *Engine) getOrCreateNetTreasuryAndGlobalInsForAssets(ctx context.Context, assets map[string]struct{}) {
 	// bit of migration - ensure that the network treasury and global insurance account are created for all assets
 	assetStr := make([]string, 0, len(assets))


### PR DESCRIPTION
Closes #9666 

Not really closing 9666 because 9666 is not an issue but it exposed some bug in the snapshot and some unnecessary caching of balances for network party which are fixed by this PR. 