### PR TITLE
fix: only remove old AMM during amend once we are past all error modes

### DIFF
--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -720,13 +720,15 @@ func (e *Engine) Amend(
 		}
 	}
 
-	// we need to remove the existing pool from the engine so that when calculating rebasing orders we do not
-	// trade with ourselves.
-	e.remove(ctx, amend.Party)
 	updated, err := pool.Update(amend, riskFactors, scalingFactors, slippage)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// we need to remove the existing pool from the engine so that when calculating rebasing orders we do not
+	// trade with ourselves.
+	e.remove(ctx, amend.Party)
+
 	e.log.Debug("AMM amended",
 		logging.String("owner", amend.Party),
 		logging.String("marketID", e.marketID),

--- a/core/execution/amm/pool.go
+++ b/core/execution/amm/pool.go
@@ -891,6 +891,10 @@ func (p *Pool) fairPrice() *num.Uint {
 		pv = cu.pv.Add(pv)
 	}
 
+	if cu.empty {
+		panic("should not be calculating fair-price on empty-curve side")
+	}
+
 	l := cu.l
 
 	// pv * sqrt(pu) * (1/L) + 1


### PR DESCRIPTION
closes #11355 