### PR TITLE
fix: Update the time weighted notional when publishing live game scores.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 - [11448](https://github.com/vegaprotocol/vega/issues/11448) - Fix team game score query with epoch filter.
 - [11457](https://github.com/vegaprotocol/vega/issues/11457) - Fix cursor column ordering for game scores.
 - [11454](https://github.com/vegaprotocol/vega/issues/11454) - Ensure ended transfers proper handling.
-
+- [11462](https://github.com/vegaprotocol/vega/issues/11462) - Update the time weighted notional when publishing live game scores.
 
 ## 0.76.1
 

--- a/core/execution/common/market_activity_tracker.go
+++ b/core/execution/common/market_activity_tracker.go
@@ -1186,8 +1186,11 @@ func (mat *MarketActivityTracker) getTWNotionalPosition(asset, party string, mar
 
 	for _, mkt := range mkts {
 		if tracker, ok := mat.getMarketTracker(asset, mkt); ok {
-			if twNotional, ok := tracker.twNotional[party]; ok {
-				total.AddSum(twNotional.currentEpochTWNotional)
+			if len(tracker.epochTimeWeightedNotional) <= 0 {
+				continue
+			}
+			if twNotional, ok := tracker.epochTimeWeightedNotional[len(tracker.epochTimeWeightedNotional)-1][party]; ok {
+				total.AddSum(twNotional)
 			}
 		}
 	}

--- a/core/execution/common/market_activity_tracker_internal_test.go
+++ b/core/execution/common/market_activity_tracker_internal_test.go
@@ -321,6 +321,7 @@ func TestAverageNotional(t *testing.T) {
 	// (( 116 * 5000000 ) + ( 600 * 5000000 )) / 10000000 = 358
 	tracker.processNotionalEndOfEpoch(time.Unix(0, 0), time.Unix(60, 0))
 	require.Equal(t, "358", tracker.twNotional["p1"].currentEpochTWNotional.String())
+	require.Equal(t, "358", tracker.epochTimeWeightedNotional[len(tracker.epochTimeWeightedNotional)-1]["p1"].String())
 
 	// epoch 2
 	// (( 358 * 0 ) + ( 600 * 10000000 )) / 10000000 = 600
@@ -330,12 +331,14 @@ func TestAverageNotional(t *testing.T) {
 	// (( 600 * 5000000 ) + ( 300 * 5000000 )) / 10000000 = 450
 	tracker.processNotionalEndOfEpoch(time.Unix(60, 0), time.Unix(120, 0))
 	require.Equal(t, "450", tracker.twNotional["p1"].currentEpochTWNotional.String())
+	require.Equal(t, "450", tracker.epochTimeWeightedNotional[len(tracker.epochTimeWeightedNotional)-1]["p1"].String())
 
 	// epoch 3
 	// no position changes over the epoch
 	// (( 450 * 0 ) + ( 300 * 10000000 )) / 10000000 = 300
 	tracker.processNotionalEndOfEpoch(time.Unix(120, 0), time.Unix(180, 0))
 	require.Equal(t, "300", tracker.twNotional["p1"].currentEpochTWNotional.String())
+	require.Equal(t, "300", tracker.epochTimeWeightedNotional[len(tracker.epochTimeWeightedNotional)-1]["p1"].String())
 }
 
 func TestCalculateMetricForIndividualsAvePosition(t *testing.T) {


### PR DESCRIPTION
Closes #11462 

The issue this fixes is the following - while we do update the tw notional for the purpose of live score updates we're not using it but rather use the ongoing live balance (rather than end of period). The change is to use the end of period one which will be similar to what it was before the change at the end of the epoch, and would show the correct value in the periodic updates during the epoch. 