### PR TITLE
fix: add missing migration for recreating the stop order views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 - [11059](https://github.com/vegaprotocol/vega/issues/11059) - Disambiguate `vega_time` in order clause.
 - [11052](https://github.com/vegaprotocol/vega/pull/11052) - Add missing rejection reason in GraphQL schema for proposals
 - [11073](https://github.com/vegaprotocol/vega/issues/11073) - Handle properly price factor < 1.
-
+- [11047](https://github.com/vegaprotocol/vega/issues/11047) - Add missing migration for recreating stop order views after the new fields were added.
 
 ## 0.75.0
 

--- a/datanode/networkhistory/service_test.go
+++ b/datanode/networkhistory/service_test.go
@@ -379,12 +379,12 @@ func TestMain(t *testing.M) {
 		log.Infof("%s", goldenSourceHistorySegment[4000].HistorySegmentID)
 		log.Infof("%s", goldenSourceHistorySegment[5000].HistorySegmentID)
 
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmNamf1t4fZmP9eZ2wMLK8c8Ab94n9PVYtpQjwdzwsu1ZG", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmPT5BkGGpuPyL4FLeM3fw7Xya4AtXrzBPeYGyddroQCxM", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmWohMzcR8doH8hXdyQZuk7uoTKq8qsXqt8k2RonVH6KhB", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmX4MtWhvM6W1cLjoJuGhn9EcqBovXx5E7sS4R9h6U5dBk", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "Qmf6ztLD5845GymWGv33KaZVSEf2MixdhXL8twVWQX5UHn", snapshots)
-		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmeVZMcD7S2EKYkDdHeGK2hr1bz7UAztbKYgGE6uMCCoJz", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[1000].HistorySegmentID, "QmaSNkTp4sUuzvc9f2FW1XPtTWFPnxGk5GnCHV19wjaqkn", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2000].HistorySegmentID, "QmcKPSYtyg1aipGrF8mhwRRT6Ar4npmA3sDt9cTi76kKrY", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[2500].HistorySegmentID, "QmWp4viRfWLeVNjhNQ6ApXVSDSN7EGSqw4RgP8ury2BJaW", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[3000].HistorySegmentID, "QmbPnBztA2oKu82cQV3S4aQ4wGZbQtWzJcVQiT262xWBWY", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[4000].HistorySegmentID, "QmWPtPwvR6GHAmgzoE1RMJCdXnqSwP3ieKrjkb8txCE7XV", snapshots)
+		panicIfHistorySegmentIdsNotEqual(goldenSourceHistorySegment[5000].HistorySegmentID, "QmaytzsEDc3zynRW2CN4wy7VBpYoi6FQNwjTLFxZvsFMbA", snapshots)
 	}, postgresRuntimePath, sqlFs)
 
 	if exitCode != 0 {

--- a/datanode/sqlstore/migrations/0079_stop_orders_linked_to_order_or_position.sql
+++ b/datanode/sqlstore/migrations/0079_stop_orders_linked_to_order_or_position.sql
@@ -4,8 +4,4 @@ alter table stop_orders
     add column if not exists size_override_setting int not null default 0,
     add column if not exists size_override_value varchar null;
 
--- +goose Down
 
-alter table stop_orders
-    drop column if exists size_override_setting,
-    drop column if exists size_override_value;

--- a/datanode/sqlstore/migrations/0104_recreate_stop_order_views.sql
+++ b/datanode/sqlstore/migrations/0104_recreate_stop_order_views.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+
+create or replace view stop_orders_current_desc
+as
+    select distinct on (so.created_at, so.id) *
+    from stop_orders so
+    order by so.created_at desc, so.id, so.vega_time desc, so.seq_num desc;
+
+create or replace view stop_orders_current_desc_by_market
+as
+    select distinct on (so.created_at, so.market_id, so.id) *
+    from stop_orders so
+    order by so.created_at desc, so.market_id, so.id, so.vega_time desc, so.seq_num desc;
+
+create or replace view stop_orders_current_desc_by_party
+as
+select distinct on (so.created_at, so.party_id, so.id) *
+from stop_orders so
+order by so.created_at desc, so.party_id, so.id, so.vega_time desc, so.seq_num desc;
+
+alter table stop_orders_live
+    add column if not exists size_override_setting int not null default 0,
+    add column if not exists size_override_value varchar null;
+
+-- +goose StatementBegin
+create or replace function stop_orders_live_insert_trigger()
+returns trigger
+    language plpgsql
+    as $$
+begin
+    delete from stop_orders_live
+    where id = new.id;
+
+    if new.status in ('STATUS_UNSPECIFIED', 'STATUS_PENDING') then
+        insert into stop_orders_live
+        values (new.id, new.oco_link_id, new.expires_at, new.expiry_strategy, new.trigger_direction, new.status,
+                new.created_at, new.updated_at, new.order_id, new.trigger_price, new.trigger_percent_offset, new.party_id,
+                new.market_id, new.vega_time, new.seq_num, new.tx_hash, new.submission, new.size_override_setting, new.size_override_value);
+    end if;
+
+    return new;
+end;
+$$;
+
+-- +goose StatementEnd
+
+drop trigger if exists stop_orders_live_insert_trigger on stop_orders;
+create trigger stop_orders_live_insert_trigger before insert on stop_orders for each row execute function stop_orders_live_insert_trigger();


### PR DESCRIPTION
Closes #11047 

The problem is that when the override fields were added to the stop order db schema, the views which are used for querying were not recreated so the views don't have the fields so always set to 0 in the API. In addition, the hyper table wasn't updated. 