### PR TITLE
chore: connect to bootstrap peers after startup to avoid race bug in …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [9516](https://github.com/vegaprotocol/vega/issues/9516) - Add filter by transfer ID for ledger entries API.
 - [9943](https://github.com/vegaprotocol/vega/issues/9943) - Support amending the order size by defining the target size.
 - [9231](https://github.com/vegaprotocol/vega/issues/9231) - Add a `JoinTeam API`
+- [10222](https://github.com/vegaprotocol/vega/issues/10222) - Supply bootstrap peers after starting the `IPFS` node to increase reliability.
 - [10097](https://github.com/vegaprotocol/vega/issues/10097) - Add funding rate modifiers to perpetual product definition.
 - [9981](https://github.com/vegaprotocol/vega/issues/9981) - Support filtering on epoch range on transfers.
 - [9981](https://github.com/vegaprotocol/vega/issues/9981) - Support filtering on status on transfers.


### PR DESCRIPTION
closes #10222 

This is a work-around for a bug in the IPFS library we use where providing bootstrap peers when the initialise the IPFS node can sometimes cause connections to bootstrap peers to not be registered properly in the bitswap process. By instead supplying bootstrap peers _after_ the node has started, we do not fall into the issue at all and the network-history is just that little bit more reliable.

Heres a full system run on a branch [with all the system-test work arounds removed](https://github.com/vegaprotocol/system-tests/compare/remove-datanode-hacks):
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/6540/pipeline

The data-node subjob is 30mins quicker, and with the only failing test due to the fact the test finished _too quickly_.