### PR TITLE
feat: move tool for parsing events into json into

### DIFF
--- a/cmd/vegatools/events.go
+++ b/cmd/vegatools/events.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2023 Gobalsky Labs Limited
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tools
+
+import (
+	"errors"
+
+	"code.vegaprotocol.io/vega/vegatools/events"
+)
+
+type eventsCmd struct {
+	OutputFile string `description:"file to write json events to"  long:"out"    short:"o"`
+	EventsFile string `description:"event file to parse into json" long:"events" short:"e"`
+}
+
+func (opts *eventsCmd) Execute(_ []string) error {
+	if opts.OutputFile == "" {
+		return errors.New("--out must be specified")
+	}
+	if opts.EventsFile == "" {
+		return errors.New("--events must be specified")
+	}
+	return events.Run(opts.EventsFile, opts.OutputFile)
+}

--- a/cmd/vegatools/root.go
+++ b/cmd/vegatools/root.go
@@ -32,6 +32,7 @@ type RootCmd struct {
 	Checkpoint checkpointCmd `command:"checkpoint" description:"Make checkpoint human-readable, or generate checkpoint from human readable format"`
 	Stream     streamCmd     `command:"stream"     description:"Stream events from vega node"`
 	CheckTx    checkTxCmd    `command:"check-tx"   description:"Check an encoded transaction from a dependent app is unmarshalled and re-encoded back to the same encoded value. Checks data integrity"`
+	Events     eventsCmd     `command:"events"     description:"Parse event files written by a core node and write them in humna-readble form"`
 }
 
 var rootCmd RootCmd
@@ -42,6 +43,7 @@ func VegaTools(ctx context.Context, parser *flags.Parser) error {
 		Checkpoint: checkpointCmd{},
 		Stream:     streamCmd{},
 		CheckTx:    checkTxCmd{},
+		Events:     eventsCmd{},
 	}
 
 	var (

--- a/datanode/broker/buffer_files_event_source.go
+++ b/datanode/broker/buffer_files_event_source.go
@@ -115,7 +115,7 @@ func (e *bufferFileEventSource) sendAllRawEventsInFile(ctx context.Context, out 
 		case <-ctx.Done():
 			return nil
 		default:
-			rawEvent, _, read, err := readRawEvent(eventFile, offset)
+			rawEvent, _, read, err := ReadRawEvent(eventFile, offset)
 			if err != nil {
 				return fmt.Errorf("failed to read buffered event:%w", err)
 			}

--- a/datanode/broker/buffered_event_source.go
+++ b/datanode/broker/buffered_event_source.go
@@ -224,7 +224,7 @@ func (m *FileBufferedEventSource) readEventsFromBuffer(ctx context.Context, sink
 				}
 			}
 
-			event, bufferSeqNum, read, err := readRawEvent(bufferFile, offset)
+			event, bufferSeqNum, read, err := ReadRawEvent(bufferFile, offset)
 			if err != nil {
 				sinkErrorCh <- fmt.Errorf("error when reading event from buffer file:%w", err)
 				return
@@ -314,7 +314,7 @@ func (m *FileBufferedEventSource) moveBufferFileToArchive(bufferFilePath string)
 	return nil
 }
 
-func readRawEvent(eventFile *os.File, offset int64) (event []byte, seqNum uint64,
+func ReadRawEvent(eventFile *os.File, offset int64) (event []byte, seqNum uint64,
 	totalBytesRead uint32, err error,
 ) {
 	sizeBytes := make([]byte, broker.NumberOfSizeBytes)

--- a/vegatools/events/events.go
+++ b/vegatools/events/events.go
@@ -1,0 +1,106 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"code.vegaprotocol.io/vega/datanode/broker"
+	eventspb "code.vegaprotocol.io/vega/protos/vega/events/v1"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+)
+
+func Run(in, out string) error {
+	marshaler := jsonpb.Marshaler{
+		EnumsAsInts: true,
+		OrigName:    true,
+		Indent:      "   ",
+	}
+
+	fmt.Println("parsing event bytes from", in, "into json:", out)
+	f, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	eventFile, err := os.Open(in)
+	if err != nil {
+		return err
+	}
+	defer eventFile.Close()
+
+	ctx, cfunc := context.WithCancel(context.Background())
+	defer cfunc()
+
+	ch, ech := startFileRead(ctx, eventFile)
+
+	for {
+		select {
+		case e, ok := <-ch:
+			if e == nil && !ok {
+				return nil
+			}
+			es, err := marshaler.MarshalToString(e)
+			if err != nil {
+				return err
+			}
+			if _, err := f.WriteString(es + "\n"); err != nil {
+				return err
+			}
+		case err, ok := <-ech:
+			if err == nil && !ok {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func startFileRead(ctx context.Context, eventFile *os.File) (<-chan *eventspb.BusEvent, <-chan error) {
+	ch := make(chan *eventspb.BusEvent, 1)
+	ech := make(chan error, 1)
+	go func() {
+		defer func() {
+			eventFile.Close()
+			close(ch)
+			close(ech)
+		}()
+
+		var offset, nEvents int64
+		now := time.Now()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				rawEvent, _, read, err := broker.ReadRawEvent(eventFile, offset)
+				if err != nil {
+					ech <- fmt.Errorf("failed to read raw event: %w", err)
+					return
+				}
+
+				if read == 0 {
+					return
+				}
+
+				offset += int64(read)
+				busEvent := &eventspb.BusEvent{}
+				if err := proto.Unmarshal(rawEvent, busEvent); err != nil {
+					ech <- fmt.Errorf("failed to unmarshal bus event: %w", err)
+					return
+				}
+				ch <- busEvent
+				// if can be quite slow so lets print something out every now and again so it doesn't look like its frozen
+				nEvents++
+				if time.Since(now) > time.Second {
+					fmt.Println("events parsed so far:", nEvents)
+					now = time.Now()
+				}
+			}
+		}
+	}()
+	return ch, ech
+}


### PR DESCRIPTION
closes #9707 

Bringing this back from the dead and moving it into core: https://github.com/vegaprotocol/vegatools/pull/153

and adding some notes in a README about how to use it to debug issues when event-file differences appear on the CI.