### PR TITLE
refactor: address the underlying cause of #10997

### DIFF
--- a/core/execution/common/interfaces.go
+++ b/core/execution/common/interfaces.go
@@ -50,6 +50,7 @@ type OracleEngine interface {
 type PriceMonitor interface {
 	OnTimeUpdate(now time.Time)
 	CheckPrice(ctx context.Context, as price.AuctionState, trades []*types.Trade, persistent bool, recordInHistory bool) bool
+	ResetPriceHistory(trades []*types.Trade)
 	GetCurrentBounds() []*types.PriceMonitoringBounds
 	SetMinDuration(d time.Duration)
 	GetValidPriceRange() (num.WrappedDecimal, num.WrappedDecimal)

--- a/core/execution/common/mark_price.go
+++ b/core/execution/common/mark_price.go
@@ -275,12 +275,17 @@ func (mpc *CompositePriceCalculator) GetConfig() *types.CompositePriceConfigurat
 	return mpc.config
 }
 
-func (mpc *CompositePriceCalculator) updateMarkPriceIfNotInAuction(ctx context.Context, checkPriceMonitor bool, priceMonitor PriceMonitor, as AuctionState, mpcCandidate *num.Uint) error {
+func (mpc *CompositePriceCalculator) updateMarkPriceIfNotInAuction(ctx context.Context, checkPriceMonitor bool, priceMonitor PriceMonitor, as AuctionState, mpcCandidate *num.Uint, resetPriceMonitoringEngine bool) error {
 	if !checkPriceMonitor {
 		mpc.price = mpcCandidate
 		return nil
 	}
-	priceMonitor.CheckPrice(ctx, as, []*types.Trade{{Price: mpcCandidate, Size: 1}}, true, true)
+	t := []*types.Trade{{Price: mpcCandidate, Size: 1}}
+	if resetPriceMonitoringEngine {
+		priceMonitor.ResetPriceHistory(t)
+	} else {
+		priceMonitor.CheckPrice(ctx, as, t, true, true)
+	}
 	if as.InAuction() || as.AuctionStart() {
 		return fmt.Errorf("price monitoring failed for the new mark price")
 	}
@@ -290,13 +295,13 @@ func (mpc *CompositePriceCalculator) updateMarkPriceIfNotInAuction(ctx context.C
 
 // CalculateMarkPrice is called at the end of each mark price calculation interval and calculates the mark price
 // using the mark price type methodology.
-func (mpc *CompositePriceCalculator) CalculateMarkPrice(ctx context.Context, priceMonitor PriceMonitor, as AuctionState, t int64, ob *matching.CachedOrderBook, markPriceFrequency time.Duration, initialScalingFactor, slippageFactor, shortRiskFactor, longRiskFactor num.Decimal, checkPriceMonitor bool) (*num.Uint, error) {
+func (mpc *CompositePriceCalculator) CalculateMarkPrice(ctx context.Context, priceMonitor PriceMonitor, as AuctionState, t int64, ob *matching.CachedOrderBook, markPriceFrequency time.Duration, initialScalingFactor, slippageFactor, shortRiskFactor, longRiskFactor num.Decimal, checkPriceMonitor bool, resetPriceMonitoringEngine bool) (*num.Uint, error) {
 	var err error
 	if mpc.config.CompositePriceType == types.CompositePriceTypeByLastTrade {
 		// if there are no trades, the mark price remains what it was before.
 		if len(mpc.trades) > 0 {
 			mpcCandidate := mpc.trades[len(mpc.trades)-1].Price.Clone()
-			err = mpc.updateMarkPriceIfNotInAuction(ctx, checkPriceMonitor, priceMonitor, as, mpcCandidate)
+			err = mpc.updateMarkPriceIfNotInAuction(ctx, checkPriceMonitor, priceMonitor, as, mpcCandidate, resetPriceMonitoringEngine)
 		}
 		mpc.trades = []*types.Trade{}
 		return mpc.price, err
@@ -324,11 +329,11 @@ func (mpc *CompositePriceCalculator) CalculateMarkPrice(ctx context.Context, pri
 	}
 	if mpc.config.CompositePriceType == types.CompositePriceTypeByMedian {
 		if p := CompositePriceByMedian(mpc.priceSources, mpc.sourceLastUpdate, mpc.config.SourceStalenessTolerance, t); p != nil && !p.IsZero() {
-			err = mpc.updateMarkPriceIfNotInAuction(ctx, checkPriceMonitor, priceMonitor, as, p)
+			err = mpc.updateMarkPriceIfNotInAuction(ctx, checkPriceMonitor, priceMonitor, as, p, resetPriceMonitoringEngine)
 		}
 	} else {
 		if p := CompositePriceByWeight(mpc.priceSources, mpc.config.SourceWeights, mpc.sourceLastUpdate, mpc.config.SourceStalenessTolerance, t); p != nil && !p.IsZero() {
-			err = mpc.updateMarkPriceIfNotInAuction(ctx, checkPriceMonitor, priceMonitor, as, p)
+			err = mpc.updateMarkPriceIfNotInAuction(ctx, checkPriceMonitor, priceMonitor, as, p, resetPriceMonitoringEngine)
 		}
 	}
 	mpc.trades = []*types.Trade{}

--- a/core/execution/future/market_test.go
+++ b/core/execution/future/market_test.go
@@ -5191,7 +5191,17 @@ func TestMarket_LeaveAuctionAndRepricePeggedOrders(t *testing.T) {
 	require.NotNil(t, o2conf)
 	require.NoError(t, err)
 
-	require.Equal(t, int64(2), tm.market.GetOrdersOnBookCount())
+	o3 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order03", types.SideSell, "party-A", 1, 1000)
+	o3conf, err := tm.market.SubmitOrder(ctx, o3)
+	require.NotNil(t, o3conf)
+	require.NoError(t, err)
+
+	o4 := getMarketOrder(tm, now, types.OrderTypeLimit, types.OrderTimeInForceGTC, "Order04", types.SideBuy, "party-A", 1, 1000)
+	o4conf, err := tm.market.SubmitOrder(ctx, o4)
+	require.NotNil(t, o4conf)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(4), tm.market.GetOrdersOnBookCount())
 
 	lps := &types.LiquidityProvisionSubmission{
 		Fee:              num.DecimalFromFloat(0.01),

--- a/core/integration/features/mark-price/panic-upon-leaving-opening-auction.feature
+++ b/core/integration/features/mark-price/panic-upon-leaving-opening-auction.feature
@@ -1,0 +1,67 @@
+Feature: Test setting of first mark price with bound violation
+  Background:
+    Given the following network parameters are set:
+      | name                                    | value |
+      | network.markPriceUpdateMaximumFrequency | 4s    |
+      | limits.markets.maxPeggedOrders          | 2     |
+    And the liquidity monitoring parameters:
+      | name       | triggering ratio | time window | scaling factor |
+      | lqm-params | 0.00             | 24h         | 1e-9           |
+    And the simple risk model named "simple-risk-model":
+      | long | short | max move up | min move down | probability of trading |
+      | 0.1  | 0.1   | 100         | -100          | 0.2                    |
+    And the price monitoring named "price-monitoring":
+      | horizon | probability | auction extension |
+      | 5       | 0.99        | 3                 |
+    And the composite price oracles from "0xCAFECAFE1":
+      | name    | price property   | price type   | price decimals |
+      | oracle1 | prices.ETH.value | TYPE_INTEGER | 0              |
+    And the markets:
+      | id        | quote name | asset | liquidity monitoring | risk model        | margin calculator         | auction duration | fees         | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params      | price type | decay weight | decay power | cash amount | source weights | source staleness tolerance | oracle1 | market type |
+      | ETH/FEB23 | ETH        | USD   | lqm-params           | simple-risk-model | default-margin-calculator | 5                | default-none | price-monitoring | default-eth-for-future | 0.25                   | 0                         | default-futures | weight     | 0.1          | 0.5         | 500000      | 0,0,1,0        | 0s,0s,24h0m0s,0s           | oracle1 | future      |
+
+  Scenario: when mark price methodology hasn't provided a price at the point of uncrossing the opening auction (0009-MRKP-001,0009-MRKP-003)
+    Given the parties deposit on asset's general account the following amount:
+      | party             | asset | amount       |
+      | buySideProvider   | USD   | 100000000000 |
+      | sellSideProvider  | USD   | 100000000000 |
+      | lp1               | USD   | 100000000000 |
+    And the parties submit the following liquidity provision:
+      | id  | party  | market id | commitment amount | fee   | lp type    |
+      | lp1 | lp1    | ETH/FEB23 | 50000             | 0.001 | submission |
+      | lp1 | lp1    | ETH/FEB23 | 50000             | 0.001 | amendment  |
+    And the parties place the following pegged iceberg orders:
+      | party | market id | peak size | minimum visible size | side | pegged reference | volume  | offset |
+      | lp1   | ETH/FEB23 | 49        | 1                    | sell | ASK              | 49      | 20     |
+      | lp1   | ETH/FEB23 | 52        | 1                    | buy  | BID              | 52      | 20     |
+    And the parties place the following orders:
+      | party             | market id | side | volume | price  | resulting trades | type       | tif     | reference    |
+      | lp1               | ETH/FEB23 | buy  | 1      | 15899  | 0                | TYPE_LIMIT | TIF_GTC |              |
+      | lp1               | ETH/FEB23 | sell | 1      | 15901  | 0                | TYPE_LIMIT | TIF_GTC |              |
+      | buySideProvider   | ETH/FEB23 | buy  | 1      | 1      | 0                | TYPE_LIMIT | TIF_GTC |              |
+      | buySideProvider   | ETH/FEB23 | buy  | 1      | 15900  | 0                | TYPE_LIMIT | TIF_GTC |              |
+      | sellSideProvider  | ETH/FEB23 | sell | 1      | 15900  | 0                | TYPE_LIMIT | TIF_GTC |              |
+      | sellSideProvider  | ETH/FEB23 | sell | 1      | 100000 | 0                | TYPE_LIMIT | TIF_GTC |              |
+
+    When the network moves ahead "1" blocks
+    Then the mark price should be "0" for the market "ETH/FEB23"
+    And the trading mode should be "TRADING_MODE_OPENING_AUCTION" for the market "ETH/FEB23"
+
+    Then the oracles broadcast data with block time signed with "0xCAFECAFE1":
+      | name             | value | time offset |
+      | prices.ETH.value | 16000 | -1s         |
+    And the market data for the market "ETH/FEB23" should be:
+      | mark price | trading mode                 | horizon | min bound | max bound |
+      | 0          | TRADING_MODE_OPENING_AUCTION | 5       | 15801     | 15999     |
+
+
+    When the network moves ahead "5" blocks
+    And the market data for the market "ETH/FEB23" should be:
+      | mark price | trading mode                    | auction trigger             | horizon | min bound | max bound |
+    # | 16000      | TRADING_MODE_CONTINUOUS         | AUCTION_TRIGGER_UNSPECIFIED | 5       | 15900     | 16100     |
+      | 0          | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE       |         |           |           |
+    And the parties place the following orders with ticks:
+      | party             | market id | side | volume | price  | resulting trades | type       | tif     | reference    |
+      | buySideProvider   | ETH/FEB23 | buy  | 1      | 14000  | 0                | TYPE_LIMIT | TIF_GTC |              |
+      | sellSideProvider  | ETH/FEB23 | sell | 1      | 14000  | 0                | TYPE_LIMIT | TIF_GTC |              |
+    

--- a/core/integration/features/mark-price/panic-upon-leaving-opening-auction.feature
+++ b/core/integration/features/mark-price/panic-upon-leaving-opening-auction.feature
@@ -58,8 +58,7 @@ Feature: Test setting of first mark price with bound violation
     When the network moves ahead "5" blocks
     And the market data for the market "ETH/FEB23" should be:
       | mark price | trading mode                    | auction trigger             | horizon | min bound | max bound |
-    # | 16000      | TRADING_MODE_CONTINUOUS         | AUCTION_TRIGGER_UNSPECIFIED | 5       | 15900     | 16100     |
-      | 0          | TRADING_MODE_MONITORING_AUCTION | AUCTION_TRIGGER_PRICE       |         |           |           |
+      | 16000      | TRADING_MODE_CONTINUOUS         | AUCTION_TRIGGER_UNSPECIFIED | 5       | 15900     | 16100     |
     And the parties place the following orders with ticks:
       | party             | market id | side | volume | price  | resulting trades | type       | tif     | reference    |
       | buySideProvider   | ETH/FEB23 | buy  | 1      | 14000  | 0                | TYPE_LIMIT | TIF_GTC |              |

--- a/core/integration/features/verified/0044-LIME_lp_at_termination.feature
+++ b/core/integration/features/verified/0044-LIME_lp_at_termination.feature
@@ -147,8 +147,8 @@ Feature: Test LP bond account when market is terminated
     #And time is updated to "2020-01-01T01:01:01Z"
     Then the market state should be "STATE_TRADING_TERMINATED" for the market "ETH/MAR22"
     And the market data for the market "ETH/MAR22" should be:
-      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
-      | 1120       | TRADING_MODE_NO_TRADING | 360000  | 786       | 1361      | 63739        | 3240           | 16            |
+      | mark price | trading mode            | horizon | ref price | min bound | max bound | target stake | supplied stake | open interest |
+      | 1120       | TRADING_MODE_NO_TRADING | 360000  | 1060      | 801       | 1387      | 63739        | 3240           | 16            |
 
     Then the oracles broadcast data signed with "0xCAFECAFE19":
       | name             | value |

--- a/core/monitor/price/pricemonitoring.go
+++ b/core/monitor/price/pricemonitoring.go
@@ -272,7 +272,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, trades []*type
 		}
 		// only reset history if there isn't any (we need to initialise the engine) or we're still in opening auction as in that case it's based on previous indicative prices which are no longer relevant
 		if (recordPriceHistory && e.noHistory()) || as.IsOpeningAuction() {
-			e.resetPriceHistory(trades)
+			e.ResetPriceHistory(trades)
 		}
 		e.initialised = true
 	}
@@ -312,7 +312,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, trades []*type
 	// opening auction -> ignore
 	if as.IsOpeningAuction() {
 		if recordPriceHistory {
-			e.resetPriceHistory(trades)
+			e.ResetPriceHistory(trades)
 		}
 		return false
 	}
@@ -329,7 +329,7 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, trades []*type
 			// auction can be terminated
 			as.SetReadyToLeave()
 			// reset the engine
-			e.resetPriceHistory(trades)
+			e.ResetPriceHistory(trades)
 			return false
 		}
 		// liquidity auction, and it was safe to end -> book is OK, price was OK, reset the engine
@@ -352,8 +352,8 @@ func (e *Engine) CheckPrice(ctx context.Context, as AuctionState, trades []*type
 	return false
 }
 
-// resetPriceHistory deletes existing price history and starts it afresh with the supplied value.
-func (e *Engine) resetPriceHistory(trades []*types.Trade) {
+// ResetPriceHistory deletes existing price history and starts it afresh with the supplied value.
+func (e *Engine) ResetPriceHistory(trades []*types.Trade) {
 	e.update = e.now
 	if len(trades) > 0 {
 		pricesNow := make([]currentPrice, 0, len(trades))


### PR DESCRIPTION
This PR proses to extend the existing behaviour (price history within price monitoring engine being continually reset whlist in opening auction) to the first mark price update after leaving opening auction (this is guaranteed to exist as we fall back on last traded price if no other sources exist at that stage).

Done as part of https://github.com/vegaprotocol/vega/issues/10997 investigation which was already addressed with an umbrella fix here: https://github.com/vegaprotocol/vega/pull/11007

