### PR TITLE
fix: GetOrdersPerParty sorts before returning as a slice

### DIFF
--- a/core/matching/orderbook.go
+++ b/core/matching/orderbook.go
@@ -599,6 +599,11 @@ func (b *OrderBook) GetOrdersPerParty(party string) []*types.Order {
 	for oid := range orderIDs {
 		orders = append(orders, b.ordersByID[oid])
 	}
+
+	// sort before returning since callers will assume they are in a deterministic order
+	sort.Slice(orders, func(i, j int) bool {
+		return orders[i].ID < orders[j].ID
+	})
 	return orders
 }
 


### PR DESCRIPTION
closes #10985 

`processFeesTransfersOnEnterAuction()` in the spot code path was calling `m.matching.GetOrdersPerParty(party)` which was returning the orders in a non-deterministic way since they originated from a map. The result was that the events sent to the data-node relating to holding-account balances arrived in a different order which can throw off network history segment IDs.

Matching engine now always sorts the orders before it returns them as a slice.