### PR TITLE
fix: do migration of asset chain-id for non-validator nodes later

### DIFF
--- a/core/assets/erc20/erc20.go
+++ b/core/assets/erc20/erc20.go
@@ -92,6 +92,13 @@ func (e *ERC20) SetEnabled() {
 	e.asset.Status = types.AssetStatusEnabled
 }
 
+// SetChainID sets the chain-id on the ERC20. This should only be used during the migration from 0.75.
+func (e *ERC20) SetChainID(chainID string) {
+	e.chainID = chainID
+	source := e.asset.Details.Source.(*types.AssetDetailsErc20)
+	source.ERC20.ChainID = chainID
+}
+
 func (e *ERC20) Update(updatedAsset *types.Asset) {
 	e.asset = updatedAsset
 }


### PR DESCRIPTION
This fixes the migration of added the chain-id to existing assets during snapshot restore.

The problem is that validator nodes need to restore the assets before the network parameters, and thats fine because they have a client they can use to ask for the chain-id.

Non-validator nodes do not have a client, and only get the knowledge of the bridge chain-id's *after* the network parameters have been restored. So for non-validator nodes to do the migration, they need a separate code path where they are update the asset at a later time.

It is very hacky.