### PR TITLE
fix: sort amm states before submitting their ELS stake

### DIFF
--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -675,6 +675,11 @@ func (e *Engine) SubmitAMM(
 			return err
 		}
 	}
+	e.log.Debug("AMM added for market",
+		logging.String("owner", submit.Party),
+		logging.String("marketID", e.market.GetID()),
+		logging.String("poolID", pool.ID),
+	)
 	e.add(pool)
 	e.sendUpdate(ctx, pool)
 	return nil


### PR DESCRIPTION
We were calling `m.equityShares.SetPartyStake(party, stake)` on the AMM map without sorting it first, which was causes nodes to fall out of consensus if they AMM's were added to the LP slice in a different order.