### PR TITLE
fix: do not touch retention policies for non-data-node schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - [10339](https://github.com/vegaprotocol/vega/issues/10339) - Fix for GraphQL batch proposals support.
 - [10326](https://github.com/vegaprotocol/vega/issues/10326) - Fix intermittent test failure.
 - [10382](https://github.com/vegaprotocol/vega/issues/10382) - Fix switch to isolated margin with parked pegged orders. 
+- [10390](https://github.com/vegaprotocol/vega/pull/10390) - Fix the data node startup when an external `hypertable` exist outside of the public schema
 
 ## 0.73.0
 

--- a/datanode/sqlstore/sqlstore.go
+++ b/datanode/sqlstore/sqlstore.go
@@ -383,10 +383,10 @@ const oneDayAsSeconds = 60 * 60 * 24
 func getRetentionEntities(db *sql.DB) ([]string, error) {
 	rows, err := db.Query(`
 select view_name as table_name
-from timescaledb_information.continuous_aggregates
+from timescaledb_information.continuous_aggregates WHERE hypertable_schema='public'
 union all
 select hypertable_name
-from timescaledb_information.hypertables
+from timescaledb_information.hypertables WHERE hypertable_schema='public';
 `)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Change

The data node operates only in the `public` schema, however, the query that fetches the retention policies fetches them from all the schemas and it results in the following error:

```

failed to apply data retention policies:setting retention policy for block_signers to forever: removing retention policy from block_signers: ERROR: relation "block_signers" does not exist (SQLSTATE 42P01)
2024-01-14T22:33:59.899+0100    DEBUG   visor   visor/binaries_runner.go:111    Stopping binary {"binaryPath": "/home/daniel/vegavisor_home/current/vega"}
2024-01-14T22:33:59.949+0100    ERROR   visor   visor/visor.go:146      Binaries executions has failed  {"error": "failed after waiting for binary /home/daniel/vegavisor_home/current/vega [datanode start --home /home/daniel/vega_home]: exit status 255"}
2024-01-14T22:33:59.949+0100    INFO    visor   visor/visor.go:153      Binaries restart is scheduled   {"restartDelay": "5s"}
```

We should not touch the things outside of the data-node universe.