### PR TITLE
chore: update snapshot migrations given mainnet patches

### DIFF
--- a/core/execution/future/market_snapshot.go
+++ b/core/execution/future/market_snapshot.go
@@ -84,8 +84,8 @@ func NewMarketFromSnapshot(
 
 	as := monitor.NewAuctionStateFromSnapshot(mkt, em.AuctionState)
 
-	if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.10") {
-		// protocol upgrade from v0.73.9, lets populate the new liquidity-fee-settings with a default marginal-cost method
+	if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.12") {
+		// protocol upgrade from v0.73.12, lets populate the new liquidity-fee-settings with a default marginal-cost method
 		log.Info("migrating liquidity fee settings for existing market", logging.String("mid", mkt.ID))
 		mkt.Fees.LiquidityFeeSettings = &types.LiquidityFeeSettings{
 			Method: types.LiquidityFeeMethodMarginalCost,

--- a/core/execution/future/market_snapshot_test.go
+++ b/core/execution/future/market_snapshot_test.go
@@ -180,7 +180,7 @@ func TestRestoreMarketUpgradeV0_73_2(t *testing.T) {
 	em.Market.Fees.LiquidityFeeSettings = nil
 
 	// and set in the context the information that says we are upgrading
-	ctx := vegacontext.WithSnapshotInfo(context.Background(), "v0.73.10", true)
+	ctx := vegacontext.WithSnapshotInfo(context.Background(), "v0.73.12", true)
 	snap, err := newMarketFromSnapshot(t, ctx, ctrl, em, oracleEngine)
 	require.NoError(t, err)
 	require.NotEmpty(t, snap)

--- a/core/governance/snapshot.go
+++ b/core/governance/snapshot.go
@@ -261,7 +261,7 @@ func (e *Engine) restoreActiveProposals(ctx context.Context, active *types.Gover
 			invalidVotes: votesAsMap(p.Invalid),
 		}
 
-		if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.10") {
+		if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.12") {
 			if nm := pp.Proposal.Terms.GetNewMarket(); nm != nil {
 				e.log.Info("migrating liquidity fee settings for new market proposal", logging.String("pid", pp.ID))
 				nm.Changes.LiquidityFeeSettings = &types.LiquidityFeeSettings{
@@ -275,7 +275,7 @@ func (e *Engine) restoreActiveProposals(ctx context.Context, active *types.Gover
 				}
 			}
 		}
-		if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.10") {
+		if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.12") {
 			if pp.Terms.IsNewMarket() {
 				pp.Terms.GetNewMarket().Changes.MarkPriceConfiguration = defaultMarkPriceConfig.DeepClone()
 			}
@@ -328,7 +328,7 @@ func (e *Engine) restoreBatchActiveProposals(ctx context.Context, active *types.
 
 		evts = append(evts, events.NewProposalEventFromProto(ctx, bp.BatchProposal.ToProto()))
 		for _, p := range bp.BatchProposal.Proposals {
-			if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.10") {
+			if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.12") {
 				if p.Terms.IsNewMarket() {
 					p.Terms.GetNewMarket().Changes.MarkPriceConfiguration = defaultMarkPriceConfig.DeepClone()
 				}

--- a/core/products/perpetual_snapshot.go
+++ b/core/products/perpetual_snapshot.go
@@ -85,7 +85,7 @@ func NewPerpetualFromSnapshot(
 	perps.startedAt = state.StartedAt
 	perps.seq = state.Seq
 
-	if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.10") {
+	if vgcontext.InProgressUpgradeFrom(ctx, "v0.73.12") {
 		// do it the old way where we'd regenerate the cached values by adding the points again
 		perps.externalTWAP = NewCachedTWAP(log, state.StartedAt, perps.auctions)
 		perps.internalTWAP = NewCachedTWAP(log, state.StartedAt, perps.auctions)


### PR DESCRIPTION
Updates the migrate-from-versions.

Note: changing it from a `from-version` to ` to-version` check would be nice, but will break the snapshot compatibility pipeline because that pipeline just builds the binary from source and gets a `+dev` version. So we'd need to work that out first.