### PR TITLE
fix: continue to use market price for average entry prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [9941](https://github.com/vegaprotocol/vega/issues/9941) - Add data node mapping for `WasEligible` field in referral set.
 - [9940](https://github.com/vegaprotocol/vega/issues/9940) - Truncate fee stats in quantum down to the 6 decimal.
 - [9998](https://github.com/vegaprotocol/vega/issues/9998) - Slippage factors can now me updated in a market.
+- [10036](https://github.com/vegaprotocol/vega/issues/10036) - Average entry price no longer flickers after a trade.
 - [9956](https://github.com/vegaprotocol/vega/issues/9956) - Prevent validator node from starting if they do not have a Ethereum `RPCAddress` set.
 - [9952](https://github.com/vegaprotocol/vega/issues/9952) - `PnL` flickering fix.
 - [9977](https://github.com/vegaprotocol/vega/issues/9977) - Transfer infra fees directly to general account without going through vesting.

--- a/datanode/entities/position.go
+++ b/datanode/entities/position.go
@@ -113,18 +113,22 @@ func (p *Position) UpdateWithTrade(trade vega.Trade, seller bool, pf num.Decimal
 	if seller {
 		size *= -1
 	}
-	marketPrice, _ := num.DecimalFromString(trade.AssetPrice) // this is market price
+	assetPrice, _ := num.DecimalFromString(trade.AssetPrice)
+	marketPrice, _ := num.DecimalFromString(trade.Price)
+
 	// Scale the trade to the correct size
 	opened, closed := CalculateOpenClosedVolume(p.PendingOpenVolume, size)
-	realisedPnlDelta := marketPrice.Sub(p.PendingAverageEntryPrice).Mul(num.DecimalFromInt64(closed)).Div(pf)
+	realisedPnlDelta := assetPrice.Sub(p.PendingAverageEntryPrice).Mul(num.DecimalFromInt64(closed)).Div(pf)
 	p.PendingRealisedPnl = p.PendingRealisedPnl.Add(realisedPnlDelta)
 	p.PendingOpenVolume -= closed
 
 	marketPriceUint, _ := num.UintFromDecimal(marketPrice)
-	p.PendingAverageEntryPrice = updateVWAP(p.PendingAverageEntryPrice, p.PendingOpenVolume, opened, marketPriceUint)
+	assetPriceUint, _ := num.UintFromDecimal(assetPrice)
+
+	p.PendingAverageEntryPrice = updateVWAP(p.PendingAverageEntryPrice, p.PendingOpenVolume, opened, assetPriceUint)
 	p.PendingAverageEntryMarketPrice = updateVWAP(p.PendingAverageEntryMarketPrice, p.PendingOpenVolume, opened, marketPriceUint)
 	p.PendingOpenVolume += opened
-	p.pendingMTM(marketPrice, pf)
+	p.pendingMTM(assetPrice, pf)
 }
 
 func (p *Position) ApplyFundingPayment(amount *num.Int) {

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -379,12 +379,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmYsX3AvyPZxSizbyLYjSSShpVdEs61sgUoretVyqZE3PK", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmbUe1Bx5pwjdyom7cFYyVzGUdacQnWyaE1HkB8frVcVq8", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmYQ7K4ZthifDwZekUEnSAdBixHgYkwLhJh2yC5QnWsEjJ", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmP2k4bHGgnpYkgGMvNRy8osjWX7ywhHPnxZCyHBqR4fWe", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmeV6riiXPDW98hijgqvz3fkGyckLnXxFmrk8HsYd11YuV", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "Qmbv13bk3ELQwh8hgRSAYQoixeC3ThFV2aH2xkuz43MGMC", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmapApyyHGXzu8A6op4VSXosQJ1cPyjDX7SBgKbfvbxwx9", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmWxwXeXHV4Pv9bEtMqQgSSuZB9UdfDbxABwdLqwgxs2b3", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmXtdoicvjfmDb7JQXroN9fUd6pY7Ld8Dbqiq1R29WcSyp", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmNdy5ekxW9LWuhD96GeMpmD41koUxNMhvUqCj7TXzPkj6", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmVw6ZWWNRGwmQ2BNYPVzwmdD8H4g7MpwNsrypzX8rVfec", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmSVkBYv7j4kh6H6QNFNFzzsFRV5KEk5bLMGKX13wqQxdY", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {


### PR DESCRIPTION
closes #10036 

If someone could check the numbers in the unittest make sense (they look of reasonable magnitude) that would be nice?