### PR TITLE
fix: volume change for price calcs is signed based on buy or sell

### DIFF
--- a/core/execution/amm/engine_test.go
+++ b/core/execution/amm/engine_test.go
@@ -160,9 +160,14 @@ func testBasicSubmitOrder(t *testing.T) {
 		Price:     num.NewUint(1900),
 	}
 
+	// fair-price is now 2020
+	bb, _, ba, _ := tst.engine.BestPricesAndVolumes()
+	assert.Equal(t, "2019", bb.String())
+	assert.Equal(t, "2021", ba.String())
+
 	orders = tst.engine.SubmitOrder(agg, num.NewUint(2020), num.NewUint(1990))
 	require.Len(t, orders, 1)
-	assert.Equal(t, "2035", orders[0].Price.String())
+	assert.Equal(t, "2004", orders[0].Price.String())
 	// note that this volume being bigger than 242367 above means we've moved back to position, then flipped
 	// sign, and took volume from the other curve.
 	assert.Equal(t, 362325, int(orders[0].Size))
@@ -189,7 +194,7 @@ func testSubmitMarketOrder(t *testing.T) {
 	ensurePosition(t, tst.pos, 0, num.NewUint(0))
 	orders := tst.engine.SubmitOrder(agg, num.NewUint(1980), num.NewUint(1990))
 	require.Len(t, orders, 1)
-	assert.Equal(t, "2005", orders[0].Price.String())
+	assert.Equal(t, "1994", orders[0].Price.String())
 	assert.Equal(t, 126420, int(orders[0].Size))
 }
 
@@ -309,16 +314,16 @@ func testSubmitOrderAcrossAMMBoundarySell(t *testing.T) {
 	require.Len(t, orders, 6)
 
 	// first round, three orders moving all pool's to the upper boundary of the shortest
-	assert.Equal(t, "2053", orders[0].Price.String())
-	assert.Equal(t, "2053", orders[1].Price.String())
-	assert.Equal(t, "2053", orders[2].Price.String())
+	assert.Equal(t, "1949", orders[0].Price.String())
+	assert.Equal(t, "1949", orders[1].Price.String())
+	assert.Equal(t, "1949", orders[2].Price.String())
 
 	// second round, 2 orders moving all pool's to the upper boundary of the second shortest
-	assert.Equal(t, "1925", orders[3].Price.String())
-	assert.Equal(t, "1925", orders[4].Price.String())
+	assert.Equal(t, "1874", orders[3].Price.String())
+	assert.Equal(t, "1874", orders[4].Price.String())
 
 	// third round, 1 orders moving the last pool to its boundary
-	assert.Equal(t, "1875", orders[5].Price.String())
+	assert.Equal(t, "1824", orders[5].Price.String())
 }
 
 func testBestPricesAndVolume(t *testing.T) {

--- a/core/execution/amm/pool_test.go
+++ b/core/execution/amm/pool_test.go
@@ -404,6 +404,16 @@ func TestNotebook(t *testing.T) {
 	ensurePosition(t, p.pos, 500, lowmid.Clone())
 	fairPrice = p.pool.BestPrice(nil)
 	assert.Equal(t, "1854", fairPrice.String())
+
+	// fair price is 2000 and the AMM quotes a best-buy at 1999 so incoming SELL should have a price <= 1999
+	ensurePositionN(t, p.pos, 0, lowmid.Clone(), 2)
+	price := p.pool.PriceForVolume(100, types.SideSell)
+	assert.Equal(t, "1984", price.String())
+
+	// fair price is 2000 and the AMM quotes a best-buy at 2001 so incoming BUY should have a price >= 2001
+	ensurePositionN(t, p.pos, 0, lowmid.Clone(), 2)
+	price = p.pool.PriceForVolume(100, types.SideBuy)
+	assert.Equal(t, "2014", price.String())
 }
 
 type tstPool struct {

--- a/core/integration/features/amm/0090-VAMM-006-014.feature
+++ b/core/integration/features/amm/0090-VAMM-006-014.feature
@@ -123,11 +123,11 @@ Feature: Ensure the vAMM positions follow the market correctly
     # see the trades that make the vAMM go long
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 350  | party4 | true   |
+      | vamm1-id | 95    | 350  | party4 | true   |
     And the network moves ahead "1" blocks
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 90        | 90               | # TODO why isn't this 90?
+      | 95         | TRADING_MODE_CONTINUOUS | 90        | 90               | # TODO why isn't this 90?
 	  Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -350   | 0              | 0            |        |
@@ -202,20 +202,20 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 22033        | 1000           | 551           | 100       | 63        | 63               | 86               | 40             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 108   | 550  | party4 | true   |
+      | vamm1-id | 92    | 550  | party4 | true   |
 
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 8              | 0            |        |
-      | party2   | -1     | -8             | 0            |        |
+      | party1   | 1      | -8             | 0            |        |
+      | party2   | -1     | 8              | 0            |        |
       | party4   | -550   | 0              | 0            |        |
       | vamm1-id | 550    | 0              | 0            | true   |
     # vAMM receives fees, but loses out in the MTM settlement
     And the following transfers should happen:
       | from     | from account            | to       | to account           | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 238    | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 100238 | USD   | true   | TRANSFER_TYPE_MARGIN_LOW        |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 203    | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 98098  | USD   | true   | TRANSFER_TYPE_MARGIN_LOW        |
 
     # Now make sure we don't trade with vAMM below 85
     When the parties place the following orders:
@@ -235,8 +235,8 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party1   | 1      | -25            | 0            |        |
       | party2   | -1     | 25             | 0            |        |
       | party3   | 10     | 0              | 0            |        |
-      | party4   | -560   | 18150          | 0            |        |
-      | vamm1-id | 550    | -18150         | 0            | true   |
+      | party4   | -560   | 9350           | 0            |        |
+      | vamm1-id | 550    | -9350          | 0            | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | target stake | supplied stake | open interest | ref price | mid price | static mid price | best offer price | best bid price |
       | 75         | TRADING_MODE_CONTINUOUS | 16824        | 1000           | 561           | 100       | 63        | 63               | 86               | 40             |
@@ -272,15 +272,15 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 104        | TRADING_MODE_CONTINUOUS | 3119         | 1000           | 75            | 100       | 100       | 100              | 101              | 99             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 115   | 74   | party3 | true   |
+      | vamm1-id | 104   | 74   | party3 | true   |
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 15             | 0            |        |
-      | party2   | -1     | -15            | 0            |        |
+      | party1   | 1      | 4              | 0            |        |
+      | party2   | -1     | -4             | 0            |        |
       | party3   | -74    | 0              | 0            |        |
-      | party4   | 74     | 814            | 0            |        |
-      | vamm1-id | 0      | 0              | -814         | true   |
+      | party4   | 74     | 0              | 0            |        |
+      | vamm1-id | 0      | 0              | 0            | true   |
 
   @VAMM
   Scenario: 0090-VAMM-011: If other traders trade to move the market mid price to 90 and then trade to move the mid price back to 100 the vAMM will have a position of 0.
@@ -293,12 +293,12 @@ Feature: Ensure the vAMM positions follow the market correctly
     # see the trades that make the vAMM go short
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 371  | party3 | true   |
+      | vamm1-id | 94    | 371  | party3 | true   |
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 5              | 0            |        |
-      | party2   | -1     | -5             | 0            |        |
+      | party1   | 1      | -6             | 0            |        |
+      | party2   | -1     | 6              | 0            |        |
       | party3   | -371   | 0              | 0            |        |
       | vamm1-id | 371    | 0              | 0            | true   |
     # move price back up to 100
@@ -306,8 +306,8 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party4 | ETH/MAR22 | buy  | 371    | 100   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
-      | mark price | trading mode            | target stake | supplied stake | open interest | ref price | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 15619        | 1000           | 372           | 100       | 100       | 100              | 101              | 99             |
+      | mark price | trading mode            | ref price | mid price | static mid price | best offer price | best bid price |
+      | 94         | TRADING_MODE_CONTINUOUS | 100       | 100       | 100              | 101              | 99             |
     And the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
       | party4 | 94    | 371  | vamm1-id | true   |
@@ -318,9 +318,9 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party1   | 1      | -6             | 0            |        |
       | party2   | -1     | 6              | 0            |        |
-      | party3   | -371   | 4081           | 0            |        |
+      | party3   | -371   | 0              | 0            |        |
       | party4   | 371    | 0              | 0            |        |
-      | vamm1-id | 0      | 0              | -4081        | true   |
+      | vamm1-id | 0      | 0              | 0            | true   |
 
   @VAMM
   Scenario: 0090-VAMM-012: If other traders trade to move the market mid price to 90 and then in one trade move the mid price to 110 then trade to move the mid price back to 100 the vAMM will have a position of 0
@@ -333,13 +333,13 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 100       | 90        | 90               | 91               | 89             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 371  | party3 | true   |
+      | vamm1-id | 94    | 371  | party3 | true   |
     # Check vAMM position
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 5              | 0            |        |
-      | party2   | -1     | -5             | 0            |        |
+      | party1   | 1      | -6             | 0            |        |
+      | party2   | -1     | 6              | 0            |        |
       | party3   | -371   | 0              | 0            |        |
       | vamm1-id | 371    | 0              | 0            | true   |
 
@@ -349,7 +349,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party4 | ETH/MAR22 | buy  | 440    | 110   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | ref price | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 100       | 110       | 110              | 111              | 109            |
+      | 94         | TRADING_MODE_CONTINUOUS | 100       | 110       | 110              | 111              | 109            |
     And the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
       | party4 | 95    | 440  | vamm1-id | true   |
@@ -359,9 +359,9 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party1   | 1      | -5             | 0            |        |
       | party2   | -1     | 5              | 0            |        |
-      | party3   | -371   | 3710           | 0            |        |
+      | party3   | -371   | -371           | 0            |        |
       | party4   | 440    | 0              | 0            |        |
-      | vamm1-id | -69    | 0              | -3710        | true   |
+      | vamm1-id | -69    | 0              | 371          | true   |
 
     # Now return the mid price back to 100
     When the parties place the following orders:
@@ -372,17 +372,17 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 95         | TRADING_MODE_CONTINUOUS | 100       | 100       | 100              | 101              | 99             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 114   | 69   | party5 | true   |
+      | vamm1-id | 104   | 69   | party5 | true   |
     # Check the resulting position, vAMM should hold 0
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 14             | 0            |        |
-      | party2   | -1     | -14            | 0            |        |
-      | party3   | -371   | -3339          | 0            |        |
-      | party4   | 440    | 8360           | 0            |        |
+      | party1   | 1      | 4              | 0            |        |
+      | party2   | -1     | -4             | 0            |        |
+      | party3   | -371   | -3710          | 0            |        |
+      | party4   | 440    | 3960           | 0            |        |
       | party5   | -69    | 0              | 0            |        |
-      | vamm1-id | 0      | 0              | -5021        | true   |
+      | vamm1-id | 0      | 0              | -250         | true   |
 
   @VAMM
   Scenario: 0090-VAMM-013: If other traders trade to move the market mid price to 90 and then move the mid price back to 100 in several trades of varying size, the vAMM will have a position of 0.
@@ -395,12 +395,12 @@ Feature: Ensure the vAMM positions follow the market correctly
     # see the trades that make the vAMM go short
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 350  | party3 | true   |
+      | vamm1-id | 95    | 350  | party3 | true   |
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 5              | 0            |        |
-      | party2   | -1     | -5             | 0            |        |
+      | party1   | 1      | -5             | 0            |        |
+      | party2   | -1     | 5              | 0            |        |
       | party3   | -350   | 0              | 0            |        |
       | vamm1-id | 350    | 0              | 0            | true   |
     # move price back up to 100, in several trades of varying sizes
@@ -410,8 +410,8 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party4 | ETH/MAR22 | buy  | 121    | 100   | 1                | TYPE_LIMIT | TIF_GTC |
       | party5 | ETH/MAR22 | buy  | 130    | 100   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
-      | mark price | trading mode            | target stake | supplied stake | open interest | ref price | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 14737        | 1000           | 351           | 100       | 100       | 100              | 101              | 99             |
+      | mark price | trading mode            | ref price | mid price | static mid price | best offer price | best bid price |
+      | 95         | TRADING_MODE_CONTINUOUS | 100       | 100       | 100              | 101              | 99             |
     And the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
       | party1 | 91    | 99   | vamm1-id | true   |
@@ -424,10 +424,10 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party1   | 100    | 591            | 0            |        |
       | party2   | -1     | 3              | 0            |        |
-      | party3   | -350   | 2800           | 0            |        |
+      | party3   | -350   | -700           | 0            |        |
       | party4   | 121    | 363            | 0            |        |
       | party5   | 130    | 0              | 0            |        |
-      | vamm1-id | 0      | 0              | -3757        | true   |
+      | vamm1-id | 0      | 0              | -257         | true   |
 
   @VAMM
   Scenario: 0090-VAMM-014: If other traders trade to move the market mid price to 90 and then in one trade move the mid price to 110 then trade to move the mid price to 120 the vAMM will have a larger (more negative) but comparable position to if they had been moved straight from 100 to 120.
@@ -440,13 +440,13 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 14035        | 1000           | 351           | 100       | 90        | 90               | 91               | 89             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 350  | party3 | true   |
+      | vamm1-id | 95    | 350  | party3 | true   |
     # Check vAMM position
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 5              | 0            |        |
-      | party2   | -1     | -5             | 0            |        |
+      | party1   | 1      | -5             | 0            |        |
+      | party2   | -1     | 5              | 0            |        |
       | party3   | -350   | 0              | 0            |        |
       | vamm1-id | 350    | 0              | 0            | true   |
 
@@ -456,7 +456,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party4 | ETH/MAR22 | buy  | 420    | 110   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | ref price | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 100       | 110       | 110              | 111              | 109            |
+      | 95         | TRADING_MODE_CONTINUOUS | 100       | 110       | 110              | 111              | 109            |
     And the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
       | party4 | 95    | 420  | vamm1-id | true   |
@@ -466,9 +466,9 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party1   | 1      | -5             | 0            |        |
       | party2   | -1     | 5              | 0            |        |
-      | party3   | -350   | 3500           | 0            |        |
+      | party3   | -350   | 0              | 0            |        |
       | party4   | 420    | 0              | 0            |        |
-      | vamm1-id | -70    | 0              | -3500        | true   |
+      | vamm1-id | -70    | 0              | 0            | true   |
 
     # Now further increase the mid price, move it up to 120
     When the parties place the following orders:
@@ -486,7 +486,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party1   | 1      | 14             | 0            |        |
       | party2   | -1     | -14            | 0            |        |
-      | party3   | -350   | -3150          | 0            |        |
+      | party3   | -350   | -6650          | 0            |        |
       | party4   | 420    | 7980           | 0            |        |
       | party5   | 64     | 0              | 0            |        |
-      | vamm1-id | -134   | -1330          | -3500        | true   |
+      | vamm1-id | -134   | -1330          | 0            | true   |

--- a/core/integration/features/amm/0090-VAMM-020.feature
+++ b/core/integration/features/amm/0090-VAMM-020.feature
@@ -97,7 +97,7 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | vamm1 | ACCOUNT_TYPE_GENERAL | vamm1-id | ACCOUNT_TYPE_GENERAL |           | 100000 | USD   | true   | TRANSFER_TYPE_AMM_LOW |
 
 
-  @VAMM
+  @VAMM2
   Scenario: 0090-VAMM-020: If a vAMM is cancelled and set in Reduce-Only mode when it is currently long, then It creates no further buy orders even if the current price is above the configured lower price. When one of it's sell orders is executed it still does not produce buy orders, and correctly quotes sell orders from a higher price. When the position reaches 0 the vAMM is closed and all funds are released to the user after the next mark to market.
     # based on 0090-VAMM-007
     When the parties place the following orders:
@@ -106,26 +106,26 @@ Feature: Test vAMM cancellation by reduce-only from long.
     # see the trades that make the vAMM go long
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 350  | party4 | true   |
+      | vamm1-id | 95    | 350  | party4 | true   |
     And the network moves ahead "1" blocks
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 90        | 90               |
+      | 95         | TRADING_MODE_CONTINUOUS | 90        | 90               |
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -350   | 0              | 0            |        |
       | vamm1-id | 350    | 0              | 0            | true   |
     And the following transfers should happen:
       | from     | from account            | to       | to account           | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 147    | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 71247  | USD   | true   | TRANSFER_TYPE_MARGIN_LOW        |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 133    | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 64462  | USD   | true   | TRANSFER_TYPE_MARGIN_LOW        |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 28900   | 71247  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 35671   | 64462  | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 90        | 90               | 91               | 89             |
+      | 95         | TRADING_MODE_CONTINUOUS | 90        | 90               | 91               | 89             |
 
     # Next: cancel the vAMM with reduce-only
     When the parties cancel the following AMM:
@@ -142,7 +142,7 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | party4 | ETH/MAR22 | sell | 10     | 91    | 0                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 65        | 65               | 91               | 40             |
+      | 95         | TRADING_MODE_CONTINUOUS | 65        | 65               | 91               | 40             |
 
     # Now start checking if the vAMM still quotes sell orders
     When the parties place the following orders:
@@ -157,11 +157,11 @@ Feature: Test vAMM cancellation by reduce-only from long.
 
     # check the state of the market, trigger MTM settlement and check balances before closing out the last 100 for the vAMM
     When the network moves ahead "1" blocks
-	Then the parties should have the following profit and loss:
+	  Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | -380   | 4110           | 0            |        |
+      | party4   | -380   | 610            | 0            |        |
       | party5   | 280    | 90             | 0            |        |
-      | vamm1-id | 100    | -1200          | -3000        | true   |
+      | vamm1-id | 100    | -200           | -500         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -171,13 +171,13 @@ Feature: Test vAMM cancellation by reduce-only from long.
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 93     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 4200   | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 49017  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 700    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45732  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 78010   | 18030  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81496   | 18030  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -209,9 +209,9 @@ Feature: Test vAMM cancellation by reduce-only from long.
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | -380   | 2210           | 0            |        |
+      | party4   | -380   | -1290          | 0            |        |
       | party5   | 380    | 1490           | 0            |        |
-      | vamm1-id | 0      | 0              | -3700        | true   |
+      | vamm1-id | 0      | 0              | -200         | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -223,10 +223,10 @@ Feature: Test vAMM cancellation by reduce-only from long.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 500    | USD   | true   | TRANSFER_TYPE_MTM_WIN                |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18530  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 96580  | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100066 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE            |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 996580  |        |        |
+      | vamm1    | USD   |           | 1000066 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |
 
   @VAMM
@@ -238,26 +238,26 @@ Feature: Test vAMM cancellation by reduce-only from long.
     # see the trades that make the vAMM go long
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 350  | party4 | true   |
+      | vamm1-id | 95    | 350  | party4 | true   |
     And the network moves ahead "1" blocks
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 90        | 90               |
+      | 95         | TRADING_MODE_CONTINUOUS | 90        | 90               |
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -350   | 0              | 0            |        |
       | vamm1-id | 350    | 0              | 0            | true   |
     And the following transfers should happen:
       | from     | from account            | to       | to account           | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 147    | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 71247  | USD   | true   | TRANSFER_TYPE_MARGIN_LOW        |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 133    | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 64462  | USD   | true   | TRANSFER_TYPE_MARGIN_LOW        |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 28900   | 71247  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 35671   | 64462  | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 90        | 90               | 91               | 89             |
+      | 95         | TRADING_MODE_CONTINUOUS | 90        | 90               | 91               | 89             |
 
     # Next: cancel the vAMM with reduce-only
     When the parties cancel the following AMM:
@@ -274,7 +274,7 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | party4 | ETH/MAR22 | sell | 10     | 91    | 0                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 105        | TRADING_MODE_CONTINUOUS | 65        | 65               | 91               | 40             |
+      | 95         | TRADING_MODE_CONTINUOUS | 65        | 65               | 91               | 40             |
 
     # Now start checking if the vAMM still quotes sell orders
     When the parties place the following orders:
@@ -291,9 +291,9 @@ Feature: Test vAMM cancellation by reduce-only from long.
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | -380   | 4110           | 0            |        |
+      | party4   | -380   | 610            | 0            |        |
       | party5   | 280    | 90             | 0            |        |
-      | vamm1-id | 100    | -1200          | -3000        | true   |
+      | vamm1-id | 100    | -200           | -500         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -303,13 +303,13 @@ Feature: Test vAMM cancellation by reduce-only from long.
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 93     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 4200   | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 49017  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 700    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45732  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 78010   | 18030  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81496   | 18030  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -340,9 +340,9 @@ Feature: Test vAMM cancellation by reduce-only from long.
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | -380   | 2210           | 0            |        |
+      | party4   | -380   | -1290          | 0            |        |
       | party5   | 380    | 1490           | 0            |        |
-      | vamm1-id | 0      | 0              | -3700        | true   |
+      | vamm1-id | 0      | 0              | -200         | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -354,8 +354,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 500    | USD   | true   | TRANSFER_TYPE_MTM_WIN                |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18530  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 96580  | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100066 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 996580  |        |        |
+      | vamm1    | USD   |           | 1000066 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |

--- a/core/integration/features/amm/0090-VAMM-021.feature
+++ b/core/integration/features/amm/0090-VAMM-021.feature
@@ -173,54 +173,53 @@ Feature: Test vAMM cancellation by reduce-only from short.
       | party4   | 154   | 10   | party5 |        |
       | party4   | 149   | 10   | party5 |        |
       | party4   | 122   | 10   | party5 |        |
-      | vamm1-id | 167   | 137  | party5 | true   |
-      | vamm1-id | 123   | 5    | party5 | true   |
+      | vamm1-id | 135   | 137  | party5 | true   |
+      | vamm1-id | 122   | 5    | party5 | true   |
 
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 321    | -269           | 0            |        |
-      | party5   | -172   | 6588           | 0            |        |
-      | vamm1-id | -149   | -149           | -6170        | true   |
+      | party4   | 321    | -590           | 0            |        |
+      | party5   | -172   | 2371           | 0            |        |
+      | vamm1-id | -149   | 0              | -1781        | true   |
     And the following transfers should happen:
        | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 92     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 6319   | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 29745  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 74     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 1781   | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 34595  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 55435   | 38484  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 60267   | 38172  | true   |
     # vAMM isn't quoting on its offer side due to being in reduce only, so best offer comes from an order
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 123        | TRADING_MODE_CONTINUOUS | 140       | 140              | 160              | 121            |
+      | 122        | TRADING_MODE_CONTINUOUS | 140       | 140              | 160              | 121            |
 
-    # Cool, now close the position of vamm completely
+    # Cool, now close the position a little bit vamm completely
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party5 | ETH/MAR22 | sell | 40     | 115   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 125   | 40   | party5 | true   |
+      | vamm1-id | 118   | 40   | party5 | true   |
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 321    | 373            | 0            |        |
-      | party5   | -212   | 6244           | 0            |        |
-      | vamm1-id | -109   | -327           | -6290        | true   |
+      | party4   | 321    | -1874          | 0            |        |
+      | party5   | -212   | 3059           | 0            |        |
+      | vamm1-id | -109   | 436            | -1621        | true   |
     And the following transfers should happen:
        | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 20     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 298    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 9575   | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 19     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 11759  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 65030   | 28611  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 72045   | 27009  | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 125        | TRADING_MODE_CONTINUOUS | 137       | 137              | 160              | 115            |
+      | 118        | TRADING_MODE_CONTINUOUS | 137       | 137              | 160              | 115            |
 
     # OK, zero-out the vAMM
     When the parties place the following orders:
@@ -228,34 +227,34 @@ Feature: Test vAMM cancellation by reduce-only from short.
       | party5 | ETH/MAR22 | sell | 109    | 100   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 124   | 109  | party5 | true   |
+      | vamm1-id | 107   | 109  | party5 | true   |
 
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 321    | 52             | 0            |        |
-      | party5   | -321   | 6456           | 0            |        |
-      | vamm1-id | 0      | 0              | -6508        | true   |
+      | party4   | 321    | -5405          | 0            |        |
+      | party5   | -321   | 5391           | 0            |        |
+      | vamm1-id | 0      | 0              | 14           | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                                 |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 55     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 28720  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 93805  | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 47     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 28208  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
+      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 100300 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 993805  |        |        |
+      | vamm1    | USD   |           | 1000300 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 124        | TRADING_MODE_CONTINUOUS | 100        | 100               | 160              | 40             |
+      | 107        | TRADING_MODE_CONTINUOUS | 100        | 100               | 160              | 40             |
 
   @VAMM
   Scenario: 0090-VAMM-021: Same as the test above, only this time, the final order that closes the vAMM position is bigger than the remaining volume, so we check if the vAMM is cancelled instead of going long.
     # based on 0090-VAMM-008: vAMM creates a position, has some general balance left in general and margin accounts.
-    When the parties place the following orders:
+       When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party4 | ETH/MAR22 | buy  | 500    | 155   | 1                | TYPE_LIMIT | TIF_GTC | p4-first  |
     # see the trades that make the vAMM go short
@@ -328,54 +327,53 @@ Feature: Test vAMM cancellation by reduce-only from short.
       | party4   | 154   | 10   | party5 |        |
       | party4   | 149   | 10   | party5 |        |
       | party4   | 122   | 10   | party5 |        |
-      | vamm1-id | 167   | 137  | party5 | true   |
-      | vamm1-id | 123   | 5    | party5 | true   |
+      | vamm1-id | 135   | 137  | party5 | true   |
+      | vamm1-id | 122   | 5    | party5 | true   |
 
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 321    | -269           | 0            |        |
-      | party5   | -172   | 6588           | 0            |        |
-      | vamm1-id | -149   | -149           | -6170        | true   |
+      | party4   | 321    | -590           | 0            |        |
+      | party5   | -172   | 2371           | 0            |        |
+      | vamm1-id | -149   | 0              | -1781        | true   |
     And the following transfers should happen:
        | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 92     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 6319   | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 29745  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 74     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 1781   | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 34595  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 55435   | 38484  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 60267   | 38172  | true   |
     # vAMM isn't quoting on its offer side due to being in reduce only, so best offer comes from an order
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 123        | TRADING_MODE_CONTINUOUS | 140       | 140              | 160              | 121            |
+      | 122        | TRADING_MODE_CONTINUOUS | 140       | 140              | 160              | 121            |
 
-    # Cool, now close the position of vamm completely
+    # Cool, now close the position a little bit vamm completely
     When the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     |
       | party5 | ETH/MAR22 | sell | 40     | 115   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 125   | 40   | party5 | true   |
+      | vamm1-id | 118   | 40   | party5 | true   |
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 321    | 373            | 0            |        |
-      | party5   | -212   | 6244           | 0            |        |
-      | vamm1-id | -109   | -327           | -6290        | true   |
+      | party4   | 321    | -1874          | 0            |        |
+      | party5   | -212   | 3059           | 0            |        |
+      | vamm1-id | -109   | 436            | -1621        | true   |
     And the following transfers should happen:
        | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 20     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 298    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 9575   | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+       |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 19     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+       | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 11759  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 65030   | 28611  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 72045   | 27009  | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 125        | TRADING_MODE_CONTINUOUS | 137       | 137              | 160              | 115            |
+      | 118        | TRADING_MODE_CONTINUOUS | 137       | 137              | 160              | 115            |
 
     # OK, zero-out the vAMM
     When the parties place the following orders:
@@ -383,26 +381,26 @@ Feature: Test vAMM cancellation by reduce-only from short.
       | party5 | ETH/MAR22 | sell | 129    | 100   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 124   | 109  | party5 | true   |
+      | vamm1-id | 107   | 109  | party5 | true   |
 
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 321    | 52             | 0            |        |
-      | party5   | -321   | 6456           | 0            |        |
-      | vamm1-id | 0      | 0              | -6508        | true   |
+      | party4   | 321    | -5405          | 0            |        |
+      | party5   | -321   | 5391           | 0            |        |
+      | vamm1-id | 0      | 0              | 14           | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                                 |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 55     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 28720  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 93805  | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 47     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 28208  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
+      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 100300 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 993805  |        |        |
+      | vamm1    | USD   |           | 1000300 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
-      | 124        | TRADING_MODE_CONTINUOUS | 70        | 70               | 100              | 40             |
+      | 107        | TRADING_MODE_CONTINUOUS | 70        | 70               | 100              | 40             |

--- a/core/integration/features/amm/0090-VAMM-028.feature
+++ b/core/integration/features/amm/0090-VAMM-028.feature
@@ -257,6 +257,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | vamm2-id | -74    | -304           | 0            | true   |
       | vamm1-id | -74    | 0              | 0            | true   |
 
+  @VAMM
   Scenario: 0090-VAMM-029: The volume quoted to move from price 100 to price 90 in one step is the same as the sum of the volumes to move in 10 steps of 1.
     # Move mid price to 90 in one go. A volume of 347 is the minimum required, 346 only gets us to 91
     When the parties place the following orders:
@@ -267,13 +268,13 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 13915        | 1000           | 348           | 100       | 90        | 90               | 91               | 89             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm1-id | 105   | 347  | party5 | true   |
+      | vamm1-id | 95    | 347  | party5 | true   |
     # Check vAMM position
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party1   | 1      | 5              | 0            |        |
-      | party2   | -1     | -5             | 0            |        |
+      | party1   | 1      | -5             | 0            |        |
+      | party2   | -1     | 5              | 0            |        |
       | party5   | -347   | 0              | 0            |        |
       | vamm1-id | 347    | 0              | 0            | true   |
 
@@ -287,7 +288,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 79           | 1000           | 2             | 100       | 99        | 99               | 100              | 98             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 100   | 1    | party6 | true   |
+      | vamm2-id | 99    | 1    | party6 | true   |
 
     # Move mid price to 98
     When the parties place the following orders:
@@ -298,7 +299,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 1519         | 1000           | 38            | 100       | 98        | 98               | 99               | 97             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 100    | 36   | party6 | true   |
+      | vamm2-id | 98    | 36   | party6 | true   |
 
     # Move mid price to 97
     When the parties place the following orders:
@@ -309,7 +310,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 2959         | 1000           | 74            | 100       | 97        | 97               | 98               | 96             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 98    | 36   | party6 | true   |
+      | vamm2-id | 97    | 36   | party6 | true   |
 
     # Move mid price to 96
     When the parties place the following orders:
@@ -320,7 +321,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 4478         | 1000           | 112           | 100       | 96        | 96               | 97               | 95             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 97    | 38   | party6 | true   |
+      | vamm2-id | 96    | 38   | party6 | true   |
 
     # Move mid price to 95
     When the parties place the following orders:
@@ -332,7 +333,7 @@ Feature: Ensure the vAMM positions follow the market correctly
     And debug trades
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 96    | 37   | party6 | true   |
+      | vamm2-id | 95    | 37   | party6 | true   |
 
     # Move mid price to 94
     When the parties place the following orders:
@@ -343,7 +344,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 7517         | 1000           | 188           | 100       | 94        | 94               | 95               | 93             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 95    | 39   | party6 | true   |
+      | vamm2-id | 94    | 39   | party6 | true   |
 
     # Move mid price to 93
     When the parties place the following orders:
@@ -354,7 +355,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 9077         | 1000           | 227           | 100       | 93        | 93               | 94               | 92             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 94    | 39   | party6 | true   |
+      | vamm2-id | 93    | 39   | party6 | true   |
 
     # Move mid price to 92
     When the parties place the following orders:
@@ -365,7 +366,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 10636        | 1000           | 266           | 100       | 92        | 92               | 93               | 91             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 93    | 39   | party6 | true   |
+      | vamm2-id | 92    | 39   | party6 | true   |
 
     # Move mid price to 91
     When the parties place the following orders:
@@ -376,7 +377,7 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 12276        | 1000           | 307           | 100       | 91        | 91               | 92               | 90             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 92    | 41   | party6 | true   |
+      | vamm2-id | 91    | 41   | party6 | true   |
 
     # Move mid price to 90
     When the parties place the following orders:
@@ -387,16 +388,16 @@ Feature: Ensure the vAMM positions follow the market correctly
       | 100        | TRADING_MODE_CONTINUOUS | 13915        | 1000           | 348           | 100       | 90        | 90               | 91               | 89             |
     And the following trades should be executed:
       | buyer    | price | size | seller | is amm |
-      | vamm2-id | 91    | 41   | party6 | true   |
+      | vamm2-id | 90    | 41   | party6 | true   |
 
     # Make sure the volumes match, PnL is expected to be different
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party3   | 1      | -9             | 0            |        |
-      | party4   | -1     | 9              | 0            |        |
-      | party6   | -347   | 1390           | 0            |        |
-      | vamm2-id | 347    | -1390          | 0            | true   |
+      | party3   | 1      | -10            | 0            |        |
+      | party4   | -1     | 10             | 0            |        |
+      | party6   | -347   | 1354           | 0            |        |
+      | vamm2-id | 347    | -1354          | 0            | true   |
       | vamm1-id | 347    | 0              | 0            | true   |
 
   @VAMM

--- a/core/integration/features/amm/0090-VAMM-rebase.feature
+++ b/core/integration/features/amm/0090-VAMM-rebase.feature
@@ -106,13 +106,13 @@ Feature: vAMM rebasing when created or amended
     # second AMM has its base 5 away from the first AMM so it must submit a rebasing-order 
     And the following trades should be executed:
       | buyer    | price | size | seller   | is amm |
-      | vamm1-id | 101   | 140  | vamm2-id | true   |
+      | vamm1-id | 98    | 140  | vamm2-id | true   |
     Then the network moves ahead "1" blocks
 
     # and now the mid-price has shifted lower to a value between the two AMM's bases 95 < 97 < 100
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | 
-      | 101        | TRADING_MODE_CONTINUOUS | 97        |
+      | 98         | TRADING_MODE_CONTINUOUS | 97        |
 
 
   @VAMM
@@ -167,7 +167,7 @@ Feature: vAMM rebasing when created or amended
 
     When the parties submit the following AMM:
       | party | market id | amount | slippage | base | lower bound | upper bound |  proposed fee |
-      | vamm2 | ETH/MAR22 | 100000 | 0.05      | 100  | 95          | 105         |  0.03         |
+      | vamm2 | ETH/MAR22 | 100000 | 0.05     | 100  | 95          | 105         |  0.03         |
     Then the AMM pool status should be:
       | party | market id | amount | status         | base | lower bound | upper bound | 
       | vamm2 | ETH/MAR22 | 100000  | STATUS_ACTIVE  | 100  | 95          | 105         |
@@ -193,13 +193,13 @@ Feature: vAMM rebasing when created or amended
     # second AMM has its base 5 away from the first AMM so it must submit a rebasing-order 
     And the following trades should be executed:
       | buyer    | price | size | seller   | is amm |
-      | vamm1-id | 101   | 140  | vamm2-id | true   |
+      | vamm1-id | 98    | 140  | vamm2-id | true   |
     Then the network moves ahead "1" blocks
 
     # and now the mid-price has shifted lower to a value between the two AMM's bases 95 < 98 < 100
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | 
-      | 101        | TRADING_MODE_CONTINUOUS | 97        |
+      | 98         | TRADING_MODE_CONTINUOUS | 97        |
 
 
   @VAMM


### PR DESCRIPTION
We weren't taking into account the direction of trade in `PriceForVolume()` which meant that an incoming sell order eating into the AMM's buy volume was creating a trade with a price above the AMM's best-buy.