### PR TITLE
test: ensure we wait for the end of the test if needed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
                 stage('core/integration tests') {
                     steps {
                         dir('vega/core/integration') {
-                            sh 'godog build -o core_integration.test && ./core_integration.test --format=junit:core-integration-report.xml'
+                            sh 'go test . --godog.format=junit:core-integration-report.xml'
                             junit checksName: 'Core Integration Tests', testResults: 'core-integration-report.xml'
                         }
                     }


### PR DESCRIPTION
Validator tests sometimes fail, probably because there's a slight delay between the last channel read and the actual call to `Command` being registered on the mock object, using a waitgroup fixes the issue.