### PR TITLE
fix: include notional volumes in SLA snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - [476](https://github.com/vegaprotocol/core-test-coverage/issues/476) - Add tests for markets expiring in opening auction, fix a bug for future markets.
 - [10354](https://github.com/vegaprotocol/vega/issues/10354) - Renumbered SQL migration scripts 0055-0067 due to 0068 being released as part of a patch without renumbering.
 - [476](https://github.com/vegaprotocol/core-test-coverage/issues/476) - Add tests for markets expiring in opening auction, fix a bug for future markets.
+- [10362](https://github.com/vegaprotocol/vega/issues/10362) - Include notional volumes in `SLA` snapshot.
 - [10339](https://github.com/vegaprotocol/vega/issues/10339) - Fix for GraphQL batch proposals support.
 - [10326](https://github.com/vegaprotocol/vega/issues/10326) - Fix intermittent test failure.
 

--- a/core/liquidity/v2/scores_test.go
+++ b/core/liquidity/v2/scores_test.go
@@ -194,9 +194,9 @@ func (tng *testEngine) submitLiquidityProvisionAndCreateOrders(
 	_, err := tng.engine.SubmitLiquidityProvision(ctx, lps, party, idgeneration.New(crypto.RandomHash()))
 	require.NoError(t, err)
 
-	zero := num.UintOne()
+	price := num.NewUint(100)
 	now := tng.tsvc.GetTimeNow()
-	tng.engine.ResetSLAEpoch(now, zero, zero, num.DecimalZero())
+	tng.engine.ResetSLAEpoch(now, price, price, num.DecimalOne())
 	tng.engine.ApplyPendingProvisions(ctx, now)
 
 	for _, o := range orders {

--- a/core/liquidity/v2/snapshot.go
+++ b/core/liquidity/v2/snapshot.go
@@ -262,6 +262,9 @@ func (e *snapshotV2) serialisePerformances() ([]byte, error) {
 			LastEpochFractionOfTimeOnBook:    partyPerformance.lastEpochTimeBookFraction,
 			LastEpochFeePenalty:              partyPerformance.lastEpochFeePenalty,
 			LastEpochBondPenalty:             partyPerformance.lastEpochBondPenalty,
+			RequiredLiquidity:                partyPerformance.requiredLiquidity,
+			NotionalVolumeBuys:               partyPerformance.notionalVolumeBuys,
+			NotionalVolumeSells:              partyPerformance.notionalVolumeSells,
 		}
 
 		performancePerPartySnapshot = append(performancePerPartySnapshot, partyPerformanceSnapshot)

--- a/core/liquidity/v2/snapshot_test.go
+++ b/core/liquidity/v2/snapshot_test.go
@@ -100,6 +100,9 @@ func TestEngineSnapshotV2(t *testing.T) {
 		"party-4": num.UintFromUint64(3),
 	})
 
+	preStats := originalEngine.engine.LiquidityProviderSLAStats(time.Now())
+	require.Len(t, preStats, 2)
+
 	// Verifying we can salvage the state for each key, and they are a valid
 	// Payload.
 	engine1Keys := originalEngine.engine.V2StateProvider().Keys()
@@ -185,6 +188,14 @@ func TestEngineSnapshotV2(t *testing.T) {
 		s2, ok := feesStats2.FeesPaidPerParty[k]
 		assert.True(t, ok)
 		assert.Equal(t, s1.String(), s2.String())
+	}
+
+	postStats := otherEngine.engine.LiquidityProviderSLAStats(time.Now())
+	require.Len(t, postStats, 2)
+	for i := range preStats {
+		assert.Equal(t, preStats[i].NotionalVolumeBuys, postStats[i].NotionalVolumeBuys)
+		assert.Equal(t, preStats[i].NotionalVolumeSells, postStats[i].NotionalVolumeSells)
+		assert.Equal(t, preStats[i].RequiredLiquidity, postStats[i].RequiredLiquidity)
 	}
 }
 


### PR DESCRIPTION
closes #10362 