### PR TITLE
fix: stop double polling evm-call-engines when starting from a snapshot

### DIFF
--- a/core/datasource/external/ethcall/engine.go
+++ b/core/datasource/external/ethcall/engine.go
@@ -121,10 +121,7 @@ func (e *Engine) Start() {
 			defer cancelEthereumQueries()
 
 			e.cancelEthereumQueries = cancelEthereumQueries
-
-			if e.log.IsDebug() {
-				e.log.Debug("Starting ethereum contract call polling engine")
-			}
+			e.log.Info("Starting ethereum contract call polling engine", logging.Uint64("chain-id", e.chainID))
 
 			e.poller.Loop(func() {
 				e.Poll(ctx, time.Now())

--- a/core/datasource/external/ethverifier/l2_verifier_snapshot.go
+++ b/core/datasource/external/ethverifier/l2_verifier_snapshot.go
@@ -22,6 +22,7 @@ import (
 	"code.vegaprotocol.io/vega/core/datasource/external/ethcall"
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/libs/proto"
+	"code.vegaprotocol.io/vega/logging"
 	snapshotpb "code.vegaprotocol.io/vega/protos/vega/snapshot/v1"
 
 	"golang.org/x/exp/maps"
@@ -56,6 +57,7 @@ func (s *L2Verifiers) GetState(k string) ([]byte, []types.StateProvider, error) 
 	}
 
 	for k, v := range s.verifiers {
+		s.log.Debug("serialising state for evm verifier", logging.String("source-chain-id", k))
 		ethOracles.L2EthOracles.ChainIdEthOracles = append(
 			ethOracles.L2EthOracles.ChainIdEthOracles,
 			&snapshotpb.ChainIdEthOracles{
@@ -95,8 +97,12 @@ func (s *L2Verifiers) LoadState(ctx context.Context, payload *types.Payload) ([]
 
 func (s *L2Verifiers) restoreState(ctx context.Context, l2EthOracles *snapshotpb.L2EthOracles) {
 	for _, v := range l2EthOracles.ChainIdEthOracles {
-		verifier := s.instantiate(v.SourceChainId)
+		verifier, ok := s.verifiers[v.SourceChainId]
+		if !ok {
+			s.log.Panic("evm verifier for chain in snapshot, but not instantiated by network-parameter", logging.String("source-chain-id", v.SourceChainId))
+		}
 
+		s.log.Info("restoring evm verifier", logging.String("source-chain-id", v.SourceChainId))
 		// might be nil so need proper check first here
 		var lastBlock *types.EthBlock
 		if v.LastBlock != nil {
@@ -128,6 +134,7 @@ func (s *L2Verifiers) OnStateLoaded(ctx context.Context) error {
 
 	// restart ethCall engines
 	for _, v := range ids {
+		s.log.Info("calling OnStateLoaded for evm verifier", logging.String("source-chain-id", v))
 		s.verifiers[v].OnStateLoaded(ctx)
 	}
 

--- a/core/protocol/l2_eth_call_engines.go
+++ b/core/protocol/l2_eth_call_engines.go
@@ -25,6 +25,7 @@ import (
 	"code.vegaprotocol.io/vega/core/datasource/external/ethverifier"
 	"code.vegaprotocol.io/vega/core/datasource/spec"
 	"code.vegaprotocol.io/vega/core/types"
+	vgcontext "code.vegaprotocol.io/vega/libs/context"
 	"code.vegaprotocol.io/vega/logging"
 )
 
@@ -89,8 +90,13 @@ func (v *L2EthCallEngines) OnEthereumL2ConfigsUpdated(
 		e.EnsureChainID(c.ChainID, v.isValidator)
 		v.engines[c.ChainID] = e
 
-		// start it here?
-		e.Start()
+		// if we are restoring from a snapshot we want to delay starting the engine
+		// until we know what block height to use. If we aren't restoring from a snapshot
+		// we are either loading from genesis, or the engine has been added dynamically and
+		// so we want to kick it off
+		if !vgcontext.InProgressSnapshotRestore(ctx) {
+			e.Start()
+		}
 
 		// setup activation listener
 		v.specActivationListener(v.engines[c.ChainID])

--- a/libs/context/context.go
+++ b/libs/context/context.go
@@ -145,6 +145,17 @@ func WithSnapshotInfo(ctx context.Context, version string, upgrade bool) context
 	return context.WithValue(ctx, snapshotKey, snapshotInfo{version: version, upgrade: upgrade})
 }
 
+// InProgressSnapshotRestore returns whether the data in the contexts tells us that a
+// snapshot restore is in progress.
+func InProgressSnapshotRestore(ctx context.Context) bool {
+	v := ctx.Value(snapshotKey)
+	if v == nil {
+		return false
+	}
+	_, ok := v.(snapshotInfo)
+	return ok
+}
+
 // InProgressUpgradeFrom returns whether the data in the contexts tells us that the
 // node is restoring from a snapshot taken for a protocol-upgrade by the given version.
 func InProgressUpgradeFrom(ctx context.Context, from string) bool {

--- a/libs/context/context_test.go
+++ b/libs/context/context_test.go
@@ -28,12 +28,15 @@ func TestRestoreDataInContext(t *testing.T) {
 	ctx := vgcontext.WithSnapshotInfo(context.Background(), "v0.74.0", true)
 	assert.True(t, vgcontext.InProgressUpgradeFrom(ctx, "v0.74.0"))
 	assert.False(t, vgcontext.InProgressUpgradeFrom(ctx, "v0.74.1"))
+	assert.True(t, vgcontext.InProgressSnapshotRestore(ctx))
 
 	ctx = vgcontext.WithSnapshotInfo(context.Background(), "v0.74.0", false)
 	assert.False(t, vgcontext.InProgressUpgradeFrom(ctx, "v0.74.0"))
 	assert.False(t, vgcontext.InProgressUpgradeFrom(ctx, "v0.74.1"))
+	assert.True(t, vgcontext.InProgressSnapshotRestore(ctx))
 
 	ctx = context.Background()
 	assert.False(t, vgcontext.InProgressUpgradeFrom(ctx, "v0.74.0"))
 	assert.False(t, vgcontext.InProgressUpgradeFrom(ctx, "v0.74.1"))
+	assert.False(t, vgcontext.InProgressSnapshotRestore(ctx))
 }


### PR DESCRIPTION
closes #10442