### PR TITLE
fix: only set up config watching is evm clients have been initialised

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
                 stage('core/integration tests') {
                     steps {
                         dir('vega/core/integration') {
-                            sh 'go test . --godog.format=junit:core-integration-report.xml'
+                            sh 'go test . -timeout 30m --godog.format=junit:core-integration-report.xml'
                             junit checksName: 'Core Integration Tests', testResults: 'core-integration-report.xml'
                         }
                     }

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -505,8 +505,14 @@ func (svcs *allServices) registerConfigWatchers() {
 		func(cfg config.Config) { svcs.banking.ReloadConf(cfg.Banking) },
 		func(cfg config.Config) { svcs.governance.ReloadConf(cfg.Governance) },
 		func(cfg config.Config) { svcs.stats.ReloadConf(cfg.Stats) },
-		func(cfg config.Config) { svcs.l2Clients.ReloadConf(cfg.Ethereum) },
 	)
+
+	if svcs.conf.HaveEthClient() {
+		svcs.confListenerIDs = svcs.confWatcher.OnConfigUpdateWithID(
+			func(cfg config.Config) { svcs.l2Clients.ReloadConf(cfg.Ethereum) },
+		)
+	}
+
 	svcs.timeService.NotifyOnTick(svcs.confWatcher.OnTimeUpdate)
 }
 


### PR DESCRIPTION
Fix for non-validator nodes crashing because they'll try to load a reloading a config into a `nil` engine.