### PR TITLE
fix: use asset quantum multiplier for max governance transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@
 - [9725](https://github.com/vegaprotocol/vega/issues/9725) - List ledger entries `API` documentation and functionality.
 - [9818](https://github.com/vegaprotocol/vega/issues/9818) - Correctly register generated rewards in fees statistics.
 - [9850](https://github.com/vegaprotocol/vega/issues/9850) - Do not use default cursor when Before or After is defined.
-
+- [9855](https://github.com/vegaprotocol/vega/issues/9855) - Use max governance transfer amount as a quantum multiplier
 ## 0.72.1
 
 ### 🐛 Fixes

--- a/core/banking/checkpoint_test.go
+++ b/core/banking/checkpoint_test.go
@@ -202,7 +202,7 @@ func testSimpledScheduledTransfer(t *testing.T) {
 
 func TestGovernancedScheduledTransfer(t *testing.T) {
 	e := getTestEngine(t)
-
+	e.assets.EXPECT().Get(gomock.Any()).AnyTimes().Return(assets.NewAsset(&mockAsset{quantum: num.DecimalFromFloat(10)}), nil)
 	e.tsvc.EXPECT().GetTimeNow().DoAndReturn(
 		func() time.Time {
 			return time.Unix(10, 0)
@@ -238,6 +238,7 @@ func TestGovernancedScheduledTransfer(t *testing.T) {
 	// now second step, we start a new engine, and load the checkpoint
 	e2 := getTestEngine(t)
 	defer e2.ctrl.Finish()
+	e2.assets.EXPECT().Get(gomock.Any()).AnyTimes().Return(assets.NewAsset(&mockAsset{quantum: num.DecimalFromFloat(10)}), nil)
 
 	// load the checkpoint
 	e2.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
@@ -269,6 +270,7 @@ func TestGovernancedScheduledTransfer(t *testing.T) {
 
 func TestGovernanceRecurringTransfer(t *testing.T) {
 	e := getTestEngine(t)
+	e.assets.EXPECT().Get(gomock.Any()).AnyTimes().Return(assets.NewAsset(&mockAsset{quantum: num.DecimalFromFloat(10)}), nil)
 
 	ctx := context.Background()
 	e.tsvc.EXPECT().GetTimeNow().DoAndReturn(
@@ -304,6 +306,7 @@ func TestGovernanceRecurringTransfer(t *testing.T) {
 	// now second step, we start a new engine, and load the checkpoint
 	e2 := getTestEngine(t)
 	defer e2.ctrl.Finish()
+	e2.assets.EXPECT().Get(gomock.Any()).Times(1).Return(assets.NewAsset(&mockAsset{num.DecimalFromFloat(10)}), nil).AnyTimes()
 
 	// load the checkpoint
 	e2.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
@@ -315,7 +318,7 @@ func TestGovernanceRecurringTransfer(t *testing.T) {
 
 	// now lets end epoch 0 and 1 so that we can get the transfer out
 	e2.col.EXPECT().GetSystemAccountBalance(gomock.Any(), gomock.Any(), gomock.Any()).Return(num.NewUint(1000), nil).AnyTimes()
-	e2.OnMaxAmountChanged(context.Background(), num.DecimalFromInt64(100000))
+	e2.OnMaxAmountChanged(context.Background(), num.DecimalFromInt64(10000))
 	e2.OnMaxFractionChanged(context.Background(), num.DecimalFromFloat(0.5))
 	e2.col.EXPECT().GovernanceTransferFunds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	e2.OnEpoch(ctx, types.Epoch{Seq: 0, StartTime: time.Unix(10, 0), Action: vega.EpochAction_EPOCH_ACTION_END})

--- a/core/banking/engine.go
+++ b/core/banking/engine.go
@@ -177,8 +177,8 @@ type Engine struct {
 
 	minWithdrawQuantumMultiple num.Decimal
 
-	maxGovTransferAmount   *num.Uint
-	maxGovTransferFraction num.Decimal
+	maxGovTransferQunatumMultiplier num.Decimal
+	maxGovTransferFraction          num.Decimal
 }
 
 type withdrawalRef struct {
@@ -248,7 +248,7 @@ func (e *Engine) OnMaxFractionChanged(ctx context.Context, f num.Decimal) error 
 }
 
 func (e *Engine) OnMaxAmountChanged(ctx context.Context, f num.Decimal) error {
-	e.maxGovTransferAmount, _ = num.UintFromDecimal(f)
+	e.maxGovTransferQunatumMultiplier = f
 	return nil
 }
 

--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -174,7 +174,7 @@ func defaultNetParams() map[string]value {
 		GovernanceProposalTransferRequiredMajority:      NewDecimal(gteD0, lteD1).Mutable(true).MustUpdate("0.66"),
 		GovernanceProposalTransferMinProposerBalance:    NewUint(gteU1, ltMaxU).Mutable(true).MustUpdate("1"),
 		GovernanceProposalTransferMinVoterBalance:       NewUint(gteU1, ltMaxU).Mutable(true).MustUpdate("1"),
-		GovernanceTransferMaxAmount:                     NewDecimal(gteD1).Mutable(true).MustUpdate("7000000000000000000000"),
+		GovernanceTransferMaxAmount:                     NewDecimal(gteD1).Mutable(true).MustUpdate("7000"),
 		GovernanceTransferMaxFraction:                   NewDecimal(gtD0, lteD1).Mutable(true).MustUpdate("1"),
 
 		// Update referral program.


### PR DESCRIPTION
Closes #9855 