### PR TITLE
fix: validate against large order sizes that may caught internal over…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [10123](https://github.com/vegaprotocol/vega/issues/10123) - Ledger exports contain account types of "UNKNOWN" type
 - [10132](https://github.com/vegaprotocol/vega/issues/10132) - Add mapping in `GraphQL` for update perps market proposal.
 - [10125](https://github.com/vegaprotocol/vega/issues/10125) - Wire the `JoinTeam` command in the wallet.
+- [10177](https://github.com/vegaprotocol/vega/issues/10177) - Add validation that order sizes are not strangely large.
 - [10166](https://github.com/vegaprotocol/vega/issues/10166) - Closed markets should not be subscribed to data sources when restored from a snapshot.
 - [10127](https://github.com/vegaprotocol/vega/issues/10127) - Untangle `ApplyReferralCode` and `JoinTeam` command verification.
 - [10153](https://github.com/vegaprotocol/vega/issues/10153) - Add metrics and reduce amount of request sent to the Ethereum `RPC`.

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -81,6 +81,7 @@ var (
 	ErrMustBeSetTo0IfSizeSet                           = errors.New("must be set to 0 if the property \"order_amendment.size\" is set")
 	ErrMustBeAtMost3600                                = errors.New("must be at most 3600")
 	ErrMustBeWithinRangeGT0LT20                        = errors.New("price range must be strictly greater than 0 and less than or equal to 20")
+	ErrSizeIsTooLarge                                  = errors.New("size is too large")
 )
 
 type Errors map[string][]error

--- a/commands/order_amendment.go
+++ b/commands/order_amendment.go
@@ -17,6 +17,7 @@ package commands
 
 import (
 	"errors"
+	"math"
 	"math/big"
 
 	types "code.vegaprotocol.io/vega/protos/vega"
@@ -70,6 +71,9 @@ func checkOrderAmendment(cmd *commandspb.OrderAmendment) Errors {
 
 	if cmd.Size != nil {
 		isAmending = true
+		if *cmd.Size > math.MaxInt64/2 {
+			errs.AddForProperty("order_amendment.size", ErrSizeIsTooLarge)
+		}
 	}
 
 	if cmd.SizeDelta != 0 {

--- a/commands/order_submission.go
+++ b/commands/order_submission.go
@@ -17,6 +17,7 @@ package commands
 
 import (
 	"errors"
+	"math"
 	"math/big"
 
 	types "code.vegaprotocol.io/vega/protos/vega"
@@ -70,6 +71,11 @@ func checkOrderSubmission(cmd *commandspb.OrderSubmission) Errors {
 
 	if cmd.Size <= 0 {
 		errs.AddForProperty("order_submission.size", ErrMustBePositive)
+	}
+
+	// just make sure its not some silly big number because we do sometimes cast to int64s
+	if cmd.Size > math.MaxInt64/2 {
+		errs.AddForProperty("order_submission.size", ErrSizeIsTooLarge)
 	}
 
 	if cmd.TimeInForce == types.Order_TIME_IN_FORCE_GTT {

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1940,6 +1940,10 @@ func (m *Market) submitOrder(ctx context.Context, order *types.Order) (*types.Or
 		return nil, nil, err
 	}
 
+	if err := m.position.ValidateOrder(order); err != nil {
+		return nil, nil, err
+	}
+
 	// Now that validation is handled, call the code to place the order
 	orderConf, orderUpdates, err := m.submitValidatedOrder(ctx, order)
 	if err == nil {
@@ -2990,6 +2994,10 @@ func (m *Market) amendOrder(
 
 	amendedOrder, err := existingOrder.ApplyOrderAmendment(orderAmendment, m.timeService.GetTimeNow().UnixNano(), m.priceFactor)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := m.position.ValidateAmendOrder(existingOrder, amendedOrder); err != nil {
 		return nil, nil, err
 	}
 

--- a/core/positions/engine.go
+++ b/core/positions/engine.go
@@ -208,6 +208,28 @@ func (e *Engine) ReloadConf(cfg Config) {
 	e.cfgMu.Unlock()
 }
 
+// ValidateOrder checks that the given order can be registered.
+func (e *Engine) ValidateOrder(order *types.Order) error {
+	pos, found := e.positions[order.Party]
+	if !found {
+		pos = NewMarketPosition(order.Party)
+	}
+	return pos.ValidateOrderRegistration(order.TrueRemaining(), order.Side)
+}
+
+// ValidateAmendOrder checks that replace the given order with a new order will no cause issues with position tracking.
+func (e *Engine) ValidateAmendOrder(order *types.Order, newOrder *types.Order) error {
+	pos, found := e.positions[order.Party]
+	if !found {
+		pos = NewMarketPosition(order.Party)
+	}
+
+	if order.TrueRemaining() >= newOrder.TrueRemaining() {
+		return nil
+	}
+	return pos.ValidateOrderRegistration(newOrder.TrueRemaining()-order.TrueRemaining(), order.Side)
+}
+
 // RegisterOrder updates the potential positions for a submitted order, as though
 // the order were already accepted.
 // It returns the updated position.

--- a/core/positions/engine_test.go
+++ b/core/positions/engine_test.go
@@ -18,6 +18,7 @@ package positions_test
 import (
 	"context"
 	"encoding/hex"
+	"math"
 	"testing"
 	"time"
 
@@ -34,6 +35,70 @@ import (
 
 func TestUpdatePosition(t *testing.T) {
 	t.Run("Update position regular", testUpdatePositionRegular)
+}
+
+func TestRegisterLargeOrder(t *testing.T) {
+	const (
+		buysize  int64 = 123
+		sellsize int64 = 456
+	)
+	ctx := context.Background()
+	e := getTestEngine(t)
+	orderBuy := types.Order{
+		Party:     "test_party",
+		Side:      types.SideBuy,
+		Size:      uint64(buysize),
+		Remaining: uint64(buysize),
+		Price:     num.UintZero(),
+	}
+
+	assert.NoError(t, e.ValidateOrder(&orderBuy))
+	_ = e.RegisterOrder(ctx, &orderBuy)
+
+	// now say we're going to do another MASSIVE one
+	orderBuy2 := types.Order{
+		Party:     "test_party",
+		Side:      types.SideBuy,
+		Size:      math.MaxInt64,
+		Remaining: math.MaxInt64,
+		Price:     num.UintZero(),
+	}
+	assert.Error(t, e.ValidateOrder(&orderBuy2)) // should fail because if we registered it'll overflow
+	require.Panics(t, func() {
+		e.RegisterOrder(ctx, &orderBuy2) // should panic and not silently overflow
+	})
+}
+
+func TestAmendLargeOrder(t *testing.T) {
+	const (
+		buysize  int64 = 123
+		sellsize int64 = 456
+	)
+	ctx := context.Background()
+	e := getTestEngine(t)
+	orderBuy := types.Order{
+		Party:     "test_party",
+		Side:      types.SideBuy,
+		Size:      uint64(buysize),
+		Remaining: uint64(buysize),
+		Price:     num.UintZero(),
+	}
+
+	assert.NoError(t, e.ValidateOrder(&orderBuy))
+	_ = e.RegisterOrder(ctx, &orderBuy)
+
+	// now say we're going to do an amend to a massive one
+	orderBuy2 := types.Order{
+		Party:     "test_party",
+		Side:      types.SideBuy,
+		Size:      math.MaxUint64,
+		Remaining: math.MaxUint64,
+		Price:     num.UintZero(),
+	}
+	assert.Error(t, e.ValidateAmendOrder(&orderBuy, &orderBuy2)) // should fail because if we registered it'll overflow
+	require.Panics(t, func() {
+		e.RegisterOrder(ctx, &orderBuy2) // should panic and not silently overflow
+	})
 }
 
 func TestGetOpenInterest(t *testing.T) {


### PR DESCRIPTION
closes #10177 

Adds validation that the order size that we might be regsitering with the position engine isn't so large that it'll cause us to overflow. We do this both in command validation, and order valiation in the execution engine.

If we do _somehow_ have an order that makes its way through, we now panic ealier with more helpful error-text.
