### PR TITLE
fix: check that an inscope market is for the asset before accepting a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@
 - [8364](https://github.com/vegaprotocol/vega/issues/8364) - Initialising from network history not working after database wipe
 - [8827](https://github.com/vegaprotocol/vega/issues/8827) - Add block height validation to validator initiated transactions and pruning to the `pow` engine cache
 - [8836](https://github.com/vegaprotocol/vega/issues/8836) - Fix enactment of market update state
+- [9760](https://github.com/vegaprotocol/vega/issues/9760) - Validate that a recurring transfer with markets matches the asset in the transfer.
 - [8848](https://github.com/vegaprotocol/vega/issues/8848) - Handle the case where the market is terminated and the epoch ends at the same block.
 - [8853](https://github.com/vegaprotocol/vega/issues/8853) - Liquidity provision amendment bug fixes
 - [8862](https://github.com/vegaprotocol/vega/issues/8862) - Fix settlement via governance

--- a/core/banking/engine.go
+++ b/core/banking/engine.go
@@ -111,6 +111,7 @@ type MarketActivityTracker interface {
 	CalculateMetricForTeams(ds *vega.DispatchStrategy) ([]*types.PartyContributionScore, map[string][]*types.PartyContributionScore)
 	GetMarketsWithEligibleProposer(asset string, markets []string, payoutAsset string, funder string) []*types.MarketContributionScore
 	MarkPaidProposer(asset, market, payoutAsset string, marketsInScope []string, funder string)
+	MarketTrackedForAsset(market, asset string) bool
 }
 
 type EthereumEventSource interface {

--- a/core/banking/mocks/mocks.go
+++ b/core/banking/mocks/mocks.go
@@ -540,6 +540,20 @@ func (mr *MockMarketActivityTrackerMockRecorder) MarkPaidProposer(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPaidProposer", reflect.TypeOf((*MockMarketActivityTracker)(nil).MarkPaidProposer), arg0, arg1, arg2, arg3, arg4)
 }
 
+// MarketTrackedForAsset mocks base method.
+func (m *MockMarketActivityTracker) MarketTrackedForAsset(arg0, arg1 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarketTrackedForAsset", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// MarketTrackedForAsset indicates an expected call of MarketTrackedForAsset.
+func (mr *MockMarketActivityTrackerMockRecorder) MarketTrackedForAsset(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarketTrackedForAsset", reflect.TypeOf((*MockMarketActivityTracker)(nil).MarketTrackedForAsset), arg0, arg1)
+}
+
 // MockERC20BridgeView is a mock of ERC20BridgeView interface.
 type MockERC20BridgeView struct {
 	ctrl     *gomock.Controller

--- a/core/banking/recurring_transfers.go
+++ b/core/banking/recurring_transfers.go
@@ -66,6 +66,20 @@ func (e *Engine) recurringTransfer(
 				return fmt.Errorf("could not transfer funds, invalid asset for metric: %w", err)
 			}
 		}
+
+		if hasAsset && len(transfer.DispatchStrategy.Markets) > 0 {
+			asset := transfer.DispatchStrategy.AssetForMetric
+			for _, mid := range transfer.DispatchStrategy.Markets {
+				if !e.marketActivityTracker.MarketTrackedForAsset(mid, asset) {
+					transfer.Status = types.TransferStatusRejected
+					e.log.Debug("cannot transfer funds, invalid market for dispatch asset",
+						logging.String("mid", mid),
+						logging.String("asset", asset),
+					)
+					return errors.New("could not transfer funds, invalid market for dispatch asset")
+				}
+			}
+		}
 	}
 
 	if err := transfer.IsValid(); err != nil {

--- a/core/banking/snapshot_test.go
+++ b/core/banking/snapshot_test.go
@@ -533,6 +533,7 @@ func TestRecurringTransfersSnapshotRoundTrip(t *testing.T) {
 	p, _ := proto.Marshal(recurring.Recurring.DispatchStrategy)
 	dsHash := hex.EncodeToString(crypto.Hash(p))
 
+	eng.marketActivityTracker.EXPECT().MarketTrackedForAsset("mmm", "zohar").Times(1).Return(true)
 	require.NoError(t, eng.TransferFunds(ctx, recurring))
 
 	// test the new transfer prompts a change

--- a/core/execution/common/market_activity_tracker.go
+++ b/core/execution/common/market_activity_tracker.go
@@ -353,6 +353,16 @@ func (mat *MarketActivityTracker) GetAllMarketIDs() []string {
 	return mIDs
 }
 
+// MarketTrackedForAsset returns whether the given market is seen to have the given asset by the tracker.
+func (mat *MarketActivityTracker) MarketTrackedForAsset(market, asset string) bool {
+	if markets, ok := mat.assetToMarketTrackers[asset]; ok {
+		if _, ok = markets[market]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // removeMarket is called when the market is removed from the network. It is not immediately removed to give a chance for rewards to be paid at the end of the epoch for activity during the epoch.
 // Instead it is marked for removal and will be removed at the beginning of the next epoch.
 func (mat *MarketActivityTracker) RemoveMarket(asset, marketID string) {

--- a/core/execution/common/market_activity_tracker_test.go
+++ b/core/execution/common/market_activity_tracker_test.go
@@ -66,6 +66,9 @@ func TestMarketTracker(t *testing.T) {
 	tracker.MarketProposed("asset1", "market1", "me")
 	tracker.MarketProposed("asset1", "market2", "me2")
 
+	assert.True(t, tracker.MarketTrackedForAsset("market1", "asset1"))
+	assert.False(t, tracker.MarketTrackedForAsset("market1", "asset2"))
+
 	require.Equal(t, false, tracker.IsMarketEligibleForBonus("asset1", "market1", "VEGA", []string{}, "zohar"))
 	require.Equal(t, false, tracker.IsMarketEligibleForBonus("asset1", "market2", "VEGA", []string{}, "zohar"))
 


### PR DESCRIPTION
closes #9760 

We now check that the market's in a recurring transfer with a dispatch-strategy, that any in-scope markets have the asset that is being dispatched.