### PR TITLE
Fix trading fees register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - [10153](https://github.com/vegaprotocol/vega/issues/10153) - Add metrics and reduce amount of request sent to the Ethereum `RPC`.
 - [10147](https://github.com/vegaprotocol/vega/issues/10147) - Add network transfer largest share to the transfers if needed.
 - [10158](https://github.com/vegaprotocol/vega/issues/10158) - Add the network as the zero-share default party in settlement engine.
+- [10183](https://github.com/vegaprotocol/vega/issues/10183) - Fix transfer fees registration and decay.
 
 ## 0.73.0
 

--- a/core/banking/checkpoint_test.go
+++ b/core/banking/checkpoint_test.go
@@ -312,7 +312,7 @@ func TestGovernanceRecurringTransfer(t *testing.T) {
 	e2.assets.EXPECT().Get(gomock.Any()).Times(1).Return(assets.NewAsset(&mockAsset{name: assetNameETH, quantum: num.DecimalFromFloat(100)}), nil).AnyTimes()
 
 	// load the checkpoint
-	e2.broker.EXPECT().SendBatch(gomock.Any()).Times(1)
+	e2.broker.EXPECT().SendBatch(gomock.Any()).Times(2)
 	require.NoError(t, e2.Load(ctx, checkp))
 
 	chp2, err := e2.Checkpoint()

--- a/core/banking/fee_discount.go
+++ b/core/banking/fee_discount.go
@@ -94,7 +94,9 @@ func (e *Engine) decayAllFeeDiscounts(ctx context.Context, perAssetAndPartyUpdat
 		))
 	}
 
-	e.broker.SendBatch(updateDiscountEvents)
+	if len(updateDiscountEvents) > 0 {
+		e.broker.SendBatch(updateDiscountEvents)
+	}
 }
 
 func (e *Engine) updateFeeDiscountsForAsset(
@@ -139,7 +141,9 @@ func (e *Engine) updateFeeDiscountsForAsset(
 		))
 	}
 
-	e.broker.SendBatch(updateDiscountEvents)
+	if len(updateDiscountEvents) > 0 {
+		e.broker.SendBatch(updateDiscountEvents)
+	}
 
 	return updatedKeys
 }

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -361,12 +361,14 @@ func (m *Market) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 		if !m.finalFeesDistributed {
 			m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow(), epoch)
 		}
+
+		m.banking.RegisterTradingFees(ctx, m.settlementAsset, m.fee.TotalTradingFeesPerParty())
+
 		assetQuantum, _ := m.collateral.GetAssetQuantum(m.settlementAsset)
 		feesStats := m.fee.GetFeesStatsOnEpochEnd(assetQuantum)
 		feesStats.Market = m.GetID()
 		feesStats.EpochSeq = epoch.Seq
 
-		m.banking.RegisterTradingFees(ctx, feesStats.Asset, m.fee.TotalTradingFeesPerParty())
 		m.broker.Send(events.NewFeesStatsEvent(ctx, feesStats))
 	}
 

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -2893,12 +2893,14 @@ func (m *Market) OnEpochEvent(ctx context.Context, epoch types.Epoch) {
 	} else if epoch.Action == vega.EpochAction_EPOCH_ACTION_END {
 		m.liquidity.OnEpochEnd(ctx, m.timeService.GetTimeNow(), epoch)
 		m.updateLiquidityFee(ctx)
+
+		m.banking.RegisterTradingFees(ctx, m.quoteAsset, m.fee.TotalTradingFeesPerParty())
+
 		quoteAssetQuantum, _ := m.collateral.GetAssetQuantum(m.quoteAsset)
 		feesStats := m.fee.GetFeesStatsOnEpochEnd(quoteAssetQuantum)
 		feesStats.EpochSeq = epoch.Seq
 		feesStats.Market = m.GetID()
 
-		m.banking.RegisterTradingFees(ctx, feesStats.Asset, m.fee.TotalTradingFeesPerParty())
 		m.broker.Send(events.NewFeesStatsEvent(ctx, feesStats))
 	}
 }

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -1054,11 +1054,11 @@ type Query {
   totalTransferFeeDiscount(
     "ID of party eligible for the discount."
     partyId: String!
-    "ID of asset to associated with the discount."
+    "ID of asset to be associated with the discount."
     assetId: String!
   ): TotalTransferFeeDiscount
 
-  "Estimate transaction fee"
+  "Get transaction fee estimate"
   estimateTransferFee(
     "Sender's ID."
     fromAccount: ID!


### PR DESCRIPTION
To fix bugs:

1. The api `GetTotalTransferFeeDiscount` always returned 0 discount
2. If more than one party on the same asset accrued discount then the decay for a party would trigger for each additional party for the same asset