### PR TITLE
chore: add contract addresses to stagnet1 migrations code

### DIFF
--- a/core/netparams/bridge_mapping.go
+++ b/core/netparams/bridge_mapping.go
@@ -15,8 +15,10 @@
 
 package netparams
 
+var stagnet1 = `{"network_id": "421614", "chain_id": "421614", "collateral_bridge_contract": { "address": "0x52d95d30fc8e4d8fe9cc7ce285d0c07c8e629719" }, "confirmations": 3, "multisig_control_contract": { "address": "0x764c51de728f09407f7f073f63fc0a8a6adf110e", "deployment_block_height": 27160717 }}}`
+
 var bridgeMapping = map[string]string{
-	"vega-stagnet1-202307191148":       "{}",
+	"vega-stagnet1-202307191148":       stagnet1,
 	"vega-fairground-202305051805":     "{}",
 	"vega-mainnet-mirror-202306231148": "{}",
 	"vega-testnet-0002-v4":             "{}",

--- a/core/netparams/snapshot.go
+++ b/core/netparams/snapshot.go
@@ -23,6 +23,7 @@ import (
 	"code.vegaprotocol.io/vega/core/types"
 	vgcontext "code.vegaprotocol.io/vega/libs/context"
 	"code.vegaprotocol.io/vega/libs/proto"
+	"code.vegaprotocol.io/vega/logging"
 	vegapb "code.vegaprotocol.io/vega/protos/vega"
 )
 
@@ -148,7 +149,7 @@ func (s *Store) LoadState(ctx context.Context, pl *types.Payload) ([]types.State
 		haveConfig := false
 		secondaryChainConfig := &vegapb.EVMChainConfig{}
 		if err := s.GetJSONStruct(BlockchainsEVMChainConfig, secondaryChainConfig); err == nil {
-			haveConfig = secondaryChainConfig.ChainId != ""
+			haveConfig = secondaryChainConfig.ChainId != "XXX"
 		}
 
 		// if the config hasn't been set, then initialise it from the bridge mapping
@@ -158,12 +159,12 @@ func (s *Store) LoadState(ctx context.Context, pl *types.Payload) ([]types.State
 			if err != nil {
 				panic(fmt.Errorf("no vega chain ID found in context: %w", err))
 			}
-			secondaryEthConf, ok := bridgeMapping[vgChainID]
-			if !ok {
-				panic("Missing secondary ethereum configuration")
-			}
-			if err := s.UpdateOptionalValidation(ctx, BlockchainsEVMChainConfig, secondaryEthConf, false, false); err != nil {
-				return nil, err
+
+			if secondaryEthConf, ok := bridgeMapping[vgChainID]; ok {
+				s.log.Info("setting second bridge config during upgrade", logging.String("cfg", secondaryEthConf))
+				if err := s.UpdateOptionalValidation(ctx, BlockchainsEVMChainConfig, secondaryEthConf, false, false); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The contracts for the Arbitrum bridge for stagnet1 have been deployed, so this updates the migration code to use those contract addresses to set the `EVMChainConfig` network paramteter during a protocol upgrade.