### PR TITLE
chore: add unittest for some simply fcap validation AC's

### DIFF
--- a/commands/proposal_submission.go
+++ b/commands/proposal_submission.go
@@ -1283,7 +1283,7 @@ func checkNewFuture(future *protoTypes.FutureProduct, tickSize string) Errors {
 				tick = num.UintOne()
 			}
 			mp, err := num.UintFromString(future.Cap.MaxPrice, 10)
-			if err {
+			if err || mp.IsZero() {
 				errs.AddForProperty("new_market.changes.instrument.product.future.cap.max_price", ErrMustBePositive)
 			} else if !mp.Mod(mp, tick).IsZero() {
 				errs.AddForProperty("new_market.changes.instrument.product.future.cap.max_price", ErrMaxPriceMustRespectTickSize)

--- a/commands/proposal_submission_new_market_test.go
+++ b/commands/proposal_submission_new_market_test.go
@@ -938,6 +938,27 @@ func testNewCappedMarketWithoutMaxPriceFails(t *testing.T) {
 	nmConf.TickSize = "10"
 	err = checkProposalSubmission(cmd)
 	assert.Contains(t, err.Get("proposal_submission.terms.change.new_market.changes.instrument.product.future.cap.max_price"), commands.ErrMaxPriceMustRespectTickSize)
+
+	// submit with no max price but other fields set (0019-MCAL-170)
+	fCap.MaxPrice = ""
+	fCap.BinarySettlement = ptr.From(true)
+	fCap.FullyCollateralised = nil
+	err = checkProposalSubmission(cmd)
+	assert.Contains(t, err.Get("proposal_submission.terms.change.new_market.changes.instrument.product.future.cap.max_price"), commands.ErrIsRequired)
+
+	// submit with no max price but other fields set (0019-MCAL-171)
+	fCap.MaxPrice = ""
+	fCap.BinarySettlement = nil
+	fCap.FullyCollateralised = ptr.From(true)
+	err = checkProposalSubmission(cmd)
+	assert.Contains(t, err.Get("proposal_submission.terms.change.new_market.changes.instrument.product.future.cap.max_price"), commands.ErrIsRequired)
+
+	// max cap of zero is rejected
+	fCap.MaxPrice = "0"
+	fCap.BinarySettlement = nil
+	fCap.FullyCollateralised = ptr.From(true)
+	err = checkProposalSubmission(cmd)
+	assert.Contains(t, err.Get("proposal_submission.terms.change.new_market.changes.instrument.product.future.cap.max_price"), commands.ErrMustBePositive)
 }
 
 func testNewMarketChangeSubmissionWithoutPriceMonitoringSucceeds(t *testing.T) {


### PR DESCRIPTION
Additional tests for capped future's validation and fix to reject the case where max-price is set to 0.