### PR TITLE
fix: teams stats doesn't aggregate from latest epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Fixes
 
+- [10722](https://github.com/vegaprotocol/vega/issues/10722) - Team API aggregation does not aggregate from the latest epoch.
 - [](https://github.com/vegaprotocol/vega/issues/xxx)
 
 ## 0.74.3

--- a/datanode/sqlstore/teams.go
+++ b/datanode/sqlstore/teams.go
@@ -36,8 +36,8 @@ const (
     SELECT *
     FROM teams_stats
     WHERE at_epoch > (
-      SELECT MAX(at_epoch) - $1
-      FROM teams_stats
+      SELECT MAX(id) - $1
+      FROM epochs
     ) %s
   ),
   team_numbers AS (
@@ -77,8 +77,8 @@ FROM team_numbers tn
     SELECT *
     FROM teams_stats
     WHERE at_epoch > (
-      SELECT MAX(at_epoch) - $1
-      FROM teams_stats
+      SELECT MAX(id) - $1
+      FROM epochs
     ) AND team_id = $2 %s
   ),
   members_numbers AS (

--- a/datanode/sqlstore/teams_test.go
+++ b/datanode/sqlstore/teams_test.go
@@ -787,6 +787,7 @@ func TestListTeamStatistics(t *testing.T) {
 	teamsStore := sqlstore.NewTeams(connectionSource)
 	blocksStore := sqlstore.NewBlocks(connectionSource)
 	rewardsStore := sqlstore.NewRewards(ctx, connectionSource)
+	epochStore := sqlstore.NewEpochs(connectionSource)
 
 	member11 := entities.PartyID(GenerateID())
 	member12 := entities.PartyID(GenerateID())
@@ -849,6 +850,16 @@ func TestListTeamStatistics(t *testing.T) {
 			Hash:     []byte(vgcrypto.RandomHash()),
 		}
 		require.NoError(t, blocksStore.Add(ctx, block))
+		require.NoError(t, epochStore.Add(ctx, entities.Epoch{
+			ID:         epoch,
+			StartTime:  blockTime.Add(-1 * time.Minute),
+			ExpireTime: blockTime,
+			EndTime:    ptr.From(blockTime),
+			TxHash:     generateTxHash(),
+			VegaTime:   blockTime,
+			FirstBlock: ptr.From(epoch),
+			LastBlock:  ptr.From(epoch),
+		}))
 
 		j := 0
 		evt := &eventspb.TeamsStatsUpdated{


### PR DESCRIPTION
Closes #10722 