### PR TITLE
fix: Use second precision in  so that perpetual product uses second p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🐛 Fixes
 
-- [](https://github.com/vegaprotocol/vega/issues/xxx)
+- [10702](https://github.com/vegaprotocol/vega/pull/10700) - Use second precision in `GetMarginIncrease()` so that perpetual product uses second precision everywhere.
 
 
 ## 0.74.2

--- a/core/products/perpetual.go
+++ b/core/products/perpetual.go
@@ -941,6 +941,8 @@ func (p *Perpetual) calculateInterestTerm(externalTWAP, internalTWAP *num.Uint, 
 // GetMarginIncrease returns the estimated extra margin required to account for the next funding payment
 // for a party with a position of +1.
 func (p *Perpetual) GetMarginIncrease(t int64) num.Decimal {
+	t = time.Unix(0, t).Truncate(time.Second).UnixNano()
+
 	// if we have no data, or the funding factor is zero, then the margin increase will always be zero
 	if !p.haveDataBeforeGivenTime(t) || p.p.MarginFundingFactor.IsZero() {
 		return num.DecimalZero()


### PR DESCRIPTION
close #10702 

When the feature to exclude auction periods from perpetual TWAP's was implemented, the perpetual product was switched to trunacte all timestamps to second-precision, this was to avoid awkward edge cases where we would see sub-second intervals. These sub-second intervals could occur due to all the external data (from the data-sources, and the funding period end) being in second's precision and everything internal having nanosecond precision.

`GetMarginIncrease()` was an entry-point into the perpetual that did not truncate to seconds precision, and so we ran into exactly the flavour of bug we were trying to avoid.

The fix is to truncate the time given to `GetMarginIncrease()` to be in seconds precision too so we only deal with seconds everywhere for the TWAP calculations.