### PR TITLE
fix: wire oracle scaling function in update of internal composite price

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -621,6 +621,7 @@ func (m *Market) Update(ctx context.Context, config *types.Market, oracleEngine 
 		} else if internalCompositePriceConfig != nil {
 			// it's a new index calculator
 			m.internalCompositePriceCalculator = NewCompositePriceCalculator(ctx, internalCompositePriceConfig, oracleEngine, m.timeService)
+			m.internalCompositePriceCalculator.setOraclePriceScalingFunc(m.scaleOracleData)
 		}
 	}
 


### PR DESCRIPTION
Added missing wiring of scaling factor when internal composite price config changes from none to some. 

https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/43486/pipeline