### PR TITLE
chore: update snapshot migrations given patches we've done

### DIFF
--- a/core/execution/future/market_snapshot.go
+++ b/core/execution/future/market_snapshot.go
@@ -83,7 +83,7 @@ func NewMarketFromSnapshot(
 
 	as := monitor.NewAuctionStateFromSnapshot(mkt, em.AuctionState)
 
-	if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.4") {
+	if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.6") {
 		// protocol upgrade from v0.73.4, lets populate the new liquidity-fee-settings with a default marginal-cost method
 		log.Info("migrating liquidity fee settings for existing market", logging.String("mid", mkt.ID))
 		mkt.Fees.LiquidityFeeSettings = &types.LiquidityFeeSettings{

--- a/core/execution/future/market_snapshot_test.go
+++ b/core/execution/future/market_snapshot_test.go
@@ -180,7 +180,7 @@ func TestRestoreMarketUpgradeV0_73_2(t *testing.T) {
 	em.Market.Fees.LiquidityFeeSettings = nil
 
 	// and set in the context the information that says we are upgrading
-	ctx := vegacontext.WithSnapshotInfo(context.Background(), "v0.73.4", true)
+	ctx := vegacontext.WithSnapshotInfo(context.Background(), "v0.73.6", true)
 	snap, err := newMarketFromSnapshot(t, ctx, ctrl, em, oracleEngine)
 	require.NoError(t, err)
 	require.NotEmpty(t, snap)

--- a/core/governance/snapshot.go
+++ b/core/governance/snapshot.go
@@ -206,7 +206,7 @@ func (e *Engine) restoreActiveProposals(ctx context.Context, active *types.Gover
 			invalidVotes: votesAsMap(p.Invalid),
 		}
 
-		if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.4") {
+		if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.6") {
 			if nm := pp.Proposal.Terms.GetNewMarket(); nm != nil {
 				e.log.Info("migrating liquidity fee settings for new market proposal", logging.String("pid", pp.ID))
 				nm.Changes.LiquidityFeeSettings = &types.LiquidityFeeSettings{


### PR DESCRIPTION
This updates the migration code for the liqudity-fee-settings feature, and the TWAP-in-auction features need to be updated given we've done mainnet patches since they were merged in.