### PR TITLE
chore: set default mark price config for spot so snapshot doesn't fai…

### DIFF
--- a/core/governance/market.go
+++ b/core/governance/market.go
@@ -354,6 +354,7 @@ func buildSpotMarketFromProposal(
 		LinearSlippageFactor:          num.DecimalZero(),
 		QuadraticSlippageFactor:       num.DecimalZero(),
 		LiquiditySLAParams:            definition.Changes.SLAParams,
+		MarkPriceConfiguration:        defaultMarkPriceConfig,
 	}
 	if err := assignSpotRiskModel(definition.Changes, market.TradableInstrument); err != nil {
 		return nil, types.ProposalErrorUnspecified, err


### PR DESCRIPTION
…l although it's not used by it