### PR TITLE
fix: wire in liquidity fee settings when updating a spot market

### DIFF
--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -1212,6 +1212,7 @@ func (e *Engine) updatedSpotMarketFromProposal(p *proposal) (*types.Market, type
 			TargetStakeParameters:     terms.Changes.TargetStakeParameters,
 			SLAParams:                 terms.Changes.SLAParams,
 			TickSize:                  terms.Changes.TickSize,
+			LiquidityFeeSettings:      terms.Changes.LiquidityFeeSettings,
 		},
 	}
 

--- a/core/types/governance_update_spot_market.go
+++ b/core/types/governance_update_spot_market.go
@@ -129,6 +129,7 @@ type UpdateSpotMarketConfiguration struct {
 	SLAParams                 *LiquiditySLAParams
 	TickSize                  *num.Uint
 	Instrument                *InstrumentConfiguration
+	LiquidityFeeSettings      *LiquidityFeeSettings
 }
 
 func (n UpdateSpotMarketConfiguration) String() string {
@@ -163,6 +164,10 @@ func (n UpdateSpotMarketConfiguration) DeepClone() *UpdateSpotMarketConfiguratio
 	if n.RiskParameters != nil {
 		cpy.RiskParameters = n.RiskParameters.DeepClone()
 	}
+
+	if n.LiquidityFeeSettings != nil {
+		cpy.LiquidityFeeSettings = n.LiquidityFeeSettings.DeepClone()
+	}
 	return cpy
 }
 
@@ -177,6 +182,11 @@ func (n UpdateSpotMarketConfiguration) IntoProto() *vegapb.UpdateSpotMarketConfi
 	}
 	targetStakeParameters := n.TargetStakeParameters.IntoProto()
 
+	var liquidityFeeSettings *vegapb.LiquidityFeeSettings
+	if n.LiquidityFeeSettings != nil {
+		liquidityFeeSettings = n.LiquidityFeeSettings.IntoProto()
+	}
+
 	r := &vegapb.UpdateSpotMarketConfiguration{
 		Metadata:                  md,
 		PriceMonitoringParameters: priceMonitoring,
@@ -187,6 +197,7 @@ func (n UpdateSpotMarketConfiguration) IntoProto() *vegapb.UpdateSpotMarketConfi
 			Code: n.Instrument.Code,
 			Name: n.Instrument.Name,
 		},
+		LiquidityFeeSettings: liquidityFeeSettings,
 	}
 	switch rp := riskParams.(type) {
 	case *vegapb.UpdateSpotMarketConfiguration_Simple:
@@ -219,6 +230,7 @@ func UpdateSpotMarketConfigurationFromProto(p *vegapb.UpdateSpotMarketConfigurat
 		TargetStakeParameters:     targetStakeParameters,
 		SLAParams:                 slaParams,
 		TickSize:                  tickSize,
+		LiquidityFeeSettings:      LiquidityFeeSettingsFromProto(p.LiquidityFeeSettings),
 		Instrument: &InstrumentConfiguration{
 			Name: p.Instrument.Name,
 			Code: p.Instrument.Code,


### PR DESCRIPTION
Missing plumbing for updating the liqudity-fee-settings for a spot market.