### PR TITLE
fix: avoid empty ledger entries from governance transfers for metric …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,6 +344,7 @@
 - [9853](https://github.com/vegaprotocol/vega/issues/9853) - Data node crashing due to duplicate key violation in paid liquidity fees table.
 - [9843](https://github.com/vegaprotocol/vega/issues/9843) - Migration script `0039` down migration drops incorrect column.
 - [9858](https://github.com/vegaprotocol/vega/issues/9858) - Fix missing where statement in list referral set referees.
+- [9868](https://github.com/vegaprotocol/vega/issues/9868) - Avoid empty ledger entries from governance transfers for metric when there is no activity.
 
 ## 0.72.1
 

--- a/core/banking/gov_transfers.go
+++ b/core/banking/gov_transfers.go
@@ -254,8 +254,12 @@ func (e *Engine) processGovernanceTransfer(
 
 			resps = append(resps, tresps...)
 		}
-		e.broker.Send(events.NewLedgerMovements(ctx, resps))
-		return transferAmount, nil
+		if len(resps) > 0 {
+			e.broker.Send(events.NewLedgerMovements(ctx, resps))
+			return transferAmount, nil
+		}
+
+		return num.UintZero(), nil
 	}
 
 	fromTransfer, toTransfer := e.makeTransfers(from, to, gTransfer.Config.Asset, fromMarket, toMarket, transferAmount)


### PR DESCRIPTION
…when there is no activity

Closes #9868 

fixed in https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/25418/artifacts/