### PR TITLE
fix: prevent division by 0 in datanode estimate API (specific to capped future)

### DIFF
--- a/datanode/api/trading_data_v2.go
+++ b/datanode/api/trading_data_v2.go
@@ -3887,6 +3887,10 @@ func calcPositionMarginCappedAndFullyCollateralised(
 		ongoing = ongoing.Add(v.Price.Mul(num.DecimalFromInt64(size)))
 	}
 
+	// no volume, and we want to prevent division by 0
+	if totalVolume == 0 {
+		return num.DecimalZero()
+	}
 	averageEntryPrice := ongoing.Div(num.DecimalFromInt64(totalVolume))
 
 	if positionSize < 0 {


### PR DESCRIPTION
Happening on staging:
```
Jul 17 11:23:02 n00.stagnet1.vega.rocks visor[2079333]: 2024-07-17T11:23:02.974Z        INFO        tendermint        txindex/indexer_service.go:102        indexed block events        {"height": 12275127}
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: panic: decimal division by 0
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: goroutine 6399737 [running]:
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: github.com/shopspring/decimal.Decimal.QuoRem({0xc0091eb540, 0x0}, {0xc0119641f0, 0x0}, 0x10)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/github.com/vegaprotocol/decimal@v1.3.1-uint256/decimal.go:590 +0x2bc
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: github.com/shopspring/decimal.Decimal.DivRound({0xc0091eb540?, 0x0?}, {0xc0119641f0?, 0x0?}, 0x10)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/github.com/vegaprotocol/decimal@v1.3.1-uint256/decimal.go:632 +0x4d
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: github.com/shopspring/decimal.Decimal.Div(...)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/github.com/vegaprotocol/decimal@v1.3.1-uint256/decimal.go:577
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/datanode/api.calcPositionMarginCappedAndFullyCollateralised({0xc010785068, 0x0, 0x2?}, {0xc010785070, 0x1, 0x410bc5?}, 0xc0091eb4a0?, 0xfffffffffffffff6, {0xc0091eb4c0, 0x0})
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/datanode/api/trading_data_v2.go:3890 +0x41c
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/datanode/api.(*TradingDataServiceV2).computeMarginRange(0x0?, _, {_, _, _}, {_, _, _}, {0xc0091eb2c0, 0x0}, ...)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/datanode/api/trading_data_v2.go:3837 +0x105
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/datanode/api.(*TradingDataServiceV2).EstimatePosition(0xc00252c580, {0x47c7d58, 0xc00b880b40}, 0xc005c3bd40)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/datanode/api/trading_data_v2.go:3658 +0x1792
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/protos/data-node/api/v2._TradingDataService_EstimatePosition_Handler.func1({0x47c7d58, 0xc00b880b40}, {0x3c803c0?, 0xc005c3bd40})
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/protos/data-node/api/v2/trading_data_grpc.pb.go:4619 +0x72
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/datanode/ratelimit.(*RateLimit).GRPCInterceptor(0xc0023d10a0, {0x47c7d58, 0xc00b880b40}, {0x3c803c0, 0xc005c3bd40}, 0x0?, 0xc00b4e8840)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/datanode/ratelimit/ratelimit.go:159 +0x7af
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: google.golang.org/grpc.getChainUnaryHandler.func1({0x47c7d58, 0xc00b880b40}, {0x3c803c0, 0xc005c3bd40})
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1192 +0xb2
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/datanode/api.(*GRPCServer).Start.headersInterceptor.func4({0x47c7d58, 0xc00b880b40}, {0x3c803c0, 0xc005c3bd40}, 0xc0094f2fc0?, 0xc00b2cf140)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/datanode/api/server.go:468 +0x482
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: google.golang.org/grpc.getChainUnaryHandler.func1({0x47c7d58, 0xc00b880b40}, {0x3c803c0, 0xc005c3bd40})
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1192 +0xb2
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/datanode/api.(*GRPCServer).Start.(*GRPCServer).remoteAddrInterceptor.func3({0x47c7d58, 0xc00b880ae0}, {0x3c803c0, 0xc005c3bd40}, 0xc0094f2fc0, 0xc00b2cf040)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/datanode/api/server.go:424 +0xc2
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1({0x47c7d58, 0xc00b880ae0}, {0x3c803c0, 0xc005c3bd40}, 0xc00e0349c0?, 0x378b960?)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1183 +0x85
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: code.vegaprotocol.io/vega/protos/data-node/api/v2._TradingDataService_EstimatePosition_Handler({0x3e0cec0?, 0xc00252c580}, {0x47c7d58, 0xc00b880ae0}, 0xc0095a6400, 0xc0023d1120)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/work/vega/vega/protos/data-node/api/v2/trading_data_grpc.pb.go:4621 +0x135
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: google.golang.org/grpc.(*Server).processUnaryRPC(0xc00017fc20, {0x47c7d58, 0xc00b880a50}, {0x47e2860, 0xc0026fa9c0}, 0xc00328d200, 0xc00459c000, 0x6a61aa8, 0x0)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1372 +0xe03
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: google.golang.org/grpc.(*Server).handleStream(0xc00017fc20, {0x47e2860, 0xc0026fa9c0}, 0xc00328d200)
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1783 +0xfec
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: google.golang.org/grpc.(*Server).serveStreams.func2.1()
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1016 +0x59
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]: created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 978
Jul 17 11:23:03 n00.stagnet1.vega.rocks visor[2079334]:         /home/runner/go/pkg/mod/google.golang.org/grpc@v1.60.0/server.go:1027 +0x115
```