### PR TITLE
fix: do not enter long block auction if market is terminated

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1499,6 +1499,10 @@ func (m *Market) uncrossOrderAtAuctionEnd(ctx context.Context) {
 }
 
 func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
+	if !m.canTrade() {
+		return
+	}
+
 	m.mkt.State = types.MarketStateSuspended
 	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
 	if m.as.InAuction() {

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -488,6 +488,10 @@ func (m *Market) uncrossOrderAtAuctionEnd(ctx context.Context) {
 }
 
 func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
+	if !m.canTrade() {
+		return
+	}
+
 	m.mkt.State = types.MarketStateSuspended
 	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
 	if m.as.InAuction() {


### PR DESCRIPTION
At the protocol-upgrade block on stagnet1, there was a market that is in a terminated state. After the protocol upgrade the new long block auction code was kicking _all_ markets into an auction, including this terminated one. The result was that eventually the market became active again.

This caused an inconsistency when restoring from a later snapshot since this now active market would be restored as active, but its time-trigger data-source would immediately terminate it again. On the "normal-node" the time-trigger data-source had been unsubscribed and so stayed active. This difference caused the restored node to fall out of consensus.