### PR TITLE
fix: cleanup mempool cache on commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@
 - [9956](https://github.com/vegaprotocol/vega/issues/9956) - Prevent validator node from starting if they do not have a Ethereum `RPCAddress` set.
 - [9952](https://github.com/vegaprotocol/vega/issues/9952) - `PnL` flickering fix.
 - [9977](https://github.com/vegaprotocol/vega/issues/9977) - Transfer infra fees directly to general account without going through vesting.
-- [10041](https://github.com/vegaprotocol/vega/issues/10041) List ledger entries `API` errors when using pagination.
+- [10041](https://github.com/vegaprotocol/vega/issues/10041) - List ledger entries `API` errors when using pagination.
+- [10050](https://github.com/vegaprotocol/vega/issues/10050) - Cleanup `mempool` cache on commit. 
 
 ## 0.73.0
 

--- a/core/pow/engine.go
+++ b/core/pow/engine.go
@@ -178,7 +178,6 @@ func (e *Engine) EndPrepareProposal(txs []ValidationEntry) {
 
 // updatePowState updates the pow state given the block transaction and cleans up out of scope states and param sets.
 func (e *Engine) updatePowState(txs []abci.Tx) {
-	e.mempoolSeenTid = map[string]struct{}{}
 	// run this once for migration cleanup
 	// this is going to clean up blocks that belong to inactive states which are unreachable by the latter loop.
 	if e.lastPruningBlock == 0 {
@@ -289,10 +288,13 @@ func (e *Engine) updatePowState(txs []abci.Tx) {
 	}
 }
 
-// OnFinalize is called when the finalizeBlock is completed to clenup the mempool cache.
-func (e *Engine) OnFinalize() {
-	e.log.Info("mempool seen cleared")
-	e.log.Debug("OnFinalize")
+// OnCommit is called when the finalizeBlock is completed to clenup the mempool cache.
+func (e *Engine) OnCommit() {
+	e.log.Debug("OnCommit")
+	e.log.Debug("mempool seen cleared")
+	e.lock.Lock()
+	e.mempoolSeenTid = map[string]struct{}{}
+	e.lock.Unlock()
 }
 
 func (e *Engine) DisableVerification() {

--- a/core/pow/engine_test.go
+++ b/core/pow/engine_test.go
@@ -173,6 +173,7 @@ func TestMempoolTidRejection(t *testing.T) {
 	res, d := e.CheckBlockTx(tx1)
 	e.rollback([]ValidationEntry{{Tx: tx1, Difficulty: d, ValResult: res}})
 	e.BeginBlock(101, crypto.RandomHash(), []abci.Tx{tx1})
+	e.OnCommit()
 	require.Equal(t, 1, len(e.seenTid))
 	_, ok := e.seenTid["2E7A16D9EF690F0D2BEED115FBA13BA2AAA16C8F971910AD88C72B9DB010C7D4"]
 	require.True(t, ok)


### PR DESCRIPTION
Closes #10050 

All performance tests runs with this branch pass:

https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fperformance-tests/detail/performance-tests/92/pipeline/
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fperformance-tests/detail/performance-tests/93/pipeline/
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fperformance-tests/detail/performance-tests/95/pipeline/
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fperformance-tests/detail/performance-tests/101/pipeline
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fperformance-tests/detail/performance-tests/103/pipeline
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fperformance-tests/detail/performance-tests/104/pipeline
