### PR TITLE
fix: unmarshall stop-order cancellation into pointer when preparing b…

### DIFF
--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -1026,7 +1026,7 @@ func (app *App) prepareProposal(height uint64, txs []abci.Tx, rawTxs [][]byte) [
 				anythingElseFromThisBlock = append(anythingElseFromThisBlock, tx.raw)
 			}
 		case txn.StopOrdersCancellationCommand:
-			s := commandspb.StopOrdersCancellation{}
+			s := &commandspb.StopOrdersCancellation{}
 			if err := tx.tx.Unmarshal(s); err != nil {
 				continue
 			}


### PR DESCRIPTION
A missing `&` meant the tx of a stop-order-cancellation couldn't be unmarshalled and resulting in the transaction being ignored when we prepared a block proposal.

Jenkins:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/62043/pipeline