### PR TITLE
fix: orderbook shape can create zero volume steps if we step tolerant…

### DIFF
--- a/core/execution/amm/pool_test.go
+++ b/core/execution/amm/pool_test.go
@@ -482,7 +482,7 @@ func testOrderbookShapeStepOverFairPrice(t *testing.T) {
 	ensurePosition(t, p.pos, position, num.UintZero())
 	require.Equal(t, "25", p.pool.BestPrice(nil).String())
 
-	ensurePosition(t, p.pos, position, num.UintZero())
+	ensurePositionN(t, p.pos, position, num.UintZero(), 2)
 	buys, sells := p.pool.OrderbookShape(low, base, nil)
 	assert.Equal(t, 3, len(buys))
 	assert.Equal(t, 8, len(sells))
@@ -492,7 +492,7 @@ func testOrderbookShapeStepOverFairPrice(t *testing.T) {
 	assert.Equal(t, 0, len(buys))
 	assert.Equal(t, 11, len(sells))
 
-	ensurePosition(t, p.pos, position, num.UintZero())
+	ensurePositionN(t, p.pos, position, num.UintZero(), 2)
 	buys, sells = p.pool.OrderbookShape(low, high, nil)
 	assert.Equal(t, 2, len(buys))
 	assert.Equal(t, 9, len(sells))


### PR DESCRIPTION
closes #11323

When an AMM's bound is wide and we exceed the network-parameter `maxCalculationLevels` to expand it into exact price levels, we have to approximate the order book shape by taking steps bigger than a price levels. Depending on where these steps land we could step _very close to_ the AMM's fair-price or _very close to_ a curves boundary such that the volume between the prices are less than zero. In that case we can just ignore that tiny interval since we are already approximating the shape.