### PR TITLE
fix: resend eth-oracle activations after snapshot restore

### DIFF
--- a/core/broker/broker_test.go
+++ b/core/broker/broker_test.go
@@ -806,6 +806,8 @@ func (e evt) Context() context.Context {
 	return e.ctx
 }
 
+func (e evt) Replace(context.Context) {}
+
 func (e *evt) SetSequenceID(s uint64) {
 	e.sid = s
 }

--- a/core/broker/mocks/broker_mock.go
+++ b/core/broker/mocks/broker_mock.go
@@ -73,6 +73,18 @@ func (mr *MockInterfaceMockRecorder) SetStreaming(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStreaming", reflect.TypeOf((*MockInterface)(nil).SetStreaming), arg0)
 }
 
+// Stage mocks base method.
+func (m *MockInterface) Stage(arg0 events.Event) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stage", arg0)
+}
+
+// Stage indicates an expected call of Stage.
+func (mr *MockInterfaceMockRecorder) Stage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stage", reflect.TypeOf((*MockInterface)(nil).Stage), arg0)
+}
+
 // Subscribe mocks base method.
 func (m *MockInterface) Subscribe(arg0 broker.Subscriber) int {
 	m.ctrl.T.Helper()

--- a/core/events/bus.go
+++ b/core/events/bus.go
@@ -76,6 +76,7 @@ type Event interface {
 	// used for events like ExpiredOrders. It is used to increment the sequence ID by the number of records
 	// this event will produce to ensure history tables using time + sequence number to function properly.
 	CompositeCount() uint64
+	Replace(context.Context)
 }
 
 const (
@@ -464,6 +465,12 @@ func newBase(ctx context.Context, t Type) *Base {
 		blockNr: int64(h),
 		et:      t,
 	}
+}
+
+// Replace updates the event to be based on the new given context.
+func (b *Base) Replace(ctx context.Context) {
+	nb := newBase(ctx, b.Type())
+	*b = *nb
 }
 
 // CompositeCount on the base event will default to 1.

--- a/core/events/bus_test.go
+++ b/core/events/bus_test.go
@@ -38,3 +38,14 @@ func TestTimeEvent(t *testing.T) {
 	assert.Equal(t, trace, e.TraceID())
 	assert.Zero(t, e.Sequence())
 }
+
+func TestContextReplace(t *testing.T) {
+	now := time.Now()
+	ctx := vgcontext.WithBlockHeight(context.Background(), 100)
+	e := events.NewTime(ctx, now)
+	assert.Equal(t, int64(100), e.BlockNr())
+
+	ctx = vgcontext.WithBlockHeight(context.Background(), 200)
+	e.Replace(ctx)
+	assert.Equal(t, int64(200), e.BlockNr())
+}

--- a/core/integration/stubs/broker_stub.go
+++ b/core/integration/stubs/broker_stub.go
@@ -135,6 +135,8 @@ func (b *BrokerStub) Send(e events.Event) {
 	b.mu.Unlock()
 }
 
+func (b *BrokerStub) Stage(e events.Event) {}
+
 func (b *BrokerStub) GetAllEventsSinceCleared() []events.Event {
 	b.mu.Lock()
 	evs := []events.Event{}

--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -463,6 +463,7 @@ func newServices(
 
 func (svcs *allServices) registerTimeServiceCallbacks() {
 	svcs.timeService.NotifyOnTick(
+		svcs.broker.OnTick,
 		svcs.epochService.OnTick,
 		svcs.builtinOracle.OnTick,
 		svcs.netParams.OnTick,

--- a/datanode/broker/broker_test.go
+++ b/datanode/broker/broker_test.go
@@ -718,6 +718,8 @@ func (e evt) Type() events.Type {
 	return e.t
 }
 
+func (e evt) Replace(context.Context) {}
+
 func (e evt) Context() context.Context {
 	return e.ctx
 }


### PR DESCRIPTION
Send in an activation event during protocol upgrade to account for the source-chain if being added to the eth-call-spec.

I've also added function to the broker to stage an event that it will send at the start of the next block. This will make it easier for us to send update events during snapshot migration a little easier.