### PR TITLE
fix: delay setting ipv cache until position engine is loaded

### DIFF
--- a/core/execution/common/amm_score_stake.go
+++ b/core/execution/common/amm_score_stake.go
@@ -33,7 +33,7 @@ func newAMMState(count int64) *AMMState {
 		stake:    num.DecimalZero(),
 		score:    num.DecimalZero(),
 		lastTick: count - 1,
-		ltD:      num.DecimalZero(),
+		ltD:      num.DecimalFromInt64(count - 1),
 	}
 }
 

--- a/core/execution/common/liquidity_provision_snapshot_test.go
+++ b/core/execution/common/liquidity_provision_snapshot_test.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2023 Gobalsky Labs Limited
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"code.vegaprotocol.io/vega/core/execution/common"
+	"code.vegaprotocol.io/vega/core/idgeneration"
+	"code.vegaprotocol.io/vega/core/types"
+	vgcrypto "code.vegaprotocol.io/vega/libs/crypto"
+	"code.vegaprotocol.io/vega/libs/num"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAMMStateSnapshot(t *testing.T) {
+	testLiquidity := newMarketLiquidity(t)
+	// set fee factor to 1, so fees are not paid out based on score.
+	testLiquidity.marketLiquidity.SetELSFeeFraction(num.DecimalOne())
+	testLiquidity.liquidityEngine.EXPECT().ReadyForFeesAllocation(gomock.Any()).Return(false).AnyTimes()
+	testLiquidity.liquidityEngine.EXPECT().UpdateAverageLiquidityScores(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	testLiquidity.liquidityEngine.EXPECT().OnStakeToCcyVolumeUpdate(gomock.Any()).AnyTimes()
+	testLiquidity.marketLiquidity.OnStakeToCcyVolumeUpdate(num.DecimalOne())
+
+	testLiquidity.orderBook.EXPECT().GetBestStaticAskPrice().Return(num.NewUint(200), nil).AnyTimes()
+	testLiquidity.orderBook.EXPECT().GetBestStaticBidPrice().Return(num.NewUint(100), nil).AnyTimes()
+	testLiquidity.liquidityEngine.EXPECT().GetPartyLiquidityScore(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(num.DecimalOne()).AnyTimes()
+
+	party1 := vgcrypto.RandomHash()
+	party2 := vgcrypto.RandomHash()
+	amms := map[string]common.AMMPool{
+		party1: dummyAMM{},
+	}
+
+	// get some AMM's to create some state
+	testLiquidity.amm.EXPECT().GetAMMPoolsBySubAccount().Return(amms)
+
+	testLiquidity.marketLiquidity.OnTick(context.Background(), time.Now())
+
+	state := testLiquidity.marketLiquidity.GetState()
+	assert.Equal(t, int64(1), state.Tick)
+	assert.Equal(t, int64(1), state.Amm[0].Tick)
+
+	// next tick we have a new AMM enter the ring
+	amms[party2] = dummyAMM{}
+	testLiquidity.amm.EXPECT().GetAMMPoolsBySubAccount().Return(amms)
+
+	testLiquidity.marketLiquidity.OnTick(context.Background(), time.Now())
+
+	state = testLiquidity.marketLiquidity.GetState()
+	assert.Equal(t, int64(2), state.Tick)
+	if state.Amm[0].Party == party1 {
+		assert.Equal(t, int64(1), state.Amm[1].Tick)
+		assert.Equal(t, int64(2), state.Amm[0].Tick)
+	} else {
+		assert.Equal(t, int64(1), state.Amm[0].Tick)
+		assert.Equal(t, int64(2), state.Amm[1].Tick)
+	}
+}
+
+type dummyAMM struct{}
+
+func (d dummyAMM) OrderbookShape(from, to *num.Uint, idgen *idgeneration.IDGenerator) ([]*types.Order, []*types.Order) {
+	return nil, nil
+}
+
+func (d dummyAMM) LiquidityFee() num.Decimal {
+	return num.DecimalZero()
+}
+
+func (d dummyAMM) CommitmentAmount() *num.Uint {
+	return num.UintOne()
+}

--- a/core/matching/cached_orderbook.go
+++ b/core/matching/cached_orderbook.go
@@ -49,12 +49,24 @@ func (b *CachedOrderBook) LoadState(ctx context.Context, payload *types.Payload)
 		return providers, err
 	}
 
+	return providers, err
+}
+
+func (b *CachedOrderBook) OnStateLoaded(ctx context.Context) error {
 	// when a market is restored we call `GetMarketData` which fills this cache based on an unrestored orderbook,
 	// now we have restored we need to recalculate.
-	b.log.Info("restoring orderbook cache for", logging.String("marketID", b.marketID))
 	b.cache.Invalidate()
-	b.GetIndicativePriceAndVolume()
-	return providers, err
+
+	// if we are in an auction we need to build the IP&V structure.
+	// note that we need to do this after the positions engine has been restored since only then can the AMM's be at their true fair-price.
+	if b.auction {
+		b.indicativePriceAndVolume = NewIndicativePriceAndVolume(b.log, b.buy, b.sell)
+
+		b.log.Info("restoring orderbook cache for", logging.String("marketID", b.marketID))
+		b.GetIndicativePriceAndVolume()
+	}
+
+	return nil
 }
 
 func (b *CachedOrderBook) EnterAuction() []*types.Order {

--- a/core/matching/snapshot.go
+++ b/core/matching/snapshot.go
@@ -129,11 +129,6 @@ func (b *OrderBook) LoadState(_ context.Context, payload *types.Payload) ([]type
 			b.peggedOrders.Add(pid)
 		}
 	}
-
-	// If we are in an auction we need to build the IP&V structure
-	if b.auction {
-		b.indicativePriceAndVolume = NewIndicativePriceAndVolume(b.log, b.buy, b.sell)
-	}
 	return nil, nil
 }
 


### PR DESCRIPTION
closes #11331 

Previously we were restoring the `indicativePriceAndVolume` cache from a snapshot at the point where we were loading the matching engine's state. This was fine because the orderbook state was the whole state. 

Now that AMM's are in the mix we need to wait until the position engine has been loaded before we can do anything with the cache. The reason is because there is a check in the cache for whether or not orders crossed, and if we haven't restored the positions engine the AMM's will report that their are at their _base price_ and not the the price they should be at for their position. So then it looks like we're crossed when we're not really and everything goes wrong.