### PR TITLE
fix: block explorer should run db migrations on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - [10396](https://github.com/vegaprotocol/vega/issues/10396) - `ListTransfers` returns error.
 - [10299](https://github.com/vegaprotocol/vega/issues/10299) - `ListTransfers` does not return staking rewards.
 - [10378](https://github.com/vegaprotocol/vega/issues/10378) - Ensure network position has price set at all times.
+- [10409](https://github.com/vegaprotocol/vega/issues/10499) - Block explorer `API` failing in release `0.74.0`.
 
 ## 0.73.0
 

--- a/cmd/blockexplorer/commands/start.go
+++ b/cmd/blockexplorer/commands/start.go
@@ -24,6 +24,7 @@ import (
 
 	"code.vegaprotocol.io/vega/blockexplorer"
 	"code.vegaprotocol.io/vega/blockexplorer/config"
+	"code.vegaprotocol.io/vega/blockexplorer/store"
 	"code.vegaprotocol.io/vega/logging"
 
 	"github.com/jessevdk/go-flags"
@@ -52,6 +53,12 @@ func (opts *Start) Execute(_ []string) error {
 
 	// Use to shutdown the block explorer.
 	beCtx, stopBlockExplorer := context.WithCancel(context.Background())
+
+	// make sure the database has been migrated to the latest version
+	err = store.MigrateToLatestSchema(logger, cfg.Store)
+	if err != nil {
+		return fmt.Errorf("creating db schema: %w", err)
+	}
 
 	blockExplorerStopped := make(chan any)
 	go func() {


### PR DESCRIPTION
Closes #10409