### PR TITLE
fix: distressed party with no trades in MTM period continues to have …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 - [10419](https://github.com/vegaprotocol/vega/issues/10419) - Block explorer database migration is slow.
 - [10431](https://github.com/vegaprotocol/vega/issues/10431) - Fix source staleness validation.
 - [10419](https://github.com/vegaprotocol/vega/issues/10419) - Block explorer database migration is slow.
+- [10510](https://github.com/vegaprotocol/vega/issues/10510) - Removing distressed position who hasn't traded does not populate trade map for network.
 - [10470](https://github.com/vegaprotocol/vega/issues/10470) - Mark non-optional parameters as required and update documentation strings.
 - [10456](https://github.com/vegaprotocol/vega/issues/10456) - Expose proper enum for `GraphQL` dispatch metric.
 - [10301](https://github.com/vegaprotocol/vega/issues/10301) - Fix get epoch by block.

--- a/core/settlement/engine.go
+++ b/core/settlement/engine.go
@@ -440,7 +440,9 @@ func (e *Engine) RemoveDistressed(ctx context.Context, evts []events.Margin) {
 		delete(e.trades, key)
 	}
 	e.settledPosition[types.NetworkParty] = netSize
-	e.trades[types.NetworkParty] = netTrades
+	if len(netTrades) > 0 {
+		e.trades[types.NetworkParty] = netTrades
+	}
 	e.mu.Unlock()
 	e.broker.SendBatch(devts)
 }

--- a/core/settlement/engine_test.go
+++ b/core/settlement/engine_test.go
@@ -1425,7 +1425,6 @@ func (te *testEngine) getMockMarketPositions(data []posValue) ([]settlement.Mark
 }
 
 func TestRemoveDistressedNoTrades(t *testing.T) {
-
 	engine := getTestEngine(t)
 	defer engine.Finish()
 	engine.prod.EXPECT().Settle(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(markPrice *num.Uint, settlementData *num.Uint, size num.Decimal) (*types.FinancialAmount, bool, num.Decimal, error) {
@@ -1457,7 +1456,6 @@ func TestRemoveDistressedNoTrades(t *testing.T) {
 	engine.Update(evts)
 	engine.RemoveDistressed(context.Background(), marginEvts)
 	assert.False(t, engine.HasTraded())
-
 }
 
 func TestConcurrent(t *testing.T) {

--- a/core/settlement/engine_test.go
+++ b/core/settlement/engine_test.go
@@ -1424,6 +1424,42 @@ func (te *testEngine) getMockMarketPositions(data []posValue) ([]settlement.Mark
 	return raw, evts
 }
 
+func TestRemoveDistressedNoTrades(t *testing.T) {
+
+	engine := getTestEngine(t)
+	defer engine.Finish()
+	engine.prod.EXPECT().Settle(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(markPrice *num.Uint, settlementData *num.Uint, size num.Decimal) (*types.FinancialAmount, bool, num.Decimal, error) {
+		return &types.FinancialAmount{Amount: num.UintZero()}, false, num.DecimalZero(), nil
+	})
+
+	data := []posValue{
+		{
+			party: "testparty1",
+			price: num.NewUint(1234),
+			size:  100,
+		},
+		{
+			party: "testparty2",
+			price: num.NewUint(1235),
+			size:  0,
+		},
+	}
+	raw, evts := engine.getMockMarketPositions(data)
+	// margin evt
+	marginEvts := make([]events.Margin, 0, len(raw))
+	for _, pe := range raw {
+		marginEvts = append(marginEvts, marginVal{
+			MarketPosition: pe,
+		})
+	}
+
+	assert.False(t, engine.HasTraded())
+	engine.Update(evts)
+	engine.RemoveDistressed(context.Background(), marginEvts)
+	assert.False(t, engine.HasTraded())
+
+}
+
 func TestConcurrent(t *testing.T) {
 	const N = 10
 


### PR DESCRIPTION
close #10510 

When a `RemovedDistressed()` is called on the settlement engine, that party's trades and settled-position are transferred to the network party. In the case where a distressed party has a position but has no trades in this MTM period we were setting this `e.trades[types.NetworkParty] = netTrades` where `netTrades` was an empty slice. The result is that `e.HasTraded()` would return true even though there had been no trades.

This was causing issues with snapshots because the way the trades are serlised in the snapshot meant that `e.trades[types.NetworkParty] == nil` restored to `e.trades` not containing a key for `types.NetworkParty`. So on restore `.HasTraded()` would be false but would (incorrectly I believe) return true on the original nodes.