### PR TITLE
feat: improve validation of evm config netparam

### DIFF
--- a/core/netparams/checks/checks.go
+++ b/core/netparams/checks/checks.go
@@ -44,8 +44,8 @@ func SpamPoWHashFunction(supportedFunctions []string) func(string) error {
 	}
 }
 
-func MarginScalingFactor() func(interface{}) error {
-	return func(v interface{}) error {
+func MarginScalingFactor() func(interface{}, interface{}) error {
+	return func(v interface{}, _ interface{}) error {
 		sf := v.(*types.ScalingFactors)
 		if sf.SearchLevel >= sf.InitialMargin || sf.InitialMargin >= sf.CollateralRelease {
 			return errors.New("invalid scaling factors (searchLevel < initialMargin < collateralRelease)")
@@ -54,8 +54,8 @@ func MarginScalingFactor() func(interface{}) error {
 	}
 }
 
-func MarginScalingFactorRange(min, max num.Decimal) func(interface{}) error {
-	return func(v interface{}) error {
+func MarginScalingFactorRange(min, max num.Decimal) func(interface{}, interface{}) error {
+	return func(v interface{}, _ interface{}) error {
 		sf := v.(*types.ScalingFactors)
 		if sf.SearchLevel < min.InexactFloat64() || sf.CollateralRelease > max.InexactFloat64() {
 			return errors.New("invalid scaling factors (" + min.String() + "< searchLevel < initialMargin < collateralRelease <=" + max.String() + ")")
@@ -64,8 +64,8 @@ func MarginScalingFactorRange(min, max num.Decimal) func(interface{}) error {
 	}
 }
 
-func PriceMonitoringParametersAuctionExtension(min, max time.Duration) func(interface{}) error {
-	return func(v interface{}) error {
+func PriceMonitoringParametersAuctionExtension(min, max time.Duration) func(interface{}, interface{}) error {
+	return func(v interface{}, _ interface{}) error {
 		pmp := v.(*types.PriceMonitoringParameters)
 		for _, pmt := range pmp.Triggers {
 			if time.Duration(pmt.AuctionExtension*int64(time.Second)) < min || time.Duration(pmt.AuctionExtension*int64(time.Second)) > max {
@@ -76,8 +76,8 @@ func PriceMonitoringParametersAuctionExtension(min, max time.Duration) func(inte
 	}
 }
 
-func PriceMonitoringParametersHorizon(min, max time.Duration) func(interface{}) error {
-	return func(v interface{}) error {
+func PriceMonitoringParametersHorizon(min, max time.Duration) func(interface{}, interface{}) error {
+	return func(v interface{}, _ interface{}) error {
 		pmp := v.(*types.PriceMonitoringParameters)
 		for _, pmt := range pmp.Triggers {
 			if time.Duration(pmt.Horizon*int64(time.Second)) < min || time.Duration(pmt.Horizon*int64(time.Second)) > max {
@@ -88,8 +88,8 @@ func PriceMonitoringParametersHorizon(min, max time.Duration) func(interface{}) 
 	}
 }
 
-func PriceMonitoringParametersProbability(min, max num.Decimal) func(interface{}) error {
-	return func(v interface{}) error {
+func PriceMonitoringParametersProbability(min, max num.Decimal) func(interface{}, interface{}) error {
+	return func(v interface{}, _ interface{}) error {
 		pmp := v.(*types.PriceMonitoringParameters)
 		for _, pmt := range pmp.Triggers {
 			p, e := num.DecimalFromString(pmt.Probability)

--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -343,7 +343,7 @@ func checkOptionalRFC3339Date(d string) error {
 	return err
 }
 
-func PriceMonitoringParametersValidation(i interface{}) error {
+func PriceMonitoringParametersValidation(i interface{}, _ interface{}) error {
 	pmp, ok := i.(*proto.PriceMonitoringParameters)
 	if !ok {
 		return errors.New("not a price monitoring parameters type")

--- a/core/netparams/values.go
+++ b/core/netparams/values.go
@@ -703,7 +703,7 @@ func DurationLT(i time.Duration) func(time.Duration) error {
 	}
 }
 
-type JSONRule func(interface{}) error
+type JSONRule func(interface{}, interface{}) error
 
 type JSON struct {
 	*baseValue
@@ -790,7 +790,7 @@ func (j *JSON) Validate(value string) error {
 	}
 
 	for _, fn := range j.rules {
-		if newerr := fn(j.value); newerr != nil {
+		if newerr := fn(j.value, j.rawval); newerr != nil {
 			if err != nil {
 				err = fmt.Errorf("%v, %w", err, newerr)
 			} else {

--- a/core/netparams/values_test.go
+++ b/core/netparams/values_test.go
@@ -16,6 +16,7 @@
 package netparams_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestNegativeUint(t *testing.T) {
 }
 
 func TestJSONValues(t *testing.T) {
-	validator := func(v interface{}) error {
+	validator := func(v interface{}, p interface{}) error {
 		a, ok := v.(*A)
 		if !ok {
 			return errors.New("invalid type")
@@ -61,6 +62,18 @@ func TestJSONValues(t *testing.T) {
 		if a.I < 0 {
 			return errors.New("I negative")
 		}
+
+		b := &A{}
+		json.Unmarshal([]byte(p.(string)), b)
+
+		if !ok {
+			return errors.New("invalid type B")
+		}
+
+		if a.I < b.I {
+			return errors.New("cannot amended to lower value")
+		}
+
 		return nil
 	}
 
@@ -97,6 +110,10 @@ func TestJSONValues(t *testing.T) {
 	// valid type, field validation failed
 	err = j.Update(`{"s": "", "i": 84}`)
 	assert.EqualError(t, err, "empty string")
+
+	// flex rule that prevents update to a lower value of i
+	err = j.Validate(`{"s": "notempty", "i": 1}`)
+	assert.EqualError(t, err, "cannot amended to lower value")
 }
 
 func TestJSONVPriceMonitoringParameters(t *testing.T) {

--- a/core/types/activity_streak_benefit_tiers.go
+++ b/core/types/activity_streak_benefit_tiers.go
@@ -82,7 +82,7 @@ func ActivityStreakBenefitTiersFromProto(ptiers *proto.ActivityStreakBenefitTier
 	return tiers, nil
 }
 
-func CheckUntypedActivityStreakBenefitTier(v interface{}) error {
+func CheckUntypedActivityStreakBenefitTier(v interface{}, _ interface{}) error {
 	tiers, err := toActivityStreakBenefitTier(v)
 	if err != nil {
 		return err

--- a/core/types/ethereum.go
+++ b/core/types/ethereum.go
@@ -16,6 +16,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -34,6 +35,11 @@ var (
 	ErrAtLeastOneOfStakingOrVestingBridgeAddressMustBeSet = errors.New("at least one of the stacking bridge or token vesting contract addresses must be specified")
 	ErrConfirmationsMustBeHigherThan0                     = errors.New("confirmation must be > 0 in Ethereum config")
 	ErrMissingNetworkName                                 = errors.New("missing network name")
+	ErrDuplicateNetworkName                               = errors.New("duplicate network name")
+	ErrDuplicateNetworkID                                 = errors.New("duplicate network ID name")
+	ErrDuplicateChainID                                   = errors.New("duplicate chain ID name")
+	ErrCannotRemoveL2Config                               = errors.New("L2 config cannot be removed")
+	ErrCanOnlyAmendedConfirmations                        = errors.New("can only amended L2 config confirmations")
 )
 
 type EthereumConfig struct {
@@ -163,7 +169,7 @@ func (c EthereumContract) HexAddress() string {
 
 // CheckUntypedEthereumConfig verifies the `v` parameter is a proto.EthereumConfig
 // struct and check if it's valid.
-func CheckUntypedEthereumConfig(v interface{}) error {
+func CheckUntypedEthereumConfig(v interface{}, _ interface{}) error {
 	cfg, err := toEthereumConfigProto(v)
 	if err != nil {
 		return err
@@ -172,13 +178,15 @@ func CheckUntypedEthereumConfig(v interface{}) error {
 	return CheckEthereumConfig(cfg)
 }
 
-func CheckUntypedEthereumL2Configs(v interface{}) error {
+func CheckUntypedEthereumL2Configs(v interface{}, o interface{}) error {
 	cfg, err := toEthereumL2ConfigsProto(v)
 	if err != nil {
 		return err
 	}
 
-	return CheckEthereumL2Configs(cfg)
+	ocfg := &proto.EthereumL2Configs{}
+	json.Unmarshal([]byte(o.(string)), ocfg)
+	return CheckEthereumL2Configs(cfg, ocfg)
 }
 
 // CheckEthereumConfig verifies the proto.EthereumConfig is valid.
@@ -259,7 +267,7 @@ func EthereumL2ConfigsFromUntypedProto(v interface{}) (*EthereumL2Configs, error
 }
 
 func EthereumL2ConfigsFromProto(cfgProto *proto.EthereumL2Configs) (*EthereumL2Configs, error) {
-	if err := CheckEthereumL2Configs(cfgProto); err != nil {
+	if err := CheckEthereumL2Configs(cfgProto, nil); err != nil {
 		return nil, fmt.Errorf("invalid Ethereum configuration: %w", err)
 	}
 
@@ -277,24 +285,77 @@ func EthereumL2ConfigsFromProto(cfgProto *proto.EthereumL2Configs) (*EthereumL2C
 }
 
 // CheckEthereumConfig verifies the proto.EthereumConfig is valid.
-func CheckEthereumL2Configs(cfgProto *proto.EthereumL2Configs) error {
+func CheckEthereumL2Configs(cfgProto *proto.EthereumL2Configs, prev *proto.EthereumL2Configs) error {
+	names := map[string]*proto.EthereumL2Config{}
+	cids := map[string]*proto.EthereumL2Config{}
+	nids := map[string]*proto.EthereumL2Config{}
+
 	for _, v := range cfgProto.Configs {
+		// check network id and ensure no duplicates
 		if len(v.NetworkId) == 0 {
 			return ErrMissingNetworkID
 		}
+		if _, ok := nids[v.NetworkId]; ok {
+			return ErrDuplicateNetworkID
+		}
+		nids[v.NetworkId] = v
 
+		// check chain id and ensure no duplicates
 		if len(v.ChainId) == 0 {
 			return ErrMissingChainID
 		}
+		if _, ok := cids[v.ChainId]; ok {
+			return ErrDuplicateChainID
+		}
+		cids[v.ChainId] = v
+
+		// check network name and ensure no duplicates
+		if len(v.Name) == 0 {
+			return ErrMissingNetworkName
+		}
+		if _, ok := names[v.Name]; ok {
+			return ErrDuplicateNetworkName
+		}
+		names[v.Name] = v
 
 		if v.Confirmations == 0 {
 			return ErrConfirmationsMustBeHigherThan0
 		}
+	}
 
-		if len(v.Name) == 0 {
-			return ErrMissingNetworkName
+	// it wasn't previously set to anything (from genesis) so nothing to check
+	if prev == nil {
+		return nil
+	}
+
+	// compare against currently set configs - we make sure they only amend confirmations, or are new additions
+	// but for now nothing can bre removed.
+	for _, c := range prev.Configs {
+		v, ok := nids[c.NetworkId]
+		if !ok {
+			return ErrCannotRemoveL2Config
+		}
+
+		if !isUpdate(v, c) {
+			return ErrCanOnlyAmendedConfirmations
 		}
 	}
 
 	return nil
+}
+
+func isUpdate(v, c *proto.EthereumL2Config) bool {
+	if v.ChainId != c.ChainId {
+		return false
+	}
+
+	if v.NetworkId != c.NetworkId {
+		return false
+	}
+
+	if v.Name != c.Name {
+		return false
+	}
+
+	return true
 }

--- a/core/types/ethereum_test.go
+++ b/core/types/ethereum_test.go
@@ -32,6 +32,9 @@ func TestEthereumConfig(t *testing.T) {
 	t.Run("Missing both staking and vesting contract addresses fails", testMissingBothStakingAndVestingContractAddressesFails)
 	t.Run("At least one of staking of vesting contract addresses succeeds", testAtLeastOneOfStackingOrVestingContractAddressesSucceeds)
 	t.Run("Confirmations set to 0 fails", testConfirmationsSetTo0Fails)
+	t.Run("Basic checks on fields of the EVM config", testEVMConfigBasic)
+	t.Run("Check that a network cannot appear twice in the config", testEVMConfigRejectDuplicateFields)
+	t.Run("Check that an EVM config can not be removed", testEVMAmendOrAppendOnly)
 }
 
 func testValidEthereumConfigSucceeds(t *testing.T) {
@@ -210,6 +213,144 @@ func testConfirmationsSetTo0Fails(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrConfirmationsMustBeHigherThan0)
 }
 
+func testEVMConfigBasic(t *testing.T) {
+	tcs := []struct {
+		name          string
+		chainID       string
+		networkID     string
+		confirmations uint32
+		expect        error
+	}{
+		{
+			name:          "hello",
+			chainID:       "11",
+			networkID:     "12",
+			confirmations: 1,
+		},
+		{
+			chainID:       "11",
+			networkID:     "12",
+			confirmations: 1,
+			expect:        types.ErrMissingNetworkName,
+		},
+		{
+			name:          "hello",
+			networkID:     "12",
+			confirmations: 1,
+			expect:        types.ErrMissingChainID,
+		},
+		{
+			name:          "hello",
+			chainID:       "11",
+			confirmations: 1,
+			expect:        types.ErrMissingNetworkID,
+		},
+		{
+			name:          "hello",
+			chainID:       "11",
+			networkID:     "12",
+			confirmations: 0,
+			expect:        types.ErrConfirmationsMustBeHigherThan0,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(tt *testing.T) {
+			// given
+			cfgs := &proto.EthereumL2Configs{
+				Configs: []*proto.EthereumL2Config{
+					{
+						NetworkId:     tc.networkID,
+						ChainId:       tc.chainID,
+						Name:          tc.name,
+						Confirmations: tc.confirmations,
+					},
+				},
+			}
+
+			// when
+			err := types.CheckEthereumL2Configs(cfgs, nil)
+
+			// then
+			require.ErrorIs(t, tc.expect, err)
+		})
+	}
+}
+
+func testEVMConfigRejectDuplicateFields(t *testing.T) {
+	cfgs := validEVMConfigs()
+
+	original := proto.EthereumL2Config{
+		NetworkId:     "999",
+		ChainId:       "9999",
+		Name:          "999999",
+		Confirmations: 100,
+	}
+
+	c := original
+	cfgs.Configs = append(cfgs.Configs, &c)
+	err := types.CheckEthereumL2Configs(cfgs, nil)
+	require.ErrorIs(t, nil, err)
+
+	c.Name = cfgs.Configs[0].Name
+	err = types.CheckEthereumL2Configs(cfgs, nil)
+	require.ErrorIs(t, types.ErrDuplicateNetworkName, err)
+	c.Name = original.Name
+
+	c.ChainId = cfgs.Configs[0].ChainId
+	err = types.CheckEthereumL2Configs(cfgs, nil)
+	require.ErrorIs(t, types.ErrDuplicateChainID, err)
+	c.ChainId = original.ChainId
+
+	c.NetworkId = cfgs.Configs[0].NetworkId
+	err = types.CheckEthereumL2Configs(cfgs, nil)
+	require.ErrorIs(t, types.ErrDuplicateNetworkID, err)
+}
+
+func testEVMAmendOrAppendOnly(t *testing.T) {
+	cfgs1 := validEVMConfigs()
+	cfgs2 := validEVMConfigs()
+
+	// update to itself
+	err := types.CheckEthereumL2Configs(cfgs1, cfgs2)
+	require.ErrorIs(t, nil, err)
+
+	// change only confirmations
+	cfgs2.Configs[0].Confirmations += 1
+	err = types.CheckEthereumL2Configs(cfgs1, cfgs2)
+	require.ErrorIs(t, nil, err)
+
+	// try to change the name
+	cfgs2 = validEVMConfigs()
+	cfgs2.Configs[0].Name += "hello"
+	err = types.CheckEthereumL2Configs(cfgs1, cfgs2)
+	require.ErrorIs(t, types.ErrCanOnlyAmendedConfirmations, err)
+
+	// try to change the chainID
+	cfgs2 = validEVMConfigs()
+	cfgs2.Configs[0].ChainId += "1"
+	err = types.CheckEthereumL2Configs(cfgs1, cfgs2)
+	require.ErrorIs(t, types.ErrCanOnlyAmendedConfirmations, err)
+
+	// try to change the networkID (counts as a remove)
+	cfgs2 = validEVMConfigs()
+	cfgs2.Configs[0].NetworkId += "1"
+	err = types.CheckEthereumL2Configs(cfgs1, cfgs2)
+	require.ErrorIs(t, types.ErrCannotRemoveL2Config, err)
+
+	// add a new config that clashes with existing
+	cfgs2 = validEVMConfigs()
+	new_cfg := proto.EthereumL2Config{
+		NetworkId:     cfgs2.Configs[0].NetworkId,
+		ChainId:       "9999",
+		Name:          "999999",
+		Confirmations: 100,
+	}
+	cfgs2.Configs = append(cfgs2.Configs, &new_cfg)
+	err = types.CheckEthereumL2Configs(cfgs1, cfgs2)
+	require.ErrorIs(t, types.ErrCanOnlyAmendedConfirmations, err)
+}
+
 func validEthereumConfig() *proto.EthereumConfig {
 	return &proto.EthereumConfig{
 		NetworkId: "1",
@@ -229,6 +370,25 @@ func validEthereumConfig() *proto.EthereumConfig {
 		TokenVestingContract: &proto.EthereumContractConfig{
 			Address:               "0x1234",
 			DeploymentBlockHeight: 567,
+		},
+	}
+}
+
+func validEVMConfigs() *proto.EthereumL2Configs {
+	return &proto.EthereumL2Configs{
+		Configs: []*proto.EthereumL2Config{
+			{
+				NetworkId:     "1",
+				ChainId:       "2",
+				Name:          "hello",
+				Confirmations: 12,
+			},
+			{
+				NetworkId:     "2",
+				ChainId:       "3",
+				Name:          "helloagain",
+				Confirmations: 13,
+			},
 		},
 	}
 }

--- a/core/types/vesting.go
+++ b/core/types/vesting.go
@@ -77,7 +77,7 @@ func VestingBenefitTiersFromProto(ptiers *proto.VestingBenefitTiers) (*VestingBe
 	return tiers, nil
 }
 
-func CheckUntypedVestingBenefitTier(v interface{}) error {
+func CheckUntypedVestingBenefitTier(v interface{}, _ interface{}) error {
 	tiers, err := toVestingBenefitTier(v)
 	if err != nil {
 		return err

--- a/protos/sources/vega/chain_events.proto
+++ b/protos/sources/vega/chain_events.proto
@@ -16,7 +16,7 @@ message EthContractCallEvent {
   bytes result = 4;
   // Error message if the call failed.
   optional string error = 5;
-  // the l2 chain for this chain event.
+  // Layer 2 chain for this chain event.
   optional uint64 l2_chain_id = 6;
 }
 

--- a/protos/sources/vega/data_source.proto
+++ b/protos/sources/vega/data_source.proto
@@ -104,9 +104,9 @@ message EthCallSpec {
   // called 'price' and use that if it exists.
   repeated Normaliser normalisers = 8;
 
-  // an optional ethereum L2 chain id, if not specified this EthCallSpec is
-  // to be used against ethereum mainnet, if set the matching L2 network
-  // for the chain_id is to be used, the network must have been registered via governance
+  // Ethereum layer 2 chain ID. If not specified this EthCallSpec is
+  // to be used against ethereum mainnet. If set, the matching L2 network
+  // for the chain ID is to be used, and the network must have been registered via governance
   // first.
   optional uint64 l2_chain_id = 9;
 }

--- a/protos/sources/vega/vega.proto
+++ b/protos/sources/vega/vega.proto
@@ -1492,14 +1492,14 @@ message LiquidityProvision {
 }
 
 message EthereumL2Config {
-  // Network ID of this Ethereum L2 network.
+  // Network ID of this Ethereum layer 2 network.
   string network_id = 1;
-  // Chain ID of this Ethereum L2 network.
+  // Chain ID of this Ethereum layer 2 network.
   string chain_id = 2;
   // Number of block confirmations to wait to consider an Ethereum transaction trusted.
   // An Ethereum block is trusted when there are at least "n" blocks confirmed by the
   // network, "n" being the number of `confirmations` required. If `confirmations` was set to `3`,
-  // and the current block to be forged (or mined) on the L2 is block 14, block
+  // and the current block to be forged, or mined, on the L2 is block 14, block
   // 10 would be considered as trusted, but not block 11.
   uint32 confirmations = 3;
   // Display name of this network

--- a/protos/vega/chain_events.pb.go
+++ b/protos/vega/chain_events.pb.go
@@ -36,7 +36,7 @@ type EthContractCallEvent struct {
 	Result []byte `protobuf:"bytes,4,opt,name=result,proto3" json:"result,omitempty"`
 	// Error message if the call failed.
 	Error *string `protobuf:"bytes,5,opt,name=error,proto3,oneof" json:"error,omitempty"`
-	// the l2 chain for this chain event.
+	// Layer 2 chain for this chain event.
 	L2ChainId *uint64 `protobuf:"varint,6,opt,name=l2_chain_id,json=l2ChainId,proto3,oneof" json:"l2_chain_id,omitempty"`
 }
 

--- a/protos/vega/data_source.pb.go
+++ b/protos/vega/data_source.pb.go
@@ -584,9 +584,9 @@ type EthCallSpec struct {
 	// in the second result returned from the contract for a structure with a key
 	// called 'price' and use that if it exists.
 	Normalisers []*Normaliser `protobuf:"bytes,8,rep,name=normalisers,proto3" json:"normalisers,omitempty"`
-	// an optional ethereum L2 chain id, if not specified this EthCallSpec is
-	// to be used against ethereum mainnet, if set the matching L2 network
-	// for the chain_id is to be used, the network must have been registered via governance
+	// Ethereum layer 2 chain ID. If not specified this EthCallSpec is
+	// to be used against ethereum mainnet. If set, the matching L2 network
+	// for the chain ID is to be used, and the network must have been registered via governance
 	// first.
 	L2ChainId *uint64 `protobuf:"varint,9,opt,name=l2_chain_id,json=l2ChainId,proto3,oneof" json:"l2_chain_id,omitempty"`
 }

--- a/protos/vega/vega.pb.go
+++ b/protos/vega/vega.pb.go
@@ -6883,14 +6883,14 @@ type EthereumL2Config struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Network ID of this Ethereum L2 network.
+	// Network ID of this Ethereum layer 2 network.
 	NetworkId string `protobuf:"bytes,1,opt,name=network_id,json=networkId,proto3" json:"network_id,omitempty"`
-	// Chain ID of this Ethereum L2 network.
+	// Chain ID of this Ethereum layer 2 network.
 	ChainId string `protobuf:"bytes,2,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	// Number of block confirmations to wait to consider an Ethereum transaction trusted.
 	// An Ethereum block is trusted when there are at least "n" blocks confirmed by the
 	// network, "n" being the number of `confirmations` required. If `confirmations` was set to `3`,
-	// and the current block to be forged (or mined) on the L2 is block 14, block
+	// and the current block to be forged, or mined, on the L2 is block 14, block
 	// 10 would be considered as trusted, but not block 11.
 	Confirmations uint32 `protobuf:"varint,3,opt,name=confirmations,proto3" json:"confirmations,omitempty"`
 	// Display name of this network


### PR DESCRIPTION
Improves the validation of the L2 configuartions network parameters to ensure that:

    A network name/chain-id/network-id does not appear in two chain configs
    That a chain configuration cannot be removed

The second one appears in the spec to try and reduce scope, which makes sense. If it causes issues when writing system-tests by not being able to restore the network to a prior state, then we may have to remove the restriction.
