### PR TITLE
fix: when a validator and not in nullchain mode, we should fail if an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - [9941](https://github.com/vegaprotocol/vega/issues/9941) - Add data node mapping for `WasEligible` field in referral set.
 - [9940](https://github.com/vegaprotocol/vega/issues/9940) - Truncate fee stats in quantum down to the 6 decimal.
+- [9956](https://github.com/vegaprotocol/vega/issues/9956) - Prevent validator node from starting if they do not have a Ethereum `RPCAddress` set.
 - [9952](https://github.com/vegaprotocol/vega/issues/9952) - `PnL` flickering fix.
 
 

--- a/cmd/vega/commands/node/node.go
+++ b/cmd/vega/commands/node/node.go
@@ -448,7 +448,7 @@ func (n *Command) startBlockchainClients() error {
 	// We may not need ethereum client initialized when we have not
 	// provided the ethereum endpoint. We skip creating client here
 	// when RPCEnpoint is empty and the nullchain present.
-	if len(n.conf.Ethereum.RPCEndpoint) < 1 {
+	if len(n.conf.Ethereum.RPCEndpoint) < 1 && n.conf.Blockchain.ChainProvider == blockchain.ProviderNullChain {
 		return nil
 	}
 


### PR DESCRIPTION
close #9956 

We were letting validator nodes start when their RPCEndpoint config was empty which meant they would chug through blocks without an eth-client. The moment a chain-event is received to verify the node would panic.

We now stop a node in validator-node from starting if they RPCEndpoint is empty. Then check already exists in `Dial()`:
```
func Dial(ctx context.Context, cfg Config) (*Client, error) {
	if len(cfg.RPCEndpoint) <= 0 {
		return nil, errors.New("no ethereum rpc endpoint configured. the configuration have move from the NodeWallet section to the Ethereum section, please make sure your vega configuration is up to date")
	}
```