### PR TITLE
fix: separate on-book and off-book volume in auction uncrossing calcs…

### DIFF
--- a/core/matching/cached_orderbook.go
+++ b/core/matching/cached_orderbook.go
@@ -200,7 +200,7 @@ func (b *CachedOrderBook) GetIndicativePriceAndVolume() (*num.Uint, uint64, type
 	volume, cachedVolOk := b.cache.GetIndicativeVolume()
 	side, cachedSideOk := b.cache.GetIndicativeUncrossingSide()
 	if !cachedPriceOk || !cachedVolOk || !cachedSideOk {
-		price, volume, side = b.OrderBook.GetIndicativePriceAndVolume()
+		price, volume, side, _ = b.OrderBook.GetIndicativePriceAndVolume()
 		b.cache.SetIndicativePrice(price.Clone())
 		b.cache.SetIndicativeVolume(volume)
 		b.cache.SetIndicativeUncrossingSide(side)

--- a/core/matching/can_uncross_test.go
+++ b/core/matching/can_uncross_test.go
@@ -80,7 +80,7 @@ func TestBidAndAskPresentAfterAuction(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	indicativePrice, indicativeVolume, indicativeSide := book.GetIndicativePriceAndVolume()
+	indicativePrice, indicativeVolume, indicativeSide, _ := book.GetIndicativePriceAndVolume()
 	assert.Equal(t, indicativePrice.Uint64(), uint64(1975))
 	assert.Equal(t, int(indicativeVolume), 5)
 	assert.Equal(t, indicativeSide, types.SideBuy)
@@ -143,7 +143,7 @@ func TestBidAndAskPresentAfterAuctionInverse(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	indicativePrice, indicativeVolume, indicativeSide := book.GetIndicativePriceAndVolume()
+	indicativePrice, indicativeVolume, indicativeSide, _ := book.GetIndicativePriceAndVolume()
 	assert.Equal(t, indicativePrice.Uint64(), uint64(1950))
 	assert.Equal(t, int(indicativeVolume), 5)
 	assert.Equal(t, indicativeSide, types.SideBuy)


### PR DESCRIPTION
During auction uncrossing, we calculate an uncrossing price and a maximum uncrossing volume. We then work out which side of the book allows us to extract that volume of orders exactly and send those in aggressively (i.e if we have 1 buy order of size 5 buy and 1 sell order of size 10 at the same price, the buy side extracts exactly).

Previously when we have both orders and AMM's being uncrossed, we would not distingush between how much of that uncrossing volume came from the orderbook and how much came from the AMM and always took the AMM volume first, resulting in us _sometimes_ taking too much volume from the AMM crossed region.

For example if we have decided that we can extract exactly 15 volume from the buy side without splitting distinct orders, and the uncrossing price is 100, and we had the following orders:
```
| price | size | is amm |
| 101   | 10   | true   | 
| 100   | 10   | true   | 
| 100   | 5    | false  | 

```

To get to a volume of 15 we need to uncross the first AMM order and the orderbook order. If we take both AMM orders we've extracted 20 and thats too much. We then try to extract `-5` from the orderbook and blow up.

Now we keep track of exactly how much AMM volume and orderbook volume we need to extract individually during the the cumulative-levels calculations so we extract the right volume from the right place.

Note: I've confirmed this fix against the chain-data on stagnet1, I'm still trying to make a feature test for it but its proving to be tricky.