### PR TITLE
chore: add parties engine to snapshot engine as a provider

### DIFF
--- a/core/protocol/all_services.go
+++ b/core/protocol/all_services.go
@@ -459,7 +459,9 @@ func newServices(
 		svcs.volumeDiscount,
 		svcs.teamsEngine,
 		svcs.spam,
-		svcs.l2Verifiers)
+		svcs.l2Verifiers,
+		svcs.partiesEngine,
+	)
 
 	pow := pow.New(svcs.log, svcs.conf.PoW)
 


### PR DESCRIPTION
Adds the `partiesEngine` to the snapshot engine's provider list.

Jenkins:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/61804/pipeline/589