### PR TITLE
refactor: fix an error in logic for perps margin calculation

### DIFF
--- a/core/risk/engine_test.go
+++ b/core/risk/engine_test.go
@@ -609,6 +609,28 @@ func TestMarginWithNoOrdersOnBook(t *testing.T) {
 			funding_payment_to_date: 10,
 			auction:                 true,
 		},
+		{
+			expectedMargin: "121",
+			positionSize:   1,
+			buyOrders:      []*risk.OrderInfo{},
+			sellOrders: []*risk.OrderInfo{
+				{
+					TrueRemaining: 5,
+					Price:         num.DecimalFromInt64(markPrice + 2),
+					IsMarketOrder: false,
+				},
+				{
+					TrueRemaining: 2,
+					Price:         num.DecimalFromInt64(markPrice + 7),
+					IsMarketOrder: false,
+				},
+			},
+			linearSlippageFactor:    num.DecimalFromFloat(0.01),
+			quadraticSlippageFactor: num.DecimalZero(),
+			margin_funding_factor:   1,
+			funding_payment_to_date: 10,
+			auction:                 false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix an error in logic that I spotted. Margin factor should be added to both the riskiest long and riskiest short and max of the two should be with the increment included.