### PR TITLE
fix: reject AMM creation when trading is not allowed on a market

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -5336,6 +5336,10 @@ func (m *Market) needsRebase(fairPrice *num.Uint) (bool, types.Side, *num.Uint) 
 }
 
 func (m *Market) SubmitAMM(ctx context.Context, submit *types.SubmitAMM, deterministicID string) error {
+	if !m.canTrade() {
+		return common.ErrTradingNotAllowed
+	}
+
 	m.idgen = idgeneration.New(deterministicID)
 	defer func() { m.idgen = nil }()
 
@@ -5405,6 +5409,10 @@ func (m *Market) SubmitAMM(ctx context.Context, submit *types.SubmitAMM, determi
 }
 
 func (m *Market) AmendAMM(ctx context.Context, amend *types.AmendAMM, deterministicID string) error {
+	if !m.canTrade() {
+		return common.ErrTradingNotAllowed
+	}
+
 	m.idgen = idgeneration.New(deterministicID)
 	defer func() { m.idgen = nil }()
 
@@ -5462,6 +5470,10 @@ func (m *Market) AmendAMM(ctx context.Context, amend *types.AmendAMM, determinis
 }
 
 func (m *Market) CancelAMM(ctx context.Context, cancel *types.CancelAMM, deterministicID string) error {
+	if !m.canTrade() {
+		return common.ErrTradingNotAllowed
+	}
+
 	ammParty, err := m.amm.GetAMMParty(cancel.Party)
 	if err != nil {
 		return err

--- a/core/integration/features/amm/0090-VAMM-021.feature
+++ b/core/integration/features/amm/0090-VAMM-021.feature
@@ -252,7 +252,7 @@ Feature: Test vAMM cancellation by reduce-only from short.
       | mark price | trading mode            | mid price | static mid price | best offer price | best bid price |
       | 107        | TRADING_MODE_CONTINUOUS | 100        | 100               | 160              | 40             |
 
-  @VAMM2
+  @VAMM
   Scenario: 0090-VAMM-021: Same as the test above, only this time, the final order that closes the vAMM position is bigger than the remaining volume, so we check if the vAMM is cancelled instead of going long.
      # based on 0090-VAMM-008: vAMM creates a position, has some general balance left in general and margin accounts.
     When the parties place the following orders:


### PR DESCRIPTION
Fail transaction to submit/amend/cancel an AMM if the market state does not allow trades, in the same way we do for orders.