### PR TITLE
fix: pre-generating IDs in batch instruction should not assume stop-o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - [9941](https://github.com/vegaprotocol/vega/issues/9941) - Add data node mapping for `WasEligible` field in referral set.
 - [9940](https://github.com/vegaprotocol/vega/issues/9940) - Truncate fee stats in quantum down to the 6 decimal.
+- [9940](https://github.com/vegaprotocol/vega/issues/9940) - Do not assume stop order is valid when generating ids up front.
 - [9998](https://github.com/vegaprotocol/vega/issues/9998) - Slippage factors can now me updated in a market.
 - [10036](https://github.com/vegaprotocol/vega/issues/10036) - Average entry price no longer flickers after a trade.
 - [9956](https://github.com/vegaprotocol/vega/issues/9956) - Prevent validator node from starting if they do not have a Ethereum `RPCAddress` set.

--- a/core/processor/batch_market_instructions_processor.go
+++ b/core/processor/batch_market_instructions_processor.go
@@ -124,20 +124,12 @@ func (p *BMIProcessor) ProcessBatch(
 	// these need to be determinitistic
 	idgen := idgeneration.New(determinitisticID)
 
-	// we will need an ID for every stop orders
-	// not all StopsOrderSubmission have 2 StopOrder
-	stopOrderSize := 0
-	for _, v := range batch.StopOrdersSubmission {
-		if v.FallsBelow != nil {
-			stopOrderSize++
-		}
-		if v.RisesAbove != nil {
-			stopOrderSize++
-		}
-	}
+	// each order will need a new ID, and each stop order can contain up to two orders (rises above, falls below)
+	// but a stop order could also be invalid and have neither, so we pre-generate the maximum ids we might need
+	nIDs := len(batch.Submissions) + (2 * len(batch.StopOrdersSubmission))
 
-	submissionsIDs := make([]string, 0, len(batch.Submissions)+stopOrderSize)
-	for i := 0; i < len(batch.Submissions)+stopOrderSize; i++ {
+	submissionsIDs := make([]string, 0, nIDs)
+	for i := 0; i < nIDs; i++ {
 		submissionsIDs = append(submissionsIDs, idgen.NextID())
 	}
 

--- a/core/processor/batch_market_instructions_processor_test.go
+++ b/core/processor/batch_market_instructions_processor_test.go
@@ -295,3 +295,53 @@ func TestBatchMarketInstructionsEnsureAllErrorReturnNonPartialError(t *testing.T
 	assert.True(t, ok)
 	assert.False(t, perr.IsPartial())
 }
+
+func TestBatchMarketInstructionInvalidStopOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	exec := mocks.NewMockExecutionEngine(ctrl)
+	proc := processor.NewBMIProcessor(logging.NewTestLogger(), exec, processor.Validate{})
+	stats := stats.New(logging.NewTestLogger(), stats.NewDefaultConfig())
+
+	batch := commandspb.BatchMarketInstructions{
+		StopOrdersSubmission: []*commandspb.StopOrdersSubmission{
+			{}, // this one is invalid
+			{
+				RisesAbove: &commandspb.StopOrderSetup{
+					Trigger: &commandspb.StopOrderSetup_Price{Price: "1000"},
+					OrderSubmission: &commandspb.OrderSubmission{
+						MarketId:    "92eea9006eaa51154cb9110b9fe982f37d3bd50f62ee9d0a7709d9c74de329aa",
+						Size:        1,
+						Side:        vega.Side_SIDE_SELL,
+						Type:        vega.Order_TYPE_MARKET,
+						TimeInForce: types.OrderTimeInForceFOK,
+						ReduceOnly:  true,
+					},
+				},
+			},
+		},
+	}
+	stopCnt := 0
+	exec.EXPECT().SubmitStopOrders(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, stop *types.StopOrdersSubmission, party string, idgen common.IDGenerator, id1, id2 *string) ([]*types.OrderConfirmation, error) {
+			stopCnt++
+			return nil, nil
+		},
+	)
+
+	err := proc.ProcessBatch(
+		context.Background(),
+		&batch,
+		"43f86066fe13743448442022c099c48abbd7e9c5eac1c2558fdac1fbf549e867",
+		"62017b6ae543d2e699f41d37598b22dab025c57ed98ef3c237bb91b948c5f8fc",
+		stats.Blockchain,
+	)
+
+	assert.EqualError(t, err, "0 (* (must have at least one of rises above or falls below))")
+
+	// ensure the errors is reported as partial
+	perr, ok := err.(abci.MaybePartialError)
+	assert.True(t, ok)
+	assert.True(t, perr.IsPartial())
+	assert.Equal(t, 1, stopCnt)
+}


### PR DESCRIPTION
closes #10068 

An invalid stop order without a rises-above or falls-below was throwing out the count of how many pre-generated IDs we would need. Now we just pre-generate 2*stop-orders regardless so we're always covered.