### PR TITLE
fix: fund rate bounds can be null in GQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,7 @@
 - [10643](https://github.com/vegaprotocol/vega/issues/10643) - Games `API` not showing quantum values and added filter for team and party.
 - [10649](https://github.com/vegaprotocol/vega/issues/10649) - Ensure markets do not get stuck in liquidity auction after protocol upgrade.
 - [10641](https://github.com/vegaprotocol/vega/issues/10641) - Fix panic in amend during auction for isolated margin.
-
-
-## 0.74.0
-
+- [10656](https://github.com/vegaprotocol/vega/issues/10656) - Fix funding rates bounds can be null for perpetuals.
 
 ## 0.74.1
 

--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -2078,11 +2078,11 @@ type Perpetual {
   "Binding between the data source spec and the settlement data"
   dataSourceSpecBinding: DataSourceSpecPerpetualBinding!
   "Factor applied to funding-rates. This scales the impact that spot price deviations have on funding payments"
-  fundingRateScalingFactor: String!
+  fundingRateScalingFactor: String
   "Lower bound for the funding-rate such that the funding-rate will never be lower than this value"
-  fundingRateLowerBound: String!
+  fundingRateLowerBound: String
   "Upper bound for the funding-rate such that the funding-rate will never be higher than this value"
-  fundingRateUpperBound: String!
+  fundingRateUpperBound: String
   "Optional configuration driving the internal composite price calculation for perpetual product"
   internalCompositePriceConfig: CompositePriceConfiguration
 }


### PR DESCRIPTION
Closes #10656 

This bug was caused by a mismatch in the GQL schema with the underlying protobuf definition which allows the funding rate values to be optional:

```
  // Factor applied to funding-rates. This scales the impact that spot price deviations have on funding payments.
  optional string funding_rate_scaling_factor = 10;
  // Lower bound for the funding-rate such that the funding-rate will never be lower than this value.
  optional string funding_rate_lower_bound = 11;
  // Upper bound for the funding-rate such that the funding-rate will never be higher than this value.
  optional string funding_rate_upper_bound = 12;
```
