### PR TITLE
feat: make nullchain staking asset configurable

### DIFF
--- a/core/blockchain/nullchain/staking_loop.go
+++ b/core/blockchain/nullchain/staking_loop.go
@@ -16,6 +16,7 @@
 package nullchain
 
 import (
+	"context"
 	"time"
 
 	"code.vegaprotocol.io/vega/core/assets"
@@ -44,10 +45,14 @@ type StakingLoop struct {
 // from the collateral engine. Used by the null-blockchain to remove the need for an Ethereum connection.
 func NewStakingLoop(col Collateral, assets Assets) *StakingLoop {
 	return &StakingLoop{
-		col:          col,
-		assets:       assets,
-		stakingAsset: "VOTE",
+		col:    col,
+		assets: assets,
 	}
+}
+
+func (s *StakingLoop) OnStakingAsstUpdate(_ context.Context, value string) error {
+	s.stakingAsset = value
+	return nil
 }
 
 func (s *StakingLoop) GetAvailableBalance(party string) (*num.Uint, error) {

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -315,6 +315,12 @@ func newServices(
 			svcs.delegation = delegation.New(svcs.log, svcs.conf.Delegation, svcs.broker, svcs.topology, svcs.stakingAccounts, svcs.epochService, svcs.timeService)
 		} else {
 			stakingLoop := nullchain.NewStakingLoop(svcs.collateral, svcs.assets)
+			svcs.netParams.Watch([]netparams.WatchParam{
+				{
+					Param:   netparams.RewardAsset,
+					Watcher: stakingLoop.OnStakingAsstUpdate,
+				},
+			}...)
 			svcs.governance = governance.NewEngine(svcs.log, svcs.conf.Governance, stakingLoop, svcs.timeService, svcs.broker, svcs.assets, svcs.witness, svcs.executionEngine, svcs.netParams, svcs.banking)
 			svcs.delegation = delegation.New(svcs.log, svcs.conf.Delegation, svcs.broker, svcs.topology, stakingLoop, svcs.epochService, svcs.timeService)
 		}


### PR DESCRIPTION
Current the network staking asset needed for governance proposals defaults to `VOTE`.

To reduce the number of faucet requests, market-sim is moving towards using transfers from a common "treasury" key. Transfers require a valid Vega ID, `VOTE` is not valid.

PR allows the staking asset to be changed through network parameters.