### PR TITLE
fix: providing an invalid date-range to ListBalanceChanges no longer …

### DIFF
--- a/datanode/api/errors.go
+++ b/datanode/api/errors.go
@@ -340,7 +340,7 @@ var (
 	// ErrGetTimeWeightedNotionalPosition is returned when the time weighted notional position cannot be retrieved.
 	ErrGetTimeWeightedNotionalPosition = errors.New("failed to get time weighted notional position")
 
-	ErrDateRangeValidationFailed = errors.New("invalid date range")
+	ErrDateRangeValidationFailed = newInvalidArgumentError("invalid date range")
 )
 
 // errorMap contains a mapping between errors and Vega numeric error codes.

--- a/datanode/entities/date_range.go
+++ b/datanode/entities/date_range.go
@@ -29,12 +29,12 @@ type DateRange struct {
 }
 
 var (
-	ErrInvalidDateRange   = errors.New("invalid date range, date range is required")
-	ErrMinimumDate        = errors.New("date range start must be after 2020-01-01")
-	ErrEndDateBeforeStart = errors.New("date range start must be before end")
-	ErrDateRangeTooLong   = errors.New("date range is too long")
-	minimumDate           = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	maximumDuration       = time.Hour * 24 * 365 // 1 year maximum duration
+	ErrDateRangeIsRequired = errors.New("date range is required")
+	ErrMinimumDate         = errors.New("date range start must be after 2020-01-01")
+	ErrEndDateBeforeStart  = errors.New("date range start must be before end")
+	ErrDateRangeTooLong    = errors.New("date range is too long")
+	minimumDate            = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	maximumDuration        = time.Hour * 24 * 365 // 1 year maximum duration
 )
 
 func DateRangeFromProto(dateRangeInput *v2.DateRange) (dateRange DateRange) {
@@ -59,7 +59,7 @@ func (dr DateRange) Validate(required bool) error {
 	}
 
 	if required && dr.Start == nil && dr.End == nil {
-		return ErrInvalidDateRange
+		return ErrDateRangeIsRequired
 	}
 
 	if dr.Start != nil && dr.Start.Before(minimumDate) {

--- a/datanode/entities/date_range_test.go
+++ b/datanode/entities/date_range_test.go
@@ -41,7 +41,7 @@ func TestDateRange_Validate(t *testing.T) {
 				End:      nil,
 				Required: true,
 			},
-			Err: entities.ErrInvalidDateRange,
+			Err: entities.ErrDateRangeIsRequired,
 		},
 		{
 			name: "Should not error if not required and no dates provided",


### PR DESCRIPTION
Looking into why a call to `ListBalanceChanges` on the overnight run was returning `500`, turns out its not an internal-error and just a mis-labled error. Not providing a date-range now returns `InvalidArgument`