### PR TITLE
Estimate margin decrease too

### DIFF
--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -3370,14 +3370,22 @@ func (t *TradingDataServiceV2) EstimatePosition(ctx context.Context, req *v2.Est
 	combinedMargin := marginAccountBalance.Add(orderAccountBalance)
 	if isolatedMarginMode {
 		requiredPositionMargin, requiredOrderMargin := risk.CalculateRequiredMarginInIsolatedMode(req.OpenVolume, avgEntryPrice, marketObservable, buyOrders, sellOrders, positionFactor, dMarginFactor)
-		posMarginDelta = num.MaxD(num.DecimalZero(), requiredPositionMargin.Sub(marginAccountBalance))
-		wMarginDelta = num.MaxD(num.DecimalZero(), requiredPositionMargin.Add(requiredOrderMargin).Sub(combinedMargin))
+		posMarginDelta = requiredPositionMargin.Sub(marginAccountBalance)
+		wMarginDelta = requiredPositionMargin.Add(requiredOrderMargin).Sub(combinedMargin)
 		bMarginDelta = wMarginDelta
 	} else {
-		worstInitial, _ := num.DecimalFromString(marginEstimate.WorstCase.InitialMargin)
-		bestInitial, _ := num.DecimalFromString(marginEstimate.BestCase.InitialMargin)
-		wMarginDelta = num.MaxD(num.DecimalZero(), worstInitial.Sub(combinedMargin))
-		bMarginDelta = num.MaxD(num.DecimalZero(), bestInitial.Sub(combinedMargin))
+		wInitial, _ := num.DecimalFromString(marginEstimate.WorstCase.InitialMargin)
+		bInitial, _ := num.DecimalFromString(marginEstimate.BestCase.InitialMargin)
+		wRelease, _ := num.DecimalFromString(marginEstimate.WorstCase.CollateralReleaseLevel)
+		bRelease, _ := num.DecimalFromString(marginEstimate.BestCase.CollateralReleaseLevel)
+		wMarginDifference := wInitial.Sub(combinedMargin)
+		bMarginDifference := bInitial.Sub(combinedMargin)
+		if wMarginDifference.IsPositive() || combinedMargin.GreaterThan(wRelease) {
+			wMarginDelta = wMarginDifference
+		}
+		if bMarginDifference.IsPositive() || combinedMargin.GreaterThan(bRelease) {
+			bMarginDelta = bMarginDifference
+		}
 	}
 
 	if isolatedMarginMode && ptr.UnBox(req.IncludeRequiredPositionMarginInAvailableCollateral) {


### PR DESCRIPTION
Currently we're flooring margin increase estimate within `EstimatePosition` at 0, this change calculates the expected value to be released if the increase is negative.