### PR TITLE
feat: amm boundaries in tradable range are now paritioned into sublevels

### DIFF
--- a/core/execution/amm/pool.go
+++ b/core/execution/amm/pool.go
@@ -480,7 +480,7 @@ func (p *Pool) getPosition() (int64, *num.Uint) {
 	return 0, num.UintZero()
 }
 
-// virtualBalancesLong returns the pools x, y balances when the pool has a negative position, where
+// virtualBalancesShort returns the pools x, y balances when the pool has a negative position, where
 //
 // x = P + (cc * rf) / sqrt(pl) + L / sqrt(pl),
 // y = abs(P) * average-entry + L * sqrt(pl).

--- a/core/integration/features/amm/0087-VAMM-005.feature
+++ b/core/integration/features/amm/0087-VAMM-005.feature
@@ -140,11 +140,11 @@ Feature: Test vAMM submission works as expected (invalid submission)
       | vamm6 | ETH/MAR22 | 1000   | STATUS_ACTIVE | 101  | 95          | 0.01               | 105         | 0.01               |
 
     When the parties submit the following AMM:
-      | party | market id | amount | slippage | base | lower bound | lower margin ratio |
-      | vamm7 | ETH/MAR22 | 1000   | 0.01     | 110  | 99          | 0.1                |
+      | party | market id | amount | slippage | base | lower bound | lower margin ratio | error |
+      | vamm7 | ETH/MAR22 | 1000   | 0.01     | 110  | 99          | 0.1                | rebase-order did not trade |
     Then the AMM pool status should be:
       | party | market id | amount | status          | base | lower bound | lower margin ratio | 
-      | vamm7 | ETH/MAR22 | 1000   | STATUS_ACTIVE | 110  | 99          | 0.1                  | 
+      | vamm7 | ETH/MAR22 | 1000   | STATUS_REJECTED | 110  | 99          | 0.1                | 
 
     And set the following AMM sub account aliases:
       | party | market id | alias     |

--- a/core/matching/side.go
+++ b/core/matching/side.go
@@ -577,7 +577,7 @@ func clonePriceLevel(lvl *PriceLevel) *PriceLevel {
 	}
 }
 
-// betweenLevels returns the inner, outer bounds for the given idx in the prive levels.
+// betweenLevels returns the inner, outer bounds for the given idx in the price levels.
 // Usually this means (inner, outer) = (lvl[i].price, lvl[i-1].price) but we also handle
 // the past the first and last price levels.
 func (s *OrderBookSide) betweenLevels(idx int, first, last *num.Uint) (*num.Uint, *num.Uint) {


### PR DESCRIPTION
closes #10733 

When there are multiple AMM's with different lower/upper boundaries, an large incoming order that takes all the remaining volume in one AMM needs to be handled in two steps. This is so that the "fair-price" of every pool remains in sync.

For example, if we have three AMM's whose upper curves look like this:
```
 [------------]
 [---------------------]
```

and an a large incoming order comes in such that it would eat the narrower pool's volume, we would first trade volume that takes the fair-price of all pool's to the boundary of the narrow pool
```
 [XXXXXXXXXXXX]
 [XXXXXXXXXXXX-------------]
```

then trade again just against with the remaining volume against the longer pool:
```
 [XXXXXXXXXXXX]
 [XXXXXXXXXXXXYYYYYYY-----]
```

there are two reason why we need to do this:
1) doing it in one shot would cause us to distribute the volume pro-rata would would cause the pool's fair-price's to be misallign resulting in them crossing
2) so that the incoming trade gets an overall fairer price

