### PR TITLE
fix: distribute rewards amongst teams pro-rata by multipliers

### DIFF
--- a/core/integration/features/rewards/team-rewards.feature
+++ b/core/integration/features/rewards/team-rewards.feature
@@ -75,21 +75,20 @@ Feature: Team Rewards
   Scenario: Party funds pool with recurring transfer scoping teams
 
     Given the parties submit the following recurring transfers:
-      | id | from                                                             | from_account_type    | to                                                               | to_account_type                     | entity_scope | teams | ntop | asset    | amount | start_epoch | end_epoch | factor | metric                          | metric_asset | markets      |
-      | 1  | a3c024b4e23230c89884a54a813b1ecb4cb0f827a38641c66eeca466da6b2ddf | ACCOUNT_TYPE_GENERAL | 0000000000000000000000000000000000000000000000000000000000000000 | ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES | TEAMS        |       | 1    | USD-1-10 | 10000  | 1           |           | 1      | DISPATCH_METRIC_MAKER_FEES_PAID | USD-1-10     | ETH/USD-1-10 |
+      | id | from                                                             | from_account_type    | to                                                               | to_account_type                     | entity_scope | teams       | ntop | asset    | amount | start_epoch | end_epoch | factor | metric                          | metric_asset | markets      |
+      | 1  | a3c024b4e23230c89884a54a813b1ecb4cb0f827a38641c66eeca466da6b2ddf | ACCOUNT_TYPE_GENERAL | 0000000000000000000000000000000000000000000000000000000000000000 | ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES | TEAMS        | team1,team2 | 1    | USD-1-10 | 10000  | 1           |           | 1      | DISPATCH_METRIC_MAKER_FEES_PAID | USD-1-10     | ETH/USD-1-10 |
     And the parties place the following orders:
       | party    | market id    | side | volume | price | resulting trades | type       | tif     |
       | aux1     | ETH/USD-1-10 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | referee1 | ETH/USD-1-10 | buy  | 10     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
-      | aux1     | ETH/USD-1-10 | sell | 9      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | referee2 | ETH/USD-1-10 | buy  | 9      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
-      | aux1     | ETH/USD-1-10 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | referee3 | ETH/USD-1-10 | buy  | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+      | aux1     | ETH/USD-1-10 | sell | 15     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | referee2 | ETH/USD-1-10 | buy  | 15     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+      | aux1     | ETH/USD-1-10 | sell | 5      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | referee3 | ETH/USD-1-10 | buy  | 5      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
     When the network moves ahead "1" epochs
-    Then debug transfers
     Then "referee1" should have vesting account balance of "5000" for asset "USD-1-10"
-    Then "referee2" should have vesting account balance of "4500" for asset "USD-1-10"
-    Then "referee3" should have vesting account balance of "500" for asset "USD-1-10"
+    And "referee2" should have vesting account balance of "2500" for asset "USD-1-10"
+    And "referee3" should have vesting account balance of "2500" for asset "USD-1-10"
 
 
 

--- a/core/integration/features/rewards/team-rewards.feature
+++ b/core/integration/features/rewards/team-rewards.feature
@@ -1,0 +1,99 @@
+Feature: Team Rewards
+
+  Background:
+
+    # Initialise the network
+    Given time is updated to "2023-01-01T00:00:00Z"
+    And the average block duration is "1"
+    And the following network parameters are set:
+      | name                                    | value |
+      | market.fee.factors.makerFee             | 0.001 |
+      | network.markPriceUpdateMaximumFrequency | 0s    |
+      | market.auction.minimumDuration          | 1     |
+      | validators.epoch.length                 | 60s   |
+      | limits.markets.maxPeggedOrders          | 4     |
+      | referralProgram.minStakedVegaTokens     | 0     |
+
+    # Initialise the markets
+    And the following assets are registered:
+      | id       | decimal places | quantum |
+      | USD-1-10 | 1              | 10      |
+    And the markets:
+      | id           | quote name | asset    | risk model                    | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params      | decimal places | position decimal places |
+      | ETH/USD-1-10 | ETH        | USD-1-10 | default-log-normal-risk-model | default-margin-calculator | 1                | default-none | default-none     | default-eth-for-future | 1e-3                   | 0                         | default-futures | 0              | 0                       |
+
+    # Initialise the parties
+    Given the parties deposit on asset's general account the following amount:
+      | party                                                            | asset    | amount      |
+      | lpprov                                                           | USD-1-10 | 10000000000 |
+      | aux1                                                             | USD-1-10 | 10000000    |
+      | aux2                                                             | USD-1-10 | 10000000    |
+      | referrer1                                                        | USD-1-10 | 10000000    |
+      | referee1                                                         | USD-1-10 | 10000000    |
+      | referee2                                                         | USD-1-10 | 10000000    |
+      | referee3                                                         | USD-1-10 | 10000000    |
+      | a3c024b4e23230c89884a54a813b1ecb4cb0f827a38641c66eeca466da6b2ddf | USD-1-10 | 10000000    |
+
+    # Exit opening auctions
+    Given the parties submit the following liquidity provision:
+      | id  | party  | market id    | commitment amount | fee  | lp type    |
+      | lp1 | lpprov | ETH/USD-1-10 | 1000000           | 0.01 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party  | market id    | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lpprov | ETH/USD-1-10 | 5000      | 1000                 | buy  | BID              | 10000  | 1      |
+      | lpprov | ETH/USD-1-10 | 5000      | 1000                 | sell | ASK              | 10000  | 1      |
+    When the parties place the following orders:
+      | party | market id    | side | volume | price | resulting trades | type       | tif     |
+      | aux1  | ETH/USD-1-10 | buy  | 1      | 990   | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux1  | ETH/USD-1-10 | buy  | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/USD-1-10 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | aux2  | ETH/USD-1-10 | sell | 1      | 1100  | 0                | TYPE_LIMIT | TIF_GTC |
+    And the opening auction period ends for market "ETH/USD-1-10"
+    When the network moves ahead "1" blocks
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/USD-1-10"
+
+    # Create the teams
+    Given the parties create the following referral codes:
+      | party     | code            | is_team | team  |
+      | referrer1 | referral-code-1 | true    | team1 |
+      | referrer2 | referral-code-2 | true    | team2 |
+    And the parties apply the following referral codes:
+      | party    | code            | is_team | team  |
+      | referee1 | referral-code-1 | true    | team1 |
+      | referee2 | referral-code-2 | true    | team2 |
+      | referee3 | referral-code-2 | true    | team2 |
+    And the team "team1" has the following members:
+      | party     |
+      | referrer1 |
+      | referee1  |
+    And the team "team2" has the following members:
+      | party     |
+      | referrer2 |
+      | referee2  |
+      | referee3  |
+
+  Scenario: Party funds pool with recurring transfer scoping teams
+
+    Given the parties submit the following recurring transfers:
+      | id | from                                                             | from_account_type    | to                                                               | to_account_type                     | entity_scope | teams | ntop | asset    | amount | start_epoch | end_epoch | factor | metric                          | metric_asset | markets      |
+      | 1  | a3c024b4e23230c89884a54a813b1ecb4cb0f827a38641c66eeca466da6b2ddf | ACCOUNT_TYPE_GENERAL | 0000000000000000000000000000000000000000000000000000000000000000 | ACCOUNT_TYPE_REWARD_MAKER_PAID_FEES | TEAMS        |       | 1    | USD-1-10 | 10000  | 1           |           | 1      | DISPATCH_METRIC_MAKER_FEES_PAID | USD-1-10     | ETH/USD-1-10 |
+    And the parties place the following orders:
+      | party    | market id    | side | volume | price | resulting trades | type       | tif     |
+      | aux1     | ETH/USD-1-10 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | referee1 | ETH/USD-1-10 | buy  | 10     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+      | aux1     | ETH/USD-1-10 | sell | 9      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | referee2 | ETH/USD-1-10 | buy  | 9      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+      | aux1     | ETH/USD-1-10 | sell | 1      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | referee3 | ETH/USD-1-10 | buy  | 1      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+    When the network moves ahead "1" epochs
+    Then debug transfers
+    Then "referee1" should have vesting account balance of "5000" for asset "USD-1-10"
+    Then "referee2" should have vesting account balance of "4500" for asset "USD-1-10"
+    Then "referee3" should have vesting account balance of "500" for asset "USD-1-10"
+
+
+
+
+
+
+

--- a/core/integration/features/rewards/team-rewards.feature
+++ b/core/integration/features/rewards/team-rewards.feature
@@ -81,8 +81,8 @@ Feature: Team Rewards
       | party    | market id    | side | volume | price | resulting trades | type       | tif     |
       | aux1     | ETH/USD-1-10 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | referee1 | ETH/USD-1-10 | buy  | 10     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
-      | aux1     | ETH/USD-1-10 | sell | 15     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
-      | referee2 | ETH/USD-1-10 | buy  | 15     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
+      | aux1     | ETH/USD-1-10 | sell | 10     | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
+      | referee2 | ETH/USD-1-10 | buy  | 10     | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
       | aux1     | ETH/USD-1-10 | sell | 5      | 1000  | 0                | TYPE_LIMIT | TIF_GTC |
       | referee3 | ETH/USD-1-10 | buy  | 5      | 1000  | 1                | TYPE_LIMIT | TIF_GTC |
     When the network moves ahead "1" epochs

--- a/core/integration/setup_test.go
+++ b/core/integration/setup_test.go
@@ -172,6 +172,8 @@ func newExecutionTestSetup() *executionTestSetup {
 	execsetup.stakingAccount = stubs.NewStakingAccountStub()
 	execsetup.epochEngine.NotifyOnEpoch(execsetup.stakingAccount.OnEpochEvent, execsetup.stakingAccount.OnEpochRestore)
 
+	execsetup.teamsEngine = teams.NewEngine(execsetup.epochEngine, execsetup.broker, execsetup.timeService)
+
 	execsetup.stateVarEngine = stubs.NewStateVar()
 	marketActivityTracker := common.NewMarketActivityTracker(execsetup.log, execsetup.epochEngine, execsetup.teamsEngine, execsetup.stakingAccount)
 
@@ -217,8 +219,6 @@ func newExecutionTestSetup() *executionTestSetup {
 	execsetup.epochEngine.NotifyOnEpoch(execsetup.vesting.OnEpochEvent, execsetup.vesting.OnEpochRestore)
 
 	execsetup.registerTimeServiceCallbacks()
-
-	execsetup.teamsEngine = teams.NewEngine(execsetup.epochEngine, execsetup.broker, execsetup.timeService)
 
 	if err := execsetup.registerNetParamsCallbacks(); err != nil {
 		panic(fmt.Errorf("failed to register network parameters: %w", err))

--- a/core/rewards/contribution_reward_calculator.go
+++ b/core/rewards/contribution_reward_calculator.go
@@ -114,9 +114,8 @@ func calcPartyInTeamRewardShare(teamScore *types.PartyContributionScore, partyTo
 		if factor, ok := rewardFactors[pcs.Party]; ok {
 			rewardFactor = factor
 		}
-		score := rewardFactor.Mul(pcs.Score)
-		ps = append(ps, &types.PartyContributionScore{Party: pcs.Party, Score: score})
-		totalScores = totalScores.Add(score)
+		ps = append(ps, &types.PartyContributionScore{Party: pcs.Party, Score: rewardFactor})
+		totalScores = totalScores.Add(rewardFactor)
 	}
 	if totalScores.IsZero() {
 		return []*types.PartyContributionScore{}

--- a/core/rewards/contribution_reward_calculator_test.go
+++ b/core/rewards/contribution_reward_calculator_test.go
@@ -130,7 +130,7 @@ func TestCalculateRewardsByContributionTeamsRank(t *testing.T) {
 		"t5": t5PartyContribution,
 	}
 
-	rewardMultipliers := map[string]num.Decimal{"p11": num.DecimalFromFloat(2.5), "p12": num.DecimalFromFloat(3), "p22": num.DecimalFromFloat(1.5), "p32": num.DecimalFromInt64(4), "p41": num.DecimalFromFloat(2.5), "p51": num.DecimalFromInt64(6)}
+	rewardMultipliers := map[string]num.Decimal{"p11": num.DecimalFromFloat(2), "p12": num.DecimalFromFloat(3), "p22": num.DecimalFromFloat(1.5), "p32": num.DecimalFromInt64(4), "p41": num.DecimalFromFloat(2.5), "p51": num.DecimalFromInt64(6)}
 
 	now := time.Now()
 	ds := &vega.DispatchStrategy{
@@ -148,19 +148,19 @@ func TestCalculateRewardsByContributionTeamsRank(t *testing.T) {
 	// t2: 0.2
 	// t4: 0.4
 
-	// p11 = 0.2 * 2.5 = 0.5
-	// p12 = 0.5 * 3 = 1.5
+	// r11 = 2
+	// r12 = 3
 	// =====================
-	// s11 = 0.4 * 0.25 = 0.1 * 10000 = 1000
-	// s12 = 0.4 * 0.75 = 0.3 * 10000 = 3000
+	// s11 = 0.4 * 0.4 = 0.24 * 10000 = 1600
+	// s12 = 0.4 * 0.6 = 0.16 * 10000 = 2400
 
-	// p21 = 0.05 = 0.05
-	// p22 = 0.3 * 1.5 = 0.45
+	// r21 = 1
+	// r22 = 1.5
 	// =====================
-	// s21 = 0.2 * 0.1 = 0.02 * 10000 = 200
-	// s22 = 0.2 * 0.9 = 0.18 * 10000 = 1800
+	// s21 = 0.2 * 0.4 = 0.08 * 10000 = 800
+	// s22 = 0.2 * 0.6 = 0.12 * 10000 = 1200
 
-	// p41 = 0.2 = 0.2
+	// p41 = 1
 	// =====================
 	// s41 = 0.4 * 10000 = 4000
 	require.Equal(t, "asset", po.asset)
@@ -168,10 +168,10 @@ func TestCalculateRewardsByContributionTeamsRank(t *testing.T) {
 	require.Equal(t, "accountID", po.fromAccount)
 	require.Equal(t, uint64(2), po.lockedForEpochs)
 	require.Equal(t, now.Unix(), po.timestamp)
-	require.Equal(t, "1000", po.partyToAmount["p11"].String())
-	require.Equal(t, "3000", po.partyToAmount["p12"].String())
-	require.Equal(t, "200", po.partyToAmount["p21"].String())
-	require.Equal(t, "1800", po.partyToAmount["p22"].String())
+	require.Equal(t, "1600", po.partyToAmount["p11"].String())
+	require.Equal(t, "2400", po.partyToAmount["p12"].String())
+	require.Equal(t, "800", po.partyToAmount["p21"].String())
+	require.Equal(t, "1200", po.partyToAmount["p22"].String())
 	require.Equal(t, "4000", po.partyToAmount["p41"].String())
 	require.Equal(t, "10000", po.totalReward.String())
 }
@@ -216,7 +216,7 @@ func TestCalculateRewardsByContributionTeamsProRata(t *testing.T) {
 		"t5": t5PartyContribution,
 	}
 
-	rewardMultipliers := map[string]num.Decimal{"p11": num.DecimalFromFloat(2.5), "p12": num.DecimalFromFloat(3), "p22": num.DecimalFromFloat(1.5), "p32": num.DecimalFromInt64(4), "p41": num.DecimalFromFloat(2.5), "p51": num.DecimalFromInt64(6)}
+	rewardMultipliers := map[string]num.Decimal{"p11": num.DecimalFromFloat(2), "p12": num.DecimalFromFloat(3), "p22": num.DecimalFromFloat(1.5), "p32": num.DecimalFromInt64(3), "p41": num.DecimalFromFloat(2.5), "p51": num.DecimalFromInt64(7)}
 
 	now := time.Now()
 	ds := &vega.DispatchStrategy{
@@ -232,50 +232,50 @@ func TestCalculateRewardsByContributionTeamsProRata(t *testing.T) {
 	// t4: 0.6/2 = 0.3
 	// t5: 0.2/2 = 0.1
 
-	// p11 = 0.2 * 2.5 = 0.5
-	// p12 = 0.5 * 3 = 1.5
+	// r11 = 2 = 0.4
+	// r12 = 3 = 0.6
 	// =====================
-	// s11 = 0.3 * 0.25 = 0.075 * 10000 = 750
-	// s12 = 0.3 * 0.75 = 0.225 * 10000 = 2250
+	// s11 = 0.3 * 0.4 = 0.12 * 10000 = 1200
+	// s12 = 0.3 * 0.6 = 0.18 * 10000 = 1800
 
-	// p21 = 0.05 = 0.05
-	// p22 = 0.3 * 1.5 = 0.45
+	// r21 = 1
+	// r22 = 1.5
 	// =====================
-	// s21 = 0.25 * 0.1 = 0.025 * 10000 = 250
-	// s22 = 0.25 * 0.9 = 0.225 * 10000 = 2250
+	// s21 = 0.25 * 0.4 = 0.1 * 10000 = 1000
+	// s22 = 0.25 * 0.5 = 0.15 * 10000 = 1500
 
-	// p31 = 0.2 = 0.2
-	// p32 = 0.3 * 4 = 1.2
-	// p33 = 0.6 = 0.6
+	// r31 = 1
+	// r32 = 3
+	// r33 = 1
 	// =====================
-	// s31 = 0.05 * 0.1 = 0.005 * 10000 = 50
+	// s31 = 0.05 * 0.2 = 0.01 * 10000 = 100
 	// s32 = 0.05 * 0.6 = 0.03 * 10000 = 300
-	// s32 = 0.05 * 0.3 = 0.015 * 10000 = 150
+	// s32 = 0.05 * 0.2 = 0.01 * 10000 = 100
 
-	// p41 = 0.2 = 0.2
+	// r41 = 2.5
 	// =====================
 	// s41 = 0.3 * 10000 = 3000
 
-	// p51 = 0.2 * 6 = 1.2
-	// p52 = 0.8
+	// r51 = 6
+	// r52 = 1
 	// =====================
-	// s51 = 0.1 * 0.6 = 0.06 * 10000 = 600
-	// s52 = 0.1 * 0.4 = 0.04 * 10000 = 400
+	// s51 = 0.1 * 0.875 = 0.0875 * 10000 = 875
+	// s52 = 0.1 * 0.125 = 0.0125 * 10000 = 125
 
 	require.Equal(t, "asset", po.asset)
 	require.Equal(t, "1", po.epochSeq)
 	require.Equal(t, "accountID", po.fromAccount)
 	require.Equal(t, uint64(2), po.lockedForEpochs)
 	require.Equal(t, now.Unix(), po.timestamp)
-	require.Equal(t, "750", po.partyToAmount["p11"].String())
-	require.Equal(t, "2250", po.partyToAmount["p12"].String())
-	require.Equal(t, "250", po.partyToAmount["p21"].String())
-	require.Equal(t, "2250", po.partyToAmount["p22"].String())
-	require.Equal(t, "50", po.partyToAmount["p31"].String())
+	require.Equal(t, "1200", po.partyToAmount["p11"].String())
+	require.Equal(t, "1800", po.partyToAmount["p12"].String())
+	require.Equal(t, "1000", po.partyToAmount["p21"].String())
+	require.Equal(t, "1500", po.partyToAmount["p22"].String())
+	require.Equal(t, "100", po.partyToAmount["p31"].String())
 	require.Equal(t, "300", po.partyToAmount["p32"].String())
-	require.Equal(t, "150", po.partyToAmount["p33"].String())
+	require.Equal(t, "100", po.partyToAmount["p33"].String())
 	require.Equal(t, "3000", po.partyToAmount["p41"].String())
-	require.Equal(t, "600", po.partyToAmount["p51"].String())
-	require.Equal(t, "400", po.partyToAmount["p52"].String())
+	require.Equal(t, "875", po.partyToAmount["p51"].String())
+	require.Equal(t, "125", po.partyToAmount["p52"].String())
 	require.Equal(t, "10000", po.totalReward.String())
 }

--- a/core/teams/engine.go
+++ b/core/teams/engine.go
@@ -197,6 +197,9 @@ func (e *Engine) GetAllPartiesInTeams(minEpochsInTeam uint64) []string {
 
 func (e *Engine) GetTeamMembers(team string, minEpochsInTeam uint64) []string {
 	t := e.teams[(types.TeamID(team))]
+	if t == nil {
+		return []string{}
+	}
 	teamMembers := make([]string, 0, len(t.Referees)+1)
 	for _, m := range t.Referees {
 		if m.StartedAtEpoch-e.currentEpoch >= minEpochsInTeam {


### PR DESCRIPTION
Spec [0056](https://github.com/vegaprotocol/specs/blob/cosmicelevator/protocol/0056-REWA-rewards_overview.md#0056-REWA-107) states rewards allocated to a team should be distributed pro-rata by each team members reward multiplier.

The parties performance (providing they have a non-zero score) should have no impact on the share of the rewards allocated to their team.