### PR TITLE
fix: validate transfer amount when estimating transfer fees

### DIFF
--- a/datanode/api/errors.go
+++ b/datanode/api/errors.go
@@ -326,6 +326,9 @@ var (
 	ErrListPaidLiquidityFees = errors.New("failed to list paid liquidity fees")
 	// List Games.
 	ErrListGames = errors.New("failed to list games")
+
+	// Transfer fee estimates.
+	ErrInvalidTransferAmount = newInvalidArgumentError("invalid transfer amount")
 )
 
 // errorMap contains a mapping between errors and Vega numeric error codes.


### PR DESCRIPTION
Adds validation to `req.amount` so that we do not panic if it cannot be parsed into a  `Uint`.