### PR TITLE
chore: add AC code 0013-ACCT-033 to feature test

### DIFF
--- a/core/integration/features/successor-markets-insurance.feature
+++ b/core/integration/features/successor-markets-insurance.feature
@@ -1,4 +1,4 @@
-Feature: Successor markets: Global insurance pool account collects all outstanding funds from closed/expired markets in a risk universe (0013-ACCT-032)
+Feature: Successor markets: Global insurance pool account collects all outstanding funds from closed/expired markets in a risk universe (0013-ACCT-032 0013-ACCT-033)
 
   Background:
     Given time is updated to "2019-11-30T00:00:00Z"


### PR DESCRIPTION
As per this comment: https://github.com/vegaprotocol/core-test-coverage/issues/475#issuecomment-1878685209 from @EVODelavega

This adds the AC code 0013-ACCT-033 to successor-markets-insurance.feature so that its covered by approbation

close https://github.com/vegaprotocol/core-test-coverage/issues/475