### PR TITLE
fix: round(0) running volume in volume discount program

### DIFF
--- a/core/volumediscount/engine.go
+++ b/core/volumediscount/engine.go
@@ -201,7 +201,7 @@ func (e *Engine) computeFactorsByParty(ctx context.Context, epoch uint64) {
 				evt.Stats = append(evt.Stats, &eventspb.PartyVolumeDiscountStats{
 					PartyId:        party.String(),
 					DiscountFactor: tier.VolumeDiscountFactor.String(),
-					RunningVolume:  notionalVolume.String(),
+					RunningVolume:  notionalVolume.Round(0).String(),
 				})
 				break
 			}


### PR DESCRIPTION
Round 0 all running volume emitted in volume discount program stats