### PR TITLE
Filter ledger by transfer ID

### DIFF
--- a/datanode/entities/aggregated_ledgerentries.go
+++ b/datanode/entities/aggregated_ledgerentries.go
@@ -33,17 +33,18 @@ import (
 type AggregatedLedgerEntry struct {
 	VegaTime     time.Time
 	Quantity     decimal.Decimal
-	TransferType *LedgerMovementType
-	AssetID      *AssetID
+	TransferType LedgerMovementType
+	AssetID      AssetID
 
-	FromAccountPartyID  *PartyID
-	ToAccountPartyID    *PartyID
-	FromAccountMarketID *MarketID
-	ToAccountMarketID   *MarketID
-	FromAccountType     *types.AccountType
-	ToAccountType       *types.AccountType
+	FromAccountPartyID  PartyID
+	ToAccountPartyID    PartyID
+	FromAccountMarketID MarketID
+	ToAccountMarketID   MarketID
+	FromAccountType     types.AccountType
+	ToAccountType       types.AccountType
 	FromAccountBalance  decimal.Decimal
 	ToAccountBalance    decimal.Decimal
+	TransferID          TransferID
 }
 
 func (ledgerEntries *AggregatedLedgerEntry) ToProto() *v2.AggregatedLedgerEntry {
@@ -52,53 +53,35 @@ func (ledgerEntries *AggregatedLedgerEntry) ToProto() *v2.AggregatedLedgerEntry 
 	lep.Quantity = ledgerEntries.Quantity.String()
 	lep.Timestamp = ledgerEntries.VegaTime.UnixNano()
 
-	if ledgerEntries.TransferType != nil {
-		lep.TransferType = vega.TransferType(*ledgerEntries.TransferType)
+	lep.TransferType = vega.TransferType(ledgerEntries.TransferType)
+
+	assetIDString := ledgerEntries.AssetID.String()
+	if assetIDString != "" {
+		lep.AssetId = &assetIDString
 	}
 
-	if ledgerEntries.AssetID != nil {
-		assetIDString := ledgerEntries.AssetID.String()
-		if assetIDString != "" {
-			lep.AssetId = &assetIDString
-		}
+	fromPartyIDString := ledgerEntries.FromAccountPartyID.String()
+	if fromPartyIDString != "" {
+		lep.FromAccountPartyId = &fromPartyIDString
 	}
 
-	if ledgerEntries.FromAccountPartyID != nil {
-		partyIDString := ledgerEntries.FromAccountPartyID.String()
-		if partyIDString != "" {
-			lep.FromAccountPartyId = &partyIDString
-		}
+	toPartyIDString := ledgerEntries.ToAccountPartyID.String()
+	if toPartyIDString != "" {
+		lep.ToAccountPartyId = &toPartyIDString
 	}
 
-	if ledgerEntries.ToAccountPartyID != nil {
-		partyIDString := ledgerEntries.ToAccountPartyID.String()
-		if partyIDString != "" {
-			lep.ToAccountPartyId = &partyIDString
-		}
+	fromMarketIDString := ledgerEntries.FromAccountMarketID.String()
+	if fromMarketIDString != "" {
+		lep.FromAccountMarketId = &fromMarketIDString
 	}
 
-	if ledgerEntries.FromAccountMarketID != nil {
-		marketIDString := ledgerEntries.FromAccountMarketID.String()
-		if marketIDString != "" {
-			lep.FromAccountMarketId = &marketIDString
-		}
+	toMarketIDString := ledgerEntries.ToAccountMarketID.String()
+	if toMarketIDString != "" {
+		lep.ToAccountMarketId = &toMarketIDString
 	}
 
-	if ledgerEntries.ToAccountMarketID != nil {
-		marketIDString := ledgerEntries.ToAccountMarketID.String()
-		if marketIDString != "" {
-			lep.ToAccountMarketId = &marketIDString
-		}
-	}
-
-	if ledgerEntries.FromAccountType != nil {
-		lep.FromAccountType = *ledgerEntries.FromAccountType
-	}
-
-	if ledgerEntries.ToAccountType != nil {
-		lep.ToAccountType = *ledgerEntries.ToAccountType
-	}
-
+	lep.FromAccountType = ledgerEntries.FromAccountType
+	lep.ToAccountType = ledgerEntries.ToAccountType
 	lep.FromAccountBalance = ledgerEntries.FromAccountBalance.String()
 	lep.ToAccountBalance = ledgerEntries.ToAccountBalance.String()
 

--- a/datanode/entities/ledgerentry.go
+++ b/datanode/entities/ledgerentry.go
@@ -100,58 +100,38 @@ func CreateLedgerEntryTime(vegaTime time.Time, seqNum int) time.Time {
 type LedgerMovementType vega.TransferType
 
 const (
-	// Default value, always invalid.
-	LedgerMovementTypeUnspecified = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_UNSPECIFIED)
-	// Loss.
-	LedgerMovementTypeLoss = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_LOSS)
-	// Win.
-	LedgerMovementTypeWin = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_WIN)
-	// Mark to market loss.
-	LedgerMovementTypeMTMLoss = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MTM_LOSS)
-	// Mark to market win.
-	LedgerMovementTypeMTMWin = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MTM_WIN)
-	// Margin too low.
-	LedgerMovementTypeMarginLow = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MARGIN_LOW)
-	// Margin too high.
-	LedgerMovementTypeMarginHigh = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MARGIN_HIGH)
-	// Margin was confiscated.
-	LedgerMovementTypeMarginConfiscated = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MARGIN_CONFISCATED)
-	// Pay maker fee.
-	LedgerMovementTypeMakerFeePay = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MAKER_FEE_PAY)
-	// Receive maker fee.
-	LedgerMovementTypeMakerFeeReceive = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MAKER_FEE_RECEIVE)
-	// Pay infrastructure fee.
-	LedgerMovementTypeInfrastructureFeePay = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_INFRASTRUCTURE_FEE_PAY)
-	// Receive infrastructure fee.
+	LedgerMovementTypeUnspecified                 = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_UNSPECIFIED)
+	LedgerMovementTypeLoss                        = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_LOSS)
+	LedgerMovementTypeWin                         = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_WIN)
+	LedgerMovementTypeMTMLoss                     = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MTM_LOSS)
+	LedgerMovementTypeMTMWin                      = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MTM_WIN)
+	LedgerMovementTypeMarginLow                   = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MARGIN_LOW)
+	LedgerMovementTypeMarginHigh                  = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MARGIN_HIGH)
+	LedgerMovementTypeMarginConfiscated           = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MARGIN_CONFISCATED)
+	LedgerMovementTypeMakerFeePay                 = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MAKER_FEE_PAY)
+	LedgerMovementTypeMakerFeeReceive             = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_MAKER_FEE_RECEIVE)
+	LedgerMovementTypeInfrastructureFeePay        = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_INFRASTRUCTURE_FEE_PAY)
 	LedgerMovementTypeInfrastructureFeeDistribute = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_INFRASTRUCTURE_FEE_DISTRIBUTE)
-	// Pay liquidity fee.
-	LedgerMovementTypeLiquidityFeePay = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_LIQUIDITY_FEE_PAY)
-	// Receive liquidity fee.
-	LedgerMovementTypeLiquidityFeeDistribute = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_LIQUIDITY_FEE_DISTRIBUTE)
-	// Bond too low.
-	LedgerMovementTypeBondLow = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_BOND_LOW)
-	// Bond too high.
-	LedgerMovementTypeBondHigh = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_BOND_HIGH)
-	// Actual withdraw from system.
-	LedgerMovementTypeWithdraw = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_WITHDRAW)
-	// Deposit funds.
-	LedgerMovementTypeDeposit = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_DEPOSIT)
-	// Bond slashing.
-	LedgerMovementTypeBondSlashing = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_BOND_SLASHING)
-	// Reward payout.
-	LedgerMovementTypeRewardPayout            = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_REWARD_PAYOUT)
-	LedgerMovementTypeTransferFundsSend       = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_SEND)
-	LedgerMovementTypeTransferFundsDistribute = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_DISTRIBUTE)
-	LedgerMovementTypeClearAccount            = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_CLEAR_ACCOUNT)
-	LedgerMovementTypePerpFundingWin          = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_PERPETUALS_FUNDING_WIN)
-	LedgerMovementTypePerpFundingLoss         = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_PERPETUALS_FUNDING_LOSS)
-	LedgerMovementTypeRewardsVested           = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_REWARDS_VESTED)
+	LedgerMovementTypeLiquidityFeePay             = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_LIQUIDITY_FEE_PAY)
+	LedgerMovementTypeLiquidityFeeDistribute      = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_LIQUIDITY_FEE_DISTRIBUTE)
+	LedgerMovementTypeBondLow                     = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_BOND_LOW)
+	LedgerMovementTypeBondHigh                    = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_BOND_HIGH)
+	LedgerMovementTypeWithdraw                    = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_WITHDRAW)
+	LedgerMovementTypeDeposit                     = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_DEPOSIT)
+	LedgerMovementTypeBondSlashing                = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_BOND_SLASHING)
+	LedgerMovementTypeRewardPayout                = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_REWARD_PAYOUT)
+	LedgerMovementTypeTransferFundsSend           = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_SEND)
+	LedgerMovementTypeTransferFundsDistribute     = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_TRANSFER_FUNDS_DISTRIBUTE)
+	LedgerMovementTypeClearAccount                = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_CLEAR_ACCOUNT)
+	LedgerMovementTypePerpFundingWin              = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_PERPETUALS_FUNDING_WIN)
+	LedgerMovementTypePerpFundingLoss             = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_PERPETUALS_FUNDING_LOSS)
+	LedgerMovementTypeRewardsVested               = LedgerMovementType(vega.TransferType_TRANSFER_TYPE_REWARDS_VESTED)
 )
 
 func (l LedgerMovementType) EncodeText(_ *pgtype.ConnInfo, buf []byte) ([]byte, error) {
 	ty, ok := vega.TransferType_name[int32(l)]
 	if !ok {
-		return buf, fmt.Errorf("unknown transfer status: %s", ty)
+		return buf, fmt.Errorf("unknown ledger movement type: %s", ty)
 	}
 	return append(buf, []byte(ty)...), nil
 }
@@ -159,7 +139,7 @@ func (l LedgerMovementType) EncodeText(_ *pgtype.ConnInfo, buf []byte) ([]byte, 
 func (l *LedgerMovementType) DecodeText(_ *pgtype.ConnInfo, src []byte) error {
 	val, ok := vega.TransferType_value[string(src)]
 	if !ok {
-		return fmt.Errorf("unknown transfer status: %s", src)
+		return fmt.Errorf("unknown ledger movement type: %s", src)
 	}
 
 	*l = LedgerMovementType(val)

--- a/datanode/entities/ledgerentry_filter.go
+++ b/datanode/entities/ledgerentry_filter.go
@@ -24,7 +24,7 @@ import (
 // Intended for generic use.
 type CloseOnLimitOperation bool
 
-// Settings for receiving closed/open sets on different parts of the outputs of LedgerEntries.
+// LedgerEntryFilter settings for receiving closed/open sets on different parts of the outputs of LedgerEntries.
 // Any kind of relation between the data types on logical and practical level in the set is the `limit operation`.
 // We close or not the set of output items on the limit operation via the `CloseOnOperation` set values.
 type LedgerEntryFilter struct {

--- a/datanode/sqlstore/ledger_test.go
+++ b/datanode/sqlstore/ledger_test.go
@@ -239,20 +239,20 @@ func TestLedger(t *testing.T) {
 	t.Run("get all ledger records", func(t *testing.T) {
 		// Account store should be empty to begin with
 		ledgerEntries, err := ledgerStore.GetAll(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, ledgerEntries)
 	})
 
 	_, err := ledgerStore.Flush(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("get by tx hash", func(t *testing.T) {
 		fetchedEntries, err := ledgerStore.GetByTxHash(ctx, ledgerEntries[0].TxHash)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		ledgerEntryEqual(t, ledgerEntries[0], fetchedEntries[0])
 
 		fetchedEntries2, err := ledgerStore.GetByTxHash(ctx, ledgerEntries[2].TxHash)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		ledgerEntryEqual(t, ledgerEntries[2], fetchedEntries2[0])
 	})
 
@@ -277,7 +277,7 @@ func TestLedger(t *testing.T) {
 
 	t.Run("query ledger entries with filters", func(t *testing.T) {
 		t.Run("by fromAccount filter", func(t *testing.T) {
-			// Set filters for FromAccount and AcountTo IDs
+			// Set filters for FromAccount and AccountTo IDs
 			filter := &entities.LedgerEntryFilter{
 				FromAccountFilter: entities.AccountFilter{
 					AssetID: asset1.ID,
@@ -303,7 +303,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// 0
 			assert.NotNil(t, entries)
@@ -316,35 +316,35 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// 6->7, 6->7, 6->7
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 
 			for _, e := range *entries {
-				assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-				assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+				assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+				assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 				if e.Quantity.Abs().String() == strconv.Itoa(80) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 					assert.Equal(t, strconv.Itoa(2310), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17000), e.ToAccountBalance.Abs().String())
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(9) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 					assert.Equal(t, strconv.Itoa(2301), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17009), e.ToAccountBalance.Abs().String())
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(41) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 					assert.Equal(t, strconv.Itoa(2260), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17050), e.ToAccountBalance.Abs().String())
 				}
 
-				assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-				assert.Equal(t, *e.ToAccountMarketID, markets[4].ID)
+				assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+				assert.Equal(t, e.ToAccountMarketID, markets[4].ID)
 			}
 
 			filter.FromAccountFilter.PartyIDs = append(filter.FromAccountFilter.PartyIDs, parties[4].ID)
@@ -391,34 +391,34 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// 6->7, 6->7, 6->7
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
-				assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-				assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+				assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+				assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 				if e.Quantity.Abs().String() == strconv.Itoa(80) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 					assert.Equal(t, strconv.Itoa(2310), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17000), e.ToAccountBalance.Abs().String())
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(9) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 					assert.Equal(t, strconv.Itoa(2301), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17009), e.ToAccountBalance.Abs().String())
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(41) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 					assert.Equal(t, strconv.Itoa(2260), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17050), e.ToAccountBalance.Abs().String())
 				}
 
-				assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-				assert.Equal(t, *e.ToAccountMarketID, markets[4].ID)
+				assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+				assert.Equal(t, e.ToAccountMarketID, markets[4].ID)
 			}
 
 			filter.ToAccountFilter.AccountTypes = []vega.AccountType{vega.AccountType_ACCOUNT_TYPE_GENERAL, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY}
@@ -429,7 +429,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// None
 			assert.NotNil(t, entries)
@@ -457,28 +457,28 @@ func TestLedger(t *testing.T) {
 				cursor,
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// 6->7, 6->7, 6->7
 			assert.NotNil(t, entries)
 			assert.Equal(t, 2, len(*entries))
 			for _, e := range *entries {
-				assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-				assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+				assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+				assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 				if e.Quantity.Abs().String() == strconv.Itoa(80) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 					assert.Equal(t, strconv.Itoa(2310), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17000), e.ToAccountBalance.Abs().String())
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(9) {
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 					assert.Equal(t, strconv.Itoa(2301), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17009), e.ToAccountBalance.Abs().String())
 				}
 
-				assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-				assert.Equal(t, *e.ToAccountMarketID, markets[4].ID)
+				assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+				assert.Equal(t, e.ToAccountMarketID, markets[4].ID)
 			}
 
 			filter.ToAccountFilter.AccountTypes = []vega.AccountType{vega.AccountType_ACCOUNT_TYPE_GENERAL, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY}
@@ -489,7 +489,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// None
 			assert.NotNil(t, entries)
@@ -526,30 +526,30 @@ func TestLedger(t *testing.T) {
 					entities.CursorPagination{},
 				)
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Output entries for accounts positions:
 				// 0->1, 2->3
 				assert.NotNil(t, entries)
 				assert.Equal(t, 2, len(*entries))
 				for _, e := range *entries {
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 
 					if e.Quantity.Abs().String() == strconv.Itoa(15) {
-						assert.Equal(t, *e.FromAccountPartyID, parties[0].ID)
-						assert.Equal(t, *e.ToAccountPartyID, parties[0].ID)
-						assert.Equal(t, *e.FromAccountMarketID, markets[0].ID)
-						assert.Equal(t, *e.ToAccountMarketID, markets[1].ID)
+						assert.Equal(t, e.FromAccountPartyID, parties[0].ID)
+						assert.Equal(t, e.ToAccountPartyID, parties[0].ID)
+						assert.Equal(t, e.FromAccountMarketID, markets[0].ID)
+						assert.Equal(t, e.ToAccountMarketID, markets[1].ID)
 						assert.Equal(t, strconv.Itoa(500), e.FromAccountBalance.Abs().String())
 						assert.Equal(t, strconv.Itoa(115), e.ToAccountBalance.Abs().String())
 					}
 
 					if e.Quantity.Abs().String() == strconv.Itoa(10) {
-						assert.Equal(t, *e.FromAccountPartyID, parties[1].ID)
-						assert.Equal(t, *e.ToAccountPartyID, parties[1].ID)
-						assert.Equal(t, *e.FromAccountMarketID, markets[1].ID)
-						assert.Equal(t, *e.ToAccountMarketID, markets[2].ID)
+						assert.Equal(t, e.FromAccountPartyID, parties[1].ID)
+						assert.Equal(t, e.ToAccountPartyID, parties[1].ID)
+						assert.Equal(t, e.FromAccountMarketID, markets[1].ID)
+						assert.Equal(t, e.ToAccountMarketID, markets[2].ID)
 						assert.Equal(t, strconv.Itoa(170), e.FromAccountBalance.Abs().String())
 						assert.Equal(t, strconv.Itoa(17890), e.ToAccountBalance.Abs().String())
 					}
@@ -562,30 +562,30 @@ func TestLedger(t *testing.T) {
 					entities.CursorPagination{},
 				)
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Output entries for accounts positions:
 				// 0->1, 2->3
 				assert.NotNil(t, entries)
 				assert.Equal(t, 2, len(*entries))
 				for _, e := range *entries {
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 
 					if e.Quantity.Abs().String() == strconv.Itoa(15) {
-						assert.Equal(t, *e.FromAccountPartyID, parties[0].ID)
-						assert.Equal(t, *e.ToAccountPartyID, parties[0].ID)
-						assert.Equal(t, *e.FromAccountMarketID, markets[0].ID)
-						assert.Equal(t, *e.ToAccountMarketID, markets[1].ID)
+						assert.Equal(t, e.FromAccountPartyID, parties[0].ID)
+						assert.Equal(t, e.ToAccountPartyID, parties[0].ID)
+						assert.Equal(t, e.FromAccountMarketID, markets[0].ID)
+						assert.Equal(t, e.ToAccountMarketID, markets[1].ID)
 						assert.Equal(t, strconv.Itoa(500), e.FromAccountBalance.Abs().String())
 						assert.Equal(t, strconv.Itoa(115), e.ToAccountBalance.Abs().String())
 					}
 
 					if e.Quantity.Abs().String() == strconv.Itoa(10) {
-						assert.Equal(t, *e.FromAccountPartyID, parties[1].ID)
-						assert.Equal(t, *e.ToAccountPartyID, parties[1].ID)
-						assert.Equal(t, *e.FromAccountMarketID, markets[1].ID)
-						assert.Equal(t, *e.ToAccountMarketID, markets[2].ID)
+						assert.Equal(t, e.FromAccountPartyID, parties[1].ID)
+						assert.Equal(t, e.ToAccountPartyID, parties[1].ID)
+						assert.Equal(t, e.FromAccountMarketID, markets[1].ID)
+						assert.Equal(t, e.ToAccountMarketID, markets[2].ID)
 						assert.Equal(t, strconv.Itoa(170), e.FromAccountBalance.Abs().String())
 						assert.Equal(t, strconv.Itoa(17890), e.ToAccountBalance.Abs().String())
 					}
@@ -620,21 +620,21 @@ func TestLedger(t *testing.T) {
 					entities.CursorPagination{},
 				)
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Output entries for accounts positions -> should output transfers for asset2 only:
 				// 10->11
 				assert.NotNil(t, entries)
 				assert.Equal(t, 1, len(*entries))
 				for _, e := range *entries {
 					assert.Equal(t, e.Quantity.Abs().String(), strconv.Itoa(40))
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeDeposit)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeDeposit)
 
-					assert.Equal(t, *e.FromAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[5].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(1500), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(5680), e.ToAccountBalance.Abs().String())
 				}
@@ -647,7 +647,7 @@ func TestLedger(t *testing.T) {
 					entities.CursorPagination{},
 				)
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Output entries for accounts positions:
 				// None
 				assert.NotNil(t, entries)
@@ -662,21 +662,21 @@ func TestLedger(t *testing.T) {
 					entities.CursorPagination{},
 				)
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Output entries for accounts positions:
 				// 14->16
 				assert.NotNil(t, entries)
 				assert.Equal(t, 1, len(*entries))
 				for _, e := range *entries {
 					assert.Equal(t, e.Quantity.Abs().String(), strconv.Itoa(12))
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeDeposit)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeDeposit)
 
-					assert.Equal(t, *e.FromAccountPartyID, parties[7].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[8].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[7].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[8].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[7].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[8].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[7].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[8].ID)
 					assert.Equal(t, strconv.Itoa(5000), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(9100), e.ToAccountBalance.Abs().String())
 				}
@@ -705,45 +705,45 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions -> should output transfers for asset3 only:
 			// 14->16, 17->15, 21->15
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(12) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[7].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[8].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[7].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[8].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[7].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[8].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[7].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[8].ID)
 					assert.Equal(t, strconv.Itoa(5000), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(9100), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(14) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[8].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[7].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[9].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[8].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[8].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[7].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[9].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[8].ID)
 					assert.Equal(t, strconv.Itoa(180), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(1410), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(28) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[10].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[7].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[10].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[7].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[9].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[8].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[9].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[8].ID)
 					assert.Equal(t, strconv.Itoa(2180), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(1438), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
 				}
 
-				assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
-				assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeDeposit)
+				assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_FEES_LIQUIDITY)
+				assert.Equal(t, e.TransferType, entities.LedgerMovementTypeDeposit)
 			}
 
 			// closed on account filters
@@ -754,7 +754,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// None
 			assert.NotNil(t, entries)
@@ -771,7 +771,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions:
 			// 0
 			assert.NotNil(t, entries)
@@ -825,42 +825,42 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(5) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[5].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2188), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17122), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 			}
 
@@ -871,45 +871,45 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Output entries for accounts positions -> should output transfers for asset3 only:
 			// 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(5) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[5].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2188), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17122), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
-				assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+				assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 			}
 
 			filter = &entities.LedgerEntryFilter{
@@ -930,42 +930,42 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(5) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[5].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2188), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17122), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 			}
 
@@ -988,7 +988,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, entries)
 			assert.Equal(t, 0, len(*entries))
 
@@ -1011,7 +1011,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// List transfers:
 			// accounts 5->11 - 3 - ACCOUNT_TYPE_INSURANCE ACCOUNT_TYPE_GENERAL
 			// accounts 5->10 - 5 - ACCOUNT_TYPE_INSURANCE ACCOUNT_TYPE_GENERAL
@@ -1021,53 +1021,53 @@ func TestLedger(t *testing.T) {
 			assert.Equal(t, 4, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2587), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(5683), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(5) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[5].ID)
 					assert.Equal(t, strconv.Itoa(2582), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(1510), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2188), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17122), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(25) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[2].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[3].ID)
 					assert.Equal(t, strconv.Itoa(1700), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(2590), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 				}
 			}
 
@@ -1092,7 +1092,7 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// List transfers:
 			// 0
 			assert.NotNil(t, entries)
@@ -1118,42 +1118,42 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
 			assert.Equal(t, 3, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(5) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[5].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2188), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17122), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 			}
 
@@ -1179,55 +1179,55 @@ func TestLedger(t *testing.T) {
 				entities.CursorPagination{},
 			)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// 4->5, 5->10, 5->11, 4->11
 			assert.NotNil(t, entries)
 			assert.Equal(t, 4, len(*entries))
 			for _, e := range *entries {
 				if e.Quantity.Abs().String() == strconv.Itoa(3) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(5) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
-					assert.Equal(t, *e.FromAccountMarketID, markets[3].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[5].ID)
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[5].ID)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(25) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[2].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[3].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[3].ID)
 					assert.Equal(t, strconv.Itoa(1700), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(2590), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeBondSlashing)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeBondSlashing)
 				}
 
 				if e.Quantity.Abs().String() == strconv.Itoa(72) {
-					assert.Equal(t, *e.FromAccountPartyID, parties[2].ID)
-					assert.Equal(t, *e.ToAccountPartyID, parties[5].ID)
+					assert.Equal(t, e.FromAccountPartyID, parties[2].ID)
+					assert.Equal(t, e.ToAccountPartyID, parties[5].ID)
 
-					assert.Equal(t, *e.FromAccountMarketID, markets[2].ID)
-					assert.Equal(t, *e.ToAccountMarketID, markets[6].ID)
+					assert.Equal(t, e.FromAccountMarketID, markets[2].ID)
+					assert.Equal(t, e.ToAccountMarketID, markets[6].ID)
 					assert.Equal(t, strconv.Itoa(2188), e.FromAccountBalance.Abs().String())
 					assert.Equal(t, strconv.Itoa(17122), e.ToAccountBalance.Abs().String())
-					assert.Equal(t, *e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
-					assert.Equal(t, *e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
-					assert.Equal(t, *e.TransferType, entities.LedgerMovementTypeRewardPayout)
+					assert.Equal(t, e.FromAccountType, vega.AccountType_ACCOUNT_TYPE_INSURANCE)
+					assert.Equal(t, e.ToAccountType, vega.AccountType_ACCOUNT_TYPE_GENERAL)
+					assert.Equal(t, e.TransferType, entities.LedgerMovementTypeRewardPayout)
 				}
 			}
 		})

--- a/datanode/sqlstore/ledgerentry_filter.go
+++ b/datanode/sqlstore/ledgerentry_filter.go
@@ -18,84 +18,81 @@ package sqlstore
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"code.vegaprotocol.io/vega/datanode/entities"
 	"code.vegaprotocol.io/vega/protos/vega"
+
+	"golang.org/x/exp/maps"
 )
 
 var (
 	ErrLedgerEntryFilterForParty = errors.New("filtering ledger entries should be limited to a single party")
-
 	ErrLedgerEntryExportForParty = errors.New("exporting ledger entries should be limited to a single party")
 )
 
 // Return an SQL query string and corresponding bind arguments to return
 // ledger entries rows resulting from different filter options.
-func filterLedgerEntriesQuery(filter *entities.LedgerEntryFilter) ([4]string, []interface{}, error) {
-	err := handlePartiesFiltering(filter)
-	if err != nil {
-		return [4]string{}, nil, err
+func filterLedgerEntriesQuery(filter *entities.LedgerEntryFilter, args *[]interface{}, whereClauses *[]string) error {
+	if err := handlePartiesFiltering(filter); err != nil {
+		return err
 	}
 
-	var args []interface{}
-	filterQueries := [4]string{}
-
-	// FromAccount filter
-	fromAccountDBQuery, nargs, err := accountFilterToDBQuery(filter.FromAccountFilter, &args, "account_from_")
+	fromAccountDBQuery, err := accountFilterToDBQuery(filter.FromAccountFilter, args, "account_from.")
 	if err != nil {
-		return [4]string{}, nil, fmt.Errorf("error parsing fromAccount filter values: %w", err)
+		return fmt.Errorf("invalid fromAccount filters: %w", err)
 	}
-	args = *nargs
 
-	// ToAccount filter
-	toAccountDBQuery, nargs, err := accountFilterToDBQuery(filter.ToAccountFilter, &args, "account_to_")
+	toAccountDBQuery, err := accountFilterToDBQuery(filter.ToAccountFilter, args, "account_to.")
 	if err != nil {
-		return [4]string{}, nil, fmt.Errorf("error parsing fromAccount filter values: %w", err)
+		return fmt.Errorf("invalid toAccount filters: %w", err)
 	}
-	args = *nargs
 
-	// TransferTypeFilters
-	accountTransferTypeDBQuery := transferTypeFilterToDBQuery(filter.TransferTypes, &args)
+	accountTransferTypeDBQuery := transferTypeFilterToDBQuery(filter.TransferTypes)
 
-	transfersDBQuery, nargs := transfersFilterToDBQuery(filter.TransferID, &args)
+	if fromAccountDBQuery != "" {
+		if toAccountDBQuery != "" {
+			if filter.CloseOnAccountFilters {
+				*whereClauses = append(*whereClauses, fromAccountDBQuery, toAccountDBQuery)
+			} else {
+				*whereClauses = append(*whereClauses, fmt.Sprintf("((%s) OR (%s))", fromAccountDBQuery, toAccountDBQuery))
+			}
+		} else {
+			*whereClauses = append(*whereClauses, fromAccountDBQuery)
+		}
+	} else if toAccountDBQuery != "" {
+		*whereClauses = append(*whereClauses, toAccountDBQuery)
+	}
 
-	args = *nargs
+	if accountTransferTypeDBQuery != "" {
+		*whereClauses = append(*whereClauses, accountTransferTypeDBQuery)
+	}
 
-	filterQueries[0] = fromAccountDBQuery
-	filterQueries[1] = toAccountDBQuery
-	filterQueries[2] = accountTransferTypeDBQuery
-	filterQueries[3] = transfersDBQuery
-
-	return filterQueries, args, nil
+	return nil
 }
 
 // accountFilterToDBQuery creates a DB query section string from the given account filter values.
-func accountFilterToDBQuery(af entities.AccountFilter, args *[]interface{}, prefix string) (string, *[]interface{}, error) {
-	var (
-		singleAccountFilter string
-		err                 error
-	)
+func accountFilterToDBQuery(af entities.AccountFilter, args *[]interface{}, prefix string) (string, error) {
+	var err error
+
+	whereClauses := []string{}
 
 	// Asset filtering
 	if af.AssetID.String() != "" {
 		assetIDAsBytes, err := af.AssetID.Bytes()
 		if err != nil {
-			return "", nil, fmt.Errorf("invalid asset id: %w", err)
+			return "", fmt.Errorf("invalid asset id: %w", err)
 		}
-		singleAccountFilter = fmt.Sprintf("%sasset_id=%s", singleAccountFilter, nextBindVar(args, assetIDAsBytes))
+		whereClauses = append(whereClauses, fmt.Sprintf("account_from.asset_id=%s", nextBindVar(args, assetIDAsBytes)))
 	}
 
 	// Party filtering
 	if len(af.PartyIDs) == 1 {
 		partyIDAsBytes, err := af.PartyIDs[0].Bytes()
 		if err != nil {
-			return "", nil, fmt.Errorf("invalid party id: %w", err)
+			return "", fmt.Errorf("invalid party id: %w", err)
 		}
-		if singleAccountFilter != "" {
-			singleAccountFilter = fmt.Sprintf(`%s AND %sparty_id=%s`, singleAccountFilter, prefix, nextBindVar(args, partyIDAsBytes))
-		} else {
-			singleAccountFilter = fmt.Sprintf(`%sparty_id=%s`, prefix, nextBindVar(args, partyIDAsBytes))
-		}
+		whereClauses = append(whereClauses, fmt.Sprintf(`%sparty_id=%s`, prefix, nextBindVar(args, partyIDAsBytes)))
 	}
 
 	// Market filtering
@@ -104,29 +101,19 @@ func accountFilterToDBQuery(af entities.AccountFilter, args *[]interface{}, pref
 		for i, market := range af.MarketIDs {
 			marketIds[i], err = market.Bytes()
 			if err != nil {
-				return "", nil, fmt.Errorf("invalid market id: %w", err)
+				return "", fmt.Errorf("invalid market id: %w", err)
 			}
 		}
 
-		if singleAccountFilter != "" {
-			singleAccountFilter = fmt.Sprintf(`%s AND %smarket_id=ANY(%s)`, singleAccountFilter, prefix, nextBindVar(args, marketIds))
-		} else {
-			singleAccountFilter = fmt.Sprintf(`%smarket_id=ANY(%s)`, prefix, nextBindVar(args, marketIds))
-		}
+		whereClauses = append(whereClauses, fmt.Sprintf("%smarket_id=ANY(%s)", prefix, nextBindVar(args, marketIds)))
 	}
 
 	// Account types filtering
 	if len(af.AccountTypes) > 0 {
-		acTypes := getUniqueAccountTypes(af.AccountTypes)
-
-		if singleAccountFilter != "" {
-			singleAccountFilter = fmt.Sprintf(`%s AND %saccount_type=ANY(%s)`, singleAccountFilter, prefix, nextBindVar(args, acTypes))
-		} else {
-			singleAccountFilter = fmt.Sprintf(`%saccount_type=ANY(%s)`, prefix, nextBindVar(args, acTypes))
-		}
+		whereClauses = append(whereClauses, fmt.Sprintf(`%stype=ANY(%s)`, prefix, nextBindVar(args, getUniqueAccountTypes(af.AccountTypes))))
 	}
 
-	return singleAccountFilter, args, nil
+	return strings.Join(whereClauses, " AND "), nil
 }
 
 func getUniqueAccountTypes(accountTypes []vega.AccountType) []vega.AccountType {
@@ -144,43 +131,38 @@ func getUniqueAccountTypes(accountTypes []vega.AccountType) []vega.AccountType {
 	return accountTypesList
 }
 
-func transferTypeFilterToDBQuery(transferTypeFilter []entities.LedgerMovementType, args *[]interface{}) string {
-	transferTypeFilterString := ""
-	if len(transferTypeFilter) > 0 {
-		transferTypesMap := map[entities.LedgerMovementType]struct{}{}
-
-		for _, transferType := range transferTypeFilter {
-			_, ok := transferTypesMap[transferType]
-			if ok {
-				continue
-			}
-			transferTypesMap[transferType] = struct{}{}
-		}
-
-		for v := range transferTypesMap {
-			_, ok := vega.TransferType_name[int32(v)]
-			if !ok {
-				continue
-			}
-
-			if transferTypeFilterString == "" {
-				transferTypeFilterString = fmt.Sprintf(`%stransfer_type=%s`, transferTypeFilterString, nextBindVar(args, v))
-			} else {
-				transferTypeFilterString = fmt.Sprintf(`%s OR transfer_type=%s`, transferTypeFilterString, nextBindVar(args, v))
-			}
-		}
+func transferTypeFilterToDBQuery(transferTypeFilter []entities.LedgerMovementType) string {
+	if len(transferTypeFilter) == 0 {
+		return ""
 	}
 
-	return transferTypeFilterString
+	transferTypesMap := map[entities.LedgerMovementType]string{}
+	for _, transferType := range transferTypeFilter {
+		if _, alreadyRegistered := transferTypesMap[transferType]; alreadyRegistered {
+			continue
+		}
+		value, valid := vega.TransferType_name[int32(transferType)]
+		if !valid {
+			continue
+		}
+
+		transferTypesMap[transferType] = "'" + value + "'"
+	}
+
+	if len(transferTypesMap) == 0 {
+		return ""
+	}
+
+	return "ledger.type IN (" + strings.Join(maps.Values(transferTypesMap), ", ") + ")"
 }
 
-func transfersFilterToDBQuery(transfersFilter entities.TransferID, args *[]interface{}) (string, *[]interface{}) {
+func transfersFilterToDBQuery(transfersFilter entities.TransferID, args *[]interface{}) string {
 	if transfersFilter == "" {
-		return "", args
+		return ""
 	}
 
-	transfersFilterString := fmt.Sprintf(`transfer_id=%s`, nextBindVar(args, transfersFilter))
-	return transfersFilterString, args
+	transfersFilterString := fmt.Sprintf(`ledger.transfer_id=%s`, nextBindVar(args, transfersFilter))
+	return transfersFilterString
 }
 
 func handlePartiesFiltering(filter *entities.LedgerEntryFilter) error {

--- a/datanode/sqlsubscribers/ledger_movement.go
+++ b/datanode/sqlsubscribers/ledger_movement.go
@@ -35,7 +35,7 @@ type Ledger interface {
 	Flush(ctx context.Context) error
 }
 
-type TransferResponseEvent interface {
+type LedgerMovementEvents interface {
 	events.Event
 	LedgerMovements() []*vega.LedgerMovement
 }
@@ -63,10 +63,10 @@ func (t *TransferResponse) Flush(ctx context.Context) error {
 }
 
 func (t *TransferResponse) Push(ctx context.Context, evt events.Event) error {
-	return t.consume(ctx, evt.(TransferResponseEvent))
+	return t.consume(ctx, evt.(LedgerMovementEvents))
 }
 
-func (t *TransferResponse) consume(ctx context.Context, e TransferResponseEvent) error {
+func (t *TransferResponse) consume(ctx context.Context, e LedgerMovementEvents) error {
 	var errs strings.Builder
 	for _, tr := range e.LedgerMovements() {
 		t.ledger.AddTransferResponse(tr)

--- a/protos/vega/governance.go
+++ b/protos/vega/governance.go
@@ -1,4 +1,6 @@
 package vega
 
-type ProposalOneOffTermChangeType = isProposalTerms_Change
-type ProposalOneOffTermBatchChangeType = isBatchProposalTermsChange_Change
+type (
+	ProposalOneOffTermChangeType      = isProposalTerms_Change
+	ProposalOneOffTermBatchChangeType = isBatchProposalTermsChange_Change
+)


### PR DESCRIPTION
- Made the ledger movement type a postgresql enum
- Clean up unnecessary complexity while building SQL query
- Remove intermediary object reading the rows as deemed unnecessary

Close #10102 