### PR TITLE
fix: oracles data query is increasingly slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [10753](https://github.com/vegaprotocol/vega/issues/10753) - Handle the case that a submitted order is `FoK` in isolated margin to not double discount it from position.
 - [10136](https://github.com/vegaprotocol/vega/issues/10136) - Assure opening auction uncrossing price gets registered in the perps engine.
 - [10727](https://github.com/vegaprotocol/vega/issues/10727) - Allow for a 0 funding rate scaling factor.
+- [10785](https://github.com/vegaprotocol/vega/issues/10785) - Oracles data is getting increasingly slow.
 
 ## 0.74.3
 


### PR DESCRIPTION
Closes #10785 

This is caused because when requesting the first page, there are no date constraints in the query, the order by clause in the query causes Timescale to scan all the segments for the hypertable in order to sort the data. As the data grows, this will get worse.

The solution is to ensure that a date constraint is added to the query when the first page of results is requested. I have restricted it to 1 day as that should be kept in memory by Timescale so should return results fairly quickly. Subsequent pages have an appropriate date information in the cursor.