### PR TITLE
fix: vega visor retry path must prep args before starting processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,7 @@
 - [9762](https://github.com/vegaprotocol/vega/issues/9762) - Referral fees API not filtering by party correctly.
 - [9775](https://github.com/vegaprotocol/vega/issues/9775) - Do not pay discount if set is not eligible
 - [9788](https://github.com/vegaprotocol/vega/issues/9788) - Fix transfer account validation.
+- [9544](https://github.com/vegaprotocol/vega/issues/9544) - Fix race in visor restart logic.
 - [9797](https://github.com/vegaprotocol/vega/issues/9797) - Default pagination limits are not always correctly set.
 
 ## 0.72.1

--- a/datanode/networkhistory/store/index.go
+++ b/datanode/networkhistory/store/index.go
@@ -42,7 +42,7 @@ type LevelDbBackedIndex struct {
 func NewIndex(dataDir string, log *logging.Logger) (*LevelDbBackedIndex, error) {
 	db, err := leveldb.OpenFile(filepath.Join(dataDir, "index.db"), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open level db file:%w", err)
+		return nil, fmt.Errorf("failed to open level db file: %w", err)
 	}
 
 	return &LevelDbBackedIndex{
@@ -58,14 +58,14 @@ func (l LevelDbBackedIndex) Get(height int64) (segment.Full, error) {
 	}
 
 	if err != nil {
-		return segment.Full{}, fmt.Errorf("failed to get index entry:%w", err)
+		return segment.Full{}, fmt.Errorf("failed to get index entry: %w", err)
 	}
 
 	var indexEntry segment.Full
 	err = json.Unmarshal(value, &indexEntry)
 
 	if err != nil {
-		return segment.Full{}, fmt.Errorf("failed to unmarshal value:%w", err)
+		return segment.Full{}, fmt.Errorf("failed to unmarshal value: %w", err)
 	}
 
 	return indexEntry, nil
@@ -80,12 +80,12 @@ func heightToKey(height int64) []byte {
 func (l LevelDbBackedIndex) Add(indexEntry segment.Full) error {
 	bytes, err := json.Marshal(indexEntry)
 	if err != nil {
-		return fmt.Errorf("failed to marshal index entry:%w", err)
+		return fmt.Errorf("failed to marshal index entry: %w", err)
 	}
 
 	err = l.db.Put(heightToKey(indexEntry.HeightTo), bytes, &opt.WriteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to put index entry:%w", err)
+		return fmt.Errorf("failed to put index entry: %w", err)
 	}
 
 	return nil
@@ -93,7 +93,7 @@ func (l LevelDbBackedIndex) Add(indexEntry segment.Full) error {
 
 func (l LevelDbBackedIndex) Remove(indexEntry segment.Full) error {
 	if err := l.db.Delete(heightToKey(indexEntry.HeightTo), &opt.WriteOptions{}); err != nil {
-		return fmt.Errorf("failed to delete key:%w", err)
+		return fmt.Errorf("failed to delete key: %w", err)
 	}
 
 	return nil
@@ -146,7 +146,7 @@ func (l LevelDbBackedIndex) listAllEntries() (segment.Segments[segment.Full], er
 		var indexEntry segment.Full
 		err := json.Unmarshal(bytes, &indexEntry)
 		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal index entry:%w", err)
+			return nil, fmt.Errorf("failed to unmarshal index entry: %w", err)
 		}
 
 		segments = append(segments, indexEntry)
@@ -158,7 +158,7 @@ func (l LevelDbBackedIndex) listAllEntries() (segment.Segments[segment.Full], er
 func (l LevelDbBackedIndex) GetHighestBlockHeightEntry() (segment.Full, error) {
 	entries, err := l.ListAllEntriesOldestFirst()
 	if err != nil {
-		return segment.Full{}, fmt.Errorf("failed to list all entries:%w", err)
+		return segment.Full{}, fmt.Errorf("failed to list all entries: %w", err)
 	}
 
 	if len(entries) == 0 {

--- a/visor/commands.go
+++ b/visor/commands.go
@@ -46,7 +46,7 @@ func latestDataNodeHistorySegment(binary string, binaryArgs Args) (*latestSegmen
 		args = append(args, dataNodeArg)
 	}
 
-	args = append(args, []string{"network-history", "latest-history-segment"}...)
+	args = append(args, []string{"network-history", "latest-history-segment", "--output=json"}...)
 	args = append(args, binaryArgs.GetFlagWithArg(homeFlagName)...)
 
 	var output latestSegmentCommanndOutput


### PR DESCRIPTION
closes #9544 

There were two issues here:
- Visor would asynchronously call into a data node CLI while also starting a data-node which caused a race on locking the leveldb behinh IPFS.
- the data node CLI was printing suprious logs from the IPFS package we use, which meant visor couldn't parse the JSON output. But we never even needed to start a whole IPFS node, we now just read into the levelDB which has the data we need.