### PR TITLE
fix: paid liquidity fee stats does not set epoch seq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,8 @@
 - [9818](https://github.com/vegaprotocol/vega/issues/9818) - Correctly register generated rewards in fees statistics.
 - [9850](https://github.com/vegaprotocol/vega/issues/9850) - Do not use default cursor when Before or After is defined.
 - [9855](https://github.com/vegaprotocol/vega/issues/9855) - Use max governance transfer amount as a quantum multiplier
+- [9853](https://github.com/vegaprotocol/vega/issues/9853) - Data node crashing due to duplicate key violation in paid liquidity fees table.
+
 ## 0.72.1
 
 ### 🐛 Fixes

--- a/core/execution/common/interfaces.go
+++ b/core/execution/common/interfaces.go
@@ -259,7 +259,7 @@ type LiquidityEngine interface {
 
 type MarketLiquidityEngine interface {
 	OnEpochStart(context.Context, time.Time, *num.Uint, *num.Uint, *num.Uint, num.Decimal)
-	OnEpochEnd(context.Context, time.Time)
+	OnEpochEnd(context.Context, time.Time, types.Epoch)
 	OnTick(context.Context, time.Time)
 	EndBlock(*num.Uint, *num.Uint, num.Decimal)
 	SubmitLiquidityProvision(context.Context, *types.LiquidityProvisionSubmission, string, string, types.MarketState) error

--- a/core/execution/common/liquidity_provision.go
+++ b/core/execution/common/liquidity_provision.go
@@ -304,13 +304,13 @@ func (m *MarketLiquidity) OnEpochStart(
 	m.syncPartyCommitmentWithBondAccount(ctx, appliedProvisions)
 }
 
-func (m *MarketLiquidity) OnEpochEnd(ctx context.Context, t time.Time) {
+func (m *MarketLiquidity) OnEpochEnd(ctx context.Context, t time.Time, epoch types.Epoch) {
 	m.calculateAndDistribute(ctx, t)
 
 	// report liquidity fees allocation stats
 	feeStats := m.liquidityEngine.PaidLiquidityFeesStats()
 	if !feeStats.TotalFeesPaid.IsZero() {
-		m.broker.Send(events.NewPaidLiquidityFeesStatsEvent(ctx, feeStats.ToProto(m.marketID, m.asset)))
+		m.broker.Send(events.NewPaidLiquidityFeesStatsEvent(ctx, feeStats.ToProto(m.marketID, m.asset, epoch.Seq)))
 	}
 }
 

--- a/core/execution/common/liquidity_provision_test.go
+++ b/core/execution/common/liquidity_provision_test.go
@@ -348,7 +348,7 @@ func TestLiquidityProvisionsFeeDistribution(t *testing.T) {
 		}).AnyTimes()
 
 	// end epoch - this should trigger the SLA fees distribution.
-	testLiquidity.marketLiquidity.OnEpochEnd(testLiquidity.ctx, now)
+	testLiquidity.marketLiquidity.OnEpochEnd(testLiquidity.ctx, now, types.Epoch{})
 
 	for _, provider := range keys {
 		generalAcc, err := testLiquidity.collateralEngine.GetPartyGeneralAccount(

--- a/core/execution/common/mocks/mocks.go
+++ b/core/execution/common/mocks/mocks.go
@@ -2190,15 +2190,15 @@ func (mr *MockMarketLiquidityEngineMockRecorder) OnEarlyExitPenalty(arg0 interfa
 }
 
 // OnEpochEnd mocks base method.
-func (m *MockMarketLiquidityEngine) OnEpochEnd(arg0 context.Context, arg1 time.Time) {
+func (m *MockMarketLiquidityEngine) OnEpochEnd(arg0 context.Context, arg1 time.Time, arg2 types.Epoch) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnEpochEnd", arg0, arg1)
+	m.ctrl.Call(m, "OnEpochEnd", arg0, arg1, arg2)
 }
 
 // OnEpochEnd indicates an expected call of OnEpochEnd.
-func (mr *MockMarketLiquidityEngineMockRecorder) OnEpochEnd(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMarketLiquidityEngineMockRecorder) OnEpochEnd(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnEpochEnd", reflect.TypeOf((*MockMarketLiquidityEngine)(nil).OnEpochEnd), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnEpochEnd", reflect.TypeOf((*MockMarketLiquidityEngine)(nil).OnEpochEnd), arg0, arg1, arg2)
 }
 
 // OnEpochStart mocks base method.

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -164,6 +164,7 @@ type Market struct {
 	// to make sure the migraton from the upgrade
 	// are applied properly
 	ensuredMigration73 bool
+	epoch              types.Epoch
 }
 
 // NewMarket creates a new market using the market framework configuration and creates underlying engines.
@@ -357,11 +358,12 @@ func (m *Market) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 	case vegapb.EpochAction_EPOCH_ACTION_START:
 		m.liquidity.UpdateSLAParameters(m.mkt.LiquiditySLAParams)
 		m.liquidity.OnEpochStart(ctx, m.timeService.GetTimeNow(), m.markPrice, m.midPrice(), m.getTargetStake(), m.positionFactor)
+		m.epoch = epoch
 	case vegapb.EpochAction_EPOCH_ACTION_END:
 		// compute parties stats for the previous epoch
 		m.onEpochEndPartiesStats()
 		if !m.finalFeesDistributed {
-			m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow())
+			m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow(), epoch)
 		}
 		feesStats := m.fee.GetFeesStatsOnEpochEnd()
 		feesStats.Market = m.GetID()
@@ -1128,7 +1130,7 @@ func (m *Market) closeMarket(ctx context.Context, t time.Time, finalState types.
 			m.log.Panic("failed to allocate liquidity provision fees", logging.Error(err))
 		}
 
-		m.liquidity.OnEpochEnd(ctx, t)
+		m.liquidity.OnEpochEnd(ctx, t, m.epoch)
 		m.finalFeesDistributed = true
 	}
 

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -375,6 +375,7 @@ func (m *Market) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 }
 
 func (m *Market) OnEpochRestore(ctx context.Context, epoch types.Epoch) {
+	m.epoch = epoch
 	m.liquidityEngine.OnEpochRestore(epoch)
 }
 

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -2876,7 +2876,7 @@ func (m *Market) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 		m.liquidity.UpdateSLAParameters(m.mkt.LiquiditySLAParams)
 		m.liquidity.OnEpochStart(ctx, m.timeService.GetTimeNow(), m.markPrice, m.midPrice(), m.getTargetStake(), m.positionFactor)
 	} else if epoch.Action == vega.EpochAction_EPOCH_ACTION_END {
-		m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow())
+		m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow(), epoch)
 		m.updateLiquidityFee(ctx)
 		feesStats := m.fee.GetFeesStatsOnEpochEnd()
 		feesStats.EpochSeq = epoch.Seq

--- a/core/liquidity/v2/snapshot.go
+++ b/core/liquidity/v2/snapshot.go
@@ -363,7 +363,7 @@ func (e *snapshotV2) serialiseFeeStats() ([]byte, error) {
 		Data: &snapshotpb.Payload_LiquidityV2PaidFeesStats{
 			LiquidityV2PaidFeesStats: &snapshotpb.LiquidityV2PaidFeesStats{
 				MarketId: e.market,
-				Stats:    e.allocatedFeesStats.ToProto(e.market, e.asset),
+				Stats:    e.allocatedFeesStats.ToProto(e.market, e.asset, 0), // I don't think it matters what the epoch is as this is just used for snapshots
 			},
 		},
 	}

--- a/core/types/liquidity_fee_stats.go
+++ b/core/types/liquidity_fee_stats.go
@@ -60,10 +60,11 @@ func (f *PaidLiquidityFeesStats) RegisterTotalFeesAmountPerParty(totalFeesAmount
 	}
 }
 
-func (f *PaidLiquidityFeesStats) ToProto(marketID, asset string) *eventspb.PaidLiquidityFeesStats {
+func (f *PaidLiquidityFeesStats) ToProto(marketID, asset string, epochSeq uint64) *eventspb.PaidLiquidityFeesStats {
 	fs := &eventspb.PaidLiquidityFeesStats{
 		Market:           marketID,
 		Asset:            asset,
+		EpochSeq:         epochSeq,
 		FeesPaidPerParty: make([]*eventspb.PartyAmount, 0, len(f.FeesPaidPerParty)),
 		TotalFeesPaid:    f.TotalFeesPaid.String(),
 	}

--- a/core/types/liquidity_fee_stats_test.go
+++ b/core/types/liquidity_fee_stats_test.go
@@ -51,15 +51,16 @@ func TestLiquidityFeeStats(t *testing.T) {
 		{Party: "d", Amount: "4"},
 	}
 
-	statsProto := stats.ToProto(market, asset)
+	statsProto := stats.ToProto(market, asset, 100)
 	require.Equal(t, market, statsProto.Market)
 	require.Equal(t, asset, statsProto.Asset)
+	require.Equal(t, uint64(100), statsProto.EpochSeq)
 	require.Equal(t, expectedAmountsPerParty, statsProto.FeesPaidPerParty)
 	require.Equal(t, "19", statsProto.TotalFeesPaid)
 
 	stats = types.NewLiquidityFeeStats()
 
-	statsProto = stats.ToProto(market, asset)
+	statsProto = stats.ToProto(market, asset, 100)
 	require.Equal(t, []*v1.PartyAmount{}, statsProto.FeesPaidPerParty)
 	require.Equal(t, "0", statsProto.TotalFeesPaid)
 
@@ -77,7 +78,7 @@ func TestLiquidityFeeStats(t *testing.T) {
 		{Party: "d", Amount: "44"},
 	}
 
-	statsProto = stats.ToProto(market, asset)
+	statsProto = stats.ToProto(market, asset, 100)
 	require.Equal(t, expectedAmountsPerParty, statsProto.FeesPaidPerParty)
 	require.Equal(t, "110", statsProto.TotalFeesPaid)
 }

--- a/datanode/sqlstore/paid_liquidity_fee_stats_test.go
+++ b/datanode/sqlstore/paid_liquidity_fee_stats_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestPaidLiquidityFeesStats_Add(t *testing.T) {
 	t.Run("Should add the stats for the epoch if they do not exist", testAddPaidLiquidityFeesStatsEpochIfNotExists)
-	t.Run("Should not return an error if the epoch already exists for the market/asset", testAddPaidLiquidityFeesStatsEpochExists)
+	t.Run("Should not return an error if the epoch already exists for the market/asset/vega_time", testAddPaidLiquidityFeesStatsEpochExists)
 }
 
 type paidLiquidityFeesStatsTestStores struct {

--- a/datanode/sqlstore/paid_liquidity_fee_stats_test.go
+++ b/datanode/sqlstore/paid_liquidity_fee_stats_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestPaidLiquidityFeesStats_Add(t *testing.T) {
 	t.Run("Should add the stats for the epoch if they do not exist", testAddPaidLiquidityFeesStatsEpochIfNotExists)
-	t.Run("Should return an error if the epoch already exists for the market/asset", testAddPaidLiquidityFeesStatsEpochExists)
+	t.Run("Should not return an error if the epoch already exists for the market/asset", testAddPaidLiquidityFeesStatsEpochExists)
 }
 
 type paidLiquidityFeesStatsTestStores struct {
@@ -123,8 +123,7 @@ func testAddPaidLiquidityFeesStatsEpochExists(t *testing.T) {
 
 	// now try to insert again and make sure we get an error
 	err = stores.ls.Add(ctx, &want)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate key value violates unique constraint")
+	require.NoError(t, err)
 }
 
 func TestPaidLiquidityFeesStats_List(t *testing.T) {


### PR DESCRIPTION
Closes #9853 

The paid liquidity fee stats did not set the EpochSeq, this caused a duplicate key error as EpochSeq is part of the primary key.