### PR TITLE
chore: backport changes from 74.9 tag

### DIFF
--- a/core/datasource/external/ethverifier/l2_verifier_snapshot.go
+++ b/core/datasource/external/ethverifier/l2_verifier_snapshot.go
@@ -126,26 +126,35 @@ func (s *L2Verifiers) restoreState(ctx context.Context, l2EthOracles *snapshotpb
 				Time:   v.LastBlock.BlockTime,
 			}
 		}
-		// do it once just in case
+
+		// do it once always
 		verifier.restoreLastEthBlock(ctx, lastBlock)
 
-		// only run this if the misc exists, which might
-		// not be the case on a new upgrade after it's
-		// introduced
-		if v.Misc != nil {
+		// this is the block of the upgrade
+		// we only initialize this the patchBlock and lastBlock
+		if v.Misc == nil {
+			if lastBlock != nil {
+				// no patchBlock, set it to the last Block
+				verifier.restorePatchBlock(ctx, &types.EthBlock{
+					Height: lastBlock.Height,
+					Time:   lastBlock.Time,
+				})
+			}
+		} else if v.Misc != nil {
+			// only run this if the misc exists, which might
+			// not be the case on a new upgrade after it's
+			// introduced
 			var patchBlock *types.EthBlock
 			if v.Misc.PatchBlock != nil {
-				lastBlock = &types.EthBlock{
+				patchBlock = &types.EthBlock{
 					Height: v.Misc.PatchBlock.BlockHeight,
 					Time:   v.Misc.PatchBlock.BlockTime,
 				}
 			}
 
-			verifier.restoreLastEthBlock(ctx, lastBlock)
 			verifier.restorePatchBlock(ctx, patchBlock)
 			verifier.restoreSeen(v.Misc.Buckets)
 		}
-
 		pending := []*ethcall.ContractCallEvent{}
 
 		for _, pr := range v.CallResults.PendingContractCallResult {


### PR DESCRIPTION
Backport following changes from the v0.74.9 release: https://github.com/vegaprotocol/vega/pull/10816/files#diff-9d8d0ab507b1af87732718aa896f3fe58f0c645c0c9896c9e5800b9880adaea6R130-R157