### PR TITLE
fix: set market type properly in liquidity engine for spot code path

### DIFF
--- a/core/execution/spot/market_snapshot.go
+++ b/core/execution/spot/market_snapshot.go
@@ -117,7 +117,7 @@ func NewMarketFromSnapshot(
 	}
 	els := common.NewEquitySharesFromSnapshot(em.EquityShare)
 	liquidity := liquidity.NewSnapshotEngine(liquidityConfig, log, timeService, broker, riskModel, pMonitor, book, as, quoteAsset, mkt.ID, stateVarEngine, positionFactor, mkt.LiquiditySLAParams)
-	marketLiquidity := common.NewMarketLiquidity(log, liquidity, collateralEngine, broker, book, els, marketActivityTracker, feeEngine, common.FutureMarketType, mkt.ID, quoteAsset, priceFactor, mkt.LiquiditySLAParams.PriceRange)
+	marketLiquidity := common.NewMarketLiquidity(log, liquidity, collateralEngine, broker, book, els, marketActivityTracker, feeEngine, common.SpotMarketType, mkt.ID, quoteAsset, priceFactor, mkt.LiquiditySLAParams.PriceRange)
 
 	// backward compatibility check for nil
 	stopOrders := stoporders.New(log)


### PR DESCRIPTION
Minor snapshot issue found when @Sohill-Patel was reviving some spot system tests.