### PR TITLE
fix: handle extraction of zero volume of orders in ExtractOrders

### DIFF
--- a/core/matching/side.go
+++ b/core/matching/side.go
@@ -220,6 +220,10 @@ func (s *OrderBookSide) amendOrder(orderAmend *types.Order) (int64, error) {
 // if removeOrders is set to True then the relevant orders also get removed.
 func (s *OrderBookSide) ExtractOrders(price *num.Uint, volume uint64, removeOrders bool) []*types.Order {
 	extractedOrders := []*types.Order{}
+	if volume == 0 {
+		return extractedOrders
+	}
+
 	var (
 		totalVolume uint64
 		checkPrice  func(*num.Uint) bool

--- a/core/matching/side_test.go
+++ b/core/matching/side_test.go
@@ -347,6 +347,12 @@ func TestExtractOrdersWrongVolume(t *testing.T) {
 	assert.Panics(t, func() { side.ExtractOrders(num.NewUint(100), 4, true) })
 }
 
+func TestExtractOrdersZeroVolume(t *testing.T) {
+	// Attempt to extract 0 volume of orders
+	side := getPopulatedTestSide(types.SideSell)
+	assert.Len(t, side.ExtractOrders(num.NewUint(101), 0, true), 0)
+}
+
 func TestBestStatic(t *testing.T) {
 	// Empty book
 	emptySide := getEmptyTestSide()


### PR DESCRIPTION
closes #11339 

In the case where the crossed region contains only AMM volume but orders exist outside of the crossed region, we would correctly calculate that there was no volume to extract from the orderbook itself when uncrossing. Unfortunately `ExtractOrders()` didn't handle this since previously if there was a crossed-region there would always be non-zero orderbook volume to extract. This is no longer the case with AMM's on the scene so we now just handle it. 

system tests still fails (test issue) but the panic is no more:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/60319/tests