### PR TITLE
fix: edge case where in auction funding-period ends on termination, A…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
 - [10393](https://github.com/vegaprotocol/vega/issues/10393) - Fixed source weight validation.
 - [10396](https://github.com/vegaprotocol/vega/issues/10396) - `ListTransfers` returns error.
 - [10299](https://github.com/vegaprotocol/vega/issues/10299) - `ListTransfers` does not return staking rewards.
+- [10496](https://github.com/vegaprotocol/vega/issues/10496) - `MarketData` API now always report correct funding payment when a perpetual market is terminated.
 - [10407](https://github.com/vegaprotocol/vega/issues/10407) - Workaround to allow running feature test with invalid 0 mark price frequency.
 - [10378](https://github.com/vegaprotocol/vega/issues/10378) - Ensure network position has price set at all times.
 - [10409](https://github.com/vegaprotocol/vega/issues/10499) - Block explorer `API` failing in release `0.74.0`.


### PR DESCRIPTION
close #10496

Note that this is only an API issue, and also only relevant when in-auction time is excluded from the TWAP's which is a palazzo feature i.e it does not affect the perptual markets currently about to be terminated on mainnet.