### PR TITLE
fix: block explorer database migration is slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,12 +142,12 @@
 - [10407](https://github.com/vegaprotocol/vega/issues/10407) - Workaround to allow running feature test with invalid 0 mark price frequency.
 - [10378](https://github.com/vegaprotocol/vega/issues/10378) - Ensure network position has price set at all times.
 - [10409](https://github.com/vegaprotocol/vega/issues/10499) - Block explorer `API` failing in release `0.74.0`.
--
 - [10417](https://github.com/vegaprotocol/vega/issues/10417) - Party margin modes `API` always errors.
 - [10431](https://github.com/vegaprotocol/vega/issues/10431) - Fix source staleness validation.
 - [10436](https://github.com/vegaprotocol/vega/issues/10436) - Fix source staleness validation when oracles are not defined.
 - [10434](https://github.com/vegaprotocol/vega/issues/10434) - Unsubscribe oracles when market is closed.
 - [10454](https://github.com/vegaprotocol/vega/issues/10454) - Fix account resolver validation to include order margin account.
+- [10419](https://github.com/vegaprotocol/vega/issues/10419) - Block explorer database migration is slow.
 
 ## 0.73.0
 

--- a/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
+++ b/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
@@ -63,7 +63,7 @@ BEGIN
     WHERE b.rowid = NEW.block_id
       AND tx_results.rowid = NEW.rowid;
 
-    RETURN NULL;
+    RETURN NEW;
 END;
 $$;
 -- +goose StatementEnd

--- a/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
+++ b/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
@@ -15,56 +15,17 @@ ALTER INDEX tx_results_tx_hash_index RENAME TO tx_results_old_tx_hash_index;
 ALTER INDEX tx_results_submitter_block_id_index_idx RENAME TO tx_results_old_submitter_block_id_index_idx;
 ALTER INDEX tx_results_cmd_type_block_id_index RENAME TO tx_results_old_cmd_type_block_id_index;
 
--- We need to make sure the next value in the rowid serial for the new tx_results table
--- continues where the old one leaves off otherwise we will break foreign key constraints
--- in the events table which we have had to drop temporarily and will restore once all the
--- data has been migrated.
--- +goose StatementBegin
-do $$
-    declare
-        tx_results_seq_name text;
-        tx_results_seq_next bigint;
-    begin
-        -- get the next value of the sequence for tx_results_old
-        -- we will use this to reset the sequence value for the new tx_results table
-        select nextval(pg_get_serial_sequence('tx_results_old', 'rowid'))
-        into tx_results_seq_next;
+-- +goose Down
 
-        -- Create a new tx_results table with all the necessary fields
-        CREATE TABLE tx_results (
-            rowid BIGSERIAL PRIMARY KEY,
-            -- The block to which this transaction belongs.
-            block_id BIGINT NOT NULL REFERENCES blocks(rowid),
-            -- The sequential index of the transaction within the block.
-            index INTEGER NOT NULL,
-            -- When this result record was logged into the sink, in UTC.
-            created_at TIMESTAMPTZ NOT NULL,
-            -- The hex-encoded hash of the transaction.
-            tx_hash VARCHAR NOT NULL,
-            -- The protobuf wire encoding of the TxResult message.
-            tx_result BYTEA NOT NULL,
-            submitter TEXT,
-            cmd_type TEXT,
-            block_height BIGINT DEFAULT 0,
-            UNIQUE (block_id, index)
-        );
+ALTER INDEX tx_results_old_cmd_type_block_id_index RENAME TO tx_results_cmd_type_block_id_index;
+ALTER INDEX tx_results_old_submitter_block_id_index_idx RENAME TO tx_results_submitter_block_id_index_idx;
+ALTER INDEX tx_results_old_tx_hash_index RENAME TO tx_results_tx_hash_index;
+ALTER TABLE tx_results_old RENAME TO tx_results;
 
-        CREATE INDEX tx_results_tx_hash_index ON tx_results(tx_hash);
-        CREATE INDEX tx_results_submitter_block_id_index_idx ON tx_results(submitter, block_id, index);
-        CREATE INDEX tx_results_cmd_type_block_id_index ON tx_results
-            USING btree (cmd_type, block_id, index);
+ALTER TABLE events ADD constraint events_tx_id_fkey FOREIGN KEY (tx_id) REFERENCES tx_results(rowid);
 
-        -- get the sequence name for the new tx_results serial
-        select pg_get_serial_sequence('tx_results', 'rowid')
-        into tx_results_seq_name;
-
-        -- restart the sequence with the current value of the sequence for tx_results_old
-        -- when nextval is called, we should get the restart value, which is the next value
-        -- in the sequence for tx_results_old
-        execute format('alter sequence %s restart with %s', tx_results_seq_name, tx_results_seq_next);
-    end;
-$$;
--- +goose StatementEnd
+ALTER TABLE tx_results
+    DROP COLUMN IF EXISTS block_height;
 
 -- Recreate views, functions and triggers associated with the original tx_results table
 CREATE OR REPLACE VIEW tx_events AS
@@ -92,30 +53,17 @@ $$;
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION add_block_height_to_tx_results()
-  RETURNS TRIGGER
-  LANGUAGE plpgsql AS
+    RETURNS TRIGGER
+    LANGUAGE plpgsql AS
 $$
 BEGIN
-  UPDATE tx_results
-  SET block_height=b.height
-  FROM blocks b
-  WHERE b.rowid = NEW.block_id
-    AND tx_results.rowid = NEW.rowid;
+    UPDATE tx_results
+    SET block_height=b.height
+    FROM blocks b
+    WHERE b.rowid = NEW.block_id
+      AND tx_results.rowid = NEW.rowid;
 
-  RETURN NULL;
+    RETURN NULL;
 END;
 $$;
 -- +goose StatementEnd
-
-CREATE TRIGGER add_block_height_to_tx_results
-  AFTER INSERT
-  ON tx_results
-  FOR EACH ROW
-EXECUTE PROCEDURE add_block_height_to_tx_results();
-
--- +goose Down
-
-DROP TRIGGER IF EXISTS add_block_height_to_tx_results ON tx_results;
-
-ALTER TABLE tx_results
-  DROP COLUMN IF EXISTS block_height;

--- a/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
+++ b/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
@@ -19,6 +19,7 @@ ALTER INDEX tx_results_cmd_type_block_id_index RENAME TO tx_results_old_cmd_type
 -- continues where the old one leaves off otherwise we will break foreign key constraints
 -- in the events table which we have had to drop temporarily and will restore once all the
 -- data has been migrated.
+-- +goose StatementBegin
 do $$
     declare
         tx_results_seq_name text;
@@ -63,6 +64,7 @@ do $$
         execute format('alter sequence %s restart with %s', tx_results_seq_name, tx_results_seq_next);
     end;
 $$;
+-- +goose StatementEnd
 
 -- Recreate views, functions and triggers associated with the original tx_results table
 CREATE OR REPLACE VIEW tx_events AS

--- a/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
+++ b/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
@@ -15,29 +15,54 @@ ALTER INDEX tx_results_tx_hash_index RENAME TO tx_results_old_tx_hash_index;
 ALTER INDEX tx_results_submitter_block_id_index_idx RENAME TO tx_results_old_submitter_block_id_index_idx;
 ALTER INDEX tx_results_cmd_type_block_id_index RENAME TO tx_results_old_cmd_type_block_id_index;
 
--- Create a new tx_results table with all the necessary fields
-CREATE TABLE tx_results (
-    rowid BIGSERIAL PRIMARY KEY,
-    -- The block to which this transaction belongs.
-    block_id BIGINT NOT NULL REFERENCES blocks(rowid),
-    -- The sequential index of the transaction within the block.
-    index INTEGER NOT NULL,
-    -- When this result record was logged into the sink, in UTC.
-    created_at TIMESTAMPTZ NOT NULL,
-    -- The hex-encoded hash of the transaction.
-    tx_hash VARCHAR NOT NULL,
-    -- The protobuf wire encoding of the TxResult message.
-    tx_result BYTEA NOT NULL,
-    submitter TEXT,
-    cmd_type TEXT,
-    block_height BIGINT DEFAULT 0,
-    UNIQUE (block_id, index)
-);
+-- We need to make sure the next value in the rowid serial for the new tx_results table
+-- continues where the old one leaves off otherwise we will break foreign key constraints
+-- in the events table which we have had to drop temporarily and will restore once all the
+-- data has been migrated.
+do $$
+    declare
+        tx_results_seq_name text;
+        tx_results_seq_next bigint;
+    begin
+        -- get the next value of the sequence for tx_results_old
+        -- we will use this to reset the sequence value for the new tx_results table
+        select nextval(pg_get_serial_sequence('tx_results_old', 'rowid'))
+        into tx_results_seq_next;
 
-CREATE INDEX tx_results_tx_hash_index ON tx_results(tx_hash);
-CREATE INDEX tx_results_submitter_block_id_index_idx ON tx_results(submitter, block_id, index);
-CREATE INDEX tx_results_cmd_type_block_id_index ON tx_results
-    USING btree (cmd_type, block_id, index);
+        -- Create a new tx_results table with all the necessary fields
+        CREATE TABLE tx_results (
+            rowid BIGSERIAL PRIMARY KEY,
+            -- The block to which this transaction belongs.
+            block_id BIGINT NOT NULL REFERENCES blocks(rowid),
+            -- The sequential index of the transaction within the block.
+            index INTEGER NOT NULL,
+            -- When this result record was logged into the sink, in UTC.
+            created_at TIMESTAMPTZ NOT NULL,
+            -- The hex-encoded hash of the transaction.
+            tx_hash VARCHAR NOT NULL,
+            -- The protobuf wire encoding of the TxResult message.
+            tx_result BYTEA NOT NULL,
+            submitter TEXT,
+            cmd_type TEXT,
+            block_height BIGINT DEFAULT 0,
+            UNIQUE (block_id, index)
+        );
+
+        CREATE INDEX tx_results_tx_hash_index ON tx_results(tx_hash);
+        CREATE INDEX tx_results_submitter_block_id_index_idx ON tx_results(submitter, block_id, index);
+        CREATE INDEX tx_results_cmd_type_block_id_index ON tx_results
+            USING btree (cmd_type, block_id, index);
+
+        -- get the sequence name for the new tx_results serial
+        select pg_get_serial_sequence('tx_results', 'rowid')
+        into tx_results_seq_name;
+
+        -- restart the sequence with the current value of the sequence for tx_results_old
+        -- when nextval is called, we should get the restart value, which is the next value
+        -- in the sequence for tx_results_old
+        execute format('alter sequence %s restart with %s', tx_results_seq_name, tx_results_seq_next);
+    end;
+$$;
 
 -- Recreate views, functions and triggers associated with the original tx_results table
 CREATE OR REPLACE VIEW tx_events AS

--- a/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
+++ b/blockexplorer/store/migrations/0005_add_block_height_to_tx_result.sql
@@ -5,10 +5,63 @@
 ALTER TABLE tx_results
   ADD COLUMN IF NOT EXISTS block_height BIGINT DEFAULT 0;
 
-UPDATE tx_results
-SET block_height=b.height
-FROM blocks b
-WHERE b.rowid = tx_results.block_id;
+-- First drop any foreign key constraints that depend on the tx_results table
+-- This will be restored after all the data has been migrated to the new tx_results table
+ALTER TABLE events DROP constraint events_tx_id_fkey;
+
+-- Rename the tx_results table to tx_results_old
+ALTER TABLE tx_results RENAME TO tx_results_old;
+ALTER INDEX tx_results_tx_hash_index RENAME TO tx_results_old_tx_hash_index;
+ALTER INDEX tx_results_submitter_block_id_index_idx RENAME TO tx_results_old_submitter_block_id_index_idx;
+ALTER INDEX tx_results_cmd_type_block_id_index RENAME TO tx_results_old_cmd_type_block_id_index;
+
+-- Create a new tx_results table with all the necessary fields
+CREATE TABLE tx_results (
+    rowid BIGSERIAL PRIMARY KEY,
+    -- The block to which this transaction belongs.
+    block_id BIGINT NOT NULL REFERENCES blocks(rowid),
+    -- The sequential index of the transaction within the block.
+    index INTEGER NOT NULL,
+    -- When this result record was logged into the sink, in UTC.
+    created_at TIMESTAMPTZ NOT NULL,
+    -- The hex-encoded hash of the transaction.
+    tx_hash VARCHAR NOT NULL,
+    -- The protobuf wire encoding of the TxResult message.
+    tx_result BYTEA NOT NULL,
+    submitter TEXT,
+    cmd_type TEXT,
+    block_height BIGINT DEFAULT 0,
+    UNIQUE (block_id, index)
+);
+
+CREATE INDEX tx_results_tx_hash_index ON tx_results(tx_hash);
+CREATE INDEX tx_results_submitter_block_id_index_idx ON tx_results(submitter, block_id, index);
+CREATE INDEX tx_results_cmd_type_block_id_index ON tx_results
+    USING btree (cmd_type, block_id, index);
+
+-- Recreate views, functions and triggers associated with the original tx_results table
+CREATE OR REPLACE VIEW tx_events AS
+SELECT height, index, chain_id, type, key, composite_key, value, tx_results.created_at
+FROM blocks JOIN tx_results ON (blocks.rowid = tx_results.block_id)
+            JOIN event_attributes ON (tx_results.rowid = event_attributes.tx_id)
+WHERE event_attributes.tx_id IS NOT NULL;
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_txresult_cmd_type()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL AS
+$$
+BEGIN
+    UPDATE tx_results SET cmd_type=NEW.value
+    FROM events e
+    WHERE e.rowid = NEW.event_ID
+      AND tx_results.rowid = e.tx_id;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION add_block_height_to_tx_results()
@@ -39,4 +92,3 @@ DROP TRIGGER IF EXISTS add_block_height_to_tx_results ON tx_results;
 
 ALTER TABLE tx_results
   DROP COLUMN IF EXISTS block_height;
-

--- a/blockexplorer/store/migrations/0006_migrate_tx_results_data_for_block_height_changes.sql
+++ b/blockexplorer/store/migrations/0006_migrate_tx_results_data_for_block_height_changes.sql
@@ -1,0 +1,103 @@
+-- +goose Up
+
+-- We need to make sure the next value in the rowid serial for the new tx_results table
+-- continues where the old one leaves off otherwise we will break foreign key constraints
+-- in the events table which we have had to drop temporarily and will restore once all the
+-- data has been migrated.
+-- +goose StatementBegin
+do $$
+    declare
+        tx_results_seq_name text;
+        tx_results_seq_next bigint;
+    begin
+        -- get the next value of the sequence for tx_results_old
+        -- we will use this to reset the sequence value for the new tx_results table
+        select nextval(pg_get_serial_sequence('tx_results_old', 'rowid'))
+        into tx_results_seq_next;
+
+        -- Create a new tx_results table with all the necessary fields
+        CREATE TABLE tx_results (
+            rowid BIGSERIAL PRIMARY KEY,
+            -- The block to which this transaction belongs.
+            block_id BIGINT NOT NULL REFERENCES blocks(rowid),
+            -- The sequential index of the transaction within the block.
+            index INTEGER NOT NULL,
+            -- When this result record was logged into the sink, in UTC.
+            created_at TIMESTAMPTZ NOT NULL,
+            -- The hex-encoded hash of the transaction.
+            tx_hash VARCHAR NOT NULL,
+            -- The protobuf wire encoding of the TxResult message.
+            tx_result BYTEA NOT NULL,
+            submitter TEXT,
+            cmd_type TEXT,
+            block_height BIGINT DEFAULT 0,
+            UNIQUE (block_id, index)
+        );
+
+        CREATE INDEX tx_results_tx_hash_index ON tx_results(tx_hash);
+        CREATE INDEX tx_results_submitter_block_id_index_idx ON tx_results(submitter, block_id, index);
+        CREATE INDEX tx_results_cmd_type_block_id_index ON tx_results
+            USING btree (cmd_type, block_id, index);
+
+        -- get the sequence name for the new tx_results serial
+        select pg_get_serial_sequence('tx_results', 'rowid')
+        into tx_results_seq_name;
+
+        -- restart the sequence with the current value of the sequence for tx_results_old
+        -- when nextval is called, we should get the restart value, which is the next value
+        -- in the sequence for tx_results_old
+        execute format('alter sequence %s restart with %s', tx_results_seq_name, tx_results_seq_next);
+    end;
+$$;
+-- +goose StatementEnd
+
+-- Recreate views, functions and triggers associated with the original tx_results table
+CREATE OR REPLACE VIEW tx_events AS
+SELECT height, index, chain_id, type, key, composite_key, value, tx_results.created_at
+FROM blocks JOIN tx_results ON (blocks.rowid = tx_results.block_id)
+            JOIN event_attributes ON (tx_results.rowid = event_attributes.tx_id)
+WHERE event_attributes.tx_id IS NOT NULL;
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_txresult_cmd_type()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL AS
+$$
+BEGIN
+    UPDATE tx_results SET cmd_type=NEW.value
+    FROM events e
+    WHERE e.rowid = NEW.event_ID
+      AND tx_results.rowid = e.tx_id;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION add_block_height_to_tx_results()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    UPDATE tx_results
+    SET block_height=b.height
+    FROM blocks b
+    WHERE b.rowid = NEW.block_id
+      AND tx_results.rowid = NEW.rowid;
+
+    RETURN NULL;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER add_block_height_to_tx_results
+    AFTER INSERT
+    ON tx_results
+    FOR EACH ROW
+EXECUTE PROCEDURE add_block_height_to_tx_results();
+
+-- +goose Down
+DROP VIEW IF EXISTS tx_events;
+DROP TABLE IF EXISTS tx_results;

--- a/blockexplorer/store/migrations/0006_migrate_tx_results_data_for_block_height_changes.sql
+++ b/blockexplorer/store/migrations/0006_migrate_tx_results_data_for_block_height_changes.sql
@@ -87,7 +87,7 @@ BEGIN
     WHERE b.rowid = NEW.block_id
       AND tx_results.rowid = NEW.rowid;
 
-    RETURN NULL;
+    RETURN NEW;
 END;
 $$;
 -- +goose StatementEnd

--- a/blockexplorer/store/transactions.go
+++ b/blockexplorer/store/transactions.go
@@ -36,7 +36,7 @@ var (
 func (s *Store) GetTransaction(ctx context.Context, txID string) (*pb.Transaction, error) {
 	txID = strings.ToUpper(txID)
 
-	query := `SELECT t.rowid, t.block_id, t.index, t.created_at, t.tx_hash, t.tx_result, t.cmd_type, t.submitter FROM tx_results t WHERE t.tx_hash=$1`
+	query := `SELECT t.rowid, t.block_height, t.index, t.created_at, t.tx_hash, t.tx_result, t.cmd_type, t.submitter FROM tx_results t WHERE t.tx_hash=$1`
 	var rows []entities.TxResultRow
 
 	if err := pgxscan.Select(ctx, s.pool, &rows, query, txID); err != nil {


### PR DESCRIPTION
Step one, this is the first step to solving the issue, we are just moving the existing tx_results in order to back it up, and allow tendermint to continue populating a new tx_results table.

Once everything is up and running, a second PR will add a background migration process that will move the existing data from the backup to the new tx_results table giving us a full history in block explorer.
