### PR TITLE
fix: estimate position API does not need to scale funding payment sin…

### DIFF
--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -3259,8 +3259,6 @@ func (t *TradingDataServiceV2) EstimatePosition(ctx context.Context, req *v2.Est
 		}
 	}
 
-	marginFactorScaledFundingPaymentPerUnitPosition = t.scaleDecimalFromMarketToAssetPrice(marginFactorScaledFundingPaymentPerUnitPosition, dPriceFactor)
-
 	marginEstimate := t.computeMarginRange(
 		req.MarketId,
 		req.OpenVolume,


### PR DESCRIPTION
relates to #10121

Funding payment is already in asset-price so scaling it in `EstimatePosition` is not necessary.