### PR TITLE
chore: fix transfer interval in schema to use camel case

### DIFF
--- a/datanode/gateway/graphql/schema.graphql
+++ b/datanode/gateway/graphql/schema.graphql
@@ -1487,7 +1487,7 @@ type DispatchStrategy {
   capRewardFeeMultiple: String
 
   "Interval for the distribution of the transfer"
-  transfer_interval: Int!
+  transferInterval: Int
 }
 
 type RankTable {


### PR DESCRIPTION
correct the notation of transfer_interval to transferInterval in GQL schema and make it optional as it should be. 