### PR TITLE
fix: update documentation and improve error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [10041](https://github.com/vegaprotocol/vega/issues/10041) - List ledger entries `API` errors when using pagination.
 - [10050](https://github.com/vegaprotocol/vega/issues/10050) - Cleanup `mempool` cache on commit.
 - [10052](https://github.com/vegaprotocol/vega/issues/10052) - Some recent stats tables should have been `hypertables` with retention periods.
+- [10103](https://github.com/vegaprotocol/vega/issues/10103) - List ledgers `API` returns bad error when filtering by transfer type only.
 
 ## 0.73.0
 

--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -434,6 +434,9 @@ func (t *TradingDataServiceV2) ListLedgerEntries(ctx context.Context, req *v2.Li
 
 	entries, pageInfo, err := t.ledgerService.Query(ctx, leFilter, dateRange, pagination)
 	if err != nil {
+		if errors.Is(err, sqlstore.ErrLedgerEntryFilterForParty) {
+			return nil, formatE(ErrInvalidFilter, err)
+		}
 		return nil, formatE(ErrLedgerServiceGet, err)
 	}
 

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -688,7 +688,19 @@ type Query {
   ): MarketDataConnection
 
   """
-  Get ledger entries by asset, market, party, account type, transfer type within the given date range.
+  Get a list of ledger entries within the given date range. The date range is restricted to a maximum of 5 days.
+  This query requests and sums the number of ledger entries from a given subset of accounts, specified via the 'filter' argument.
+  It returns a time series - implemented as a list of AggregateLedgerEntry structs - with a row for every time
+  the summed ledger entries of the set of specified accounts changes.
+  Each account filter must contain no more than one party ID.
+  At least one party ID must be specified in the from or to account filter.
+
+  Entries can be filtered by:
+    - the sending account (market ID, asset ID, account type)
+    - receiving account (market ID, asset ID, account type)
+    - sending AND receiving account
+    - transfer type either in addition to the above filters or as a standalone option
+
   Note: The date range is restricted to any 5 days.
   If no start or end date is provided, only ledger entries from the last 5 days will be returned.
   If a start and end date are provided, but the end date is more than 5 days after the start date, only data up to 5 days after the start date will be returned.

--- a/datanode/sqlstore/ledger_test.go
+++ b/datanode/sqlstore/ledger_test.go
@@ -778,6 +778,34 @@ func TestLedger(t *testing.T) {
 			assert.Equal(t, 0, len(*entries))
 		})
 
+		t.Run("by transferType only", func(t *testing.T) {
+			// open on account filters
+			// Set filters for FromAccount and AcountTo IDs
+			filter := &entities.LedgerEntryFilter{
+				TransferTypes: []entities.LedgerMovementType{
+					entities.LedgerMovementTypeDeposit,
+				},
+			}
+
+			_, _, err := ledgerStore.Query(ctx,
+				filter,
+				entities.DateRange{Start: &tStart, End: &tEnd},
+				entities.CursorPagination{},
+			)
+
+			assert.Error(t, err)
+
+			// closed on account filters
+			filter.CloseOnAccountFilters = true
+			_, _, err = ledgerStore.Query(ctx,
+				filter,
+				entities.DateRange{Start: &tStart, End: &tEnd},
+				entities.CursorPagination{},
+			)
+
+			assert.Error(t, err)
+		})
+
 		t.Run("test open/closing with different account and transfer types", func(t *testing.T) {
 			filter := &entities.LedgerEntryFilter{
 				FromAccountFilter: entities.AccountFilter{

--- a/protos/data-node/api/v2/trading_data_grpc.pb.go
+++ b/protos/data-node/api/v2/trading_data_grpc.pb.go
@@ -91,6 +91,13 @@ type TradingDataServiceClient interface {
 	//   - receiving account (market ID, asset ID, account type)
 	//   - sending AND receiving account
 	//   - transfer type either in addition to the above filters or as a standalone option
+	//
+	// Note: The date range is restricted to any 5 days.
+	//
+	//	If no start or end date is provided, only ledger entries from the last 5 days will be returned.
+	//	If a start and end date are provided, but the end date is more than 5 days after the start date, only data up to 5 days after the start date will be returned.
+	//	If a start date is provided but no end date, the end date will be set to 5 days after the start date.
+	//	If no start date is provided, but the end date is, the start date will be set to 5 days before the end date.
 	ListLedgerEntries(ctx context.Context, in *ListLedgerEntriesRequest, opts ...grpc.CallOption) (*ListLedgerEntriesResponse, error)
 	// Export ledger entries
 	//
@@ -2074,6 +2081,13 @@ type TradingDataServiceServer interface {
 	//   - receiving account (market ID, asset ID, account type)
 	//   - sending AND receiving account
 	//   - transfer type either in addition to the above filters or as a standalone option
+	//
+	// Note: The date range is restricted to any 5 days.
+	//
+	//	If no start or end date is provided, only ledger entries from the last 5 days will be returned.
+	//	If a start and end date are provided, but the end date is more than 5 days after the start date, only data up to 5 days after the start date will be returned.
+	//	If a start date is provided but no end date, the end date will be set to 5 days after the start date.
+	//	If no start date is provided, but the end date is, the start date will be set to 5 days before the end date.
 	ListLedgerEntries(context.Context, *ListLedgerEntriesRequest) (*ListLedgerEntriesResponse, error)
 	// Export ledger entries
 	//

--- a/protos/sources/data-node/api/v2/trading_data.proto
+++ b/protos/sources/data-node/api/v2/trading_data.proto
@@ -141,6 +141,11 @@ service TradingDataService {
   //   - receiving account (market ID, asset ID, account type)
   //   - sending AND receiving account
   //   - transfer type either in addition to the above filters or as a standalone option
+  // Note: The date range is restricted to any 5 days.
+  //   If no start or end date is provided, only ledger entries from the last 5 days will be returned.
+  //   If a start and end date are provided, but the end date is more than 5 days after the start date, only data up to 5 days after the start date will be returned.
+  //   If a start date is provided but no end date, the end date will be set to 5 days after the start date.
+  //   If no start date is provided, but the end date is, the start date will be set to 5 days before the end date.
   rpc ListLedgerEntries(ListLedgerEntriesRequest) returns (ListLedgerEntriesResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Ledger entries"};
   }


### PR DESCRIPTION
Closes #10103 

The API works as it should but the error returns a bad error that makes users think something has gone wrong. Also the API documentation is not consistent between the gRPC and GQL documentation and doesn't make it clear what is required in the GQL version.

The error message now returns:

```json
{
  "errors": [
    {
      "message": "invalid filter",
      "path": [
        "ledgerEntries"
      ],
      "extensions": {
        "code": 3,
        "type": "InvalidArgument"
      }
    }
  ],
  "data": null
}
```