### PR TITLE
Fix teams stats views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 - [10464](https://github.com/vegaprotocol/vega/issues/10464) - Add total of members in teams API.
 - [10464](https://github.com/vegaprotocol/vega/issues/10464) - Add total of members in referral sets API.
 - [10508](https://github.com/vegaprotocol/vega/issues/10508) - Change the behaviour of aggregation epochs for teams statistics API.
-- [10523](https://github.com/vegaprotocol/vega/issues/10523) - Fix repeated game_stats for multiple recurring transfers.
+- [10523](https://github.com/vegaprotocol/vega/issues/10523) - Fix repeated games statistics for multiple recurring transfers.
 
 ### 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,12 +76,13 @@
 - [10459](https://github.com/vegaprotocol/vega/issues/10459) - Update `pMedian` to consider staleness of the inputs.
 - [10429](https://github.com/vegaprotocol/vega/issues/10439) - Account for isolated margin mode in `EstimatePosition` endpoint.
 - [10441](https://github.com/vegaprotocol/vega/issues/10441) - Remove active restore check in collateral snapshot loading, snapshot order change removes the need for it.
-- [10286](https://github.com/vegaprotocol/vega/issues/10286) - If probability of trading is less than or equal to the minimum, assign it weight of zero for liquidity score calculation and change the validation of the tau scaling network parameter. 
+- [10286](https://github.com/vegaprotocol/vega/issues/10286) - If probability of trading is less than or equal to the minimum, assign it weight of zero for liquidity score calculation and change the validation of the tau scaling network parameter.
 - [10376](https://github.com/vegaprotocol/vega/issues/10376) - Add spam protection for update profile.
 - [10502](https://github.com/vegaprotocol/vega/issues/10502) - Rename index price to `internalCompositePrice`
 - [10464](https://github.com/vegaprotocol/vega/issues/10464) - Add total of members in teams API.
 - [10464](https://github.com/vegaprotocol/vega/issues/10464) - Add total of members in referral sets API.
 - [10508](https://github.com/vegaprotocol/vega/issues/10508) - Change the behaviour of aggregation epochs for teams statistics API.
+- [10523](https://github.com/vegaprotocol/vega/issues/10523) - Fix repeated game_stats for multiple recurring transfers.
 
 ### 🐛 Fixes
 
@@ -166,7 +167,7 @@
 - [10470](https://github.com/vegaprotocol/vega/issues/10470) - Mark non-optional parameters as required and update documentation strings.
 - [10456](https://github.com/vegaprotocol/vega/issues/10456) - Expose proper enum for `GraphQL` dispatch metric.
 - [10301](https://github.com/vegaprotocol/vega/issues/10301) - Fix get epoch by block.
-- [10343](https://github.com/vegaprotocol/vega/issues/10343) - Remove auction trigger extension and triggering ratio from liquidity monitoring parameters. 
+- [10343](https://github.com/vegaprotocol/vega/issues/10343) - Remove auction trigger extension and triggering ratio from liquidity monitoring parameters.
 - [10493](https://github.com/vegaprotocol/vega/issues/10493) - Fix isolated margin panic on amend order.
 - [10490](https://github.com/vegaprotocol/vega/issues/10490) - Handle the `quant` library returning `NaN`
 - [10504](https://github.com/vegaprotocol/vega/issues/10504) - Make sure the referral sets API accounts for referees switch.

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -379,12 +379,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmXrVTLPdFmAhHfbdv9b4D78KkzjFwByH8ZapNSTej311k", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmcV9AePA6UJW62kTL4JAyk3qiUTBR76PAaQi17SE1zqMQ", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmYmkSXWp9wvDSVZeVnA5cTKpkiA6ACNjbYDc1Pie1W8jL", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmYZVW1AgQZ28qi6hDJQSjGYgRVoiRAR3GGzqKXFSroXCW", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmTdb6e6aVWrngGUWfAHt5CSNFensMtox5GyNNqdCydf8z", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmSPzprzdCbJgqMPzSdw6nk1F9tNF7qJcGC2DuNxzAX3zM", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmemfwJGfJgh4NT85KGr2qLYKirCG6kYC8BM1SxvfVouyQ", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmWdNNZeXPyg8nVEUEhR8HqRgQWPjGEx6Pi26vkB8e4txD", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmVyzeGMrBngcVjU2fYSCCtNdbyGi9m6x6Dtb6cvzTwq13", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmUxYwUq4uvpaCaW3xZXrgTF8C2pubZGyWv5erosLZHBCe", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmPToYL9awKuVve1UHAHR4i6Gsqv3MDeEpCoXDgDbDbsje", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmdEe2HV8TifP1Y9vMGKgd6vdqqTmsoxRPox4K4dimCVru", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/games.go
+++ b/datanode/sqlstore/games.go
@@ -64,7 +64,7 @@ type GameReward struct {
 	GameID             []byte
 	DispatchStrategy   vega.DispatchStrategy
 	TeamID             entities.TeamID
-	MemberRank         int64
+	MemberRank         *int64
 	TeamRank           *int64
 	TotalRewards       num.Decimal
 	TeamTotalRewards   *num.Decimal
@@ -242,9 +242,14 @@ func parseGameRewards(rewards []GameReward) ([]entities.Game, error) {
 		rewardEarned, _ := num.UintFromDecimal(rewards[i].Amount)
 		totalRewardsEarned, _ := num.UintFromDecimal(rewards[i].TotalRewards)
 
+		var rank uint64
+		if rewards[i].MemberRank != nil {
+			rank = uint64(*rewards[i].MemberRank)
+		}
+
 		individual := entities.IndividualGameEntity{
 			Individual:         rewards[i].PartyID.String(),
-			Rank:               uint64(rewards[i].MemberRank),
+			Rank:               rank,
 			Volume:             num.DecimalZero(),
 			RewardMetric:       rewards[i].DispatchStrategy.Metric,
 			RewardEarned:       rewardEarned,

--- a/datanode/sqlstore/migrations/0088_update_game_stats.sql
+++ b/datanode/sqlstore/migrations/0088_update_game_stats.sql
@@ -1,132 +1,197 @@
 -- +goose Up
 
 create or replace view game_stats as
-WITH
-  game_epochs AS (
-    SELECT DISTINCT game_id, epoch_id
-    FROM rewards
-    WHERE game_id IS NOT NULL
-  ),
-  dispatch_strategies AS (
-    SELECT game_id, dispatch_strategy FROM transfers WHERE transfer_type = 'Recurring' ORDER BY vega_time DESC LIMIT 1
-  ),
-  game_rewards AS (
-    SELECT r.*,
-           t.dispatch_strategy,
-           tm.team_id,
-           tmr.rank AS member_rank,
-           tr.rank AS team_rank,
-           tmr.total_rewards,
-           tr.total_rewards AS team_total_rewards,
-           'ENTITY_SCOPE_TEAMS' AS entity_scope
-    FROM rewards r
-      JOIN game_epochs ge ON r.game_id = ge.game_id AND r.epoch_id = ge.epoch_id
-      JOIN dispatch_strategies t ON r.game_id = t.game_id AND t.dispatch_strategy ->> 'entity_scope' = '2'
-      JOIN team_members tm ON r.party_id = tm.party_id
-      LEFT JOIN game_team_rankings tr ON r.game_id = tr.game_id AND r.epoch_id = tr.epoch_id AND tm.team_id = tr.team_id
-      LEFT JOIN game_team_member_rankings tmr
-                ON r.game_id = tmr.game_id AND r.epoch_id = tmr.epoch_id AND tm.team_id = tmr.team_id AND
-                   r.party_id = tmr.party_id
-    UNION ALL
-    SELECT r.*,
-           t.dispatch_strategy,
-           NULL AS team_id,
-           tmr.rank AS member_rank,
-           NULL AS team_rank,
-           tmr.total_rewards,
-           NULL AS team_total_rewards,
-           'ENTITY_SCOPE_INDIVIDUALS' AS entity_scope
-    FROM rewards r
-      JOIN game_epochs ge ON r.game_id = ge.game_id AND r.epoch_id = ge.epoch_id
-      JOIN dispatch_strategies t ON r.game_id = t.game_id AND dispatch_strategy ->> 'entity_scope' = '1'
-      LEFT JOIN game_individual_rankings tmr
-                ON r.game_id = tmr.game_id AND r.epoch_id = tmr.epoch_id AND r.party_id = tmr.party_id
-  )
-SELECT s.*
-FROM game_rewards s;
+with
+    game_epochs as (
+        select distinct
+            game_id, epoch_id
+        from rewards
+        where
+            game_id is not null
+    ),
+    dispatch_strategies AS (
+        SELECT DISTINCT
+            ON (game_id) game_id, dispatch_strategy
+        FROM transfers
+        WHERE
+            transfer_type = 'Recurring'
+        ORDER BY game_id, vega_time DESC
+    ),
+    game_rewards as (
+        select
+            r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, tr.total_rewards as team_total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            JOIN dispatch_strategies t ON r.game_id = t.game_id
+            AND t.dispatch_strategy ->> 'entity_scope' = '2'
+            join team_members tm on r.party_id = tm.party_id
+            left join game_team_rankings tr on r.game_id = tr.game_id
+            and r.epoch_id = tr.epoch_id
+            and tm.team_id = tr.team_id
+            left join game_team_member_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and tm.team_id = tmr.team_id
+            and r.party_id = tmr.party_id
+        union all
+        select
+            r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, null as team_total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            JOIN dispatch_strategies t ON r.game_id = t.game_id
+            AND t.dispatch_strategy ->> 'entity_scope' = '1'
+            left join game_individual_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and r.party_id = tmr.party_id
+    )
+select *
+from game_rewards;
 
 create or replace view game_stats_current as
-with game_epochs as (
-    select game_id, max(epoch_id) as epoch_id
-    from rewards
-    where game_id is not null
-    group by game_id
-),
-dispatch_strategies AS (
-    SELECT game_id, dispatch_strategy FROM transfers WHERE transfer_type = 'Recurring' ORDER BY vega_time DESC LIMIT 1
-),
-game_rewards as (
-  select r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
-  from rewards r
-  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
-  JOIN dispatch_strategies t ON r.game_id = t.game_id AND t.dispatch_strategy ->> 'entity_scope' = '2'
-  join team_members tm on r.party_id = tm.party_id
-  left join game_team_rankings tr on r.game_id = tr.game_id and r.epoch_id = tr.epoch_id and tm.team_id = tr.team_id
-  left join game_team_member_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and tm.team_id = tmr.team_id and r.party_id = tmr.party_id
-  where dispatch_strategy->>'entity_scope' = '2'
-  union all
-  select r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
-  from rewards r
-  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
-  JOIN dispatch_strategies t ON r.game_id = t.game_id AND dispatch_strategy ->> 'entity_scope' = '1'
-  left join game_individual_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and r.party_id = tmr.party_id
-  where dispatch_strategy->>'entity_scope' = '1'
-)
+with
+    game_epochs as (
+        select game_id, max(epoch_id) as epoch_id
+        from rewards
+        where
+            game_id is not null
+        group by
+            game_id
+    ),
+    dispatch_strategies AS (
+        SELECT DISTINCT
+            ON (game_id) game_id, dispatch_strategy
+        FROM transfers
+        WHERE
+            transfer_type = 'Recurring'
+        ORDER BY game_id, vega_time DESC
+    ),
+    game_rewards as (
+        select
+            r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            JOIN dispatch_strategies t ON r.game_id = t.game_id
+            AND t.dispatch_strategy ->> 'entity_scope' = '2'
+            join team_members tm on r.party_id = tm.party_id
+            left join game_team_rankings tr on r.game_id = tr.game_id
+            and r.epoch_id = tr.epoch_id
+            and tm.team_id = tr.team_id
+            left join game_team_member_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and tm.team_id = tmr.team_id
+            and r.party_id = tmr.party_id
+        union all
+        select
+            r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            JOIN dispatch_strategies t ON r.game_id = t.game_id
+            AND t.dispatch_strategy ->> 'entity_scope' = '1'
+            left join game_individual_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and r.party_id = tmr.party_id
+    )
 select *
-from game_rewards
-;
+from game_rewards;
 
 -- +goose Down
 
 create or replace view game_stats as
-with game_epochs as (
-  select distinct game_id, epoch_id
-  from rewards
-  where game_id is not null
-), game_rewards as (
-  select r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, tr.total_rewards as team_total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
-  from rewards r
-  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
-  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
-  join team_members tm on r.party_id = tm.party_id
-  left join game_team_rankings tr on r.game_id = tr.game_id and r.epoch_id = tr.epoch_id and tm.team_id = tr.team_id
-  left join game_team_member_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and tm.team_id = tmr.team_id and r.party_id = tmr.party_id
-  where dispatch_strategy->>'entity_scope' = '2'
-  union all
-  select r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, null as team_total_rewards,'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
-  from rewards r
-  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
-  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
-  left join game_individual_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and r.party_id = tmr.party_id
-  where dispatch_strategy->>'entity_scope' = '1'
-)
+with
+    game_epochs as (
+        select distinct
+            game_id, epoch_id
+        from rewards
+        where
+            game_id is not null
+    ),
+    game_rewards as (
+        select
+            r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, tr.total_rewards as team_total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            join transfers t on r.game_id = t.game_id
+            and t.transfer_type = 'Recurring'
+            join team_members tm on r.party_id = tm.party_id
+            left join game_team_rankings tr on r.game_id = tr.game_id
+            and r.epoch_id = tr.epoch_id
+            and tm.team_id = tr.team_id
+            left join game_team_member_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and tm.team_id = tmr.team_id
+            and r.party_id = tmr.party_id
+        where
+            dispatch_strategy ->> 'entity_scope' = '2'
+        union all
+        select
+            r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, null as team_total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            join transfers t on r.game_id = t.game_id
+            and t.transfer_type = 'Recurring'
+            left join game_individual_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and r.party_id = tmr.party_id
+        where
+            dispatch_strategy ->> 'entity_scope' = '1'
+    )
 select *
-from game_rewards
-;
+from game_rewards;
 
 create or replace view game_stats_current as
-with game_epochs as (
-    select game_id, max(epoch_id) as epoch_id
-    from rewards
-    where game_id is not null
-    group by game_id
-), game_rewards as (
-  select r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
-  from rewards r
-  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
-  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
-  join team_members tm on r.party_id = tm.party_id
-  left join game_team_rankings tr on r.game_id = tr.game_id and r.epoch_id = tr.epoch_id and tm.team_id = tr.team_id
-  left join game_team_member_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and tm.team_id = tmr.team_id and r.party_id = tmr.party_id
-  where dispatch_strategy->>'entity_scope' = '2'
-  union all
-  select r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
-  from rewards r
-  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
-  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
-  left join game_individual_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and r.party_id = tmr.party_id
-  where dispatch_strategy->>'entity_scope' = '1'
-)
+with
+    game_epochs as (
+        select game_id, max(epoch_id) as epoch_id
+        from rewards
+        where
+            game_id is not null
+        group by
+            game_id
+    ),
+    game_rewards as (
+        select
+            r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            join transfers t on r.game_id = t.game_id
+            and t.transfer_type = 'Recurring'
+            join team_members tm on r.party_id = tm.party_id
+            left join game_team_rankings tr on r.game_id = tr.game_id
+            and r.epoch_id = tr.epoch_id
+            and tm.team_id = tr.team_id
+            left join game_team_member_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and tm.team_id = tmr.team_id
+            and r.party_id = tmr.party_id
+        where
+            dispatch_strategy ->> 'entity_scope' = '2'
+        union all
+        select
+            r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+        from
+            rewards r
+            join game_epochs ge on r.game_id = ge.game_id
+            and r.epoch_id = ge.epoch_id
+            join transfers t on r.game_id = t.game_id
+            and t.transfer_type = 'Recurring'
+            left join game_individual_rankings tmr on r.game_id = tmr.game_id
+            and r.epoch_id = tmr.epoch_id
+            and r.party_id = tmr.party_id
+        where
+            dispatch_strategy ->> 'entity_scope' = '1'
+    )
 select *
-from game_rewards
-;
+from game_rewards;

--- a/datanode/sqlstore/migrations/0088_update_game_stats.sql
+++ b/datanode/sqlstore/migrations/0088_update_game_stats.sql
@@ -1,0 +1,132 @@
+-- +goose Up
+
+create or replace view game_stats as
+WITH
+  game_epochs AS (
+    SELECT DISTINCT game_id, epoch_id
+    FROM rewards
+    WHERE game_id IS NOT NULL
+  ),
+  dispatch_strategies AS (
+    SELECT game_id, dispatch_strategy FROM transfers WHERE transfer_type = 'Recurring' ORDER BY vega_time DESC LIMIT 1
+  ),
+  game_rewards AS (
+    SELECT r.*,
+           t.dispatch_strategy,
+           tm.team_id,
+           tmr.rank AS member_rank,
+           tr.rank AS team_rank,
+           tmr.total_rewards,
+           tr.total_rewards AS team_total_rewards,
+           'ENTITY_SCOPE_TEAMS' AS entity_scope
+    FROM rewards r
+      JOIN game_epochs ge ON r.game_id = ge.game_id AND r.epoch_id = ge.epoch_id
+      JOIN dispatch_strategies t ON r.game_id = t.game_id AND t.dispatch_strategy ->> 'entity_scope' = '2'
+      JOIN team_members tm ON r.party_id = tm.party_id
+      LEFT JOIN game_team_rankings tr ON r.game_id = tr.game_id AND r.epoch_id = tr.epoch_id AND tm.team_id = tr.team_id
+      LEFT JOIN game_team_member_rankings tmr
+                ON r.game_id = tmr.game_id AND r.epoch_id = tmr.epoch_id AND tm.team_id = tmr.team_id AND
+                   r.party_id = tmr.party_id
+    UNION ALL
+    SELECT r.*,
+           t.dispatch_strategy,
+           NULL AS team_id,
+           tmr.rank AS member_rank,
+           NULL AS team_rank,
+           tmr.total_rewards,
+           NULL AS team_total_rewards,
+           'ENTITY_SCOPE_INDIVIDUALS' AS entity_scope
+    FROM rewards r
+      JOIN game_epochs ge ON r.game_id = ge.game_id AND r.epoch_id = ge.epoch_id
+      JOIN dispatch_strategies t ON r.game_id = t.game_id AND dispatch_strategy ->> 'entity_scope' = '1'
+      LEFT JOIN game_individual_rankings tmr
+                ON r.game_id = tmr.game_id AND r.epoch_id = tmr.epoch_id AND r.party_id = tmr.party_id
+  )
+SELECT s.*
+FROM game_rewards s;
+
+create or replace view game_stats_current as
+with game_epochs as (
+    select game_id, max(epoch_id) as epoch_id
+    from rewards
+    where game_id is not null
+    group by game_id
+),
+dispatch_strategies AS (
+    SELECT game_id, dispatch_strategy FROM transfers WHERE transfer_type = 'Recurring' ORDER BY vega_time DESC LIMIT 1
+),
+game_rewards as (
+  select r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+  from rewards r
+  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
+  JOIN dispatch_strategies t ON r.game_id = t.game_id AND t.dispatch_strategy ->> 'entity_scope' = '2'
+  join team_members tm on r.party_id = tm.party_id
+  left join game_team_rankings tr on r.game_id = tr.game_id and r.epoch_id = tr.epoch_id and tm.team_id = tr.team_id
+  left join game_team_member_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and tm.team_id = tmr.team_id and r.party_id = tmr.party_id
+  where dispatch_strategy->>'entity_scope' = '2'
+  union all
+  select r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+  from rewards r
+  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
+  JOIN dispatch_strategies t ON r.game_id = t.game_id AND dispatch_strategy ->> 'entity_scope' = '1'
+  left join game_individual_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and r.party_id = tmr.party_id
+  where dispatch_strategy->>'entity_scope' = '1'
+)
+select *
+from game_rewards
+;
+
+-- +goose Down
+
+create or replace view game_stats as
+with game_epochs as (
+  select distinct game_id, epoch_id
+  from rewards
+  where game_id is not null
+), game_rewards as (
+  select r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, tr.total_rewards as team_total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+  from rewards r
+  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
+  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
+  join team_members tm on r.party_id = tm.party_id
+  left join game_team_rankings tr on r.game_id = tr.game_id and r.epoch_id = tr.epoch_id and tm.team_id = tr.team_id
+  left join game_team_member_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and tm.team_id = tmr.team_id and r.party_id = tmr.party_id
+  where dispatch_strategy->>'entity_scope' = '2'
+  union all
+  select r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, null as team_total_rewards,'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+  from rewards r
+  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
+  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
+  left join game_individual_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and r.party_id = tmr.party_id
+  where dispatch_strategy->>'entity_scope' = '1'
+)
+select *
+from game_rewards
+;
+
+create or replace view game_stats_current as
+with game_epochs as (
+    select game_id, max(epoch_id) as epoch_id
+    from rewards
+    where game_id is not null
+    group by game_id
+), game_rewards as (
+  select r.*, t.dispatch_strategy, tm.team_id, tmr.rank as member_rank, tr.rank as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_TEAMS' as entity_scope
+  from rewards r
+  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
+  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
+  join team_members tm on r.party_id = tm.party_id
+  left join game_team_rankings tr on r.game_id = tr.game_id and r.epoch_id = tr.epoch_id and tm.team_id = tr.team_id
+  left join game_team_member_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and tm.team_id = tmr.team_id and r.party_id = tmr.party_id
+  where dispatch_strategy->>'entity_scope' = '2'
+  union all
+  select r.*, t.dispatch_strategy, null as team_id, tmr.rank as member_rank, null as team_rank, tmr.total_rewards, 'ENTITY_SCOPE_INDIVIDUALS' as entity_scope
+  from rewards r
+  join game_epochs ge on r.game_id = ge.game_id and r.epoch_id = ge.epoch_id
+  join transfers t on r.game_id = t.game_id and t.transfer_type = 'Recurring'
+  left join game_individual_rankings tmr on r.game_id = tmr.game_id and r.epoch_id = tmr.epoch_id and r.party_id = tmr.party_id
+  where dispatch_strategy->>'entity_scope' = '1'
+)
+select *
+from game_rewards
+;


### PR DESCRIPTION
Close #10488 

There was an issue with duplicated `membersParticipating` in the `games_stats` table when there were multiple `transfers` associated with a single `game_id`. This could just be the same recurring transfer once with pending and second with done status. The join that joins the `transfers` table and would use essentially the record (same transfer) multiple times. The fix here just makes sure that we always get the latest transfer for the game_id instead.