### PR TITLE
fix: extend long block auction relative to the time now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [11136](https://github.com/vegaprotocol/vega/issues/11136) - Fix premature invocation of post commit hooks in case of fee stats event.
 - [11409](https://github.com/vegaprotocol/vega/issues/11409) - When updating a capped market - copy the cap from the existing market definition. 
 - [11415](https://github.com/vegaprotocol/vega/issues/11415) - End long block auction when expired. 
+- [11419](https://github.com/vegaprotocol/vega/issues/11419) - Fix long block auction extension to be calculated from current time. 
 
 ## 0.76.1
 

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1502,7 +1502,11 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 	m.mkt.State = types.MarketStateSuspended
 	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
 	if m.as.InAuction() {
-		m.as.ExtendAuctionLongBlock(types.AuctionDuration{Duration: duration})
+		effDuration := int(m.timeService.GetTimeNow().UnixNano()/1e9) + int(duration) - int(m.as.ExpiresAt().UnixNano()/1e9)
+		if effDuration <= 0 {
+			return
+		}
+		m.as.ExtendAuctionLongBlock(types.AuctionDuration{Duration: int64(effDuration)})
 		evt := m.as.AuctionExtended(ctx, m.timeService.GetTimeNow())
 		if evt != nil {
 			m.broker.Send(evt)


### PR DESCRIPTION
Closes #11419 