### PR TITLE
fix: ensure AMM best bid/ask is capped at boundaries to we not not ov…

### DIFF
--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -328,7 +328,7 @@ func (e *Engine) BestPricesAndVolumes() (*num.Uint, uint64, *num.Uint, uint64) {
 		fp := pool.BestPrice(nil)
 
 		// get the volume on the buy side by simulating an incoming sell order
-		bid := num.UintZero().Sub(fp, pool.oneTick)
+		bid := num.Max(pool.lower.low, num.UintZero().Sub(fp, pool.oneTick))
 		volume := pool.TradableVolumeInRange(types.SideSell, fp.Clone(), bid)
 
 		if volume != 0 {
@@ -341,7 +341,7 @@ func (e *Engine) BestPricesAndVolumes() (*num.Uint, uint64, *num.Uint, uint64) {
 		}
 
 		// get the volume on the sell side by simulating an incoming buy order
-		ask := num.UintZero().Add(fp, pool.oneTick)
+		ask := num.Min(pool.upper.high, num.UintZero().Add(fp, pool.oneTick))
 		volume = pool.TradableVolumeInRange(types.SideBuy, fp.Clone(), ask)
 		if volume != 0 {
 			if bestAsk == nil || ask.LT(bestAsk) {


### PR DESCRIPTION
closes #11489 

The issue was that when querying best bid/ask of an AMM when its position was *very close* to one of its boundaries, we would step outside of its boundaires and report a best bid/ask outside of its range.

This caused the crossed region during auction to be slightly bigger than it should be, and then we were unable to expand the AMM to the crossed regions boundaries because in `OrderbookShape()` we properly respect the AMM bounds. Things got out of sync and the uncrossing failed.