### PR TITLE
fix: always leave liquidity auction straightaway after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@
 
 ### 🛠 Improvements
 
-- [](https://github.com/vegaprotocol/vega/issues/xxx) -
+- [10647](https://github.com/vegaprotocol/vega/issues/10647) - Add filter by game ID to transfers API.
 
 ### 🐛 Fixes
 
 - [10631](https://github.com/vegaprotocol/vega/issues/10631) - Fix snapshot for `ethCallEvents`
+- [10643](https://github.com/vegaprotocol/vega/issues/10643) - Games `API` not showing quantum values and added filter for team and party.
+- [10649](https://github.com/vegaprotocol/vega/issues/10649) - Ensure markets do not get stuck in liquidity auction after protocol upgrade.
+
+
+## 0.74.0
 
 
 ## 0.74.1
@@ -31,17 +36,13 @@
 
 ### 🛠 Improvements
 
-- [10647](https://github.com/vegaprotocol/vega/issues/10647) - Add filter by game ID to transfers API.
+- [](https://github.com/vegaprotocol/vega/issues/xxx) -
 
 ### 🐛 Fixes
 
 - [10611](https://github.com/vegaprotocol/vega/issues/10611) - Added internal config price to update `perps`.
 - [10615](https://github.com/vegaprotocol/vega/issues/10615) - Fix oracle scaling function in internal composite price.
 - [10621](https://github.com/vegaprotocol/vega/issues/10621) - Fix market activity tracker storing incorrect data for previous `epochMakerFeesPaid`.
-- [10643](https://github.com/vegaprotocol/vega/issues/10643) - Games `API` not showing quantum values and added filter for team and party.
-
-
-## 0.74.0
 
 ### 🚨 Breaking changes
 
@@ -233,6 +234,7 @@
 - [10595](https://github.com/vegaprotocol/vega/issues/10595) - Fix failed amends for isolated margin orders causing negative spread in console.
 - [10606](https://github.com/vegaprotocol/vega/issues/10606) - Party profiles `API` was not returning results.
 - [10625](https://github.com/vegaprotocol/vega/issues/10625) - Fix panic in update spot market.
+- [10649](https://github.com/vegaprotocol/vega/issues/10649) - Ensure markets do not get stuck in liquidity auction after protocol upgrade.
 
 ## 0.73.0
 

--- a/core/execution/future/auction.go
+++ b/core/execution/future/auction.go
@@ -134,9 +134,7 @@ func (m *Market) checkAuction(ctx context.Context, now time.Time, idgen common.I
 	// Liquidity auctions are no longer a thing, we know we're not in opening auction here
 	// if we're not in price auction, we should just let the liquidity auction expire
 	if m.as.Trigger() == types.AuctionTriggerLiquidityTargetNotMet || m.as.Trigger() == types.AuctionTriggerUnableToDeployLPOrders {
-		if end := m.as.ExpiresAt(); end == nil || !end.Before(now) {
-			m.as.SetReadyToLeave()
-		}
+		m.as.SetReadyToLeave()
 	}
 	// price and liquidity auctions
 	isPrice := m.as.IsPriceAuction() || m.as.IsPriceExtension()


### PR DESCRIPTION
The issue was this bit `!end.Before(now)`. `end` was always before`now` after the protocol-upgrade. This logic would mean we only left the liquidity aution if the auction ended was after `now`? Which is a bit weird. Eitherway, we now leave a liquidity auction straight away.

Replaying stagnet with this change, I can see that we do leave-auction and get to this line of code where we send out an event:
```
// only send the auction-left event if we actually *left* the auction.
m.broker.Send(endEvt)
```

then my node falls out of consensus, but thats not unexpected.

close #10649  