### PR TITLE
chore: remove unneeded workaround for auction

### DIFF
--- a/core/monitor/auction.go
+++ b/core/monitor/auction.go
@@ -122,12 +122,6 @@ func (a *AuctionState) EndGovernanceSuspensionAuction() {
 			a.trigger = types.AuctionTriggerUnspecified
 			a.start = false
 			a.stop = true
-			if a.m.State == types.MarketStateProposed {
-				// this is a workaround to the governance auction ending before
-				// market enters opening auction. When https://github.com/vegaprotocol/vega/issues/10976 is fixed
-				// this should probably be removed
-				a.start = true
-			}
 			a.begin = nil
 			a.end = nil
 		} else {


### PR DESCRIPTION
This is removing an unneeded workaround for leaving a governance auction before the market goes into opening auction. The workaround is not needed because it is not possible to call updateMarketState while there is still an open proposal for the market. The updateMarketState will fail with `original market proposal is still open` so it is not possible to suspend a market before it is in pending state therefore this workaround isn't needed. 

