### PR TITLE
feat: add vega datanode migrate-ipfs subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [9945](https://github.com/vegaprotocol/vega/issues/9945) - Add liquidation strategy.
 - [10215](https://github.com/vegaprotocol/vega/issues/10215) - Listing transactions on block explorer does not support the field `limit` any more.
 - [8056](https://github.com/vegaprotocol/vega/issues/8056) - Getting a transfer by ID now returns a `TransferNode`.
+- [10597](https://github.com/vegaprotocol/vega/pull/10597) - Migrate the `IPFS` store for the network history to version 15.
 
 ### 🗑️ Deprecation
 

--- a/cmd/data-node/commands/migrate-ipfs.go
+++ b/cmd/data-node/commands/migrate-ipfs.go
@@ -23,6 +23,7 @@ import (
 	"code.vegaprotocol.io/vega/datanode/networkhistory/ipfs"
 	"code.vegaprotocol.io/vega/logging"
 	"code.vegaprotocol.io/vega/paths"
+
 	"github.com/jessevdk/go-flags"
 )
 

--- a/cmd/data-node/commands/migrate-ipfs.go
+++ b/cmd/data-node/commands/migrate-ipfs.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2023 Gobalsky Labs Limited
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package commands
+
+import (
+	"context"
+	"path/filepath"
+
+	"code.vegaprotocol.io/vega/datanode/config"
+	"code.vegaprotocol.io/vega/datanode/networkhistory/ipfs"
+	"code.vegaprotocol.io/vega/logging"
+	"code.vegaprotocol.io/vega/paths"
+	"github.com/jessevdk/go-flags"
+)
+
+type MigrateIpfsCmd struct {
+	config.VegaHomeFlag
+}
+
+func MigrateIpfs(ctx context.Context, parser *flags.Parser) error {
+	migrateIpfsCmd = MigrateIpfsCmd{}
+
+	_, err := parser.AddCommand("migrate-ipfs", "Update IPFS store version", "Migrate IPFS store to the latest version supported by Vega", &migrateIpfsCmd)
+
+	return err
+}
+
+var migrateIpfsCmd MigrateIpfsCmd
+
+func (cmd *MigrateIpfsCmd) Execute(_ []string) error {
+	log := logging.NewLoggerFromConfig(logging.NewDefaultConfig())
+	defer log.AtExit()
+
+	vegaPaths := paths.New(cmd.VegaHome)
+	ipfsDir := filepath.Join(vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome), "store", "ipfs")
+
+	return ipfs.MigrateIpfsStorageVersion(log, ipfsDir)
+}

--- a/cmd/data-node/commands/root.go
+++ b/cmd/data-node/commands/root.go
@@ -52,6 +52,7 @@ func Execute(ctx context.Context) error {
 		LastBlock,
 		UnsafeResetAll,
 		networkhistory.NetworkHistory,
+		MigrateIpfs,
 	); err != nil {
 		fmt.Printf("%+v\n", err)
 		return err

--- a/cmd/data-node/commands/start/node_pre.go
+++ b/cmd/data-node/commands/start/node_pre.go
@@ -25,9 +25,11 @@ import (
 	"code.vegaprotocol.io/vega/datanode/broker"
 	"code.vegaprotocol.io/vega/datanode/config"
 	"code.vegaprotocol.io/vega/datanode/networkhistory"
+	"code.vegaprotocol.io/vega/datanode/networkhistory/ipfs"
 	"code.vegaprotocol.io/vega/datanode/networkhistory/snapshot"
 	"code.vegaprotocol.io/vega/datanode/networkhistory/store"
 	"code.vegaprotocol.io/vega/datanode/sqlstore"
+	"code.vegaprotocol.io/vega/libs/fs"
 	"code.vegaprotocol.io/vega/libs/pprof"
 	"code.vegaprotocol.io/vega/libs/subscribers"
 	"code.vegaprotocol.io/vega/logging"
@@ -96,6 +98,23 @@ func (l *NodeCommand) persistentPre([]string) (err error) {
 	if l.conf.SQLStore.WipeOnStartup {
 		if ResetDatabaseAndNetworkHistory(l.ctx, l.Log, l.vegaPaths, l.conf.SQLStore.ConnectionConfig); err != nil {
 			return fmt.Errorf("failed to reset database and network history: %w", err)
+		}
+	} else if !l.conf.SQLStore.WipeOnStartup && l.conf.NetworkHistory.Enabled {
+		ipfsDir := filepath.Join(l.vegaPaths.StatePathFor(paths.DataNodeNetworkHistoryHome), "store", "ipfs")
+		ipfsExists, err := fs.PathExists(ipfsDir)
+		if err != nil {
+			return fmt.Errorf("failed to check if ipfs store is already initialized")
+		}
+
+		// We do not care for migration when the ipfs store does not exist on the local file system
+		if ipfsExists {
+			preLog.Info("Migrating the IPFS storage to the latest version")
+			if err := ipfs.MigrateIpfsStorageVersion(preLog, ipfsDir); err != nil {
+				return fmt.Errorf("failed to migrate the ipfs version")
+			}
+			preLog.Info("Migrating the IPFS storage finished")
+		} else {
+			preLog.Info("IPFS store not initialized. Migration not needed")
 		}
 	}
 

--- a/datanode/networkhistory/ipfs/ipfsfetcher.go
+++ b/datanode/networkhistory/ipfs/ipfsfetcher.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023 Gobalsky Labs Limited
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package ipfs
 
 import (
@@ -16,9 +31,6 @@ import (
 const (
 	shellUpTimeout    = 2 * time.Second
 	defaultFetchLimit = 1024 * 1024 * 512
-
-	// Local IPFS API
-	apiFile = "api"
 )
 
 type ipfsFetcher struct {

--- a/datanode/networkhistory/ipfs/ipfsfetcher.go
+++ b/datanode/networkhistory/ipfs/ipfsfetcher.go
@@ -1,0 +1,90 @@
+package ipfs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	kuboClient "github.com/ipfs/kubo/client/rpc"
+	"github.com/ipfs/kubo/repo/fsrepo/migrations"
+)
+
+const (
+	shellUpTimeout    = 2 * time.Second
+	defaultFetchLimit = 1024 * 1024 * 512
+
+	// Local IPFS API
+	apiFile = "api"
+)
+
+type ipfsFetcher struct {
+	distPath string
+	ipfsDir  string
+	limit    int64
+}
+
+// newIpfsFetcher creates a new IpfsFetcher
+//
+// Specifying "" for distPath sets the default IPNS path.
+// Specifying 0 for fetchLimit sets the default, -1 means no limit.
+func newIpfsFetcher(distPath string, ipfsDir string, fetchLimit int64) *ipfsFetcher {
+	f := &ipfsFetcher{
+		limit:    defaultFetchLimit,
+		distPath: migrations.LatestIpfsDist,
+		ipfsDir:  ipfsDir,
+	}
+
+	if distPath != "" {
+		if !strings.HasPrefix(distPath, "/") {
+			distPath = "/" + distPath
+		}
+		f.distPath = distPath
+	}
+
+	if fetchLimit != 0 {
+		if fetchLimit == -1 {
+			fetchLimit = 0
+		}
+		f.limit = fetchLimit
+	}
+
+	return f
+}
+
+func (f *ipfsFetcher) Close() error {
+	return nil
+}
+
+// Fetch attempts to fetch the file at the given path, from the distribution
+// site configured for this HttpFetcher.  Returns io.ReadCloser on success,
+// which caller must close.
+func (f *ipfsFetcher) Fetch(ctx context.Context, filePath string) ([]byte, error) {
+	sh, err := kuboClient.NewPathApi(f.ipfsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a ipfs shell migration: %w", err)
+	}
+	resp, err := sh.Request("cat", path.Join(f.distPath, filePath)).Send(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file from the ipfs node: %w", err)
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+	defer resp.Close()
+
+	var output io.Reader
+	if f.limit != 0 {
+		output = migrations.NewLimitReadCloser(resp.Output, f.limit)
+	} else {
+		output = resp.Output
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(output)
+
+	return buf.Bytes(), nil
+}

--- a/datanode/networkhistory/ipfs/migration.go
+++ b/datanode/networkhistory/ipfs/migration.go
@@ -37,6 +37,11 @@ func isMigrationNeeded(ipfsDir string) (bool, error) {
 	return repoVersion < latestSupportedVersion(), nil
 }
 
+func isIpfsDirExisting(ipfsDir string) (bool, error) {
+
+	return false, nil
+}
+
 func MigrateIpfsStorageVersion(log *logging.Logger, ipfsDir string) error {
 	isMigrationNeeded, err := isMigrationNeeded(ipfsDir)
 	if err != nil {

--- a/datanode/networkhistory/ipfs/migration.go
+++ b/datanode/networkhistory/ipfs/migration.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"code.vegaprotocol.io/vega/logging"
+
 	"github.com/ipfs/kubo/repo/fsrepo"
 	"github.com/ipfs/kubo/repo/fsrepo/migrations"
 )
@@ -36,13 +37,13 @@ func createFetcher(distPath string, ipfsDir string) migrations.Fetcher {
 		migrations.NewHttpFetcher(distPath, "", userAgent, 0))
 }
 
-// LatestSupportedVersion returns the latest version supported by the kubo library
+// LatestSupportedVersion returns the latest version supported by the kubo library.
 func latestSupportedVersion() int {
 	// TODO: Maybe We should hardcode it to be safe and control when the migration happens?
 	return fsrepo.RepoVersion
 }
 
-// IsMigrationNeeded check if migration of the IPFS repository is needed
+// IsMigrationNeeded check if migration of the IPFS repository is needed.
 func isMigrationNeeded(ipfsDir string) (bool, error) {
 	repoVersion, err := migrations.RepoVersion(ipfsDir)
 	if err != nil {
@@ -52,6 +53,13 @@ func isMigrationNeeded(ipfsDir string) (bool, error) {
 	return repoVersion < latestSupportedVersion(), nil
 }
 
+// MigrateIpfsStorageVersion migrates the IPFS store to the latest supported by the
+// library version.
+// High level overview:
+//  1. Check version of the local store,
+//  2. Check max supported version for the kubo library,
+//  3. Connect to local or remote IPFS node and download required migration binaries,
+//  4. Run downloaded binaries to migrate the file system.
 func MigrateIpfsStorageVersion(log *logging.Logger, ipfsDir string) error {
 	isMigrationNeeded, err := isMigrationNeeded(ipfsDir)
 	if err != nil {

--- a/datanode/networkhistory/ipfs/migration.go
+++ b/datanode/networkhistory/ipfs/migration.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023 Gobalsky Labs Limited
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package ipfs
 
 import (
@@ -35,11 +50,6 @@ func isMigrationNeeded(ipfsDir string) (bool, error) {
 	}
 
 	return repoVersion < latestSupportedVersion(), nil
-}
-
-func isIpfsDirExisting(ipfsDir string) (bool, error) {
-
-	return false, nil
 }
 
 func MigrateIpfsStorageVersion(log *logging.Logger, ipfsDir string) error {

--- a/datanode/networkhistory/ipfs/migration.go
+++ b/datanode/networkhistory/ipfs/migration.go
@@ -1,0 +1,64 @@
+package ipfs
+
+import (
+	"context"
+	"fmt"
+
+	"code.vegaprotocol.io/vega/logging"
+	"github.com/ipfs/kubo/repo/fsrepo"
+	"github.com/ipfs/kubo/repo/fsrepo/migrations"
+)
+
+func createFetcher(distPath string, ipfsDir string) migrations.Fetcher {
+	const userAgent = "fs-repo-migrations"
+
+	if distPath == "" {
+		distPath = migrations.GetDistPathEnv(migrations.LatestIpfsDist)
+	}
+
+	return migrations.NewMultiFetcher(
+		newIpfsFetcher(distPath, ipfsDir, 0),
+		migrations.NewHttpFetcher(distPath, "", userAgent, 0))
+}
+
+// LatestSupportedVersion returns the latest version supported by the kubo library
+func latestSupportedVersion() int {
+	// TODO: Maybe We should hardcode it to be safe and control when the migration happens?
+	return fsrepo.RepoVersion
+}
+
+// IsMigrationNeeded check if migration of the IPFS repository is needed
+func isMigrationNeeded(ipfsDir string) (bool, error) {
+	repoVersion, err := migrations.RepoVersion(ipfsDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to check version for the %s IPFS repository: %w", ipfsDir, err)
+	}
+
+	return repoVersion < latestSupportedVersion(), nil
+}
+
+func MigrateIpfsStorageVersion(log *logging.Logger, ipfsDir string) error {
+	isMigrationNeeded, err := isMigrationNeeded(ipfsDir)
+	if err != nil {
+		return fmt.Errorf("failed to check if the ipfs migration is needed: %w", err)
+	}
+	if !isMigrationNeeded {
+		if log != nil {
+			log.Info("The IPFS for the network-history is up to date. Migration not needed")
+		}
+		return nil
+	}
+
+	localIpfsDir, err := migrations.IpfsDir(ipfsDir)
+	if err != nil {
+		return fmt.Errorf("failed to find local ipfs directory: %w", err)
+	}
+
+	fetcher := createFetcher("", localIpfsDir)
+	err = migrations.RunMigration(context.Background(), fetcher, latestSupportedVersion(), localIpfsDir, false)
+	if err != nil {
+		return fmt.Errorf("failed to execute the ipfs migration: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes vegaprotocol/documentation#910 .

# Changes

There is a tool designed to run the migration for the IPFS store to a newer version: https://github.com/ipfs/fs-repo-migrations/tree/master

I have incorporated this tool into the vega. I added a standalone command (`go run main datanode migrate-ipfs`), which is also fired when migration is needed before the data node is started (in the `pre-start` step).

High overview of how the IPFS migration tool is working:

1. It checks if the local node is working if yes, it looks for the required migration binaries
2. If the local node is not working it connects to the remote node(the node is hard coded in the Kubo library: https://pkg.go.dev/github.com/ipfs/kubo@v0.23.0/repo/fsrepo/migrations#pkg-constants) and checks for the binaries to migrate the ipfs repo.
3. It downloads the binaries from the IPFS
4. It runs binaries to migrate the IPFS filesystem.

# Testing

## The command embedded into the `datanode start`

### When the migration is needed

```shell
Downloading migration: fs-repo-14-to-15...
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-14-to-15/versions"
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-13-to-14/versions"
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-14-to-15/v1.0.1/fs-repo-14-to-15_v1.0.1_linux-amd64.tar.gz"
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-13-to-14/v1.0.0/fs-repo-13-to-14_v1.0.0_linux-amd64.tar.gz"
Downloaded and unpacked migration: /tmp/migrations1355099032/fs-repo-14-to-15 (v1.0.1)
Downloaded and unpacked migration: /tmp/migrations1355099032/fs-repo-13-to-14 (v1.0.0)
Running migration fs-repo-13-to-14 ...
  => Running: /tmp/migrations1355099032/fs-repo-13-to-14 -path=/home/daniel/vega_home2/state/data-node/networkhistory/store/ipfs -verbose=true
applying 13-to-14 repo migration
locking repo at "/home/daniel/vega_home2/state/data-node/networkhistory/store/ipfs"
  - verifying version is '13'
> Upgrading config to new format
updated version file
Migration 13 to 14 succeeded
Running migration fs-repo-14-to-15 ...
  => Running: /tmp/migrations1355099032/fs-repo-14-to-15 -path=/home/daniel/vega_home2/state/data-node/networkhistory/store/ipfs -verbose=true
applying 14-to-15 repo migration
locking repo at "/home/daniel/vega_home2/state/data-node/networkhistory/store/ipfs"
  - verifying version is '14'
> Upgrading config to new format
updated version file
Migration 14 to 15 succeeded
Success: fs-repo migrated to version 15.
2024-02-08T23:32:39.315+0100	INFO	datanode.start.persistentPre	start/node_pre.go:115	Migrating the IPFS storage finished
2024-02-08T23:32:42.153+0100	INFO	datanode.start.persistentPre	start/node_pre.go:123	Initializing Network History

...
```

### When the migration is not needed

```shell
2024-02-08T23:29:35.190+0100	INFO	datanode.cfgwatcher	config/watcher.go:94	config watcher started successfully	{"config": "/home/daniel/vega_home2/config/data-node/config.toml"}
2024-02-08T23:29:35.191+0100	INFO	datanode.start.persistentPre	start/node_pre.go:70	Starting Vega Datanode	{"version": "v0.74.0-dev", "version-hash": ""}
2024-02-08T23:29:43.672+0100	INFO	datanode.start.persistentPre	start/node_pre.go:111	Migrating the IPFS storage to the latest version
2024-02-08T23:29:49.117+0100	INFO	datanode.start.persistentPre	ipfs/migration.go:52	The IPFS for the network-history is up to date. Migration not needed
2024-02-08T23:29:58.243+0100	INFO	datanode.start.persistentPre	start/node_pre.go:115	Migrating the IPFS storage finished
2024-02-08T23:30:00.183+0100	INFO	datanode.start.persistentPre	start/node_pre.go:123	Initializing Network History
...
...
```

## The standalone migration command: `go run main datanode migrate-ipfs`

### When migration is needed:

```shell
# go run main datanode migrate-ipfs --home /home/daniel/vega_home2

Looking for suitable migration binaries.
Need 2 migrations, downloading.
Downloading migration: fs-repo-13-to-14...
Downloading migration: fs-repo-14-to-15...
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-14-to-15/versions"
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-13-to-14/versions"
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-14-to-15/v1.0.1/fs-repo-14-to-15_v1.0.1_linux-amd64.tar.gz"
Error fetching: failed to create a ipfs shell migration: ipfs api address could not be found
Fetching with HTTP: "https://dweb.link/ipns/dist.ipfs.tech/fs-repo-13-to-14/v1.0.0/fs-repo-13-to-14_v1.0.0_linux-amd64.tar.gz"
Downloaded and unpacked migration: /tmp/migrations3323001421/fs-repo-13-to-14 (v1.0.0)
Downloaded and unpacked migration: /tmp/migrations3323001421/fs-repo-14-to-15 (v1.0.1)
Running migration fs-repo-13-to-14 ...
  => Running: /tmp/migrations3323001421/fs-repo-13-to-14 -path=/home/daniel/vega_home2/state/data-node/networkhistory/store/ipfs -verbose=true
applying 13-to-14 repo migration
locking repo at "/home/daniel/vega_home2/state/data-node/networkhistory/store/ipfs"
  - verifying version is '13'
> Upgrading config to new format
```

### When the migration is not needed

```shell
# go run main datanode migrate-ipfs --home /home/daniel/vega_home2

2024-02-08T22:54:02.413+0100	INFO	root	ipfs/migration.go:47	The IPFS for the network-history is up to date. Migration not needed
```