### PR TITLE
fix: latest stats tables should be hypertables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 - [9952](https://github.com/vegaprotocol/vega/issues/9952) - `PnL` flickering fix.
 - [9977](https://github.com/vegaprotocol/vega/issues/9977) - Transfer infra fees directly to general account without going through vesting.
 - [10041](https://github.com/vegaprotocol/vega/issues/10041) - List ledger entries `API` errors when using pagination.
-- [10050](https://github.com/vegaprotocol/vega/issues/10050) - Cleanup `mempool` cache on commit. 
+- [10050](https://github.com/vegaprotocol/vega/issues/10050) - Cleanup `mempool` cache on commit.
+- [10052](https://github.com/vegaprotocol/vega/issues/10052) - Some recent stats tables should have been `hypertables` with retention periods.
 
 ## 0.73.0
 

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -379,12 +379,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmapApyyHGXzu8A6op4VSXosQJ1cPyjDX7SBgKbfvbxwx9", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmWxwXeXHV4Pv9bEtMqQgSSuZB9UdfDbxABwdLqwgxs2b3", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmXtdoicvjfmDb7JQXroN9fUd6pY7Ld8Dbqiq1R29WcSyp", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmNdy5ekxW9LWuhD96GeMpmD41koUxNMhvUqCj7TXzPkj6", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmVw6ZWWNRGwmQ2BNYPVzwmdD8H4g7MpwNsrypzX8rVfec", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmSVkBYv7j4kh6H6QNFNFzzsFRV5KEk5bLMGKX13wqQxdY", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmPbWk1Jkxt7auGSsgj4GDCZ8X3s8aw2aiPSKgc4MNso6G", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmQCDHYkSZTHUNc46UrDrjWX4ePxCqik3GAgxzRz9HQJNy", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmWA2aLBamDn66HM97iMqvtXZs77mBXVsoePNaUUbSCXxL", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmZ7Z6bs38sdPrGe2ToFosaygSPyBmAqZt8iabcXSM21CU", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmbyPRmTwTfydWJgMd8WqsweiCiouTkXtHzKBBTtK3WG7s", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "Qmbfe2gXfoX3vksFbAWJKnccZaRWSsJxViaL4Xh4cXDCHC", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0057_fix_for_10052.sql
+++ b/datanode/sqlstore/migrations/0057_fix_for_10052.sql
@@ -4,7 +4,7 @@
 do $$
 begin
     if not exists (select * from timescaledb_information.hypertables where hypertable_name = 'fees_stats_by_party') then
-        perform create_hypertable('fees_stats_by_party', 'vega_time', chunk_time_interval => INTERVAL '1 day');
+        perform create_hypertable('fees_stats_by_party', 'vega_time', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
     end if;
 end $$;
 -- +goose StatementEnd
@@ -13,7 +13,7 @@ end $$;
 do $$
 begin
     if not exists (select * from timescaledb_information.hypertables where hypertable_name = 'paid_liquidity_fees') then
-        perform create_hypertable('paid_liquidity_fees', 'vega_time', chunk_time_interval => INTERVAL '1 day');
+        perform create_hypertable('paid_liquidity_fees', 'vega_time', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
     end if;
 end $$;
 -- +goose StatementEnd

--- a/datanode/sqlstore/migrations/0057_fix_for_10052.sql
+++ b/datanode/sqlstore/migrations/0057_fix_for_10052.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+
+-- +goose StatementBegin
+do $$
+begin
+    if not exists (select * from timescaledb_information.hypertables where hypertable_name = 'fees_stats_by_party') then
+        perform create_hypertable('fees_stats_by_party', 'vega_time', chunk_time_interval => INTERVAL '1 day');
+    end if;
+end $$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+do $$
+begin
+    if not exists (select * from timescaledb_information.hypertables where hypertable_name = 'paid_liquidity_fees') then
+        perform create_hypertable('paid_liquidity_fees', 'vega_time', chunk_time_interval => INTERVAL '1 day');
+    end if;
+end $$;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- nothing to do, we're not going to convert it back

--- a/datanode/sqlstore/sqlstore.go
+++ b/datanode/sqlstore/sqlstore.go
@@ -104,6 +104,8 @@ var defaultRetentionPolicies = map[RetentionPeriod][]RetentionPolicy{
 		{HypertableOrCaggName: "party_locked_balances", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "party_vesting_balances", DataRetentionPeriod: "1 year"},
 		{HypertableOrCaggName: "party_vesting_stats", DataRetentionPeriod: "1 year"},
+		{HypertableOrCaggName: "fees_stats_by_party", DataRetentionPeriod: "1 year"},
+		{HypertableOrCaggName: "paid_liquidity_fees", DataRetentionPeriod: "1 year"},
 	},
 	RetentionPeriodArchive: {
 		{HypertableOrCaggName: "*", DataRetentionPeriod: string(RetentionPeriodArchive)},


### PR DESCRIPTION
Closes #10052 

Tables `paid_liquidity_fees` and `fees_stats_by_party` should have been created as hypertables but were not.

The `rewards_scores`, `ranking_scores` and `delegation_current` table have not changed since inception so have left as they are.