### PR TITLE
chore: improve API docs around candle IDs

### DIFF
--- a/protos/data-node/api/v2/trading_data_grpc.pb.go
+++ b/protos/data-node/api/v2/trading_data_grpc.pb.go
@@ -168,15 +168,17 @@ type TradingDataServiceClient interface {
 	GetNetworkLimits(ctx context.Context, in *GetNetworkLimitsRequest, opts ...grpc.CallOption) (*GetNetworkLimitsResponse, error)
 	// List candle data
 	//
-	// Get a list of candle data for a given candle ID. Candle IDs can be obtained by calling list-candle-intervals
+	// Get a list of candle data for a given candle ID.
+	// A candle ID encapsulates a market ID and candle interval. A list of available candle IDs, and therefore candle intervals can be found using the list-candle-intervals API.
 	ListCandleData(ctx context.Context, in *ListCandleDataRequest, opts ...grpc.CallOption) (*ListCandleDataResponse, error)
 	// Observe candle data
 	//
-	// Subscribe to a stream of candle updates
+	// Subscribe to a stream of candle updates given a candle ID.
+	// A candle ID encapsulates a market ID and candle interval. A list of available candle IDs, and therefore candle intervals can be found using the list-candle-intervals API.
 	ObserveCandleData(ctx context.Context, in *ObserveCandleDataRequest, opts ...grpc.CallOption) (TradingDataService_ObserveCandleDataClient, error)
 	// List candle intervals
 	//
-	// Get a list of all available intervals for a given market along with the corresponding candle ID
+	// Get a list of all available candle intervals for a given market along with the corresponding candle ID.
 	ListCandleIntervals(ctx context.Context, in *ListCandleIntervalsRequest, opts ...grpc.CallOption) (*ListCandleIntervalsResponse, error)
 	// List votes
 	//
@@ -2308,15 +2310,17 @@ type TradingDataServiceServer interface {
 	GetNetworkLimits(context.Context, *GetNetworkLimitsRequest) (*GetNetworkLimitsResponse, error)
 	// List candle data
 	//
-	// Get a list of candle data for a given candle ID. Candle IDs can be obtained by calling list-candle-intervals
+	// Get a list of candle data for a given candle ID.
+	// A candle ID encapsulates a market ID and candle interval. A list of available candle IDs, and therefore candle intervals can be found using the list-candle-intervals API.
 	ListCandleData(context.Context, *ListCandleDataRequest) (*ListCandleDataResponse, error)
 	// Observe candle data
 	//
-	// Subscribe to a stream of candle updates
+	// Subscribe to a stream of candle updates given a candle ID.
+	// A candle ID encapsulates a market ID and candle interval. A list of available candle IDs, and therefore candle intervals can be found using the list-candle-intervals API.
 	ObserveCandleData(*ObserveCandleDataRequest, TradingDataService_ObserveCandleDataServer) error
 	// List candle intervals
 	//
-	// Get a list of all available intervals for a given market along with the corresponding candle ID
+	// Get a list of all available candle intervals for a given market along with the corresponding candle ID.
 	ListCandleIntervals(context.Context, *ListCandleIntervalsRequest) (*ListCandleIntervalsResponse, error)
 	// List votes
 	//

--- a/protos/sources/data-node/api/v2/trading_data.proto
+++ b/protos/sources/data-node/api/v2/trading_data.proto
@@ -260,21 +260,23 @@ service TradingDataService {
 
   // List candle data
   //
-  // Get a list of candle data for a given candle ID. Candle IDs can be obtained by calling list-candle-intervals
+  // Get a list of candle data for a given candle ID.
+  // A candle ID encapsulates a market ID and candle interval. A list of available candle IDs, and therefore candle intervals can be found using the list-candle-intervals API.
   rpc ListCandleData(ListCandleDataRequest) returns (ListCandleDataResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Candles"};
   }
 
   // Observe candle data
   //
-  // Subscribe to a stream of candle updates
+  // Subscribe to a stream of candle updates given a candle ID.
+  // A candle ID encapsulates a market ID and candle interval. A list of available candle IDs, and therefore candle intervals can be found using the list-candle-intervals API.
   rpc ObserveCandleData(ObserveCandleDataRequest) returns (stream ObserveCandleDataResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Candles"};
   }
 
   // List candle intervals
   //
-  // Get a list of all available intervals for a given market along with the corresponding candle ID
+  // Get a list of all available candle intervals for a given market along with the corresponding candle ID.
   rpc ListCandleIntervals(ListCandleIntervalsRequest) returns (ListCandleIntervalsResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Candles"};
   }


### PR DESCRIPTION
A community member on discord was looking at the docs for `ObserveCandleData` where it gave no information about what a candleID is or where to get them from.

This PR is quick fix to tidy up the doc-strings. Ideally we should deprecate candle ID's in favour of passing in a market+interval-enum directly to the candle API, but thats for another day.