### PR TITLE
fix: join tx_results table to get the actual block height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,7 @@
 - [9280](https://github.com/vegaprotocol/vega/issues/9280) - Fix block height off by one issue.
 - [9658](https://github.com/vegaprotocol/vega/issues/9658) - Fix `updateVolumeDiscountProgram` GraphQL resolver.
 - [9672](https://github.com/vegaprotocol/vega/issues/9672) - Fix margin being non-zero on `PERPS`, add tests to ensure distressed parties are handled correctly
+- [9280](https://github.com/vegaprotocol/vega/issues/9280) - Get block height directly from `blocks` table.
 
 ## 0.72.1
 

--- a/blockexplorer/entities/transaction.go
+++ b/blockexplorer/entities/transaction.go
@@ -63,7 +63,7 @@ func (t *TxResultRow) ToProto() (*pb.Transaction, error) {
 	}
 
 	return &pb.Transaction{
-		Block:     uint64(t.BlockID) - 1, // subtract 1, block_id is rowid (BIGSERIAL), which starts at 1. Block height starts at 0
+		Block:     uint64(t.BlockID),
 		Index:     uint32(t.Index),
 		Type:      extractAttribute(&txResult, "command", "type"),
 		Submitter: extractAttribute(&txResult, "tx", "submitter"),
@@ -78,7 +78,7 @@ func (t *TxResultRow) ToProto() (*pb.Transaction, error) {
 
 func (t *TxResultRow) Cursor() TxCursor {
 	return TxCursor{
-		BlockNumber: uint64(t.BlockID) - 1,
+		BlockNumber: uint64(t.BlockID),
 		TxIndex:     uint32(t.Index),
 	}
 }
@@ -118,7 +118,7 @@ func TxCursorFromString(s string) (TxCursor, error) {
 	}
 
 	return TxCursor{
-		BlockNumber: blockNumber + 1, // increase by one again to make the behaviour consistent
+		BlockNumber: blockNumber, // increase by one again to make the behaviour consistent
 		TxIndex:     uint32(txIndex),
 	}, nil
 }

--- a/blockexplorer/store/transactions_test.go
+++ b/blockexplorer/store/transactions_test.go
@@ -135,6 +135,7 @@ func addTestTxResults(ctx context.Context, t *testing.T, txResults ...txResult) 
 		err := conn.QueryRow(ctx, resultSQL, blockID, txr.index, txr.createdAt, txr.txHash, txr.txResult, txr.submitter, txr.cmdType).Scan(&rowID)
 		require.NoError(t, err)
 		row.RowID = rowID
+		row.BlockID = txr.height
 
 		proto, err := row.ToProto()
 		require.NoError(t, err)
@@ -280,7 +281,7 @@ func TestStore_ListTransactions(t *testing.T) {
 
 	t.Run("should return the transactions after the cursor when first is set", func(t *testing.T) {
 		first := entities.TxCursor{
-			BlockNumber: 6,
+			BlockNumber: 5,
 			TxIndex:     1,
 		}
 		got, err := s.ListTransactions(ctx, nil, nil, nil, nil, 2, &first, 0, nil)
@@ -296,7 +297,7 @@ func TestStore_ListTransactions(t *testing.T) {
 		}
 		got, err := s.ListTransactions(ctx, nil, nil, nil, nil, 2, &first, 0, nil)
 		require.NoError(t, err)
-		want := []*pb.Transaction{inserted[1], inserted[0]}
+		want := []*pb.Transaction{inserted[2], inserted[1]}
 		assert.Equal(t, want, got)
 	})
 }


### PR DESCRIPTION
Closes #9280 - Use join to get the actual block height.