### PR TITLE
fix: ensure the liquidity fee setting is set on markets before using it. (validator testnet temp fix)

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -2705,7 +2705,7 @@ func (m *Market) updateLiquidityFee(ctx context.Context) {
 	var fee num.Decimal
 	provisions := m.liquidityEngine.ProvisionsPerParty()
 
-	// FIXME: just a temporay patch for validators testnet
+	// FIXME: just a temporary patch for validators testnet
 	// so the state of the network is fixed.
 	if m.mkt.Fees.LiquidityFeeSettings == nil {
 		m.mkt.Fees.LiquidityFeeSettings = &types.LiquidityFeeSettings{

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -2705,6 +2705,14 @@ func (m *Market) updateLiquidityFee(ctx context.Context) {
 	var fee num.Decimal
 	provisions := m.liquidityEngine.ProvisionsPerParty()
 
+	// FIXME: just a temporay patch for validators testnet
+	// so the state of the network is fixed.
+	if m.mkt.Fees.LiquidityFeeSettings == nil {
+		m.mkt.Fees.LiquidityFeeSettings = &types.LiquidityFeeSettings{
+			Method: types.LiquidityFeeMethodMarginalCost,
+		}
+	}
+
 	switch m.mkt.Fees.LiquidityFeeSettings.Method {
 	case types.LiquidityFeeMethodConstant:
 		if len(provisions) != 0 {


### PR DESCRIPTION
### **_DO NOT MERGE, FOR VALIDATORS TESTNET ONLY_**