### PR TITLE
fix: do not use default when before or after is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,7 @@
 - [9833](https://github.com/vegaprotocol/vega/issues/9833) - Validate market exists before enacting governance transfer.
 - [9725](https://github.com/vegaprotocol/vega/issues/9725) - List ledger entries `API` documentation and functionality.
 - [9818](https://github.com/vegaprotocol/vega/issues/9818) - Correctly register generated rewards in fees statistics.
+- [9850](https://github.com/vegaprotocol/vega/issues/9850) - Do not use default cursor when Before or After is defined.
 
 ## 0.72.1
 

--- a/datanode/entities/pagination.go
+++ b/datanode/entities/pagination.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultPageSize int32 = 1000
+	DefaultPageSize int32 = 1000
 	maxPageSize     int32 = 5000
 )
 
@@ -87,8 +87,8 @@ func (c *Cursor) Value() string {
 
 type CursorPagination struct {
 	Pagination
-	Forward     *offset
-	Backward    *offset
+	Forward     *CursorOffset
+	Backward    *CursorOffset
 	NewestFirst bool
 }
 
@@ -120,7 +120,7 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 
 	var after, before Cursor
 	var err error
-	var forwardOffset, backwardOffset *offset
+	var forwardOffset, backwardOffset *CursorOffset
 
 	if cp.Before != nil && cp.After != nil {
 		return CursorPagination{}, errors.New("cannot set both a before and after cursor")
@@ -130,7 +130,7 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 		if *cp.First < 0 || *cp.First > maxPageSize {
 			return CursorPagination{}, ErrCursorOverflow
 		}
-		forwardOffset = &offset{
+		forwardOffset = &CursorOffset{
 			Limit: cp.First,
 		}
 		// Proto cursors should be encoded values, so we want to decode them in order to use them
@@ -145,7 +145,7 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 		if *cp.Last < 0 || *cp.Last > maxPageSize {
 			return CursorPagination{}, ErrCursorOverflow
 		}
-		backwardOffset = &offset{
+		backwardOffset = &CursorOffset{
 			Limit: cp.Last,
 		}
 		// Proto cursors should be encoded values, so we want to decode them in order to use them
@@ -161,8 +161,8 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 			return CursorPagination{}, errors.Wrap(err, "failed to decode after cursor")
 		}
 
-		forwardOffset = &offset{
-			Limit:  ptr.From(defaultPageSize),
+		forwardOffset = &CursorOffset{
+			Limit:  ptr.From(DefaultPageSize),
 			Cursor: &after,
 		}
 	} else if cp.Before != nil {
@@ -171,8 +171,8 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 			return CursorPagination{}, errors.Wrap(err, "failed to decode before cursor")
 		}
 
-		backwardOffset = &offset{
-			Limit:  ptr.From(defaultPageSize),
+		backwardOffset = &CursorOffset{
+			Limit:  ptr.From(DefaultPageSize),
 			Cursor: &before,
 		}
 	}
@@ -198,23 +198,23 @@ func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
 
 func DefaultCursorPagination(newestFirst bool) CursorPagination {
 	return CursorPagination{
-		Forward: &offset{
-			Limit: ptr.From(defaultPageSize),
+		Forward: &CursorOffset{
+			Limit: ptr.From(DefaultPageSize),
 		},
 		NewestFirst: newestFirst,
 	}
 }
 
-type offset struct {
+type CursorOffset struct {
 	Limit  *int32
 	Cursor *Cursor
 }
 
-func (o offset) IsSet() bool {
+func (o CursorOffset) IsSet() bool {
 	return o.Limit != nil
 }
 
-func (o offset) HasCursor() bool {
+func (o CursorOffset) HasCursor() bool {
 	return o.Cursor != nil && o.Cursor.IsSet()
 }
 
@@ -223,7 +223,7 @@ func validatePagination(pagination CursorPagination) error {
 		return errors.New("cannot provide both forward and backward cursors")
 	}
 
-	var cursorOffset offset
+	var cursorOffset CursorOffset
 
 	if pagination.HasForward() {
 		cursorOffset = *pagination.Forward

--- a/datanode/entities/pagination.go
+++ b/datanode/entities/pagination.go
@@ -111,7 +111,7 @@ func NewCursorPagination(first *int32, after *string, last *int32, before *strin
 }
 
 func CursorPaginationFromProto(cp *v2.Pagination) (CursorPagination, error) {
-	if cp == nil || (cp != nil && cp.First == nil && cp.Last == nil) {
+	if cp == nil || (cp != nil && cp.First == nil && cp.Last == nil && cp.After == nil && cp.Before == nil) {
 		if cp != nil && cp.NewestFirst != nil {
 			return DefaultCursorPagination(*cp.NewestFirst), nil
 		}

--- a/datanode/entities/pagination_test.go
+++ b/datanode/entities/pagination_test.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2023 Gobalsky Labs Limited
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Copyright (c) 2022 Gobalsky Labs Limited
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE.DATANODE file and at https://www.mariadb.com/bsl11.
+//
+// Change Date: 18 months from the later of the date of the first publicly
+// available Distribution of this version of the repository, and 25 June 2022.
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by version 3 or later of the GNU General
+// Public License.
+
+package entities_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"code.vegaprotocol.io/vega/datanode/entities"
+	"code.vegaprotocol.io/vega/libs/ptr"
+	v2 "code.vegaprotocol.io/vega/protos/data-node/api/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCursorPaginationFromProto_Combinations(t *testing.T) {
+	// returns default when pagination is nil
+	cursor, err := entities.CursorPaginationFromProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.DefaultCursorPagination(true), cursor)
+
+	// returns default but uses newest first variable when defined
+	pagination := &v2.Pagination{NewestFirst: ptr.From(false)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.DefaultCursorPagination(false), cursor)
+
+	// uses the first filter
+	pagination = &v2.Pagination{First: ptr.From[int32](100)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Forward:     &entities.CursorOffset{Limit: ptr.From[int32](100)},
+	}, cursor)
+
+	// uses the last filter
+	pagination = &v2.Pagination{Last: ptr.From[int32](50)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Backward:    &entities.CursorOffset{Limit: ptr.From[int32](50)},
+	}, cursor)
+
+	encodedTestCursor := base64.StdEncoding.EncodeToString([]byte("abcd"))
+	testCursor := &entities.Cursor{}
+	testCursor.Decode(encodedTestCursor)
+	assert.NoError(t, err)
+
+	defaultPageSize := ptr.From[int32](entities.DefaultPageSize)
+
+	// uses after filter
+	pagination = &v2.Pagination{After: ptr.From(encodedTestCursor)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Forward: &entities.CursorOffset{
+			Limit:  defaultPageSize,
+			Cursor: testCursor,
+		},
+	}, cursor)
+
+	// uses before filter
+	pagination = &v2.Pagination{Before: ptr.From(encodedTestCursor)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Backward: &entities.CursorOffset{
+			Limit:  defaultPageSize,
+			Cursor: testCursor,
+		},
+	}, cursor)
+
+	// uses the first and after filters in conjunction
+	pagination = &v2.Pagination{First: ptr.From[int32](200), After: ptr.From(encodedTestCursor)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Forward: &entities.CursorOffset{
+			Limit:  ptr.From[int32](200),
+			Cursor: testCursor,
+		},
+	}, cursor)
+
+	// uses the last and before filters in conjunction
+	pagination = &v2.Pagination{Last: ptr.From[int32](200), Before: ptr.From(encodedTestCursor)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Backward: &entities.CursorOffset{
+			Limit:  ptr.From[int32](200),
+			Cursor: testCursor,
+		},
+	}, cursor)
+
+	// using first and before ignores before
+	pagination = &v2.Pagination{First: ptr.From[int32](30), Before: ptr.From(encodedTestCursor)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Forward: &entities.CursorOffset{
+			Limit: ptr.From[int32](30),
+		},
+	}, cursor)
+
+	// using last and after ignores after
+	pagination = &v2.Pagination{Last: ptr.From[int32](50), After: ptr.From(encodedTestCursor)}
+	cursor, err = entities.CursorPaginationFromProto(pagination)
+	assert.NoError(t, err)
+	assert.Equal(t, entities.CursorPagination{
+		NewestFirst: true,
+		Backward: &entities.CursorOffset{
+			Limit: ptr.From[int32](50),
+		},
+	}, cursor)
+}


### PR DESCRIPTION
Closes #9836 