### PR TITLE
fix: add method for update margin mode event

### DIFF
--- a/core/events/margin_mode.go
+++ b/core/events/margin_mode.go
@@ -30,6 +30,10 @@ func (e PartyMarginModeUpdated) Proto() eventspb.PartyMarginModeUpdated {
 	return *e.update
 }
 
+func (e *PartyMarginModeUpdated) PartyMarginModeUpdated() *eventspb.PartyMarginModeUpdated {
+	return e.update
+}
+
 func (e PartyMarginModeUpdated) StreamMessage() *eventspb.BusEvent {
 	busEvent := newBusEventFromBase(e.Base)
 	busEvent.Event = &eventspb.BusEvent_PartyMarginModeUpdated{


### PR DESCRIPTION
The sqlsubscriber in datanode expect this method but it didn't exists.