### PR TITLE
fix: copy existing capped market cap configuration on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [11368](https://github.com/vegaprotocol/vega/issues/11368) - Add support for update vesting stats in REST API and fix summing the quantum balance for vesting stats.
 - [11380](https://github.com/vegaprotocol/vega/issues/11380) - Handle broken stop orders in prepare proposal. 
 - [11136](https://github.com/vegaprotocol/vega/issues/11136) - Fix premature invocation of post commit hooks in case of fee stats event.
+- [11409](https://github.com/vegaprotocol/vega/issues/11409) - When updating a capped market - copy the cap from the existing market definition. 
 
 ## 0.76.1
 

--- a/core/governance/engine.go
+++ b/core/governance/engine.go
@@ -1349,6 +1349,7 @@ func (e *Engine) updatedMarketFromProposal(p *proposal) (*types.Market, types.Pr
 				DataSourceSpecForSettlementData:     product.Future.DataSourceSpecForSettlementData,
 				DataSourceSpecForTradingTermination: product.Future.DataSourceSpecForTradingTermination,
 				DataSourceSpecBinding:               product.Future.DataSourceSpecBinding,
+				Cap:                                 existingMarket.GetFuture().Cap(),
 			},
 		}
 	case *types.UpdateInstrumentConfigurationPerps:
@@ -1377,7 +1378,6 @@ func (e *Engine) updatedMarketFromProposal(p *proposal) (*types.Market, types.Pr
 	if newMarket.Changes.LiquidationStrategy == nil {
 		newMarket.Changes.LiquidationStrategy = existingMarket.LiquidationStrategy
 	}
-
 	if perr, err := validateUpdateMarketChange(terms, existingMarket, &enactmentTime{current: p.Terms.EnactmentTimestamp, shouldNotVerify: true}, e.timeService.GetTimeNow(), e.netp); err != nil {
 		return nil, perr, err
 	}


### PR DESCRIPTION
Closes #11409 