### PR TITLE
fix: do not account for started block in the past block range

### DIFF
--- a/core/pow/engine.go
+++ b/core/pow/engine.go
@@ -250,7 +250,7 @@ func (e *Engine) updatePowState(txs []abci.Tx) {
 	}
 
 	for i, p := range e.activeParams {
-		outOfScopeBlock := int64(e.currentBlock) + 1 - int64(p.spamPoWNumberOfPastBlocks)
+		outOfScopeBlock := int64(e.currentBlock) - int64(p.spamPoWNumberOfPastBlocks)
 		if outOfScopeBlock < 0 {
 			continue
 		}

--- a/core/pow/engine_test.go
+++ b/core/pow/engine_test.go
@@ -232,7 +232,7 @@ func TestDeliverTxDuplciateNonce(t *testing.T) {
 	require.Equal(t, 2, len(e.heightToNonceRef[100]))
 
 	// check the maps are purged when we leave scope
-	e.BeginBlock(104, crypto.RandomHash(), []abci.Tx{})
+	e.BeginBlock(105, crypto.RandomHash(), []abci.Tx{})
 	require.Equal(t, 0, len(e.seenTid))
 	require.Equal(t, 0, len(e.heightToTid))
 	require.Equal(t, 0, len(e.heightToNonceRef))


### PR DESCRIPTION
Quick fix for testnet duplicate order