### PR TITLE
fix: demote order-spam logs to debug and avoid data-node warning log

### DIFF
--- a/core/collateral/engine.go
+++ b/core/collateral/engine.go
@@ -211,7 +211,10 @@ func (e *Engine) CheckOrderSpamAllMarkets(party string) error {
 func (e *Engine) CheckOrderSpam(party, market string, assets []string) error {
 	e.cacheLock.RLock()
 	defer e.cacheLock.RUnlock()
-	e.log.Info("CheckOrderSpam", logging.String("party", party), logging.String("market", market), logging.Strings("assets", assets))
+
+	if e.log.IsDebug() {
+		e.log.Debug("CheckOrderSpam", logging.String("party", party), logging.String("market", market), logging.Strings("assets", assets))
+	}
 	if assetBalances, ok := e.partyAssetCache[party]; !ok {
 		return fmt.Errorf("party " + party + " is not eligible to submit order transactions in market " + market + " (no general account in no asset)")
 	} else {
@@ -225,8 +228,10 @@ func (e *Engine) CheckOrderSpam(party, market string, assets []string) error {
 			}
 		}
 		if !found {
-			for ast, balance := range e.partyAssetCache[party] {
-				e.log.Info("party asset cache", logging.String("party", party), logging.String("asset", ast), logging.String("balance", balance.String()))
+			if e.log.IsDebug() {
+				for ast, balance := range e.partyAssetCache[party] {
+					e.log.Debug("party asset cache", logging.String("party", party), logging.String("asset", ast), logging.String("balance", balance.String()))
+				}
 			}
 			return fmt.Errorf("party " + party + " is not eligible to submit order transactions in market " + market + " (no general account found)")
 		}

--- a/datanode/sqlsubscribers/order.go
+++ b/datanode/sqlsubscribers/order.go
@@ -142,11 +142,15 @@ func (os *Order) cancelled(ctx context.Context, co CancelledOrdersEvent, seqNum 
 			ids = append(ids, id)
 		}
 	}
-	ncOrders, err := os.store.GetByMarketAndID(ctx, co.MarketID(), ids)
-	if err != nil {
-		return err
+
+	if len(ids) > 0 {
+		ncOrders, err := os.store.GetByMarketAndID(ctx, co.MarketID(), ids)
+		if err != nil {
+			return err
+		}
+		orders = append(orders, ncOrders...)
 	}
-	orders = append(orders, ncOrders...)
+
 	txHash := entities.TxHash(co.TxHash())
 	for _, o := range orders {
 		o.Status = entities.OrderStatusCancelled


### PR DESCRIPTION
closes #11399 

Everytime a cancelled-order-batch event was received and all of the orders were already in the cache (which turns out is quite often)  we were filling the log files with a warning log `GetByMarketAndID called with an empty order slice`. I've changed this so that we do not call `GetByMarketAndID` if we have no orders to find.

Also there are info logs for order spam that were filling the log file for every incoming order. I'm demoted them to debug.
