### PR TITLE
fix: manually set defaults for unset values in EVM bridge configs sin…

### DIFF
--- a/core/evtforward/ethereum/config.go
+++ b/core/evtforward/ethereum/config.go
@@ -43,3 +43,13 @@ func NewDefaultConfig() Config {
 		MaxEthereumBlocks:      maxEthereumBlocks,
 	}
 }
+
+func (c *Config) setDefaults() {
+	if c.MaxEthereumBlocks == 0 {
+		c.MaxEthereumBlocks = maxEthereumBlocks
+	}
+
+	if c.PollEventRetryDuration.Duration == 0 {
+		c.PollEventRetryDuration.Duration = defaultDurationBetweenTwoRetry
+	}
+}

--- a/core/evtforward/ethereum/engine.go
+++ b/core/evtforward/ethereum/engine.go
@@ -94,6 +94,11 @@ func NewEngine(
 ) *Engine {
 	l := log.Named(engineLogger)
 
+	// given that the EVM bridge configs are and array the "unset" values do not get populated
+	// with reasonable defaults so we need to make sure they are set to something reasonable
+	// if they are left out
+	cfg.setDefaults()
+
 	return &Engine{
 		cfg:                            cfg,
 		log:                            l,


### PR DESCRIPTION
Now that the EVm bridge configs are an array, default values are no longer being set for fields left unset. For example in system-tests `MaxEthereumBlocks` was left unset which caused it to come through as `0` which isn't great.

So now we always check for unset values for the important fields and set them to the defaults by hand.