### PR TITLE
fix: Handle properly asset decimals < market decimals when uncrossing…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [11279](https://github.com/vegaprotocol/vega/issues/11279) - Handle properly the case of multiple transfers for the same game id.
 - [11293](https://github.com/vegaprotocol/vega/issues/11293) - Panic in data node with position estimate endpoint.
 - [11279](https://github.com/vegaprotocol/vega/issues/11279) - Handle properly the case of multiple transfers for the same game id.
+- [11297](https://github.com/vegaprotocol/vega/issues/11297) - Handle properly asset decimals < market decimals when uncrossing the order book upon leaving auction.
 
 ## 0.76.1
 

--- a/core/matching/orderbook.go
+++ b/core/matching/orderbook.go
@@ -567,8 +567,8 @@ func (b *OrderBook) uncrossBookSide(
 	}
 	// get price factor, if price is 10,000, but market price is 100, this is 10,000/100 -> 100
 	// so we can get the market price simply by doing price / (order.Price/ order.OriginalPrice)
-	mPrice := num.UintZero().Div(uncrossOrders[0].Price, uncrossOrders[0].OriginalPrice)
-	mPrice.Div(price, mPrice)
+	// as the asset decimals may be < market decimals, the calculation must be done in decimals.
+	mPrice, _ := num.UintFromDecimal(price.ToDecimal().Div(uncrossOrders[0].Price.ToDecimal().Div(uncrossOrders[0].OriginalPrice.ToDecimal())))
 	// Uncross each one
 	for _, order := range uncrossOrders {
 		// since all of uncrossOrders will be traded away and at the same uncrossing price


### PR DESCRIPTION
… the order book upon leaving auction

Closes #11297 