### PR TITLE
chore: renable support for teams in update-referal-set

### DIFF
--- a/commands/update_referral_set.go
+++ b/commands/update_referral_set.go
@@ -53,9 +53,6 @@ func checkUpdateReferralSet(cmd *commandspb.UpdateReferralSet) Errors {
 		if cmd.Team.TeamUrl != nil && len(*cmd.Team.TeamUrl) > 200 {
 			errs.AddForProperty("update_referral_set.team.team_url", ErrMustBeLessThan200Chars)
 		}
-
-		// temporarily disable team support
-		errs.AddForProperty("update_referral_set.team", ErrIsNotSupported)
 	}
 
 	return errs

--- a/commands/update_referral_set_test.go
+++ b/commands/update_referral_set_test.go
@@ -104,11 +104,7 @@ func testUpdatingTeamSucceeds(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(tt *testing.T) {
-			if !tc.cmd.IsTeam {
-				require.Empty(tt, checkUpdateReferralSet(tt, tc.cmd))
-			} else {
-				require.Contains(tt, checkUpdateReferralSet(tt, tc.cmd).Get("update_referral_set.team"), commands.ErrIsNotSupported, tc.name)
-			}
+			require.Empty(tt, checkUpdateReferralSet(tt, tc.cmd))
 		})
 	}
 }


### PR DESCRIPTION
Teams was half-renabled yesterday, but `update-referral-set` was still blocked.