### PR TITLE
fix: allow market maker to vote on governance proposal with their ELS only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [11158](https://github.com/vegaprotocol/vega/issues/11158) - resolve the quote asset for fee estimation in spot market.
 - [11143](https://github.com/vegaprotocol/vega/issues/11143) - Add support for new asset proposal in batch governance proposal
 - [11182](https://github.com/vegaprotocol/vega/issues/11182) - Remove reduce only restriction on spot markets stop orders.
+- [11057](https://github.com/vegaprotocol/vega/issues/11057) - Allow market maker to vote on governance proposals with their equity like shares only.
 
 ### 🐛 Fixes
 

--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -948,9 +948,15 @@ func (e *Engine) canVote(
 	params *types.ProposalParameters,
 	party string,
 ) error {
+	// Here the error can only happen in case the party
+	// have no balances, which is not an error per se
+	// and we should keep going.
+	// This would allow us to go further in case a
+	// party is a market maker and they'd be voting
+	// with their equity like share.
 	voterTokens, err := getGovernanceTokens(e.accs, party)
 	if err != nil {
-		return err
+		voterTokens = num.UintZero()
 	}
 
 	if proposal.IsMarketUpdate() || proposal.IsSpotMarketUpdate() {
@@ -970,6 +976,10 @@ func (e *Engine) canVote(
 			return ErrVoterInsufficientTokens
 		}
 	} else {
+		// here the party had no balance, return existing error
+		if err != nil {
+			return err
+		}
 		if voterTokens.LT(params.MinVoterBalance) {
 			return ErrVoterInsufficientTokens
 		}


### PR DESCRIPTION
fix: do not return error on non existing balance when checking for governance vote until ELS are checked


close #11057  