### PR TITLE
fix: handle invalid offset for pegged on market update when tick size…

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -670,6 +670,8 @@ func (m *Market) Update(ctx context.Context, config *types.Market, oracleEngine 
 	if tickSizeChanged {
 		peggedOrders := m.matching.GetActivePeggedOrderIDs()
 		peggedOrders = append(peggedOrders, m.peggedOrders.GetParkedIDs()...)
+
+		tickSizeInAsset, _ := num.UintFromDecimal(m.mkt.TickSize.ToDecimal().Mul(m.priceFactor))
 		for _, po := range peggedOrders {
 			order, err := m.matching.GetOrderByID(po)
 			if err != nil {
@@ -678,7 +680,9 @@ func (m *Market) Update(ctx context.Context, config *types.Market, oracleEngine 
 					continue
 				}
 			}
-			if !num.UintZero().Mod(order.PeggedOrder.Offset, m.mkt.TickSize).IsZero() {
+			offsetInAsset, _ := num.UintFromDecimal(order.PeggedOrder.Offset.ToDecimal().Mul(m.priceFactor))
+			if !num.UintZero().Mod(order.PeggedOrder.Offset, m.mkt.TickSize).IsZero() ||
+				(order.PeggedOrder.Reference == types.PeggedReferenceMid && offsetInAsset.IsZero() && tickSizeInAsset.IsZero()) {
 				m.cancelOrder(ctx, order.Party, order.ID)
 			}
 		}


### PR DESCRIPTION
… changes

when market is updated we need to validate the offsets of pegged orders with mid reference and cancel orders where both the offset and the tickSize translate to 0 in asset decimals. 