### PR TITLE
fix: use asset-scaled AMM fair-price for rebase check on submission

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -5438,7 +5438,7 @@ func (m *Market) SubmitAMM(ctx context.Context, submit *types.SubmitAMM, determi
 	}
 
 	// create a rebasing order if the AMM needs it i.e its base if not within best-bid/best-ask
-	if ok, side, quote := m.needsRebase(submit.Parameters.Base); ok {
+	if ok, side, quote := m.needsRebase(pool.BestPrice(nil)); ok {
 		order, err = m.getRebasingOrder(quote, side, submit.SlippageTolerance, pool)
 		if err != nil {
 			m.broker.Send(


### PR DESCRIPTION
closes #11389

To check whether an AMM crosses on entry we compare its fair-price to whatever is on the book. A new AMM's fair-price will equal its base-price and we were previously using that value directly from the submission.

The problem is that the price is the submission hasn't been scaled to the necessary DP's yet, so we now use the scaled-version from the AMM engine.