### PR TITLE
fix: add metrics for ethereum rpc request + add initial delay for ethereum validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [10132](https://github.com/vegaprotocol/vega/issues/10132) - Add mapping in `GraphQL` for update perps market proposal.
 - [10125](https://github.com/vegaprotocol/vega/issues/10125) - Wire the `JoinTeam` command in the wallet.
 - [10127](https://github.com/vegaprotocol/vega/issues/10127) - Untangle `ApplyReferralCode` and `JoinTeam` command verification.
+- [10153](https://github.com/vegaprotocol/vega/issues/10153) - Add metrics and reduce amount of request sent to the Ethereum `RPC`.
 
 ## 0.73.0
 

--- a/core/datasource/external/ethverifier/mocks/witness_mock.go
+++ b/core/datasource/external/ethverifier/mocks/witness_mock.go
@@ -49,16 +49,16 @@ func (mr *MockWitnessMockRecorder) RestoreResource(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreResource", reflect.TypeOf((*MockWitness)(nil).RestoreResource), arg0, arg1)
 }
 
-// StartCheck mocks base method.
-func (m *MockWitness) StartCheck(arg0 validators.Resource, arg1 func(interface{}, bool), arg2 time.Time) error {
+// StartCheckWithDelay mocks base method.
+func (m *MockWitness) StartCheckWithDelay(arg0 validators.Resource, arg1 func(interface{}, bool), arg2 time.Time, arg3 int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartCheck", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "StartCheckWithDelay", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// StartCheck indicates an expected call of StartCheck.
-func (mr *MockWitnessMockRecorder) StartCheck(arg0, arg1, arg2 interface{}) *gomock.Call {
+// StartCheckWithDelay indicates an expected call of StartCheckWithDelay.
+func (mr *MockWitnessMockRecorder) StartCheckWithDelay(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartCheck", reflect.TypeOf((*MockWitness)(nil).StartCheck), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartCheckWithDelay", reflect.TypeOf((*MockWitness)(nil).StartCheckWithDelay), arg0, arg1, arg2, arg3)
 }

--- a/core/datasource/external/ethverifier/verifier.go
+++ b/core/datasource/external/ethverifier/verifier.go
@@ -27,6 +27,7 @@ import (
 	"code.vegaprotocol.io/vega/core/datasource/errors"
 	"code.vegaprotocol.io/vega/core/datasource/external/ethcall"
 	"code.vegaprotocol.io/vega/core/events"
+	"code.vegaprotocol.io/vega/core/metrics"
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/core/validators"
 	"code.vegaprotocol.io/vega/logging"
@@ -36,7 +37,7 @@ import (
 
 //go:generate go run github.com/golang/mock/mockgen -destination mocks/witness_mock.go -package mocks code.vegaprotocol.io/vega/core/datasource/external/ethverifier Witness
 type Witness interface {
-	StartCheck(validators.Resource, func(interface{}, bool), time.Time) error
+	StartCheckWithDelay(validators.Resource, func(interface{}, bool), time.Time, int64) error
 	RestoreResource(validators.Resource, func(interface{}, bool)) error
 }
 
@@ -120,6 +121,7 @@ func (p pendingCallEvent) GetID() string { return p.callEvent.Hash() }
 func (p pendingCallEvent) GetType() types.NodeVoteType {
 	return types.NodeVoteTypeEthereumContractCallResult
 }
+
 func (p *pendingCallEvent) Check(ctx context.Context) error { return p.check(ctx) }
 
 func New(
@@ -179,23 +181,32 @@ func (s *Verifier) ProcessEthereumContractCallResult(callEvent ethcall.ContractC
 		check:     func(ctx context.Context) error { return s.checkCallEventResult(ctx, callEvent) },
 	}
 
+	confirmations, err := s.ethEngine.GetRequiredConfirmations(callEvent.SpecId)
+	if err != nil {
+		return err
+	}
+
 	s.pendingCallEvents = append(s.pendingCallEvents, pending)
 
 	s.log.Info("ethereum call event received, starting validation",
 		logging.String("call-event", fmt.Sprintf("%+v", callEvent)))
 
 	// Timeout for the check set to 1 day, to allow for validator outage scenarios
-	err := s.witness.StartCheck(
-		pending, s.onCallEventVerified, s.timeService.GetTimeNow().Add(24*time.Hour))
+	err = s.witness.StartCheckWithDelay(
+		pending, s.onCallEventVerified, s.timeService.GetTimeNow().Add(30*time.Minute), int64(confirmations))
 	if err != nil {
 		s.log.Error("could not start witness routine", logging.String("id", pending.GetID()))
 		s.removePendingCallEvent(pending.GetID())
 	}
 
+	metrics.DataSourceEthVerifierCallGaugeAdd(1, callEvent.SpecId)
+
 	return err
 }
 
 func (s *Verifier) checkCallEventResult(ctx context.Context, callEvent ethcall.ContractCallEvent) error {
+	metrics.DataSourceEthVerifierCallCounterInc(callEvent.SpecId)
+
 	// Ensure that the ethtime on the call event matches the block number on the eth chain
 	// (submitting call events with malicious times could subvert, e.g. TWAPs on perp markets)
 	checkedTime, err := s.ethEngine.GetEthTime(ctx, callEvent.BlockHeight)
@@ -208,6 +219,7 @@ func (s *Verifier) checkCallEventResult(ctx context.Context, callEvent ethcall.C
 			callEvent.BlockHeight, callEvent.BlockTime, checkedTime)
 	}
 
+	metrics.DataSourceEthVerifierCallCounterInc(callEvent.SpecId)
 	checkResult, err := s.ethEngine.CallSpec(ctx, callEvent.SpecId, callEvent.BlockHeight)
 	if callEvent.Error != nil {
 		if err != nil {
@@ -271,6 +283,8 @@ func (s *Verifier) onCallEventVerified(event interface{}, ok bool) {
 
 	if err := s.removePendingCallEvent(pv.GetID()); err != nil {
 		s.log.Error("could not remove pending call event", logging.Error(err))
+	} else {
+		metrics.DataSourceEthVerifierCallGaugeAdd(-1, pv.callEvent.SpecId)
 	}
 
 	if ok {

--- a/core/datasource/external/ethverifier/verifier_snapshot_test.go
+++ b/core/datasource/external/ethverifier/verifier_snapshot_test.go
@@ -83,15 +83,15 @@ func TestEthereumOracleVerifierWithPendingQueryResults(t *testing.T) {
 	eov.ethCallEngine.EXPECT().GetEthTime(gomock.Any(), uint64(5)).Return(uint64(100), nil)
 	eov.ethCallEngine.EXPECT().CallSpec(gomock.Any(), "testspec", uint64(5)).Return(result, nil)
 	eov.ethCallEngine.EXPECT().GetInitialTriggerTime("testspec").Return(uint64(90), nil)
-	eov.ethCallEngine.EXPECT().GetRequiredConfirmations("testspec").Return(uint64(5), nil)
+	eov.ethCallEngine.EXPECT().GetRequiredConfirmations("testspec").Return(uint64(5), nil).Times(2)
 
 	eov.ts.EXPECT().GetTimeNow().Times(1)
 	eov.ethConfirmations.EXPECT().CheckRequiredConfirmations(uint64(5), uint64(5)).Return(nil)
 
 	var checkResult error
-	eov.witness.EXPECT().StartCheck(gomock.Any(), gomock.Any(), gomock.Any()).
+	eov.witness.EXPECT().StartCheckWithDelay(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(1).
-		DoAndReturn(func(toCheck validators.Resource, fn func(interface{}, bool), _ time.Time) error {
+		DoAndReturn(func(toCheck validators.Resource, fn func(interface{}, bool), _ time.Time, _ int64) error {
 			checkResult = toCheck.Check(context.Background())
 			return nil
 		})

--- a/core/metrics/prometheus.go
+++ b/core/metrics/prometheus.go
@@ -48,12 +48,14 @@ var (
 )
 
 var (
-	unconfirmedTxGauge prometheus.Gauge
-	engineTime         *prometheus.CounterVec
-	orderCounter       *prometheus.CounterVec
-	ethCallCounter     *prometheus.CounterVec
-	evtForwardCounter  *prometheus.CounterVec
-	orderGauge         *prometheus.GaugeVec
+	unconfirmedTxGauge                      prometheus.Gauge
+	engineTime                              *prometheus.CounterVec
+	orderCounter                            *prometheus.CounterVec
+	dataSourceEthVerifierOnGoingCallCounter *prometheus.CounterVec
+	ethCallCounter                          *prometheus.CounterVec
+	evtForwardCounter                       *prometheus.CounterVec
+	orderGauge                              *prometheus.GaugeVec
+	dataSourceEthVerifierOnGoingCallGauge   *prometheus.GaugeVec
 	// Call counters for each request type per API.
 	apiRequestCallCounter *prometheus.CounterVec
 	// Total time counters for each request type per API.
@@ -379,6 +381,22 @@ func setupMetrics() error {
 
 	h, err = addInstrument(
 		Counter,
+		"data_source_ethverifier_calls_total",
+		Namespace("vega"),
+		Vectors("spec"),
+		Help("Number of orders processed"),
+	)
+	if err != nil {
+		return err
+	}
+	dataC, err := h.CounterVec()
+	if err != nil {
+		return err
+	}
+	dataSourceEthVerifierOnGoingCallCounter = dataC
+
+	h, err = addInstrument(
+		Counter,
 		"eth_calls_total",
 		Namespace("vega"),
 		Vectors("func", "asset", "respcode"),
@@ -425,6 +443,24 @@ func setupMetrics() error {
 		return err
 	}
 	orderGauge = g
+
+	// now add the orders gauge
+	h, err = addInstrument(
+		Gauge,
+		"data_source_ethverifier_calls_ongoing",
+		Namespace("vega"),
+		Vectors("spec"),
+		Help("Number of event being verified"),
+	)
+	if err != nil {
+		return err
+	}
+	dataD, err := h.GaugeVec()
+	if err != nil {
+		return err
+	}
+	dataSourceEthVerifierOnGoingCallGauge = dataD
+
 	// example usage of this simple gauge:
 	// e.orderGauge.WithLabelValues(mkt.Name).Add(float64(len(orders)))
 	// e.orderGauge.WithLabelValues(mkt.Name).Sub(float64(len(completedOrders)))
@@ -547,6 +583,14 @@ func OrderCounterInc(labelValues ...string) {
 	orderCounter.WithLabelValues(labelValues...).Inc()
 }
 
+// DataSourceEthVerifierCallCounterInc increments the order counter.
+func DataSourceEthVerifierCallCounterInc(labelValues ...string) {
+	if dataSourceEthVerifierOnGoingCallCounter == nil {
+		return
+	}
+	dataSourceEthVerifierOnGoingCallCounter.WithLabelValues(labelValues...).Inc()
+}
+
 // EthCallInc increments the eth call counter.
 func EthCallInc(labelValues ...string) {
 	if ethCallCounter == nil {
@@ -569,6 +613,21 @@ func OrderGaugeAdd(n int, labelValues ...string) {
 		return
 	}
 	orderGauge.WithLabelValues(labelValues...).Add(float64(n))
+}
+
+// DataSourceEthVerifierCallGaugeAdd increments the eth verified calls.
+func DataSourceEthVerifierCallGaugeAdd(n int, labelValues ...string) {
+	if dataSourceEthVerifierOnGoingCallGauge == nil {
+		return
+	}
+	dataSourceEthVerifierOnGoingCallGauge.WithLabelValues(labelValues...).Add(float64(n))
+}
+
+func DataSourceEthVerifierCallGaugeReset(labelValues ...string) {
+	if dataSourceEthVerifierOnGoingCallGauge == nil {
+		return
+	}
+	dataSourceEthVerifierOnGoingCallGauge.WithLabelValues(labelValues...).Set(0)
 }
 
 // UnconfirmedTxGaugeSet update the number of unconfirmed transactions.

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -802,6 +802,22 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 			},
 		},
 		{
+			Param: netparams.BlockchainsEthereumConfig,
+			Watcher: func(_ context.Context, cfg interface{}) error {
+				// nothing to do if not a validator
+				if !svcs.conf.HaveEthClient() {
+					return nil
+				}
+				ethCfg, err := types.EthereumConfigFromUntypedProto(cfg)
+				if err != nil {
+					return fmt.Errorf("invalid ethereum configuration: %w", err)
+				}
+
+				svcs.witness.SetDefaultConfirmations(ethCfg.Confirmations())
+				return nil
+			},
+		},
+		{
 			Param:   netparams.LimitsProposeMarketEnabledFrom,
 			Watcher: svcs.limits.OnLimitsProposeMarketEnabledFromUpdate,
 		},

--- a/core/validators/config.go
+++ b/core/validators/config.go
@@ -16,6 +16,8 @@
 package validators
 
 import (
+	"time"
+
 	"code.vegaprotocol.io/vega/libs/config/encoding"
 	"code.vegaprotocol.io/vega/logging"
 )
@@ -27,12 +29,14 @@ const (
 // Config represents governance specific configuration.
 type Config struct {
 	// logging level
-	Level encoding.LogLevel `long:"log-level"`
+	Level                   encoding.LogLevel `long:"log-level"`
+	ApproxEthereumBlockTime encoding.Duration
 }
 
 // NewDefaultConfig creates an instance of the package specific configuration.
 func NewDefaultConfig() Config {
 	return Config{
-		Level: encoding.LogLevel{Level: logging.InfoLevel},
+		Level:                   encoding.LogLevel{Level: logging.InfoLevel},
+		ApproxEthereumBlockTime: encoding.Duration{Duration: 15 * time.Second},
 	}
 }

--- a/core/validators/witness.go
+++ b/core/validators/witness.go
@@ -154,6 +154,7 @@ type Witness struct {
 
 	validatorVotesRequired num.Decimal
 	wss                    *witnessSnapshotState
+	defaultConfirmations   int64
 }
 
 func NewWitness(ctx context.Context, log *logging.Logger, cfg Config, top ValidatorTopology, cmd Commander, tsvc TimeService) (w *Witness) {
@@ -174,6 +175,10 @@ func NewWitness(ctx context.Context, log *logging.Logger, cfg Config, top Valida
 			serialised: []byte{},
 		},
 	}
+}
+
+func (w *Witness) SetDefaultConfirmations(c uint64) {
+	w.defaultConfirmations = int64(c)
 }
 
 func (w *Witness) OnDefaultValidatorsVoteRequiredUpdate(ctx context.Context, d num.Decimal) error {
@@ -229,6 +234,24 @@ func (w *Witness) StartCheck(
 	cb func(interface{}, bool),
 	checkUntil time.Time,
 ) error {
+	return w.startCheck(r, cb, checkUntil, w.defaultConfirmations)
+}
+
+func (w *Witness) StartCheckWithDelay(
+	r Resource,
+	cb func(interface{}, bool),
+	checkUntil time.Time,
+	initialDelay int64,
+) error {
+	return w.startCheck(r, cb, checkUntil, initialDelay)
+}
+
+func (w *Witness) startCheck(
+	r Resource,
+	cb func(interface{}, bool),
+	checkUntil time.Time,
+	initialDelay int64,
+) error {
 	id := r.GetID()
 	if _, ok := w.resources[id]; ok {
 		return ErrResourceDuplicate
@@ -254,7 +277,7 @@ func (w *Witness) StartCheck(
 	// if we are a validator, we just start the routine.
 	// so we can ensure the resources exists
 	if w.top.IsValidator() {
-		go w.start(ctx, rs)
+		go w.start(ctx, rs, &initialDelay)
 	} else {
 		// if not a validator, we just jump to the state voteSent
 		// and will wait for all validator to approve basically.
@@ -287,7 +310,13 @@ func newBackoff(ctx context.Context, maxElapsedTime time.Duration) backoff.BackO
 	return backoff.WithContext(bo, ctx)
 }
 
-func (w *Witness) start(ctx context.Context, r *res) {
+func (w *Witness) start(ctx context.Context, r *res, initialDelay *int64) {
+	if initialDelay != nil {
+		t := time.NewTimer(time.Duration(*initialDelay) * w.cfg.ApproxEthereumBlockTime.Duration)
+		<-t.C
+		t.Stop()
+	}
+
 	backff := newBackoff(ctx, r.checkUntil.Sub(w.now))
 	f := func() error {
 		w.log.Debug("Checking the resource",

--- a/core/validators/witness_snapshot.go
+++ b/core/validators/witness_snapshot.go
@@ -165,7 +165,8 @@ func (w *Witness) RestoreResource(r Resource, cb func(interface{}, bool)) error 
 	ctx, cfunc := context.WithDeadline(context.Background(), res.checkUntil)
 	res.cfunc = cfunc
 	if w.top.IsValidator() && res.state.Load() != voteSent {
-		go w.start(ctx, res)
+		// no initial delay
+		go w.start(ctx, res, nil)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds:
 - new metrics to monitor the amount of requests made to the ethereum rpc
 - add an initial delay to avoid spamming the rpc while we know we haven't reach the confirmations yet.

We can now see at least a 10x reduction in calls made to the ethereum RPC, but this is also depending on the frequency of the calls to source prices.

See screen shot for before / after usage of the RPC:
<img width="1920" alt="Screenshot 2023-11-21 at 14 57 37" src="https://github.com/vegaprotocol/vega/assets/4346460/6a9cd76d-80bb-49d7-9d8f-32f8161f391e">


close #10153. 
