### PR TITLE
fix: restore positions before orderbook so that AMMs have true state …

### DIFF
--- a/core/execution/common/interfaces.go
+++ b/core/execution/common/interfaces.go
@@ -355,6 +355,7 @@ type CommonMarket interface {
 	BeginBlock(context.Context)
 	UpdateMarketState(ctx context.Context, changes *types.MarketStateUpdateConfiguration) error
 	GetFillPrice(volume uint64, side types.Side) (*num.Uint, error)
+	Mkt() *types.Market
 
 	IsOpeningAuction() bool
 

--- a/core/execution/engine_snapshot.go
+++ b/core/execution/engine_snapshot.go
@@ -156,8 +156,6 @@ func (e *Engine) restoreSpotMarket(ctx context.Context, em *types.ExecSpotMarket
 	}
 	// ensure this is set correctly
 	mkt.SetNextMTM(nextMTM)
-
-	e.publishNewMarketInfos(ctx, mkt.GetMarketData(), *mkt.Mkt())
 	return mkt, nil
 }
 
@@ -240,8 +238,6 @@ func (e *Engine) restoreMarket(ctx context.Context, em *types.ExecMarket) (*futu
 	// ensure this is set correctly
 	mkt.SetNextMTM(nextMTM)
 	mkt.SetNextInternalCompositePriceCalc(nextInternalCompositePriceCalc)
-
-	e.publishNewMarketInfos(ctx, mkt.GetMarketData(), *mkt.Mkt())
 	return mkt, nil
 }
 
@@ -403,6 +399,9 @@ func (e *Engine) OnStateLoaded(ctx context.Context) error {
 		if err := m.PostRestore(ctx); err != nil {
 			return err
 		}
+
+		// let the core state API know about the markets
+		e.publishNewMarketInfos(ctx, m.GetMarketData(), *m.Mkt())
 	}
 	// use the time as restored by the snapshot
 	t := e.timeService.GetTimeNow()

--- a/core/matching/cached_orderbook.go
+++ b/core/matching/cached_orderbook.go
@@ -49,24 +49,13 @@ func (b *CachedOrderBook) LoadState(ctx context.Context, payload *types.Payload)
 		return providers, err
 	}
 
-	return providers, err
-}
-
-func (b *CachedOrderBook) OnStateLoaded(ctx context.Context) error {
-	// when a market is restored we call `GetMarketData` which fills this cache based on an unrestored orderbook,
-	// now we have restored we need to recalculate.
-	b.cache.Invalidate()
-
-	// if we are in an auction we need to build the IP&V structure.
-	// note that we need to do this after the positions engine has been restored since only then can the AMM's be at their true fair-price.
 	if b.auction {
-		b.indicativePriceAndVolume = NewIndicativePriceAndVolume(b.log, b.buy, b.sell)
-
+		b.cache.Invalidate()
 		b.log.Info("restoring orderbook cache for", logging.String("marketID", b.marketID))
 		b.GetIndicativePriceAndVolume()
 	}
 
-	return nil
+	return providers, err
 }
 
 func (b *CachedOrderBook) EnterAuction() []*types.Order {

--- a/core/matching/snapshot.go
+++ b/core/matching/snapshot.go
@@ -129,6 +129,11 @@ func (b *OrderBook) LoadState(_ context.Context, payload *types.Payload) ([]type
 			b.peggedOrders.Add(pid)
 		}
 	}
+
+	if b.auction {
+		b.indicativePriceAndVolume = NewIndicativePriceAndVolume(b.log, b.buy, b.sell)
+	}
+
 	return nil, nil
 }
 

--- a/core/snapshot/providers.go
+++ b/core/snapshot/providers.go
@@ -36,8 +36,8 @@ var providersInCallOrder = []types.SnapshotNamespace{
 	types.DelegationSnapshot,
 	types.FloatingPointConsensusSnapshot, // Shouldn't matter but maybe best before the markets are restored.
 	types.ExecutionSnapshot,              // Creates the markets, returns matching and positions engines for state providers.
-	types.MatchingSnapshot,               // Requires markets.
 	types.PositionsSnapshot,              // Requires markets.
+	types.MatchingSnapshot,               // Requires markets, and positions so that AMM's evaluate properly
 	types.SettlementSnapshot,             // Requires markets.
 	types.LiquidationSnapshot,            // Requires markets.
 	types.HoldingAccountTrackerSnapshot,


### PR DESCRIPTION
closes #11356 

Issue is with the order the engines are restore, and when the execution engine sends out martket-data-events. The _current_ order is:
- is market restored, market-data event is sent out
- orderbook is restored
- positions engine is restored
- (post-restore) orderbook IPV cache is restored

The problem is that when in an auction the market-data-event will call the orderbook but the IPV hasn't been restored yet. To restore the IPV cache the orderbook needs the positions engine to be restored which is why the cache restoration happens in a post-restore.

Its a tangle.

The new order is
- market is restored
- positions engine is restored
- orderbook and IPV cache is restored
- (post restore) market-data event sent out


full run:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/12387/pipeline

(note the soak-test failure is an event-file diff which turns out is a false positive)

