### PR TITLE
fix: AMM tradable-volume query should respect its fair-price

### DIFF
--- a/core/execution/amm/engine_test.go
+++ b/core/execution/amm/engine_test.go
@@ -265,10 +265,10 @@ func testSubmitOrderAcrossAMMBoundary(t *testing.T) {
 
 	// second round, 2 orders moving all pool's to the upper boundary of the second shortest
 	assert.Equal(t, "2124", orders[3].Price.String())
-	assert.Equal(t, "2125", orders[4].Price.String())
+	assert.Equal(t, "2124", orders[4].Price.String())
 
 	// third round, 1 orders moving the last pool to its boundary
-	assert.Equal(t, "2175", orders[5].Price.String())
+	assert.Equal(t, "2174", orders[5].Price.String())
 }
 
 func testSubmitOrderAcrossAMMBoundarySell(t *testing.T) {
@@ -333,7 +333,7 @@ func testBestPricesAndVolume(t *testing.T) {
 		whenAMMIsSubmitted(t, tst, submit)
 	}
 
-	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(9).Return(
+	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).AnyTimes().Return(
 		[]events.MarketPosition{&marketPosition{size: 0, averageEntry: num.NewUint(0)}},
 	)
 
@@ -344,9 +344,6 @@ func testBestPricesAndVolume(t *testing.T) {
 	assert.Equal(t, 35781, int(avolume))
 
 	// test GetVolumeAtPrice returns the same volume given best bid/ask
-	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(6 * 2).Return(
-		[]events.MarketPosition{&marketPosition{size: 0, averageEntry: num.NewUint(0)}},
-	)
 	bvAt := tst.engine.GetVolumeAtPrice(bid, types.SideSell)
 	assert.Equal(t, bvolume, bvAt)
 	avAt := tst.engine.GetVolumeAtPrice(ask, types.SideBuy)

--- a/core/execution/amm/pool.go
+++ b/core/execution/amm/pool.go
@@ -572,6 +572,17 @@ func (p *Pool) TradableVolumeInRange(side types.Side, price1 *num.Uint, price2 *
 		st, nd = nd, st
 	}
 
+	fp := p.fairPrice()
+	if side == types.SideSell {
+		// want all buy volume so everything below fair price
+		nd = num.Min(fp, nd)
+	}
+
+	if side == types.SideBuy {
+		// want all sell volume so everything above fair price
+		st = num.Max(fp, st)
+	}
+
 	var other *curve
 	var volume uint64
 	// get the curve based on the pool's current position, if the position is zero we take the curve the trade will put us in

--- a/core/integration/features/amm/0090-VAMM-006-014.feature
+++ b/core/integration/features/amm/0090-VAMM-006-014.feature
@@ -479,7 +479,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 95         | TRADING_MODE_CONTINUOUS | 100       | 120       | 120              | 121              | 119            |
     And the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
-      | party5 | 114   | 65   | vamm1-id | true   |
+      | party5 | 114   | 64   | vamm1-id | true   |
     # Check the resulting position, vAMM further increased their position
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
@@ -488,5 +488,5 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party2   | -1     | -14            | 0            |        |
       | party3   | -350   | -3150          | 0            |        |
       | party4   | 420    | 7980           | 0            |        |
-      | party5   | 65     | 0              | 0            |        |
-      | vamm1-id | -135   | -1330          | -3500        | true   |
+      | party5   | 64     | 0              | 0            |        |
+      | vamm1-id | -134   | -1330          | -3500        | true   |


### PR DESCRIPTION
The method `TradableVolumeInRange()` on an AMM wasn't quite right and would sometimes calculate too much volume because we weren't considering the pool's fair price.