### PR TITLE
fix: more flaky game data api unit test fixes

### DIFF
--- a/datanode/entities/game.go
+++ b/datanode/entities/game.go
@@ -75,7 +75,7 @@ type GameEntity interface {
 
 type TeamGameParticipation struct {
 	TeamID               TeamID
-	MembersParticipating []IndividualGameEntity
+	MembersParticipating []*IndividualGameEntity
 }
 
 func (t TeamGameParticipation) ToProto() *v2.TeamGameParticipation {

--- a/datanode/sqlstore/games.go
+++ b/datanode/sqlstore/games.go
@@ -177,7 +177,7 @@ func parseGameRewards(rewards []GameReward) ([]entities.Game, error) {
 	participants := uint64(0)
 
 	gameIndividuals := make(map[gameKey][]entities.GameEntity)
-	teamMembers := make(map[gameKey]map[entities.TeamID][]entities.IndividualGameEntity)
+	teamMembers := make(map[gameKey]map[entities.TeamID][]*entities.IndividualGameEntity)
 	teamRanks := make(map[gameKey]map[entities.TeamID]uint64)
 
 	var game entities.Game
@@ -233,9 +233,9 @@ func parseGameRewards(rewards []GameReward) ([]entities.Game, error) {
 		if rewards[i].TeamID != "" {
 			currentTeamID := rewards[i].TeamID
 			if teamMembers[gk] == nil {
-				teamMembers[gk] = make(map[entities.TeamID][]entities.IndividualGameEntity)
+				teamMembers[gk] = make(map[entities.TeamID][]*entities.IndividualGameEntity)
 			}
-			teamMembers[gk][currentTeamID] = append(teamMembers[gk][currentTeamID], individual)
+			teamMembers[gk][currentTeamID] = append(teamMembers[gk][currentTeamID], &individual)
 			if rewards[i].TeamRank == nil {
 				return nil, fmt.Errorf("team rank is nil for team %s", currentTeamID)
 			}

--- a/datanode/sqlstore/games_test.go
+++ b/datanode/sqlstore/games_test.go
@@ -405,7 +405,7 @@ func setupGamesData(ctx context.Context, t *testing.T, stores gameStores, block 
 					}
 					teamRewards := num.NewUint(0)
 					teamVolume := num.DecimalZero()
-					memberEntities := make([]entities.IndividualGameEntity, 0)
+					memberEntities := make([]*entities.IndividualGameEntity, 0)
 					for _, member := range members {
 						amount := num.DecimalFromInt64(r.Int63n(1000))
 						reward := addTestReward(t, ctx, stores.rewards, member, *asset, market, epoch, "", block.VegaTime, block, seqNum, amount, generateTxHash(), gID)
@@ -429,7 +429,7 @@ func setupGamesData(ctx context.Context, t *testing.T, stores gameStores, block 
 						teamMemberTotalRewards[gk][team][member.ID.String()] = teamMemberTotalRewards[gk][team][member.ID.String()].
 							Add(teamMemberTotalRewards[gk][team][member.ID.String()], individualEntity.RewardEarned)
 						individualEntity.TotalRewardsEarned = teamMemberTotalRewards[gk][team][member.ID.String()]
-						memberEntities = append(memberEntities, individualEntity)
+						memberEntities = append(memberEntities, &individualEntity)
 						participants++
 						seqNum++
 					}

--- a/datanode/sqlstore/referral_sets_test.go
+++ b/datanode/sqlstore/referral_sets_test.go
@@ -467,7 +467,7 @@ func TestReferralSets_ListReferralSetReferees(t *testing.T) {
 func TestReferralSets_AddReferralSetStats(t *testing.T) {
 	bs, ps, rs := setupReferralSetsTest(t)
 
-	ctx := context.Background()
+	ctx := tempTransaction(t)
 
 	sets, referees := setupReferralSetsAndReferees(t, ctx, bs, ps, rs)
 	src := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/datanode/sqlstore/stop_orders_test.go
+++ b/datanode/sqlstore/stop_orders_test.go
@@ -16,7 +16,6 @@
 package sqlstore_test
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -214,10 +213,7 @@ func TestStopOrders_ListStopOrders(t *testing.T) {
 	ps := sqlstore.NewParties(connectionSource)
 	ms := sqlstore.NewMarkets(connectionSource)
 
-	// ctx := tempTransaction(t)
-	//
-
-	ctx := context.Background()
+	ctx := tempTransaction(t)
 
 	blocks := []entities.Block{
 		addTestBlock(t, ctx, bs),

--- a/datanode/sqlstore/vesting_stats_test.go
+++ b/datanode/sqlstore/vesting_stats_test.go
@@ -16,7 +16,6 @@
 package sqlstore_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -44,10 +43,12 @@ func TestVestingStats(t *testing.T) {
 		party2 = "a696300fec90755c90e2489af68fe2dfede5744184711ea3acde0ca55ae19585"
 	)
 
+	ctx := tempTransaction(t)
+
 	t.Run("return error if do not exists", func(t *testing.T) {
-		_, err := vs.GetByPartyID(context.Background(), party1)
+		_, err := vs.GetByPartyID(ctx, party1)
 		require.EqualError(t, err, "no resource corresponding to this id")
-		_, err = vs.GetByPartyID(context.Background(), party2)
+		_, err = vs.GetByPartyID(ctx, party2)
 		require.EqualError(t, err, "no resource corresponding to this id")
 	})
 
@@ -75,12 +76,12 @@ func TestVestingStats(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, vs.Add(context.Background(), &w))
+		assert.NoError(t, vs.Add(ctx, &w))
 
-		pvs1, err := vs.GetByPartyID(context.Background(), party1)
+		pvs1, err := vs.GetByPartyID(ctx, party1)
 		require.NoError(t, err)
 		require.Equal(t, *w.PartyVestingStats[0], pvs1)
-		pvs2, err := vs.GetByPartyID(context.Background(), party2)
+		pvs2, err := vs.GetByPartyID(ctx, party2)
 		require.NoError(t, err)
 		require.Equal(t, *w.PartyVestingStats[1], pvs2)
 	})
@@ -109,12 +110,12 @@ func TestVestingStats(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, vs.Add(context.Background(), &w))
+		assert.NoError(t, vs.Add(ctx, &w))
 
-		pvs1, err := vs.GetByPartyID(context.Background(), party1)
+		pvs1, err := vs.GetByPartyID(ctx, party1)
 		require.NoError(t, err)
 		require.Equal(t, *w.PartyVestingStats[0], pvs1)
-		pvs2, err := vs.GetByPartyID(context.Background(), party2)
+		pvs2, err := vs.GetByPartyID(ctx, party2)
 		require.NoError(t, err)
 		require.Equal(t, *w.PartyVestingStats[1], pvs2)
 	})


### PR DESCRIPTION
This fixes the ListGame unit tests which can occasionally fail due to mismatches in the ranking of team individuals.

I also made some changes to other database tests that did not use a transactional context to clean up the database after a test has been completed.