### PR TITLE
Small fix for AC 022 behaviour

### DIFF
--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -729,12 +729,10 @@ func (e *Engine) CancelAMM(
 	}
 
 	if cancel.Method == types.AMMPoolCancellationMethodReduceOnly {
-		if pos, _ := pool.getPosition(); pos != 0 {
-			// pool will now only accept trades that will reduce its position
-			pool.status = types.AMMPoolStatusReduceOnly
-			e.sendUpdate(ctx, pool)
-			return nil, nil
-		}
+		// pool will now only accept trades that will reduce its position
+		pool.status = types.AMMPoolStatusReduceOnly
+		e.sendUpdate(ctx, pool)
+		return nil, nil
 	}
 
 	// either pool has no position or owner wants out right now, so release general balance and

--- a/core/execution/amm/engine_test.go
+++ b/core/execution/amm/engine_test.go
@@ -476,6 +476,7 @@ func testClosingReduceOnlyPool(t *testing.T) {
 	mevt, err := tst.engine.CancelAMM(ctx, cancel)
 	require.NoError(t, err)
 	assert.Nil(t, mevt) // no closeout necessary so not event
+	tst.engine.OnMTM(ctx)
 	assert.Len(t, tst.engine.pools, 0)
 }
 
@@ -515,6 +516,7 @@ func testAmendMakesClosingPoolActive(t *testing.T) {
 	closeout, err := tst.engine.CancelAMM(ctx, cancel)
 	require.NoError(t, err)
 	assert.Nil(t, closeout)
+	tst.engine.OnMTM(ctx)
 	assert.Len(t, tst.engine.pools, 1)
 	assert.True(t, tst.engine.poolsCpy[0].closing())
 
@@ -545,6 +547,7 @@ func testClosingPoolRemovedWhenPositionZero(t *testing.T) {
 	closeout, err := tst.engine.CancelAMM(ctx, cancel)
 	require.NoError(t, err)
 	assert.Nil(t, closeout)
+	tst.engine.OnMTM(ctx)
 	assert.True(t, tst.engine.poolsCpy[0].closing())
 
 	// position is lower but non-zero


### PR DESCRIPTION
Small fix for reduce-only cancellations: when position hits zero, the vAMM is cancelled on next MTM instead of instantly