### PR TITLE
fix: ensure we hit leave auction trigger on mark-price calc, and hand…

### DIFF
--- a/core/execution/common/mark_price.go
+++ b/core/execution/common/mark_price.go
@@ -281,11 +281,11 @@ func (mpc *CompositePriceCalculator) updateMarkPriceIfNotInAuction(ctx context.C
 		return nil
 	}
 	priceMonitor.CheckPrice(ctx, as, []*types.Trade{{Price: mpcCandidate, Size: 1}}, true, true)
-	if !as.InAuction() {
-		mpc.price = mpcCandidate
-		return nil
+	if as.InAuction() || as.AuctionStart() {
+		return fmt.Errorf("price monitoring failed for the new mark price")
 	}
-	return fmt.Errorf("price monitoring failed for the new mark price")
+	mpc.price = mpcCandidate
+	return nil
 }
 
 // CalculateMarkPrice is called at the end of each mark price calculation interval and calculates the mark price

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1580,7 +1580,6 @@ func (m *Market) leaveAuction(ctx context.Context, now time.Time) {
 
 			m.mkt.State = types.MarketStateActive
 			m.mkt.TradingMode = types.MarketTradingModeContinuous
-			m.tradableInstrument.Instrument.UpdateAuctionState(ctx, false)
 			m.broker.Send(events.NewMarketUpdatedEvent(ctx, *m.mkt))
 
 			m.updateLiquidityFee(ctx)
@@ -1612,6 +1611,9 @@ func (m *Market) leaveAuction(ctx context.Context, now time.Time) {
 
 	// update auction state, so we know what the new tradeMode ought to be
 	endEvt := m.as.Left(ctx, now)
+	// we tell the perp that we've left auction, we might re-enter just a bit down but thats fine as
+	// we will at least keep the in/out orders in sync
+	m.tradableInstrument.Instrument.UpdateAuctionState(ctx, false)
 
 	for _, uncrossedOrder := range uncrossedOrders {
 		updatedOrders = append(updatedOrders, uncrossedOrder.Order)

--- a/core/integration/features/perpetual.feature
+++ b/core/integration/features/perpetual.feature
@@ -226,7 +226,7 @@ Feature: Simple test creating a perpetual market.
       | 976        | TRADING_MODE_CONTINUOUS | AUCTION_TRIGGER_UNSPECIFIED | 1             |
     And the following funding period events should be emitted:
       | start      | end        | internal twap    | external twap    |
-      | 1575072002 |            | 9760000000000000 |                  |
+      | 1575072002 |            |                  |                  |
 
     # perps payment doesn't happen in the absence of oracle data
     When the oracles broadcast data with block time signed with "0xCAFECAFE1":

--- a/core/integration/features/price-mon-trigger-leaving-auction.feature
+++ b/core/integration/features/price-mon-trigger-leaving-auction.feature
@@ -1,0 +1,107 @@
+Feature: replicating the incentive panic from issue 10858.
+  Background:
+    Given the following network parameters are set:
+      | name                                    | value |
+      | network.markPriceUpdateMaximumFrequency | 1s    |
+    And the price monitoring named "my-price-monitoring":
+      | horizon | probability | auction extension |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 30      | 0.99999     | 1                 |
+      | 120     | 0.9999999   | 5                 |
+      | 120     | 0.9999999   | 5                 |
+      | 120     | 0.9999999   | 5                 |
+      | 120     | 0.9999999   | 5                 |
+      | 120     | 0.9999999   | 5                 |
+      | 200     | 0.9999999   | 5                 |
+      | 200     | 0.9999999   | 5                 |
+      | 200     | 0.9999999   | 5                 |
+      | 200     | 0.9999999   | 5                 |
+      | 200     | 0.9999999   | 5                 |
+    And the liquidity monitoring parameters:
+      | name       | triggering ratio | time window | scaling factor |
+      | lqm-params | 0.00             | 24h         | 1e-9           |
+    And the simple risk model named "simple-risk-model":
+      | long | short | max move up | min move down | probability of trading |
+      | 0.1  | 0.1   | 100         | -100          | 0.2                    |
+
+        # this is just an example of setting up oracles
+    And the composite price oracles from "0xCAFECAFE1":
+      | name    | price property   | price type   | price decimals |
+      | oracle1 | price1.USD.value | TYPE_INTEGER | 0              |
+      | oracle2 | price2.USD.value | TYPE_INTEGER | 0              |
+      | oracle3 | price3.USD.value | TYPE_INTEGER | 0              |
+
+    And the markets:
+      | id        | quote name | asset | liquidity monitoring | risk model        | margin calculator         | auction duration | fees         | price monitoring    | data source config     | linear slippage factor | quadratic slippage factor | sla params      | price type | decay weight | decay power | cash amount | source weights | source staleness tolerance | oracle1 | oracle2 | oracle3 |
+      | ETH/FEB23 | ETH        | USD   | lqm-params           | simple-risk-model | default-margin-calculator | 1                | default-none | my-price-monitoring | default-eth-for-future | 0.25                   | 0                         | default-futures | weight     | 1            | 1           | 0           | 0,0,0,1,0      | 1m0s,1m0s,1m0s,1m0s,1m0s   | oracle1 | oracle2 | oracle3 |
+
+  @MPP
+  Scenario: Oracle data significantly higher than trade price, submitted before leaving opening auction
+    Given the parties deposit on asset's general account the following amount:
+      | party            | asset | amount       |
+      | buySideProvider  | USD   | 100000000000 |
+      | sellSideProvider | USD   | 100000000000 |
+      | party            | USD   | 948050       |
+
+    When the parties place the following orders:
+      | party            | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | buySideProvider  | ETH/FEB23 | buy  | 10     | 14900  | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | buySideProvider  | ETH/FEB23 | buy  | 1      | 15000  | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | buySideProvider  | ETH/FEB23 | buy  | 3      | 15900  | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | party            | ETH/FEB23 | sell | 3      | 15900  | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | sellSideProvider | ETH/FEB23 | sell | 2      | 15920  | 0                | TYPE_LIMIT | TIF_GTC | sell-2    |
+      | sellSideProvider | ETH/FEB23 | sell | 1      | 15940  | 0                | TYPE_LIMIT | TIF_GTC | sell-3    |
+      | sellSideProvider | ETH/FEB23 | sell | 3      | 15960  | 0                | TYPE_LIMIT | TIF_GTC | sell-4    |
+      | sellSideProvider | ETH/FEB23 | sell | 5      | 15990  | 0                | TYPE_LIMIT | TIF_GTC | sell-5    |
+      | sellSideProvider | ETH/FEB23 | sell | 2      | 16000  | 0                | TYPE_LIMIT | TIF_GTC | sell-7    |
+      | sellSideProvider | ETH/FEB23 | sell | 4      | 16020  | 0                | TYPE_LIMIT | TIF_GTC | sell-8    |
+      | sellSideProvider | ETH/FEB23 | sell | 1      | 100000 | 0                | TYPE_LIMIT | TIF_GTC |           |
+   
+
+        # AC 0009-MRKP-012
+    When the network moves ahead "2" blocks
+    Then the mark price should be "15900" for the market "ETH/FEB23"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/FEB23"
+
+    And the parties place the following orders:
+      | party           | market id | side | volume   | price | resulting trades | type       | tif     | reference |
+      | buySideProvider | ETH/FEB23 | buy  | 1        | 10 | 0                | TYPE_LIMIT | TIF_GTC |     cancel1      |
+      | sellSideProvider | ETH/FEB23 | sell  | 1      | 10 | 0                | TYPE_LIMIT | TIF_GTC |     cancel2      |
+
+    #When the network moves ahead "1" blocks
+    #Then the mark price should be "15900" for the market "ETH/FEB23"
+
+    And the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/FEB23"
+
+     # Broadcast significantly higher prices via the oracle
+    Then the oracles broadcast data with block time signed with "0xCAFECAFE1":
+      | name             | value | time offset |
+      | price1.USD.value | 26000 | 0s          |
+      | price2.USD.value | 25900 | 0s          |
+      | price3.USD.value | 25940 | 0s          |
+
+     Then the parties cancel the following orders:
+      | party  | reference  |
+      | buySideProvider | cancel1 |
+      | sellSideProvider | cancel2 |
+
+    And the parties place the following orders:
+      | party           | market id | side | volume   | price | resulting trades | type       | tif     | reference |
+      | buySideProvider | ETH/FEB23 | buy  | 1        | 15900 | 0                | TYPE_LIMIT | TIF_GTC |     cancel1      |
+      | sellSideProvider | ETH/FEB23 | sell  | 1      | 15900 | 0                | TYPE_LIMIT | TIF_GTC |     cancel2      |
+
+    When the network moves ahead "10" blocks
+    Then the mark price should be "15900" for the market "ETH/FEB23"
+
+    When the network moves ahead "2" blocks
+    Then the mark price should be "15900" for the market "ETH/FEB23"
+
+
+    

--- a/core/products/perpetual.go
+++ b/core/products/perpetual.go
@@ -74,7 +74,25 @@ func (a *auctionIntervals) update(t int64, enter bool) {
 	}
 
 	if enter {
-		a.auctionStart = t
+		if len(a.auctions) == 0 {
+			a.auctionStart = t
+			return
+		}
+
+		st, nd := a.auctions[len(a.auctions)-2], a.auctions[len(a.auctions)-1]
+		if t != nd {
+			a.auctionStart = t
+			return
+		}
+
+		a.auctions = slices.Delete(a.auctions, len(a.auctions)-2, len(a.auctions))
+		a.auctionStart = st
+		return
+	}
+
+	if t == a.auctionStart {
+		// left an auction as soon as we entered it, no need to log it
+		a.auctionStart = 0
 		return
 	}
 


### PR DESCRIPTION
close #10858 

The addition of the check that the mark price calculation can trigger a price auction was causing the book-keeping of enter/leaving auctions for perpetuals to become out of sync.

We now tell the perp that we are leaving when we call `as.Left()` and then update it again to entering an auction if the price-monitoring is triggered. The perpetual then just handles this zero length interval.

Another interesting thing is that the flow was a bit borked in `leaveAuction()` where price monitoring is triggered by the mark price calculation, we would never hit the call to `enterAuction()` after the call to `CalculateMarkPrice()` but would by luck start the auction by falling into `commandLiquidityAuction()`.

I've changed the check in `updateMarkPriceIfNotInAuction()` to properly return an `err` if we hit price-monitoring, hopefully this does not cause integration tests to fail.
