### PR TITLE
fix: only sort what has comes from maps, and not input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,7 @@
 - [9658](https://github.com/vegaprotocol/vega/issues/9658) - Fix `updateVolumeDiscountProgram` GraphQL resolver.
 - [9672](https://github.com/vegaprotocol/vega/issues/9672) - Fix margin being non-zero on `PERPS`, add tests to ensure distressed parties are handled correctly
 - [9280](https://github.com/vegaprotocol/vega/issues/9280) - Get block height directly from `blocks` table.
+- [9787](https://github.com/vegaprotocol/vega/issues/9787) - Do not sort market input so that tracking of dispatch strategies are not disturbed.
 - [9675](https://github.com/vegaprotocol/vega/issues/9675) - Fix snapshot issue with not applying `providersCalculationStep` at epoch start.
 - [9693](https://github.com/vegaprotocol/vega/issues/9693) - Add missing validation for general account public key in governance transfer
 - [9691](https://github.com/vegaprotocol/vega/issues/9691) - Refactor referral engine snapshot

--- a/core/banking/recurring_transfers.go
+++ b/core/banking/recurring_transfers.go
@@ -107,15 +107,7 @@ func (e *Engine) recurringTransfer(
 	// in the recurringTransfer map/slice
 	e.recurringTransfers = append(e.recurringTransfers, transfer)
 	e.recurringTransfersMap[transfer.ID] = transfer
-
-	if transfer.DispatchStrategy != nil {
-		hash := e.hashDispatchStrategy(transfer.DispatchStrategy)
-		if _, ok := e.hashToStrategy[hash]; !ok {
-			e.hashToStrategy[hash] = &dispatchStrategyCacheEntry{ds: transfer.DispatchStrategy, refCount: 1}
-		} else {
-			e.hashToStrategy[hash].refCount++
-		}
-	}
+	e.registerDispatchStrategy(transfer.DispatchStrategy)
 
 	return nil
 }

--- a/core/execution/common/market_activity_tracker.go
+++ b/core/execution/common/market_activity_tracker.go
@@ -221,9 +221,8 @@ func (mat *MarketActivityTracker) GetMarketsWithEligibleProposer(asset string, m
 				}
 			}
 		}
+		sort.Strings(mkts)
 	}
-
-	sort.Strings(mkts)
 
 	assets := []string{}
 	if len(asset) > 0 {


### PR DESCRIPTION
closes #9787 

Sorting the markets passed into the market-tracker would change the slice in the dispatch-strategy changing its hash. This would result is the banking engine trying to unregister a dispatch-strategy that it didn't register.

Now we only sort when we have to construct the markets from the maps in the tracker.