### PR TITLE
fix: rename net param appropriately for spam create/update referral s…

### DIFF
--- a/core/netparams/defaults.go
+++ b/core/netparams/defaults.go
@@ -225,7 +225,7 @@ func defaultNetParams() map[string]value {
 		SpamProtectionMaxApplyReferralCode:             NewInt(gteI0).Mutable(true).MustUpdate("5"),
 		SpamProtectionBalanceSnapshotFrequency:         NewDuration(gte0s, lte1h).Mutable(true).MustUpdate("5s"),
 		SpamProtectionApplyReferralMinFunds:            NewUint(UintGTE(num.NewUint(0))).Mutable(true).MustUpdate("10"),
-		SpamProtectionReferralProgramMinFunds:          NewUint(UintGTE(num.NewUint(0))).Mutable(true).MustUpdate("0"),
+		SpamProtectionReferralSetMinFunds:              NewUint(UintGTE(num.NewUint(0))).Mutable(true).MustUpdate("10"),
 		SpamProtectionMaxUpdatePartyProfile:            NewInt(gteI0).Mutable(true).MustUpdate("5"),
 		SpamProtectionUpdateProfileMinFunds:            NewUint(UintGTE(num.NewUint(0))).Mutable(true).MustUpdate("10"),
 

--- a/core/netparams/keys.go
+++ b/core/netparams/keys.go
@@ -173,7 +173,7 @@ const (
 	SpamProtectionMaxApplyReferralCode     = "spam.protection.max.applyReferralCode"
 	SpamProtectionBalanceSnapshotFrequency = "spam.protection.balanceSnapshotFrequency"
 	SpamProtectionApplyReferralMinFunds    = "spam.protection.applyReferral.min.funds"
-	SpamProtectionReferralProgramMinFunds  = "spam.protection.referralProgram.min.funds"
+	SpamProtectionReferralSetMinFunds      = "spam.protection.referralSet.min.funds"
 
 	SpamProtectionMaxUpdatePartyProfile = "spam.protection.max.updatePartyProfile"
 	SpamProtectionUpdateProfileMinFunds = "spam.protection.updatePartyProfile.min.funds"
@@ -446,6 +446,6 @@ var AllKeys = map[string]struct{}{
 	SpamProtectionMaxApplyReferralCode:                           {},
 	SpamProtectionBalanceSnapshotFrequency:                       {},
 	SpamProtectionApplyReferralMinFunds:                          {},
-	SpamProtectionReferralProgramMinFunds:                        {},
+	SpamProtectionReferralSetMinFunds:                            {},
 	BlockchainsEthereumL2Configs:                                 {},
 }

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -156,7 +156,7 @@ type ReferralProgram interface {
 	CreateReferralSet(context.Context, types.PartyID, types.ReferralSetID) error
 	ApplyReferralCode(context.Context, types.PartyID, types.ReferralSetID) error
 	CheckSufficientBalanceForApplyReferralCode(types.PartyID, *num.Uint) error
-	CheckSufficientBalanceForCreateOrUpdateReferralProgram(types.PartyID, *num.Uint) error
+	CheckSufficientBalanceForCreateOrUpdateReferralSet(types.PartyID, *num.Uint) error
 }
 
 type VolumeDiscountProgram interface {
@@ -378,8 +378,8 @@ func NewApp(
 		HandleCheckTx(txn.BatchProposeCommand, addDeterministicID(app.CheckBatchPropose)).
 		HandleCheckTx(txn.TransferFundsCommand, app.CheckTransferCommand).
 		HandleCheckTx(txn.ApplyReferralCodeCommand, app.CheckApplyReferralCode).
-		HandleCheckTx(txn.CreateReferralSetCommand, app.CheckCreateOrUpdateReferralProgram).
-		HandleCheckTx(txn.UpdateReferralSetCommand, app.CheckCreateOrUpdateReferralProgram)
+		HandleCheckTx(txn.CreateReferralSetCommand, app.CheckCreateOrUpdateReferralSet).
+		HandleCheckTx(txn.UpdateReferralSetCommand, app.CheckCreateOrUpdateReferralSet)
 
 	app.abci.
 		// node commands
@@ -1576,8 +1576,8 @@ func (app *App) CheckApplyReferralCode(_ context.Context, tx abci.Tx) error {
 	return nil
 }
 
-func (app *App) CheckCreateOrUpdateReferralProgram(_ context.Context, tx abci.Tx) error {
-	if err := app.referralProgram.CheckSufficientBalanceForCreateOrUpdateReferralProgram(types.PartyID(tx.Party()), app.balanceChecker.GetPartyBalance(tx.Party())); err != nil {
+func (app *App) CheckCreateOrUpdateReferralSet(_ context.Context, tx abci.Tx) error {
+	if err := app.referralProgram.CheckSufficientBalanceForCreateOrUpdateReferralSet(types.PartyID(tx.Party()), app.balanceChecker.GetPartyBalance(tx.Party())); err != nil {
 		return err
 	}
 	return nil

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -963,7 +963,7 @@ func (svcs *allServices) setupNetParameters(powWatchers []netparams.WatchParam) 
 			Watcher: svcs.referralProgram.OnMinBalanceForApplyReferralCodeUpdated,
 		},
 		{
-			Param:   netparams.SpamProtectionReferralProgramMinFunds,
+			Param:   netparams.SpamProtectionReferralSetMinFunds,
 			Watcher: svcs.referralProgram.OnMinBalanceForReferralProgramUpdated,
 		},
 		{

--- a/core/referral/engine.go
+++ b/core/referral/engine.go
@@ -85,7 +85,7 @@ type Engine struct {
 
 	// minBalanceForReferralProgram defines the minimum balance a party should possess
 	// to create/update referral program.
-	minBalanceForReferralProgram *num.Uint
+	minBalanceForReferralSet *num.Uint
 
 	// latestProgramVersion tracks the latest version of the program. It used to
 	// value any new program that comes in. It starts at 1.
@@ -119,15 +119,15 @@ func (e *Engine) CheckSufficientBalanceForApplyReferralCode(party types.PartyID,
 	return nil
 }
 
-func (e *Engine) CheckSufficientBalanceForCreateOrUpdateReferralProgram(party types.PartyID, balance *num.Uint) error {
-	if balance.LT(e.minBalanceForReferralProgram) {
-		return fmt.Errorf("party %q does not have sufficient balance to create or update a referral program, required balance %s available balance %s", party, e.minBalanceForReferralProgram.String(), balance.String())
+func (e *Engine) CheckSufficientBalanceForCreateOrUpdateReferralSet(party types.PartyID, balance *num.Uint) error {
+	if balance.LT(e.minBalanceForReferralSet) {
+		return fmt.Errorf("party %q does not have sufficient balance to create or update a referral set, required balance %s available balance %s", party, e.minBalanceForReferralSet.String(), balance.String())
 	}
 	return nil
 }
 
 func (e *Engine) OnMinBalanceForReferralProgramUpdated(_ context.Context, min *num.Uint) error {
-	e.minBalanceForReferralProgram = min
+	e.minBalanceForReferralSet = min
 	return nil
 }
 


### PR DESCRIPTION
…et, not program

* renaming the network param from referral program to set
* rename the checking function appropriately
* correct the error message
* set the default to 10 as requested