### PR TITLE
fix: coverage for 0042-LIQF-091 not correctly labelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,8 @@
 - [11047](https://github.com/vegaprotocol/vega/issues/11047) - Add missing migration for recreating stop order views after the new fields were added.
 - [11090](https://github.com/vegaprotocol/vega/issues/11090) - Games API should only use the current team members.
 - [11089](https://github.com/vegaprotocol/vega/issues/11089) - Add tests for proto `enums` persisted to database.
-- [11105](https://github.com/vegaprotocol/vega/issues/11105) - Include all paid fees in reward cap. 
-
+- [11105](https://github.com/vegaprotocol/vega/issues/11105) - Include all paid fees in reward cap.
+- [1109](https://github.com/vegaprotocol/core-test-coverage/issues/1109) - Correctly label acceptance coverage for `0042-LIQF-091`.
 
 ## 0.75.0
 

--- a/core/integration/features/verified/0042-LIQF-SLA_spot.feature
+++ b/core/integration/features/verified/0042-LIQF-SLA_spot.feature
@@ -305,7 +305,7 @@ Feature: Calculating SLA Performance
       | lp1  |     | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | BTC/ETH   | 25     | ETH   |
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL                           | BTC/ETH   | 25     | ETH   |
 
-  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-090)(0042-LIQF-101)(0042-LIQF-104)
+  Scenario: LPs average penalty over the last N epochs is worse then their current performance when performance hysteresis epochs is > 1. (0042-LIQF-090)(0042-LIQF-101)(0042-LIQF-104)(0042-LIQF-091)
     # Initialise the market with the required parameters
     Given the liquidity sla params named "scenario-sla-params":
       | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
@@ -563,4 +563,3 @@ Feature: Calculating SLA Performance
       |      | lp1 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL           | BTC/ETH   | 24673  | ETH   |
       |      | lp2 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL           | BTC/ETH   | 2344   | ETH   |
       |      | lp3 | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL           | BTC/ETH   | 69087  | ETH   |
-


### PR DESCRIPTION
Closes https://github.com/vegaprotocol/core-test-coverage/issues/1109

The feature tests were just not correctly labelled to include the AC for this one