### PR TITLE
fix: mark price config from last trade to weighted fix for nil reference

### DIFF
--- a/core/execution/future/mark_price.go
+++ b/core/execution/future/mark_price.go
@@ -166,6 +166,9 @@ func (mpc *CompositePriceCalculator) UpdateConfig(ctx context.Context, oe excomm
 	mpc.config = config
 	mpc.priceSources = make([]*num.Uint, priceSourcesLen)
 	mpc.sourceLastUpdate = make([]int64, priceSourcesLen)
+	if mpc.bookPriceAtTime == nil {
+		mpc.bookPriceAtTime = map[int64]*num.Uint{}
+	}
 
 	if len(config.DataSources) > 0 {
 		oracles := make([]*products.CompositePriceOracle, 0, len(config.DataSources))

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -614,7 +614,7 @@ func (m *Market) Update(ctx context.Context, config *types.Market, oracleEngine 
 			m.internalCompositePriceCalculator = nil
 		} else if m.internalCompositePriceCalculator != nil {
 			// there was previously a intenal composite price calculator
-			if err := m.internalCompositePriceCalculator.UpdateConfig(ctx, oracleEngine, m.mkt.MarkPriceConfiguration); err != nil {
+			if err := m.internalCompositePriceCalculator.UpdateConfig(ctx, oracleEngine, internalCompositePriceConfig); err != nil {
 				m.internalCompositePriceCalculator.setOraclePriceScalingFunc(m.scaleOracleData)
 				return err
 			}
@@ -2542,13 +2542,14 @@ func (m *Market) handleConfirmation(ctx context.Context, conf *types.OrderConfir
 	tradedValue, _ := num.UintFromDecimal(
 		conf.TradedValue().ToDecimal().Div(m.positionFactor))
 	for idx, trade := range conf.Trades {
-		m.markPriceCalculator.NewTrade(trade)
-		if m.internalCompositePriceCalculator != nil {
-			m.internalCompositePriceCalculator.NewTrade(trade)
-		}
 		trade.SetIDs(m.idgen.NextID(), conf.Order, conf.PassiveOrdersAffected[idx])
 		if tradeT != nil {
 			trade.Type = *tradeT
+		} else {
+			m.markPriceCalculator.NewTrade(trade)
+			if m.internalCompositePriceCalculator != nil {
+				m.internalCompositePriceCalculator.NewTrade(trade)
+			}
 		}
 
 		tradeEvts = append(tradeEvts, events.NewTradeEvent(ctx, *trade))


### PR DESCRIPTION
fixes:
1. use internal composite price configuration on updates to internal composite.
2. initialise bookPriceAtTimeT if needed
3. push price to mark price only if not network trade