### PR TITLE
chore: stop panic when relaod config on non-validator's who don't nee…

### DIFF
--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -543,7 +543,11 @@ func (svcs *allServices) registerConfigWatchers() {
 		func(cfg config.Config) { svcs.notary.ReloadConf(cfg.Notary) },
 		func(cfg config.Config) { svcs.primaryEventForwarderEngine.ReloadConf(cfg.EvtForward.Ethereum) },
 		func(cfg config.Config) { svcs.primaryEventForwarder.ReloadConf(cfg.EvtForward) },
-		func(cfg config.Config) { svcs.secondaryEventForwarderEngine.ReloadConf(cfg.EvtForward.EVMBridges[0]) },
+		func(cfg config.Config) {
+			if len(cfg.EvtForward.EVMBridges) > 0 {
+				svcs.secondaryEventForwarderEngine.ReloadConf(cfg.EvtForward.EVMBridges[0])
+			}
+		},
 		func(cfg config.Config) { svcs.topology.ReloadConf(cfg.Validators) },
 		func(cfg config.Config) { svcs.witness.ReloadConf(cfg.Validators) },
 		func(cfg config.Config) { svcs.assets.ReloadConf(cfg.Assets) },


### PR DESCRIPTION
Overnight network-infra runs have been having their non-validator node's panicking:
```
{"err": "runtime error: index out of range [0] with length 0", "stack": "goroutine 268 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x5e\ngithub.com/cometbft/cometbft/consensus.(*State).receiveRoutine.func2()\n\t/jenkins/GOPATH/pkg/mod/github.com/cometbft/cometbft@v0.38.6/consensus/state.go:801 +0x46\npanic({0x5617020?, 0xc013cedef0?})\n\t/usr/local/go/src/runtime/panic.go:914 +0x21f\ncode.vegaprotocol.io/vega/core/protocol.(*allServices).registerConfigWatchers.func5({{{0x0}, {{0xc000da5ec0, 0x57}, {0xc013ed1d40, 0x4}}}, {{0x0}, {0x12a05f200}, 0xbec, {0xc013ed1380, 0x7}, ...}, ...})\n\t/jenkins/workspace/common/system-tests-wrapper/vega/core/protocol/all_services.go:546
```

because they don't have (and don't need) the config options for the second bridge clients etc. but when the config is reloaded it assumes it will be in the config.