### PR TITLE
feat: factor returns by asset decimals to lower the values

### DIFF
--- a/core/execution/future/market_snapshot.go
+++ b/core/execution/future/market_snapshot.go
@@ -88,6 +88,7 @@ func NewMarketFromSnapshot(
 	asset := tradableInstrument.Instrument.Product.GetAsset()
 	exp := int(assetDecimals) - int(mkt.DecimalPlaces)
 	priceFactor := num.DecimalFromInt64(10).Pow(num.DecimalFromInt64(int64(exp)))
+	assetFactor := num.DecimalFromInt64(10).Pow(num.DecimalFromInt64(int64(assetDecimals)))
 
 	as := monitor.NewAuctionStateFromSnapshot(mkt, em.AuctionState)
 	positionEngine := positions.NewSnapshotEngine(log, positionConfig, mkt.ID, broker)
@@ -249,6 +250,7 @@ func NewMarketFromSnapshot(
 		lastMidSellPrice:              em.LastMidAsk.Clone(),
 		lastTradedPrice:               em.LastTradedPrice,
 		priceFactor:                   priceFactor,
+		assetFactor:                   assetFactor,
 		lastMarketValueProxy:          em.LastMarketValueProxy,
 		marketActivityTracker:         marketActivityTracker,
 		positionFactor:                positionFactor,


### PR DESCRIPTION
MTM amounts are used for return volatility calculation - as the numbers are unscaled and the return volatility is defined as 1/variance(returns) - the number goes to zero very quickly. It was decided to scale down the MTM amounts by asset decimals so that the variance is sensible and 1/variance(returns) is meaningful. 

https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/60171/tests