### PR TITLE
fix: reduce precision loss when close to AMM boundary to prevent over…

### DIFF
--- a/core/integration/features/amm/0042-LIQF-109.feature
+++ b/core/integration/features/amm/0042-LIQF-109.feature
@@ -206,6 +206,6 @@ Feature: Test vAMM implied commitment is working as expected
     #virtual stake is 75% * 4669 = 3501
     And the liquidity provider fee shares for the market "ETH/MAR22" should be:
       | party                                                            | equity like share | virtual stake         | average entry valuation |
-      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0                 | 3501.0000000000000000 | 23501                   |
+      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0                 | 3502.0000000000000000 | 23502                   |
 
 

--- a/core/integration/features/amm/0090-VAMM-005.feature
+++ b/core/integration/features/amm/0090-VAMM-005.feature
@@ -119,10 +119,10 @@ Feature: Test vAMM submission works as expected (invalid submission)
 
      When the parties submit the following AMM:
        | party | market id | amount | slippage | base | lower bound | lower leverage | proposed fee |
-       | vamm4 | ETH/MAR22 | 100000  | 0.1      | 105  | 99         | 0.1            | 0.01         |
+       | vamm4 | ETH/MAR22 | 100000 | 0.1      | 100  | 99          | 0.1            | 0.01         |
      Then the AMM pool status should be:
        | party | market id | amount | status         | base | lower bound | lower leverage |
-       | vamm4 | ETH/MAR22 | 100000  | STATUS_ACTIVE | 105  | 99          | 0.1            |
+       | vamm4 | ETH/MAR22 | 100000  | STATUS_ACTIVE | 100  | 99          | 0.1            |
 
      When the parties submit the following AMM:
        | party | market id | amount | slippage | base | upper bound | upper leverage | proposed fee |

--- a/core/integration/features/amm/0090-VAMM-016.feature
+++ b/core/integration/features/amm/0090-VAMM-016.feature
@@ -90,7 +90,7 @@ Feature: vAMM has the same ELS as liquidity provision with the same commitment a
     When the parties submit the following liquidity provision:
       # Using 9788 instead of exactly 10,000 makes things easier because getting exactly 10,000 from an AMM pool as virtual stake can be tricky due to complex math.
       | id   | party | market id | commitment amount | fee   | lp type    |
-      | lp_2 | lp2   | ETH/MAR22 | 9884              | 0.03  | submission |
+      | lp_2 | lp2   | ETH/MAR22 | 9887              | 0.03  | submission |
 
     When the parties submit the following AMM:
       | party | market id | amount | slippage | base | lower bound | upper bound | lower leverage | upper leverage | proposed fee |
@@ -110,8 +110,8 @@ Feature: vAMM has the same ELS as liquidity provision with the same commitment a
     And the current epoch is "2"
     And the liquidity provider fee shares for the market "ETH/MAR22" should be:
       | party                                                            | equity like share  | virtual stake         | average entry valuation |
-      | lp2                                                              | 0.3320343993550121 | 9884.0000000000000000 | 29768                   |
-      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0.3320343993550121 | 9884.0000000000000000 | 19884                   |  
+      | lp2                                                              | 0.3320682474642305 | 9887.0000000000000000 | 29774                   |
+      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0.3320682474642305 | 9887.0000000000000000 | 19887                   |  
   
   @VAMM
   Scenario: 0090-VAMM-017: A vAMM's virtual ELS should be equal to the ELS of a regular LP with the same committed volume on the book (i.e. if a vAMM has an average volume on each side of the book across the epoch of 10k USDT, their ELS should be equal to that of a regular LP who has a commitment which requires supplying 10k USDT who joined at the same time as them).
@@ -123,7 +123,7 @@ Feature: vAMM has the same ELS as liquidity provision with the same commitment a
     When the parties submit the following liquidity provision:
       # Using 10,093 instead of exactly 10,000 makes things easier because getting exactly 10,000 from an AMM pool as virtual stake can be tricky due to complex math.
       | id   | party | market id | commitment amount | fee   | lp type    |
-      | lp_2 | lp2   | ETH/MAR22 | 9884              | 0.03  | submission |
+      | lp_2 | lp2   | ETH/MAR22 | 9887              | 0.03  | submission |
 
     And the parties place the following orders:
       | party | market id | side | volume | price | resulting trades | type       | tif   |
@@ -148,13 +148,13 @@ Feature: vAMM has the same ELS as liquidity provision with the same commitment a
     And the current epoch is "2"
     And the liquidity provider fee shares for the market "ETH/MAR22" should be:
       | party                                                            | equity like share  | virtual stake         | average entry valuation |
-      | lp2                                                              | 0.3320343993550121 | 9884.0000000000000000 | 29768                   |
-      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0.3320343993550121 | 9884.0000000000000000 | 19884                   |
+      | lp2                                                              | 0.3320682474642305 | 9887.0000000000000000 | 29774                   |
+      | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0.3320682474642305 | 9887.0000000000000000 | 19887                   |
 
   Then the network moves ahead "2" epochs
   And the current epoch is "4"
 
   And the liquidity provider fee shares for the market "ETH/MAR22" should be:
     | party                                                            | equity like share  | virtual stake         | average entry valuation |
-    | lp2                                                              | 0.3320343993550121 | 9884.0000000000000000 | 29768                   |
-    | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0.3320343993550121 | 9884.0000000000000000 | 19884                   |
+    | lp2                                                              | 0.3320682474642305 | 9887.0000000000000000 | 29774                   |
+    | 137112507e25d3845a56c47db15d8ced0f28daa8498a0fd52648969c4b296aba | 0.3320682474642305 | 9887.0000000000000000 | 19887                   |

--- a/core/integration/features/amm/0090-VAMM-020.feature
+++ b/core/integration/features/amm/0090-VAMM-020.feature
@@ -151,18 +151,18 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | buyer  | price | size | seller   | is amm |
       | party5 | 89    | 10   | party4   |        |
       | party5 | 90    | 10   | party4   |        |
-      | party5 | 90    | 40   | vamm1-id | true   |
+      | party5 | 90    | 39   | vamm1-id | true   |
       | party5 | 91    | 10   | party4   |        |
-      | party5 | 90    | 40   | vamm1-id | true   |
-      | party5 | 94    | 210  | vamm1-id | true   |
+      | party5 | 90    | 39   | vamm1-id | true   |
+      | party5 | 94    | 211  | vamm1-id | true   |
 
     # check the state of the market, trigger MTM settlement and check balances before closing out the last 100 for the vAMM
     When the network moves ahead "1" blocks
 	  Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | 230            | 0            |        |
-      | party5   | 280    | 280            | 0            |        |
-      | vamm1-id | 100    | -100           | -410         | true   |
+      | party5   | 280    | 276            | 0            |        |
+      | vamm1-id | 100    | -100           | -406         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -171,14 +171,14 @@ Feature: Test vAMM cancellation by reduce-only from long.
     # vAMM receives some fees, but pays MTM loss, excess margin is released
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 79     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 510    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45727  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 80     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 506    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45731  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 81492   | 18225  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81497   | 18225  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -211,8 +211,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | -1290          | 0            |        |
-      | party5   | 380    | 1400           | 0            |        |
-      | vamm1-id | 0      | 0              | -110         | true   |
+      | party5   | 380    | 1396           | 0            |        |
+      | vamm1-id | 0      | 0              | -106         | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -224,10 +224,10 @@ Feature: Test vAMM cancellation by reduce-only from long.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 400    | USD   | true   | TRANSFER_TYPE_MTM_WIN                |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18625  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100157 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE            |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100162 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE            |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 1000157 |        |        |
+      | vamm1    | USD   |           | 1000162 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |
 
   @VAMM
@@ -284,18 +284,18 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | buyer  | price | size | seller   | is amm |
       | party5 | 89    | 10   | party4   |        |
       | party5 | 90    | 10   | party4   |        |
-      | party5 | 90    | 40   | vamm1-id | true   |
+      | party5 | 90    | 39   | vamm1-id | true   |
       | party5 | 91    | 10   | party4   |        |
-      | party5 | 90    | 40   | vamm1-id | true   |
-      | party5 | 94    | 210  | vamm1-id | true   |
+      | party5 | 90    | 39   | vamm1-id | true   |
+      | party5 | 94    | 211  | vamm1-id | true   |
 
     # check the state of the market, trigger MTM settlement and check balances before closing out the last 100 for the vAMM
     When the network moves ahead "1" blocks
 	  Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | 230            | 0            |        |
-      | party5   | 280    | 280            | 0            |        |
-      | vamm1-id | 100    | -100           | -410         | true   |
+      | party5   | 280    | 276            | 0            |        |
+      | vamm1-id | 100    | -100           | -406         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -304,14 +304,14 @@ Feature: Test vAMM cancellation by reduce-only from long.
     # vAMM receives some fees, but pays MTM loss, excess margin is released
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 79     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 510    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45727  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 80     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 506    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45731  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 81492   | 18225  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81497   | 18225  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -343,8 +343,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | -1290          | 0            |        |
-      | party5   | 380    | 1400           | 0            |        |
-      | vamm1-id | 0      | 0              | -110         | true   |
+      | party5   | 380    | 1396           | 0            |        |
+      | vamm1-id | 0      | 0              | -106         | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -356,8 +356,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 400    | USD   | true   | TRANSFER_TYPE_MTM_WIN                |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18625  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100157 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100162 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 1000157 |        |        |
+      | vamm1    | USD   |           | 1000162 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |

--- a/core/integration/features/amm/0090-VAMM-auction.feature
+++ b/core/integration/features/amm/0090-VAMM-auction.feature
@@ -91,7 +91,7 @@ Feature: vAMM rebasing when created or amended
 
    And the market data for the market "ETH/MAR22" should be:
       | trading mode                 | indicative price | indicative volume |
-      | TRADING_MODE_OPENING_AUCTION | 100              | 92                |
+      | TRADING_MODE_OPENING_AUCTION | 100              | 91                |
 
    When the opening auction period ends for market "ETH/MAR22"
     Then the following trades should be executed:
@@ -103,7 +103,7 @@ Feature: vAMM rebasing when created or amended
     # two AMMs are now prices at ~100 which is between their base values
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode             | best bid price | best offer price |
-      | 100        | TRADING_MODE_CONTINUOUS  | 100            | 101              |
+      | 100        | TRADING_MODE_CONTINUOUS  | 99             | 101              |
 
 
   @VAMM
@@ -354,7 +354,7 @@ Feature: vAMM rebasing when created or amended
 
     And the market data for the market "ETH/MAR22" should be:
       | trading mode                 | indicative price | indicative volume |
-      | TRADING_MODE_OPENING_AUCTION | 100              | 92                |
+      | TRADING_MODE_OPENING_AUCTION | 100              | 91                |
 
 
     # now uncross
@@ -367,4 +367,4 @@ Feature: vAMM rebasing when created or amended
     Then the network moves ahead "1" blocks
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode             | best bid price | best offer price |
-      | 100        | TRADING_MODE_CONTINUOUS  | 100            | 101              |
+      | 100        | TRADING_MODE_CONTINUOUS  | 99             | 101              |

--- a/core/integration/features/amm/0090-VAMM-rebase.feature
+++ b/core/integration/features/amm/0090-VAMM-rebase.feature
@@ -152,13 +152,13 @@ Feature: vAMM rebasing when created or amended
     # second AMM has its base 5 away from the first AMM so it must submit a rebasing-order 
     And the following trades should be executed:
       | buyer    | price | size | seller   | is amm |
-      | vamm2-id | 101   | 177  | vamm1-id | true   |
+      | vamm2-id | 101   | 176  | vamm1-id | true   |
     Then the network moves ahead "1" blocks
 
     # and now the mid-price has shifted lower to a value between the two AMM's bases 100 < 104 < 105
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | 
-      | 101        | TRADING_MODE_CONTINUOUS | 104       |
+      | 101        | TRADING_MODE_CONTINUOUS | 103       |
   
 
 
@@ -233,13 +233,13 @@ Feature: vAMM rebasing when created or amended
     # second AMM has its base 5 away from the first AMM so it must submit a rebasing-order 
     And the following trades should be executed:
       | buyer    | price | size | seller   | is amm |
-      | vamm2-id | 101   | 177  | vamm1-id | true   |
+      | vamm2-id | 101   | 176  | vamm1-id | true   |
     Then the network moves ahead "1" blocks
 
     # and now the mid-price has shifted lower to a value between the two AMM's bases 100 < 104 < 105
     And the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | 
-      | 101        | TRADING_MODE_CONTINUOUS | 104       |
+      | 101        | TRADING_MODE_CONTINUOUS | 103       |
 
 
 @VAMM


### PR DESCRIPTION
closes #11389 

There are two ways to look at an AMM and its boundaries, as prices or as positions. There are equations that allow to jump from one to another what happens is that an integer-price will map to a decimal-position, and a integer-position maps to a decimal-price.

After one of these jumps, and some point core *has* to round the decimal since the price and position must be integers, and when we do this we have to be careful.

For example in this particular fuzzing run we have an AMM with integer base and lower bounds  in _price-space:_
```
[6712720000000000000000, 6765400000000000000000]
```

but in _position-space_ these map to positions of:
```
[12546.4537027400278, 0]
```

If the AMM becomes fully long the maximum position is can hold is `12546` since it cannot have a decimal position. The result of this is a fair-price of _not-quite_ the lower bound. 

If we were then to query of tradable volume between `lower-bound -> not-quite-lower-bound` an intermediate calculation that was rounding the decimals too early, would calculate a tradeable volume of 1 in this region, and then a trade would put the AMM into a position outside of its bounds.

This intermediate-calculation, namely `impliedPosition()` now retains full decimals so that this error does not occur.