### PR TITLE
fix: party margin modes API not returning data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,11 @@
 - [10393](https://github.com/vegaprotocol/vega/issues/10393) - Fixed source weight validation.
 - [10396](https://github.com/vegaprotocol/vega/issues/10396) - `ListTransfers` returns error.
 - [10299](https://github.com/vegaprotocol/vega/issues/10299) - `ListTransfers` does not return staking rewards.
-- [10407](https://github.com/vegaprotocol/vega/issues/10407) - Workaround to allow running feature test with invalid 0 mark price frequency. 
+- [10407](https://github.com/vegaprotocol/vega/issues/10407) - Workaround to allow running feature test with invalid 0 mark price frequency.
 - [10378](https://github.com/vegaprotocol/vega/issues/10378) - Ensure network position has price set at all times.
 - [10409](https://github.com/vegaprotocol/vega/issues/10499) - Block explorer `API` failing in release `0.74.0`.
 - 
+- [10417](https://github.com/vegaprotocol/vega/issues/10417) - Party margin modes `API` always errors.
 
 ## 0.73.0
 

--- a/datanode/entities/margin_mode.go
+++ b/datanode/entities/margin_mode.go
@@ -44,10 +44,31 @@ func (t PartyMarginMode) Cursor() *Cursor {
 }
 
 func (t PartyMarginMode) ToProto() *v2.PartyMarginMode {
+	var marginFactor, minTheoreticalMarginFactor, maxTheoreticalLeverage *string
+
+	if t.MarginFactor != nil {
+		factor := t.MarginFactor.String()
+		marginFactor = &factor
+	}
+
+	if t.MinTheoreticalMarginFactor != nil {
+		factor := t.MinTheoreticalMarginFactor.String()
+		minTheoreticalMarginFactor = &factor
+	}
+
+	if t.MaxTheoreticalLeverage != nil {
+		leverage := t.MaxTheoreticalLeverage.String()
+		maxTheoreticalLeverage = &leverage
+	}
+
 	return &v2.PartyMarginMode{
-		MarketId: string(t.MarketID),
-		PartyId:  string(t.PartyID),
-		AtEpoch:  t.AtEpoch,
+		MarketId:                   string(t.MarketID),
+		PartyId:                    string(t.PartyID),
+		MarginMode:                 t.MarginMode,
+		MarginFactor:               marginFactor,
+		MinTheoreticalMarginFactor: minTheoreticalMarginFactor,
+		MaxTheoreticalLeverage:     maxTheoreticalLeverage,
+		AtEpoch:                    t.AtEpoch,
 	}
 }
 

--- a/datanode/gateway/graphql/gqlgen.yml
+++ b/datanode/gateway/graphql/gqlgen.yml
@@ -787,3 +787,5 @@ models:
     model: code.vegaprotocol.io/vega/protos/vega.PartyProfile
   Metadata:
     model: code.vegaprotocol.io/vega/protos/vega.Metadata
+  MarginMode:
+    model: code.vegaprotocol.io/vega/datanode/gateway/graphql/marshallers.MarginMode

--- a/datanode/gateway/graphql/margin_mode_resolver.go
+++ b/datanode/gateway/graphql/margin_mode_resolver.go
@@ -23,10 +23,6 @@ import (
 
 type marginModeResolver VegaResolverRoot
 
-func (m marginModeResolver) MarginMode(_ context.Context, obj *v2.PartyMarginMode) (MarginMode, error) {
-	return MarginMode(obj.MarginMode), nil
-}
-
 func (m marginModeResolver) AtEpoch(_ context.Context, obj *v2.PartyMarginMode) (int, error) {
 	return int(obj.AtEpoch), nil
 }

--- a/datanode/gateway/graphql/marshallers/marshallers.go
+++ b/datanode/gateway/graphql/marshallers/marshallers.go
@@ -670,3 +670,23 @@ func UnmarshalLiquidityFeeMethod(v interface{}) (vega.LiquidityFeeSettings_Metho
 
 	return vega.LiquidityFeeSettings_Method(side), nil
 }
+
+func MarshalMarginMode(s vega.MarginMode) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		w.Write([]byte(strconv.Quote(s.String())))
+	})
+}
+
+func UnmarshalMarginMode(v interface{}) (vega.MarginMode, error) {
+	s, ok := v.(string)
+	if !ok {
+		return vega.MarginMode_MARGIN_MODE_UNSPECIFIED, fmt.Errorf("expected margin mode to be a string")
+	}
+
+	side, ok := vega.MarginMode_value[s]
+	if !ok {
+		return vega.MarginMode_MARGIN_MODE_UNSPECIFIED, fmt.Errorf("failed to convert margin mode from GraphQL to Proto: %v", s)
+	}
+
+	return vega.MarginMode(side), nil
+}

--- a/datanode/gateway/graphql/models.go
+++ b/datanode/gateway/graphql/models.go
@@ -1102,49 +1102,6 @@ func (e GovernanceTransferType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
-type MarginMode string
-
-const (
-	// Party is in cross margin mode
-	MarginModeMarginModeCrossMargin MarginMode = "MARGIN_MODE_CROSS_MARGIN"
-	// Party is in isolated margin mode
-	MarginModeMarginModeIsolatedMargin MarginMode = "MARGIN_MODE_ISOLATED_MARGIN"
-)
-
-var AllMarginMode = []MarginMode{
-	MarginModeMarginModeCrossMargin,
-	MarginModeMarginModeIsolatedMargin,
-}
-
-func (e MarginMode) IsValid() bool {
-	switch e {
-	case MarginModeMarginModeCrossMargin, MarginModeMarginModeIsolatedMargin:
-		return true
-	}
-	return false
-}
-
-func (e MarginMode) String() string {
-	return string(e)
-}
-
-func (e *MarginMode) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = MarginMode(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid MarginMode", str)
-	}
-	return nil
-}
-
-func (e MarginMode) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
 type MarketUpdateType string
 
 const (

--- a/datanode/gateway/graphql/resolvers.go
+++ b/datanode/gateway/graphql/resolvers.go
@@ -2499,13 +2499,6 @@ func (r *myMarginLevelsUpdateResolver) MarginFactor(_ context.Context, m *vegapb
 	return m.MarginFactor, nil
 }
 
-func (r *myMarginLevelsUpdateResolver) MarginMode(_ context.Context, m *vegapb.MarginLevels) (MarginMode, error) {
-	if m.MarginMode == vegapb.MarginMode_MARGIN_MODE_ISOLATED_MARGIN {
-		return MarginModeMarginModeIsolatedMargin, nil
-	}
-	return MarginModeMarginModeCrossMargin, nil
-}
-
 // BEGIN: MarginLevels Resolver
 
 type myMarginLevelsResolver VegaResolverRoot
@@ -2556,13 +2549,6 @@ func (r *myMarginLevelsResolver) OrderMarginLevel(_ context.Context, m *vegapb.M
 
 func (r *myMarginLevelsResolver) MarginFactor(_ context.Context, m *vegapb.MarginLevels) (string, error) {
 	return m.MarginFactor, nil
-}
-
-func (r *myMarginLevelsResolver) MarginMode(_ context.Context, m *vegapb.MarginLevels) (MarginMode, error) {
-	if m.MarginMode == vegapb.MarginMode_MARGIN_MODE_ISOLATED_MARGIN {
-		return MarginModeMarginModeIsolatedMargin, nil
-	}
-	return MarginModeMarginModeCrossMargin, nil
 }
 
 // END: MarginLevels Resolver

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -186,6 +186,8 @@ type MarginLevels {
 }
 
 enum MarginMode {
+  "Margin mode is not specified."
+  MARGIN_MODE_UNSPECIFIED
   "Party is in cross margin mode"
   MARGIN_MODE_CROSS_MARGIN
   "Party is in isolated margin mode"
@@ -7115,11 +7117,11 @@ type PartyMarginMode {
   "Selected margin mode."
   marginMode: MarginMode!
   "Margin factor for the market. Isolated mode only."
-  margin_factor: String
+  marginFactor: String
   "Minimum theoretical margin factor for the market. Isolated mode only."
-  min_theoretical_margin_factor: String
+  minTheoreticalMarginFactor: String
   "Maximum theoretical leverage for the market. Isolated mode only."
-  max_theoretical_leverage: String
+  maxTheoreticalLeverage: String
   "Epoch at which the update happened."
   atEpoch: Int!
 }


### PR DESCRIPTION
Closes #10417 

- Margin mode was not correctly resolving to the GQL equivalent
- Party margin mode data was not returning all data points to the API as some field mappings were missing
- GraphQL field names on some of the party margin mode object did not follow the same naming convention as the rest of the API (snake_case, instead of camelCase)
