### PR TITLE
feat: add a check on node started that EVM chain RPC nodes are config…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [11158](https://github.com/vegaprotocol/vega/issues/11158) - resolve the quote asset for fee estimation in spot market.
 - [11143](https://github.com/vegaprotocol/vega/issues/11143) - Add support for new asset proposal in batch governance proposal
 - [11182](https://github.com/vegaprotocol/vega/issues/11182) - Remove reduce only restriction on spot markets stop orders.
+- [11153](https://github.com/vegaprotocol/vega/issues/11153) - Add check on start-up that bridge `RPC-endpoints` are functional.
 
 ### 🐛 Fixes
 

--- a/core/evtforward/engine.go
+++ b/core/evtforward/engine.go
@@ -139,6 +139,10 @@ func (e *Engine) SetupEthereumEngine(
 		e.ethEngine.UpdateStakingStartingBlock(e.stakingStartingBlock)
 	}
 
+	if err := filterer.VerifyClient(context.Background()); err != nil {
+		return err
+	}
+
 	e.Start()
 
 	return nil
@@ -202,6 +206,10 @@ func (e *Engine) SetupSecondaryEthereumEngine(
 	}
 	if e.stakingStartingBlock != 0 {
 		e.ethEngine.UpdateStakingStartingBlock(e.stakingStartingBlock)
+	}
+
+	if err := filterer.VerifyClient(context.Background()); err != nil {
+		return err
 	}
 
 	e.Start()

--- a/core/evtforward/ethereum/config.go
+++ b/core/evtforward/ethereum/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	MaxEthereumBlocks      uint64            `long:"max-ethereum-blocks"`
 	PollEventRetryDuration encoding.Duration
 	ChainID                string
+	SkipClientVerification bool
 }
 
 func NewDefaultConfig() Config {


### PR DESCRIPTION
closes #11153 

Validators with Ethereum/Atrbitrum nodes configured that are unable to query contract logs will now fail to start.

I've added a handy `SkipClientVerification` config option to override the check in case it causes trouble in our environments in times when we simply want the Vega network running.

Note that I've had to skip the check in the system-tests since the deployment height of the multisig is different between the `arm64` and `amd64` docker images, so I can't set a height in the genesis file that will work both on the CI and locally for me:
```
{
    "system-tests": "set-multisig-deployment-heights",
    "vegacapsule": "update-vega"
}
```