### PR TITLE
fix: clone internal composite price before scaling for API

### DIFF
--- a/core/execution/common/mark_price.go
+++ b/core/execution/common/mark_price.go
@@ -255,6 +255,9 @@ func (mpc *CompositePriceCalculator) CalculateBookMarkPriceAtTimeT(initialScalin
 }
 
 func (mpc *CompositePriceCalculator) GetPrice() *num.Uint {
+	if mpc.price != nil {
+		return mpc.price.Clone()
+	}
 	return mpc.price
 }
 

--- a/core/integration/features/settlement/0019-MCAL_fundingMargin5.feature
+++ b/core/integration/features/settlement/0019-MCAL_fundingMargin5.feature
@@ -131,6 +131,6 @@ Feature: check when settlement data precision is different/equal to the settleme
       | market | party2 | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 432741366 | USD   |
       | market | party3 | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 432741368 | USD   |
       | market | aux2   | ACCOUNT_TYPE_SETTLEMENT | ACCOUNT_TYPE_MARGIN     | ETH/DEC19 | 432741366 | USD   |
-      | aux2   | aux2   | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL    | ETH/DEC19 | 434311866 | USD   |
-      | party2 | party2 | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL    | ETH/DEC19 | 434311866 | USD   |
-      | party3 | party3 | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL    | ETH/DEC19 | 434311868 | USD   |
+      | aux2   | aux2   | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL    | ETH/DEC19 | 432666666 | USD   |
+      | party2 | party2 | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL    | ETH/DEC19 | 432666666 | USD   |
+      | party3 | party3 | ACCOUNT_TYPE_MARGIN     | ACCOUNT_TYPE_GENERAL    | ETH/DEC19 | 432666668 | USD   |


### PR DESCRIPTION
close #10676 

The internal-composite price is scaled before being added to the market data, but it wasn't cloned beforehand which meant it was changing the price in the actual market-price calculator too. So each block it would get chopped down until it eventually reached zero:
https://api.n00.testnet.vega.rocks/api/v2/market/data/6a6520fb81106f127411bf35cfc16210992d6e82eb66b6213f51fdccf3f8d353/latest

This causes issues with snapshot because, for whatever reason, we call GetMarketData() after loading so the snapshot version of node will have done an one extra scaling and it gets out of sync.