### PR TITLE
feat: create FT to check when vAMM is inside/outside SLA range

### DIFF
--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -316,11 +316,6 @@ func (e *Engine) RemoveDistressed(ctx context.Context, closed []events.MarketPos
 	}
 }
 
-func (e *Engine) IsAMMPartyID(key string) bool {
-	_, yes := e.ammParties[key]
-	return yes
-}
-
 // BestPricesAndVolumes returns the best bid/ask and their volumes across all the registered AMM's.
 func (e *Engine) BestPricesAndVolumes() (*num.Uint, uint64, *num.Uint, uint64) {
 	var bestBid, bestAsk *num.Uint
@@ -925,14 +920,6 @@ func (e *Engine) UpdateSubAccountBalance(
 	return currentCommitment, nil
 }
 
-func (e *Engine) GetAMMPoolsBySubAccount() map[string]common.AMMPool {
-	ret := make(map[string]common.AMMPool, len(e.pools))
-	for _, v := range e.pools {
-		ret[v.AMMParty] = v
-	}
-	return ret
-}
-
 // OrderbookShape expands all registered AMM's into orders between the given prices. If `ammParty` is supplied then just the pool
 // with that party id is expanded.
 func (e *Engine) OrderbookShape(st, nd *num.Uint, ammParty *string) ([]*types.Order, []*types.Order) {
@@ -963,6 +950,14 @@ func (e *Engine) OrderbookShape(st, nd *num.Uint, ammParty *string) ([]*types.Or
 	return p.OrderbookShape(st, nd, e.idgen)
 }
 
+func (e *Engine) GetAMMPoolsBySubAccount() map[string]common.AMMPool {
+	ret := make(map[string]common.AMMPool, len(e.pools))
+	for _, v := range e.pools {
+		ret[v.AMMParty] = v
+	}
+	return ret
+}
+
 func (e *Engine) GetAllSubAccounts() []string {
 	ret := make([]string, 0, len(e.ammParties))
 	for _, subAccount := range e.ammParties {
@@ -977,6 +972,12 @@ func (e *Engine) GetAMMParty(party string) (string, error) {
 		return p.AMMParty, nil
 	}
 	return "", ErrNoPoolMatchingParty
+}
+
+// IsAMMPartyID returns whether the given key is the key of AMM registered with the engine.
+func (e *Engine) IsAMMPartyID(key string) bool {
+	_, yes := e.ammParties[key]
+	return yes
 }
 
 func (e *Engine) add(p *Pool) {

--- a/core/execution/common/amm_score_stake.go
+++ b/core/execution/common/amm_score_stake.go
@@ -20,7 +20,7 @@ import "code.vegaprotocol.io/vega/libs/num"
 type AMMState struct {
 	stake    num.Decimal // stake during epoch
 	score    num.Decimal // running liquidity score
-	lastTick int64       // last time update, not used currently, but useful when we want to start caching this stuff
+	lastTick int64       // last time update
 	ltD      num.Decimal // last time update, just in decimal because it saves on pointless conversions between int64 and num.Decimal
 }
 

--- a/core/execution/common/equity_shares.go
+++ b/core/execution/common/equity_shares.go
@@ -313,6 +313,12 @@ func (es *EquityShares) SharesFromParty(party string) num.Decimal {
 	return partyELS.Div(totalEquity)
 }
 
+// HasShares returns whether the given party is registered as an LP with ELS.
+func (es *EquityShares) HasShares(party string) bool {
+	_, ok := es.lps[party]
+	return ok
+}
+
 // SharesExcept returns the ratio of equity for each party on the market, except
 // the ones listed in parameter.
 func (es *EquityShares) SharesExcept(except map[string]struct{}) map[string]num.Decimal {

--- a/core/execution/common/interfaces.go
+++ b/core/execution/common/interfaces.go
@@ -326,6 +326,7 @@ type MarketLiquidityEngine interface {
 type EquityLikeShares interface {
 	AllShares() map[string]num.Decimal
 	SetPartyStake(id string, newStakeU *num.Uint)
+	HasShares(id string) bool
 }
 
 type AMMPool interface {
@@ -337,6 +338,7 @@ type AMMPool interface {
 type AMM interface {
 	GetAMMPoolsBySubAccount() map[string]AMMPool
 	GetAllSubAccounts() []string
+	IsAMMPartyID(string) bool
 }
 
 type CommonMarket interface {

--- a/core/execution/common/liquidity_provision.go
+++ b/core/execution/common/liquidity_provision.go
@@ -356,6 +356,7 @@ func (m *MarketLiquidity) calculateAndDistribute(ctx context.Context, t time.Tim
 				Fee:  num.DecimalZero(),
 				Bond: num.DecimalZero(),
 			}
+			penalties.AllPartiesHaveFullFeePenalty = false
 		}
 	}
 

--- a/core/execution/common/liquidity_provision.go
+++ b/core/execution/common/liquidity_provision.go
@@ -134,11 +134,21 @@ func (m *MarketLiquidity) transferFees(ctx context.Context, ft events.FeesTransf
 func (m *MarketLiquidity) applyAMMStats() {
 	ids := maps.Keys(m.ammStats)
 	sort.Strings(ids)
+
 	for _, party := range ids {
 		amm := m.ammStats[party]
+
+		// if the amm has been cancelled for a whole epoch then just kill their ELS
+		if !m.amm.IsAMMPartyID(party) && amm.stake.IsZero() {
+			m.equityShares.SetPartyStake(party, nil)
+			delete(m.ammStats, party)
+			continue
+		}
+
+		// otherwise update it and start our stats again
 		stake, _ := num.UintFromDecimal(amm.stake)
 		m.equityShares.SetPartyStake(party, stake)
-		amm.StartEpoch() // mark as new epoch having started
+		amm.StartEpoch()
 	}
 }
 

--- a/core/execution/common/mocks/mocks.go
+++ b/core/execution/common/mocks/mocks.go
@@ -2158,6 +2158,20 @@ func (mr *MockEquityLikeSharesMockRecorder) AllShares() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllShares", reflect.TypeOf((*MockEquityLikeShares)(nil).AllShares))
 }
 
+// HasShares mocks base method.
+func (m *MockEquityLikeShares) HasShares(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasShares", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasShares indicates an expected call of HasShares.
+func (mr *MockEquityLikeSharesMockRecorder) HasShares(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasShares", reflect.TypeOf((*MockEquityLikeShares)(nil).HasShares), arg0)
+}
+
 // SetPartyStake mocks base method.
 func (m *MockEquityLikeShares) SetPartyStake(arg0 string, arg1 *num.Uint) {
 	m.ctrl.T.Helper()

--- a/core/execution/common/mocks_amm/mocks.go
+++ b/core/execution/common/mocks_amm/mocks.go
@@ -131,3 +131,17 @@ func (mr *MockAMMMockRecorder) GetAllSubAccounts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSubAccounts", reflect.TypeOf((*MockAMM)(nil).GetAllSubAccounts))
 }
+
+// IsAMMPartyID mocks base method.
+func (m *MockAMM) IsAMMPartyID(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAMMPartyID", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsAMMPartyID indicates an expected call of IsAMMPartyID.
+func (mr *MockAMMMockRecorder) IsAMMPartyID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAMMPartyID", reflect.TypeOf((*MockAMM)(nil).IsAMMPartyID), arg0)
+}

--- a/core/integration/features/amm/0042-LIQF-107.feature
+++ b/core/integration/features/amm/0042-LIQF-107.feature
@@ -48,7 +48,6 @@ Feature: Test vAMM implied commitment is working as expected
       | id        | quote name | asset | liquidity monitoring | risk model            | margin calculator   | auction duration | fees          | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params |
       | ETH/MAR22 | USD        | USD   | lqm-params           | log-normal-risk-model | margin-calculator-1 | 2                | fees-config-1 | default-none     | default-eth-for-future | 1e0                    | 0                         | SLA-22     |
 
-    # Setting up the accounts and vAMM submission now is part of the background, because we'll be running scenarios 0090-VAMM-006 through 0090-VAMM-014 on this setup
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount  |
       | lp1    | USD   | 1000000 |

--- a/core/integration/features/amm/0042-LIQF-107.feature
+++ b/core/integration/features/amm/0042-LIQF-107.feature
@@ -1,0 +1,118 @@
+Feature: Test vAMM implied commitment is working as expected
+
+  Background:
+    Given the average block duration is "1"
+    And the margin calculator named "margin-calculator-1":
+      | search factor | initial factor | release factor |
+      | 1.2           | 1.5            | 1.7            |
+    And the log normal risk model named "log-normal-risk-model":
+      | risk aversion | tau                   | mu | r   | sigma |
+      | 0.001         | 0.0011407711613050422 | 0  | 0.9 | 3.0   |
+    And the liquidity monitoring parameters:
+      | name       | triggering ratio | time window | scaling factor |
+      | lqm-params | 1.00             | 20s         | 1              |
+
+    And the following network parameters are set:
+      | name                                                | value |
+      | market.value.windowLength                           | 60s   |
+      | network.markPriceUpdateMaximumFrequency             | 0s    |
+      | limits.markets.maxPeggedOrders                      | 6     |
+      | market.auction.minimumDuration                      | 1     |
+      | market.fee.factors.infrastructureFee                | 0.001 |
+      | market.fee.factors.makerFee                         | 0.004 |
+      | spam.protection.max.stopOrdersPerMarket             | 5     |
+      | market.liquidity.equityLikeShareFeeFraction         | 1     |
+      | market.amm.minCommitmentQuantum                     | 1     |
+      | market.liquidity.bondPenaltyParameter               | 0.2   |
+      | market.liquidity.stakeToCcyVolume                   | 1     |
+      | market.liquidity.successorLaunchWindowLength        | 1h    |
+      | market.liquidity.sla.nonPerformanceBondPenaltySlope | 0     |
+      | market.liquidity.sla.nonPerformanceBondPenaltyMax   | 0.6   |
+      | validators.epoch.length                             | 10s   |
+      | market.liquidity.earlyExitPenalty                   | 0.25  |
+      | market.liquidity.maximumLiquidityFeeFactorLevel     | 0.25  |
+    #risk factor short:3.5569036
+    #risk factor long:0.801225765
+    And the following assets are registered:
+      | id  | decimal places |
+      | USD | 0              |
+    And the fees configuration named "fees-config-1":
+      | maker fee | infrastructure fee |
+      | 0.0004    | 0.001              |
+
+    And the liquidity sla params named "SLA-22":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 0.05        | 0.6                          | 1                             | 1.0                    |
+
+    And the markets:
+      | id        | quote name | asset | liquidity monitoring | risk model            | margin calculator   | auction duration | fees          | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params |
+      | ETH/MAR22 | USD        | USD   | lqm-params           | log-normal-risk-model | margin-calculator-1 | 2                | fees-config-1 | default-none     | default-eth-for-future | 1e0                    | 0                         | SLA-22     |
+
+    # Setting up the accounts and vAMM submission now is part of the background, because we'll be running scenarios 0090-VAMM-006 through 0090-VAMM-014 on this setup
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount  |
+      | lp1    | USD   | 1000000 |
+      | lp2    | USD   | 1000000 |
+      | lp3    | USD   | 1000000 |
+      | party1 | USD   | 1000000 |
+      | party2 | USD   | 1000000 |
+      | party3 | USD   | 1000000 |
+      | party4 | USD   | 1000000 |
+      | party5 | USD   | 1000000 |
+      | vamm1  | USD   | 1000000 |
+      | vamm2  | USD   | 1000000 |
+
+    When the parties submit the following liquidity provision:
+      | id   | party | market id | commitment amount | fee  | lp type    |
+      | lp_1 | vamm1 | ETH/MAR22 | 100000            | 0.02 | submission |
+      | lp_2 | vamm2 | ETH/MAR22 | 100000            | 0.02 | submission |
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | lp1    | ETH/MAR22 | buy  | 20     | 40    | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
+      | party1 | ETH/MAR22 | buy  | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | party2 | ETH/MAR22 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | lp1    | ETH/MAR22 | sell | 20     | 160   | 0                | TYPE_LIMIT | TIF_GTC | lp1-s     |
+
+    When the opening auction period ends for market "ETH/MAR22"
+    Then the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 100   | 1    | party2 |
+
+    Then the network moves ahead "1" blocks
+    And the current epoch is "0"
+
+    Then the parties submit the following AMM:
+      | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee |
+      | vamm1 | ETH/MAR22 | 100000 | 0.05     | 100  | 95          | 105         | 0.03         |
+    Then the AMM pool status should be:
+      | party | market id | amount | status        | base | lower bound | upper bound |
+      | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 95          | 105         |
+
+  @VAMM
+  Scenario: 0042-LIQF-107: a vAMM which was active on the market throughout the epoch but with an active range which never overlapped with the SLA range is counted with an implied commitment of `0`.
+    When the parties submit the following AMM:
+      | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee | error |
+      | vamm2 | ETH/MAR22 | 100000 | 0.5      | 120  | 110         | 130         | 0.03         | a     |
+    Then the AMM pool status should be:
+      | party | market id | amount | status        | base | lower bound | upper bound |
+      | vamm2 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 120  | 110         | 130         |
+
+    And set the following AMM sub account aliases:
+      | party | market id | alias    |
+      | vamm1 | ETH/MAR22 | vamm1-id |
+      | vamm2 | ETH/MAR22 | vamm2-id |
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
+      | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
+
+    Then the network moves ahead "1" epochs
+
+    And the following transfers should happen:
+      | type                                   | from   | to     | from account                   | to account                     | market id | amount | asset |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | vamm1  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | vamm2  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | vamm1  | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 467    | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | vamm2  | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 467    | USD   |

--- a/core/integration/features/amm/0042-LIQF-107.feature
+++ b/core/integration/features/amm/0042-LIQF-107.feature
@@ -89,7 +89,6 @@ Feature: Test vAMM implied commitment is working as expected
       | party | market id | amount | status        | base | lower bound | upper bound |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 95          | 105         |
 
-
   @VAMM
   Scenario: 0042-LIQF-107: a vAMM which was active on the market throughout the epoch but with an active range which never overlapped with the SLA range is counted with an implied commitment of `0`.
     When the parties submit the following AMM:
@@ -102,19 +101,21 @@ Feature: Test vAMM implied commitment is working as expected
 
     And the following trades should be executed:
       | buyer                                                            | price | size | seller                                                           |
-      | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 448   | 102  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
+      | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 102   | 448  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
 
     And set the following AMM sub account aliases:
       | party | market id | alias    |
       | vamm1 | ETH/MAR22 | vamm1-id |
       | vamm2 | ETH/MAR22 | vamm2-id |
 
-    Then debug trades
-
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
       | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
+
+    And the following trades should be executed:
+      | buyer                                                            | price | size | seller |
+      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 104   | 10   | party2 |
 
     Then the network moves ahead "1" epochs
 

--- a/core/integration/features/amm/0042-LIQF-107.feature
+++ b/core/integration/features/amm/0042-LIQF-107.feature
@@ -111,8 +111,10 @@ Feature: Test vAMM implied commitment is working as expected
     Then the network moves ahead "1" epochs
 
     And the following transfers should happen:
-      | type                                   | from   | to     | from account                   | to account                     | market id | amount | asset |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | vamm1  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | vamm2  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | vamm1  | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 467    | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | vamm2  | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 467    | USD   |
+      | type                                   | from                                                             | to     | from account                   | to account                     | market id | amount | asset |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_PAY        | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | market | ACCOUNT_TYPE_GENERAL           | ACCOUNT_TYPE_FEES_LIQUIDITY    | ETH/MAR22 | 914     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_PAY        | party2                                                           | market | ACCOUNT_TYPE_GENERAL           | ACCOUNT_TYPE_FEES_LIQUIDITY    | ETH/MAR22 | 21     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | vamm1  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | vamm2  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | vamm1                                                            | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 467    | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | vamm2                                                            | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 467    | USD   |

--- a/core/integration/features/amm/0042-LIQF-107.feature
+++ b/core/integration/features/amm/0042-LIQF-107.feature
@@ -64,8 +64,8 @@ Feature: Test vAMM implied commitment is working as expected
 
     When the parties submit the following liquidity provision:
       | id   | party | market id | commitment amount | fee  | lp type    |
-      | lp_1 | vamm1 | ETH/MAR22 | 100000            | 0.02 | submission |
-      | lp_2 | vamm2 | ETH/MAR22 | 100000            | 0.02 | submission |
+      | lp_1 | lp1   | ETH/MAR22 | 100000            | 0.02 | submission |
+      | lp_2 | lp2   | ETH/MAR22 | 100000            | 0.02 | submission |
 
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
@@ -91,25 +91,26 @@ Feature: Test vAMM implied commitment is working as expected
 
   @VAMM
   Scenario: 0042-LIQF-107: a vAMM which was active on the market throughout the epoch but with an active range which never overlapped with the SLA range is counted with an implied commitment of `0`.
-    When the parties submit the following AMM:
-      | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee | error |
-      | vamm2 | ETH/MAR22 | 100000 | 0.5      | 120  | 110         | 130         | 0.03         |       |
-    Then the AMM pool status should be:
-      | party | market id | amount | status        | base | lower bound | upper bound |
-      | vamm2 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 120  | 110         | 130         |
+    # When the parties submit the following AMM:
+    #   | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee | error |
+    #   | vamm2 | ETH/MAR22 | 100000 | 0.5      | 120  | 110         | 130         | 0.03         |       |
+    # Then the AMM pool status should be:
+    #   | party | market id | amount | status        | base | lower bound | upper bound |
+    #   | vamm2 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 120  | 110         | 130         |
     Then the network moves ahead "1" blocks
+    Then debug trades
 
     #vamm1 best sell 101, vol ?
     #vamm2 best buy 121, vol ?
     #traded price 102, vol 448
 
-    And the following trades should be executed:
-      | buyer                                                            | price | size | seller                                                           |
-      | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 104   | 423  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
+    # And the following trades should be executed:
+    #   | buyer                                                            | price | size | seller                                                           |
+    #   | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 104   | 423  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
 
-    And the following trades should be executed:
-      | buyer                                                            | price | size | seller                                                           |
-      | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 102   | 448  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
+    # And the following trades should be executed:
+    #   | buyer                                                            | price | size | seller                                                           |
+    #   | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 102   | 448  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
 
 
 # And set the following AMM sub account aliases:
@@ -117,16 +118,18 @@ Feature: Test vAMM implied commitment is working as expected
 #   | vamm1 | ETH/MAR22 | vamm1-id |
 #   | vamm2 | ETH/MAR22 | vamm2-id |
 
-# And the parties place the following orders:
-#   | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
-#   | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
-#   | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
+And the parties place the following orders:
+  | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+  | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
+  | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
 
 # And the following trades should be executed:
 #   | buyer                                                            | price | size | seller |
 #   | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 104   | 10   | party2 |
 
-# Then the network moves ahead "1" epochs
+Then the network moves ahead "1" epochs
+
+Then debug transfers
 
 # And the following transfers should happen:
 #   | type                                   | from                                                             | to     | from account                   | to account                     | market id | amount | asset |

--- a/core/integration/features/amm/0042-LIQF-107.feature
+++ b/core/integration/features/amm/0042-LIQF-107.feature
@@ -89,19 +89,27 @@ Feature: Test vAMM implied commitment is working as expected
       | party | market id | amount | status        | base | lower bound | upper bound |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 95          | 105         |
 
+
   @VAMM
   Scenario: 0042-LIQF-107: a vAMM which was active on the market throughout the epoch but with an active range which never overlapped with the SLA range is counted with an implied commitment of `0`.
     When the parties submit the following AMM:
       | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee | error |
-      | vamm2 | ETH/MAR22 | 100000 | 0.5      | 120  | 110         | 130         | 0.03         | a     |
+      | vamm2 | ETH/MAR22 | 100000 | 0.5      | 120  | 110         | 130         | 0.03         |       |
     Then the AMM pool status should be:
       | party | market id | amount | status        | base | lower bound | upper bound |
       | vamm2 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 120  | 110         | 130         |
+    Then the network moves ahead "1" blocks
+
+    And the following trades should be executed:
+      | buyer                                                            | price | size | seller                                                           |
+      | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 448   | 102  | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba |
 
     And set the following AMM sub account aliases:
       | party | market id | alias    |
       | vamm1 | ETH/MAR22 | vamm1-id |
       | vamm2 | ETH/MAR22 | vamm2-id |
+
+    Then debug trades
 
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
@@ -112,7 +120,7 @@ Feature: Test vAMM implied commitment is working as expected
 
     And the following transfers should happen:
       | type                                   | from                                                             | to     | from account                   | to account                     | market id | amount | asset |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_PAY        | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | market | ACCOUNT_TYPE_GENERAL           | ACCOUNT_TYPE_FEES_LIQUIDITY    | ETH/MAR22 | 914     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_PAY        | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | market | ACCOUNT_TYPE_GENERAL           | ACCOUNT_TYPE_FEES_LIQUIDITY    | ETH/MAR22 | 914    | USD   |
       | TRANSFER_TYPE_LIQUIDITY_FEE_PAY        | party2                                                           | market | ACCOUNT_TYPE_GENERAL           | ACCOUNT_TYPE_FEES_LIQUIDITY    | ETH/MAR22 | 21     | USD   |
       | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | vamm1  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |
       | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | vamm2  | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 467    | USD   |

--- a/core/integration/features/amm/0042-LIQF-108.feature
+++ b/core/integration/features/amm/0042-LIQF-108.feature
@@ -48,7 +48,6 @@ Feature: Test vAMM implied commitment is working as expected
       | id        | quote name | asset | liquidity monitoring | risk model            | margin calculator   | auction duration | fees          | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params |
       | ETH/MAR22 | USD        | USD   | lqm-params           | log-normal-risk-model | margin-calculator-1 | 2                | fees-config-1 | default-none     | default-eth-for-future | 1e0                    | 0                         | SLA-22     |
 
-    # Setting up the accounts and vAMM submission now is part of the background, because we'll be running scenarios 0090-VAMM-006 through 0090-VAMM-014 on this setup
     Given the parties deposit on asset's general account the following amount:
       | party  | asset | amount  |
       | lp1    | USD   | 1000000 |
@@ -86,10 +85,10 @@ Feature: Test vAMM implied commitment is working as expected
   Scenario: 0042-LIQF-108: A vAMM which was active on the market with an average of `10000` liquidity units (`price * volume`) provided across the epoch, and where the `market.liquidity.stakeToCcyVolume` value is `100`, will have an implied commitment of `100`.
     Then the parties submit the following AMM:
       | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee |
-      | vamm1 | ETH/MAR22 | 100000 | 0.05     | 100  | 95          | 110         | 0.03         |
+      | vamm1 | ETH/MAR22 | 100000 | 0.05     | 100  | 98          | 102         | 0.03         |
     Then the AMM pool status should be:
       | party | market id | amount | status        | base | lower bound | upper bound |
-      | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 95          | 110         |
+      | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 98          | 102         |
     Then the network moves ahead "1" blocks
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |

--- a/core/integration/features/amm/0042-LIQF-108.feature
+++ b/core/integration/features/amm/0042-LIQF-108.feature
@@ -83,28 +83,28 @@ Feature: Test vAMM implied commitment is working as expected
     And the current epoch is "0"
 
   @VAMM
-  Scenario: 0042-LIQF-107: a vAMM which was active on the market throughout the epoch but with an active range which never overlapped with the SLA range is counted with an implied commitment of `0`.
-    When the parties submit the following AMM:
-      | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee | error |
-      | vamm2 | ETH/MAR22 | 100000 | 0.5      | 120  | 110         | 130         | 0.03         |       |
+  Scenario: 0042-LIQF-108: A vAMM which was active on the market with an average of `10000` liquidity units (`price * volume`) provided across the epoch, and where the `market.liquidity.stakeToCcyVolume` value is `100`, will have an implied commitment of `100`.
+    Then the parties submit the following AMM:
+      | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee |
+      | vamm1 | ETH/MAR22 | 100000 | 0.05     | 100  | 95          | 110         | 0.03         |
     Then the AMM pool status should be:
       | party | market id | amount | status        | base | lower bound | upper bound |
-      | vamm2 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 120  | 110         | 130         |
+      | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 95          | 110         |
     Then the network moves ahead "1" blocks
-   
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
       | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
       | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
 
+    Then the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 100   | 10   | party2 |
+
     Then the network moves ahead "1" epochs
-    And the following trades should be executed:
-      | buyer                                                            | price | size | seller |
-      | 4582953f1f1dd07603befe97994d6414c0ebb53c7d52c29e866bb3e85d7b30b4 | 119   | 10   | party2 |
 
     And the following transfers should happen:
       | type                                   | from   | to     | from account                   | to account                     | market id | amount | asset |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp1    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 12     | USD   |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 12     | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 12     | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 12     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp1    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |

--- a/core/integration/features/amm/0042-LIQF-108.feature
+++ b/core/integration/features/amm/0042-LIQF-108.feature
@@ -107,3 +107,23 @@ Feature: Test vAMM implied commitment is working as expected
       | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
       | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
       | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
+      | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
+
+    Then the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 100   | 10   | party2 |
+
+    Then the network moves ahead "1" epochs
+
+    And the following transfers should happen:
+      | type                                   | from                                                             | to                                                               | from account                   | to account                     | market id | amount | asset |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 3      | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | lp1                                                              | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 8      | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | lp2                                                              | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 8      | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 3      | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1                                                              | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 8      | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2                                                              | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 8      | USD   |

--- a/core/integration/features/amm/0042-LIQF-108.feature
+++ b/core/integration/features/amm/0042-LIQF-108.feature
@@ -102,11 +102,11 @@ Feature: Test vAMM implied commitment is working as expected
     Then the network moves ahead "1" epochs
 
     And the following transfers should happen:
-      | type                                   | from   | to     | from account                   | to account                     | market id | amount | asset |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp1    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
+      | type                                       | from   | to     | from account                   | to account                                     | market id | amount | asset |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE       | market | lp1    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE       | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES                 | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_UNPAID_COLLECT | lp1    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_UNPAID_COLLECT | lp2    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ETH/MAR22 | 10     | USD   |
 
     And the parties place the following orders:
       | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
@@ -120,10 +120,10 @@ Feature: Test vAMM implied commitment is working as expected
     Then the network moves ahead "1" epochs
 
     And the following transfers should happen:
-      | type                                   | from                                                             | to                                                               | from account                   | to account                     | market id | amount | asset |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 3      | USD   |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | lp1                                                              | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 8      | USD   |
-      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market                                                           | lp2                                                              | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 8      | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 3      | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1                                                              | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 8      | USD   |
-      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2                                                              | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 8      | USD   |
+      | type                                            | from      | to                                                               | from account                   | to account                      | market id | amount | asset |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE            | market    | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES  | ETH/MAR22 | 0      | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE            | market    | lp1                                                              | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES  | ETH/MAR22 | 8      | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE            | market    | lp2                                                              | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES  | ETH/MAR22 | 8      | USD   |
+      | TRANSFER_TYPE_SLA_PERFORMANCE_BONUS_DISTRIBUTE  | market    | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION | ACCOUNT_TYPE_GENERAL         | ETH/MAR22 | 16      | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_UNPAID_COLLECT      | lp1       | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION         | ETH/MAR22 | 8      | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_UNPAID_COLLECT      | lp2       | market                                                           | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_LIQUIDITY_FEES_BONUS_DISTRIBUTION         | ETH/MAR22 | 8      | USD   |

--- a/core/integration/features/amm/0042-LIQF-108_before_openingAuction.feature
+++ b/core/integration/features/amm/0042-LIQF-108_before_openingAuction.feature
@@ -17,7 +17,7 @@ Feature: Test vAMM implied commitment is working as expected
       | market.value.windowLength                           | 60s   |
       | network.markPriceUpdateMaximumFrequency             | 0s    |
       | limits.markets.maxPeggedOrders                      | 6     |
-      | market.auction.minimumDuration                      | 15    |
+      | market.auction.minimumDuration                      | 2     |
       | market.fee.factors.infrastructureFee                | 0.001 |
       | market.fee.factors.makerFee                         | 0.004 |
       | spam.protection.max.stopOrdersPerMarket             | 5     |
@@ -80,17 +80,13 @@ Feature: Test vAMM implied commitment is working as expected
       | party2 | ETH/MAR22 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC |           |
       | lp1    | ETH/MAR22 | sell | 20     | 160   | 0                | TYPE_LIMIT | TIF_GTC | lp1-s     |
 
-    # enter new epoch while in opening auction
-    Then the network moves ahead "14" blocks
-    And the current epoch is "1"
-    
     When the opening auction period ends for market "ETH/MAR22"
     Then the following trades should be executed:
       | buyer  | price | size | seller |
       | party1 | 100   | 1    | party2 |
 
     Then the network moves ahead "1" blocks
-    And the current epoch is "1"
+    And the current epoch is "0"
 
   @VAMM
   Scenario: 0042-LIQF-108_before_openingAuction : A vAMM which was active on the market during opening auction, vAMM should be getting LP fee in the same way as normal LPs 
@@ -104,7 +100,7 @@ Feature: Test vAMM implied commitment is working as expected
       | buyer  | price | size | seller |
       | party1 | 100   | 10   | party2 |
     Then the network moves ahead "1" epochs
-    And the current epoch is "2"
+    And the current epoch is "1"
 
     And the following transfers should happen:
       | type                                   | from   | to                                                                  | from account                   | to account                     | market id | amount | asset |

--- a/core/integration/features/amm/0042-LIQF-108_before_openingAuction.feature
+++ b/core/integration/features/amm/0042-LIQF-108_before_openingAuction.feature
@@ -1,0 +1,113 @@
+Feature: Test vAMM implied commitment is working as expected
+
+  Background:
+    Given the average block duration is "1"
+    And the margin calculator named "margin-calculator-1":
+      | search factor | initial factor | release factor |
+      | 1.2           | 1.5            | 1.7            |
+    And the log normal risk model named "log-normal-risk-model":
+      | risk aversion | tau                   | mu | r   | sigma |
+      | 0.001         | 0.0011407711613050422 | 0  | 0.9 | 3.0   |
+    And the liquidity monitoring parameters:
+      | name       | triggering ratio | time window | scaling factor |
+      | lqm-params | 1.00             | 20s         | 1              |
+
+    And the following network parameters are set:
+      | name                                                | value |
+      | market.value.windowLength                           | 60s   |
+      | network.markPriceUpdateMaximumFrequency             | 0s    |
+      | limits.markets.maxPeggedOrders                      | 6     |
+      | market.auction.minimumDuration                      | 1     |
+      | market.fee.factors.infrastructureFee                | 0.001 |
+      | market.fee.factors.makerFee                         | 0.004 |
+      | spam.protection.max.stopOrdersPerMarket             | 5     |
+      | market.liquidity.equityLikeShareFeeFraction         | 1     |
+      | market.amm.minCommitmentQuantum                     | 1     |
+      | market.liquidity.bondPenaltyParameter               | 0.2   |
+      | market.liquidity.stakeToCcyVolume                   | 1     |
+      | market.liquidity.successorLaunchWindowLength        | 1h    |
+      | market.liquidity.sla.nonPerformanceBondPenaltySlope | 0     |
+      | market.liquidity.sla.nonPerformanceBondPenaltyMax   | 0.6   |
+      | validators.epoch.length                             | 10s   |
+      | market.liquidity.earlyExitPenalty                   | 0.25  |
+      | market.liquidity.maximumLiquidityFeeFactorLevel     | 0.25  |
+    #risk factor short:3.5569036
+    #risk factor long:0.801225765
+    And the following assets are registered:
+      | id  | decimal places |
+      | USD | 0              |
+    And the fees configuration named "fees-config-1":
+      | maker fee | infrastructure fee |
+      | 0.0004    | 0.001              |
+
+    And the liquidity sla params named "SLA-22":
+      | price range | commitment min time fraction | performance hysteresis epochs | sla competition factor |
+      | 0.05        | 0.6                          | 1                             | 1.0                    |
+
+    And the markets:
+      | id        | quote name | asset | liquidity monitoring | risk model            | margin calculator   | auction duration | fees          | price monitoring | data source config     | linear slippage factor | quadratic slippage factor | sla params |
+      | ETH/MAR22 | USD        | USD   | lqm-params           | log-normal-risk-model | margin-calculator-1 | 2                | fees-config-1 | default-none     | default-eth-for-future | 1e0                    | 0                         | SLA-22     |
+
+    Given the parties deposit on asset's general account the following amount:
+      | party  | asset | amount  |
+      | lp1    | USD   | 1000000 |
+      | lp2    | USD   | 1000000 |
+      | lp3    | USD   | 1000000 |
+      | party1 | USD   | 1000000 |
+      | party2 | USD   | 1000000 |
+      | party3 | USD   | 1000000 |
+      | party4 | USD   | 1000000 |
+      | party5 | USD   | 1000000 |
+      | vamm1  | USD   | 1000000 |
+      | vamm2  | USD   | 1000000 |
+
+    When the parties submit the following liquidity provision:
+      | id   | party | market id | commitment amount | fee  | lp type    |
+      | lp_1 | lp1   | ETH/MAR22 | 100000            | 0.02 | submission |
+      | lp_2 | lp2   | ETH/MAR22 | 100000            | 0.02 | submission |
+
+    Then the parties submit the following AMM:
+      | party | market id | amount | slippage | base | lower bound | upper bound | proposed fee |
+      | vamm1 | ETH/MAR22 | 100000 | 0.05     | 100  | 98          | 102         | 0.03         |
+    Then the AMM pool status should be:
+      | party | market id | amount | status        | base | lower bound | upper bound |
+      | vamm1 | ETH/MAR22 | 100000 | STATUS_ACTIVE | 100  | 98          | 102         |
+
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | lp1    | ETH/MAR22 | buy  | 20     | 40    | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
+      | party1 | ETH/MAR22 | buy  | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | party2 | ETH/MAR22 | sell | 1      | 100   | 0                | TYPE_LIMIT | TIF_GTC |           |
+      | lp1    | ETH/MAR22 | sell | 20     | 160   | 0                | TYPE_LIMIT | TIF_GTC | lp1-s     |
+
+    When the opening auction period ends for market "ETH/MAR22"
+    Then the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 100   | 1    | party2 |
+
+    Then the network moves ahead "1" blocks
+    And the current epoch is "0"
+
+  @VAMM
+  Scenario: 0042-LIQF-108_before_openingAuction : A vAMM which was active on the market during opening auction, vAMM should be getting LP fee in the same way as normal LPs 
+
+    Then the network moves ahead "1" blocks
+    And the parties place the following orders:
+      | party  | market id | side | volume | price | resulting trades | type       | tif     | reference |
+      | party1 | ETH/MAR22 | buy  | 10     | 100   | 0                | TYPE_LIMIT | TIF_GTC | lp1-b     |
+      | party2 | ETH/MAR22 | sell | 10     | 100   | 1                | TYPE_LIMIT | TIF_GTC |           |
+
+    Then the following trades should be executed:
+      | buyer  | price | size | seller |
+      | party1 | 100   | 10   | party2 |
+
+    Then the network moves ahead "1" epochs
+
+    And the following transfers should happen:
+      | type                                   | from   | to     | from account                   | to account                     | market id | amount | asset |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp1    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_LIQUIDITY_FEE_ALLOCATE   | market | lp2    | ACCOUNT_TYPE_FEES_LIQUIDITY    | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp1    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
+      | TRANSFER_TYPE_SLA_PENALTY_LP_FEE_APPLY | lp2    | market | ACCOUNT_TYPE_LP_LIQUIDITY_FEES | ACCOUNT_TYPE_INSURANCE         | ETH/MAR22 | 10     | USD   |
+
+   

--- a/core/integration/features/amm/0090-VAMM-031.feature
+++ b/core/integration/features/amm/0090-VAMM-031.feature
@@ -158,8 +158,8 @@ Feature: vAMM behaviour when a market settles
     # Different scenario's involving a final settlement: break even, profit and loss.
     Examples:
       | settle price | margin | amm balance | general balance |
-      | 105          | 205    | 29996       | 29996            | # settle price < market price: +1 from fees +1 from final settlement
-      | 107          | 203    | 29994       | 29994            | # settle price > market price: +1 from fees, -1 from final settlement
-      | 104          | 206    | 29997       | 29997            | # settle price < market price: +1 from fees +2 from final settlement
-      | 106          | 204    | 29995       | 29995            | # settle price = market price: +1 from fees
-      | 108          | 202    | 29993       | 29993           | # settle price > market price: +1 from fees, -2 from final settlement
+      | 105          | 205    | 29997       | 29997            | # settle price < market price: +1 from fees +1 from final settlement
+      | 107          | 203    | 29995       | 29995            | # settle price > market price: +1 from fees, -1 from final settlement
+      | 104          | 206    | 29998       | 29998            | # settle price < market price: +1 from fees +2 from final settlement
+      | 106          | 204    | 29996       | 29996            | # settle price = market price: +1 from fees
+      | 108          | 202    | 29994       | 29994           | # settle price > market price: +1 from fees, -2 from final settlement

--- a/core/integration/features/amm/0090-VAMM-032.feature
+++ b/core/integration/features/amm/0090-VAMM-032.feature
@@ -157,8 +157,8 @@ Feature: vAMM behaviour when a market settles with distressed AMM.
       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1-id | ACCOUNT_TYPE_MARGIN     | ETH/MAR22 | 420    | USD   | true   | TRANSFER_TYPE_MARGIN_LOW             |
       | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 420    | USD   | true   | TRANSFER_TYPE_LOSS                   |
       | vamm1-id | ACCOUNT_TYPE_GENERAL    |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 1380   | USD   | true   | TRANSFER_TYPE_LOSS                   |
-      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL    |           | 28202  | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
+      | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL    |           | 28204  | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 28202   |        |        |
+      | vamm1    | USD   |           | 28204   |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |


### PR DESCRIPTION
closes [0042-LIQF-107](https://github.com/vegaprotocol/core-test-coverage/issues/1347)
closes [0042-LIQF-108](https://github.com/vegaprotocol/core-test-coverage/issues/1348)
closes [0042-LIQF-109](https://github.com/vegaprotocol/core-test-coverage/issues/1349)
closes [0042-LIQF-110](https://github.com/vegaprotocol/core-test-coverage/issues/1350)
closes [0042-LIQF-111](https://github.com/vegaprotocol/core-test-coverage/issues/1351)
closes #11377 
closes #11371 
closes #11369 