### PR TITLE
chore: sort votes with party ID instead of timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - [8857](https://github.com/vegaprotocol/vega/issues/8857) - Add a step for getting the balance of the liquidity provider liquidity fee account
 - [8847](https://github.com/vegaprotocol/vega/issues/8847) - Implement internal time trigger data source.
 - [8895](https://github.com/vegaprotocol/vega/issues/8895) - Allow to set runtime parameters in the SQL Store connection structure
-- [9678](https://github.com/vegaprotocol/vega/issues/9678) - Cache and forward referral rewards multiplier and factor multiplier 
+- [9678](https://github.com/vegaprotocol/vega/issues/9678) - Cache and forward referral rewards multiplier and factor multiplier
 - [8779](https://github.com/vegaprotocol/vega/issues/8779) - Query all details of liquidity providers via an API.
 - [8924](https://github.com/vegaprotocol/vega/issues/8924) - Refactor slightly to remove need to deep clone `proto` types
 - [8782](https://github.com/vegaprotocol/vega/issues/8782) - List all active liquidity providers for a market via API.
@@ -276,6 +276,7 @@
 - [9693](https://github.com/vegaprotocol/vega/issues/9693) - Add missing validation for general account public key in governance transfer
 - [9691](https://github.com/vegaprotocol/vega/issues/9691) - Refactor referral engine snapshot
 - [8570](https://github.com/vegaprotocol/vega/issues/8570) - Ensure pagination doesn't trigger a sequential scan on block-explorer transactions table.
+- [9705](https://github.com/vegaprotocol/vega/issues/9705) - Ensure vote events are sent in the same order.
 
 ## 0.72.1
 

--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -1121,7 +1121,7 @@ func newUpdatedProposalEvents(ctx context.Context, proposal *proposal) []events.
 	}
 
 	sort.SliceStable(votes, func(i, j int) bool {
-		return votes[i].Proto().Timestamp < votes[j].Proto().Timestamp
+		return votes[i].PartyID() < votes[j].PartyID()
 	})
 
 	evts := make([]events.Event, 0, len(votes))


### PR DESCRIPTION
Events for governances votes are updated and sent at the end of a proposal. but ordered by Timestamps. However the timestamps is from the block of submission, which could be the same in case multiples votes have been submitted in the same block.

close #9705  