### PR TITLE
feat: feat: include AMM's in best bid/ask queries on orderbook

### DIFF
--- a/core/matching/mocks/mocks.go
+++ b/core/matching/mocks/mocks.go
@@ -35,6 +35,23 @@ func (m *MockOffbookSource) EXPECT() *MockOffbookSourceMockRecorder {
 	return m.recorder
 }
 
+// BestPricesAndVolumes mocks base method.
+func (m *MockOffbookSource) BestPricesAndVolumes() (*num.Uint, uint64, *num.Uint, uint64) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BestPricesAndVolumes")
+	ret0, _ := ret[0].(*num.Uint)
+	ret1, _ := ret[1].(uint64)
+	ret2, _ := ret[2].(*num.Uint)
+	ret3, _ := ret[3].(uint64)
+	return ret0, ret1, ret2, ret3
+}
+
+// BestPricesAndVolumes indicates an expected call of BestPricesAndVolumes.
+func (mr *MockOffbookSourceMockRecorder) BestPricesAndVolumes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestPricesAndVolumes", reflect.TypeOf((*MockOffbookSource)(nil).BestPricesAndVolumes))
+}
+
 // NotifyFinished mocks base method.
 func (m *MockOffbookSource) NotifyFinished() {
 	m.ctrl.T.Helper()

--- a/core/matching/orderbook_amm_test.go
+++ b/core/matching/orderbook_amm_test.go
@@ -196,6 +196,58 @@ func testMatchOrdersBothSide(t *testing.T) {
 	assertConf(t, conf, 8, 10)
 }
 
+func TestAMMOnlyBestPrices(t *testing.T) {
+	tst := getTestOrderBookWithAMM(t)
+	defer tst.ctrl.Finish()
+
+	tst.obs.EXPECT().BestPricesAndVolumes().Return(
+		num.NewUint(1999),
+		uint64(10),
+		num.NewUint(2001),
+		uint64(9),
+	).AnyTimes()
+
+	// Best
+	price, err := tst.book.GetBestAskPrice()
+	require.NoError(t, err)
+	assert.Equal(t, "2001", price.String())
+
+	price, err = tst.book.GetBestBidPrice()
+	require.NoError(t, err)
+	assert.Equal(t, "1999", price.String())
+
+	// Best and volume
+	price, volume, err := tst.book.BestOfferPriceAndVolume()
+	require.NoError(t, err)
+	assert.Equal(t, "2001", price.String())
+	assert.Equal(t, uint64(9), volume)
+
+	price, volume, err = tst.book.BestBidPriceAndVolume()
+	require.NoError(t, err)
+	assert.Equal(t, "1999", price.String())
+	assert.Equal(t, uint64(10), volume)
+
+	// Best static
+	price, err = tst.book.GetBestStaticAskPrice()
+	require.NoError(t, err)
+	assert.Equal(t, "2001", price.String())
+
+	price, err = tst.book.GetBestStaticBidPrice()
+	require.NoError(t, err)
+	assert.Equal(t, "1999", price.String())
+
+	// Best static and volume
+	price, volume, err = tst.book.GetBestStaticAskPriceAndVolume()
+	require.NoError(t, err)
+	assert.Equal(t, "2001", price.String())
+	assert.Equal(t, uint64(9), volume)
+
+	price, volume, err = tst.book.GetBestStaticBidPriceAndVolume()
+	require.NoError(t, err)
+	assert.Equal(t, "1999", price.String())
+	assert.Equal(t, uint64(10), volume)
+}
+
 func assertConf(t *testing.T, conf *types.OrderConfirmation, n int, size uint64) {
 	t.Helper()
 	assert.Len(t, conf.PassiveOrdersAffected, n)


### PR DESCRIPTION
closes #10740 

This means that the AMM's current best-ask and best-bid volumes, as well as the mid price (it's fair price) are reported through the market-data. This is needed for the feature test AC's where we need to use the mid-price to know the AMM's current position.

Things of note:
- if we are repricing a lot of pegged orders, we'll be calling `BestPricesAndVolumes()` for each one so performance will be crap. But now isn't the time to be refactoring the pegged orders code. I'll add a note to the AMM performance ticket.
- _in theory_ all AMM's should always have the same fair-price (unless the last-traded price has moved outside of a boundary). There are some inaccuracies at play related to the fact that calculations end up with fractional volumes, so in reality they will only be equal _to some tolerance_ and so the API _may_ report a very small crossed orderbook. We will need to work this through with research once we have some solid examples.
