### PR TITLE
test: add coverage for protective auction ACs

### DIFF
--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1502,7 +1502,7 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 	if !m.canTrade() {
 		return
 	}
-	// markets that are suspended via governance, or are in monitoring auction should be unaffected by long block auctions.
+	// markets that are suspended via governance should be unaffected by long block auctions.
 	if m.mkt.TradingMode == types.MarketTradingModeSuspendedViaGovernance {
 		return
 	}

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1510,27 +1510,15 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 	m.mkt.State = types.MarketStateSuspended
 	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
 	if m.as.InAuction() {
-		ds := time.Duration(duration) * time.Second
-		lbaExpires := m.timeService.GetTimeNow().Add(ds)
-		expires := m.as.ExpiresAt()
-		if !expires.Before(lbaExpires) {
+		effDuration := int(m.timeService.GetTimeNow().UnixNano()/1e9) + int(duration) - int(m.as.ExpiresAt().UnixNano()/1e9)
+		if effDuration <= 0 {
 			return
 		}
-		extend := lbaExpires.Sub(*expires)
-		m.as.ExtendAuctionLongBlock(types.AuctionDuration{Duration: int64(extend / time.Second)})
+		m.as.ExtendAuctionLongBlock(types.AuctionDuration{Duration: int64(effDuration)})
 		evt := m.as.AuctionExtended(ctx, m.timeService.GetTimeNow())
 		if evt != nil {
 			m.broker.Send(evt)
 		}
-		// effDuration := int(m.timeService.GetTimeNow().UnixNano()/1e9) + int(duration) - int(m.as.ExpiresAt().UnixNano()/1e9)
-		// if effDuration <= 0 {
-		// return
-		// }
-		// m.as.ExtendAuctionLongBlock(types.AuctionDuration{Duration: int64(effDuration)})
-		// evt := m.as.AuctionExtended(ctx, m.timeService.GetTimeNow())
-		// if evt != nil {
-		// m.broker.Send(evt)
-		// }
 	} else {
 		m.as.StartLongBlockAuction(m.timeService.GetTimeNow(), duration)
 		m.tradableInstrument.Instrument.UpdateAuctionState(ctx, true)

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -1502,6 +1502,10 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 	if !m.canTrade() {
 		return
 	}
+	// markets that are suspended via governance, or are in monitoring auction should be unaffected by long block auctions.
+	if m.mkt.TradingMode == types.MarketTradingModeSuspendedViaGovernance || m.mkt.TradingMode == types.MarketTradingModeMonitoringAuction {
+		return
+	}
 
 	m.mkt.State = types.MarketStateSuspended
 	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -492,7 +492,7 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 		return
 	}
 
-	// markets in monitoring or governance auction are unaffected by long block auctions.
+	// markets in governance auction are unaffected by long block auctions.
 	if m.mkt.TradingMode == types.MarketTradingModeSuspendedViaGovernance {
 		return
 	}

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -492,6 +492,11 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 		return
 	}
 
+	// markets in monitoring or governance auction are unaffected by long block auctions.
+	if m.mkt.TradingMode == types.MarketTradingModeSuspendedViaGovernance || m.mkt.TradingMode == types.MarketTradingModeMonitoringAuction {
+		return
+	}
+
 	m.mkt.State = types.MarketStateSuspended
 	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
 	if m.as.InAuction() {

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -493,7 +493,7 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 	}
 
 	// markets in monitoring or governance auction are unaffected by long block auctions.
-	if m.mkt.TradingMode == types.MarketTradingModeSuspendedViaGovernance || m.mkt.TradingMode == types.MarketTradingModeMonitoringAuction {
+	if m.mkt.TradingMode == types.MarketTradingModeSuspendedViaGovernance {
 		return
 	}
 

--- a/core/integration/features/auctions/0094-PRAC-007.feature
+++ b/core/integration/features/auctions/0094-PRAC-007.feature
@@ -1,0 +1,128 @@
+Feature: When a market's trigger or extension_trigger is set to represent a governance suspension then no other triggers can affect the market. (0094-PRAC-007)
+
+
+
+  Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | ETH | 5              |
+    And the long block duration table is:
+      | threshold | duration |
+      | 3s        | 1m       |
+      | 40s       | 10m      |
+      | 2m        | 1h       |
+    And the simple risk model named "my-simple-risk-model":
+      | long                   | short                  | max move up | min move down | probability of trading |
+      | 0.08628781058136630000 | 0.09370922348428490000 | -1          | -1            | 0.2                    |
+    And the fees configuration named "my-fees-config":
+      | maker fee | infrastructure fee |
+      | 0.004     | 0.001              |
+    # create 2 markets
+    And the markets:
+      | id        | quote name | asset | risk model           | margin calculator         | auction duration | fees           | price monitoring | data source config     | decimal places | linear slippage factor | quadratic slippage factor | sla params      |
+      | ETH/DEC19 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | default-none     | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
+      | ETH/DEC20 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | default-none     | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
+    And the following network parameters are set:
+      | name                           | value |
+      | limits.markets.maxPeggedOrders | 2     |
+    And the average block duration is "1"
+    And the parties deposit on asset's general account the following amount:
+      | party   | asset | amount        |
+      | party1  | ETH   | 1000000000000 |
+      | party2  | ETH   | 1000000000000 |
+      | party3  | ETH   | 1000000000000 |
+      | party4  | ETH   | 1000000000000 |
+      | lpprov1 | ETH   | 1000000000000 |
+      | lpprov2 | ETH   | 1000000000000 |
+    And the parties submit the following liquidity provision:
+      | id  | party   | market id | commitment amount | fee | lp type    |
+      | lp1 | lpprov1 | ETH/DEC20 | 937000000         | 0.1 | submission |
+      | lp2 | lpprov2 | ETH/DEC19 | 937000000         | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party   | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lpprov1 | ETH/DEC20 | 2         | 1                    | buy  | BID              | 50     | 100    |
+      | lpprov1 | ETH/DEC20 | 2         | 1                    | sell | ASK              | 50     | 100    |
+      | lpprov2 | ETH/DEC19 | 2         | 1                    | buy  | MID              | 50     | 100    |
+      | lpprov2 | ETH/DEC19 | 2         | 1                    | sell | MID              | 50     | 100    |
+
+  @LBA
+  Scenario: 0094-PRAC-007: market suspended via governance is unaffected by long block auction triggers.
+    # place orders and generate trades - slippage 100
+    When the parties place the following orders:
+      | party  | market id | side | volume | price   | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | buy  | 1      | 999500  | 0                | TYPE_LIMIT | TIF_GTC | t1-b-1    |
+      | party1 | ETH/DEC20 | buy  | 1      | 1000000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC20 | sell | 2      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t2-s-1    |
+      | party3 | ETH/DEC19 | buy  | 1      | 999500  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t3-b-2    |
+      | party4 | ETH/DEC19 | sell | 2      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+    Then the market data for the market "ETH/DEC20" should be:
+      | trading mode                 | supplied stake | target stake |
+      | TRADING_MODE_OPENING_AUCTION | 937000000      | 937000000    |
+    And the market data for the market "ETH/DEC19" should be:
+      | trading mode                 | supplied stake | target stake |
+      | TRADING_MODE_OPENING_AUCTION | 937000000      | 937000000    |
+
+    When the network moves ahead "2" blocks
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    #And debug detailed orderbook volumes for market "ETH/DEC20"
+    And the order book should have the following volumes for market "ETH/DEC20":
+      | volume | price   | side |
+      | 2      | 999400  | buy  |
+      | 1      | 999500  | buy  |
+      | 1      | 1000000 | sell |
+      | 2      | 1000100 | sell |
+    #And debug detailed orderbook volumes for market "ETH/DEC19"
+    And the order book should have the following volumes for market "ETH/DEC19":
+      | volume | price   | side |
+      | 1      | 999500  | buy  |
+      | 2      | 999650  | buy  |
+      | 2      | 999850  | sell |
+      | 1      | 1000000 | sell |
+
+    And the following trades should be executed:
+      | buyer  | price   | size | seller |
+      | party1 | 1000000 | 1    | party2 |
+      | party3 | 1000000 | 1    | party4 |
+    And the mark price should be "1000000" for the market "ETH/DEC20"
+    And the mark price should be "1000000" for the market "ETH/DEC19"
+
+    When the market states are updated through governance:
+      | market id | state                            |
+      | ETH/DEC20 | MARKET_STATE_UPDATE_TYPE_SUSPEND |
+
+    When the previous block duration was "90s"
+    Then the trading mode should be "TRADING_MODE_SUSPENDED_VIA_GOVERNANCE" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
+
+    # We know what the volume on the books look like, but let's submit some orders that will trade regardless
+    # And we'll see no trades happen
+    When the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | buy  | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t1-b-3    |
+      | party2 | ETH/DEC20 | sell | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t2-s-2    |
+      | party3 | ETH/DEC19 | buy  | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t3-b-3    |
+      | party4 | ETH/DEC19 | sell | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-2    |
+    Then the trading mode should be "TRADING_MODE_SUSPENDED_VIA_GOVERNANCE" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
+
+    When the network moves ahead "1s" with block duration of "1s"
+    And the market states are updated through governance:
+      | market id | state                           |
+      | ETH/DEC20 | MARKET_STATE_UPDATE_TYPE_RESUME |
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    When the network moves ahead "9m50s" with block duration of "2s"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
+
+    # still in auction, 10 seconds later, though:
+    When the network moves ahead "11" blocks
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the following trades should be executed:
+      | buyer  | price  | size | seller |
+      | party1 | 999999 | 1    | party2 |
+      | party3 | 999999 | 1    | party4 |
+

--- a/core/integration/features/auctions/0094-PRAC-008.feature
+++ b/core/integration/features/auctions/0094-PRAC-008.feature
@@ -1,7 +1,5 @@
 Feature: When a market's trigger and extension_trigger are set to represent that the market went into auction due to the price monitoring mechanism and was later extended by the same mechanism and the auction is meant to finish at 11am, but now a long block auction is being triggered so that it ends at 10am then this market is unaffected in any way. (0094-PRAC-008)
 
-
-
   Background:
     Given the following assets are registered:
       | id  | decimal places |
@@ -11,9 +9,12 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | 3s        | 1m       |
       | 40s       | 10m      |
       | 2m        | 1h       |
+    And the price monitoring named "my-price-monitoring-2":
+      | horizon | probability | auction extension |
+      | 360     | 0.95        | 3600              |
     And the price monitoring named "my-price-monitoring":
       | horizon | probability | auction extension |
-      | 360     | 0.95        | 55                |
+      | 360     | 0.95        | 61                |
     And the log normal risk model named "my-log-normal-risk-model":
       | risk aversion | tau                    | mu | r     | sigma |
       | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
@@ -25,9 +26,9 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | 0.004     | 0.001              |
     # create 2 markets
     And the markets:
-      | id        | quote name | asset | risk model           | margin calculator         | auction duration | fees           | price monitoring    | data source config     | decimal places | linear slippage factor | quadratic slippage factor | sla params      |
-      | ETH/DEC19 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | default-none        | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
-      | ETH/DEC20 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | my-price-monitoring | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
+      | id        | quote name | asset | risk model           | margin calculator         | auction duration | fees           | price monitoring      | data source config     | decimal places | linear slippage factor | quadratic slippage factor | sla params      |
+      | ETH/DEC19 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | my-price-monitoring-2 | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
+      | ETH/DEC20 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | my-price-monitoring   | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
     And the following network parameters are set:
       | name                           | value |
       | limits.markets.maxPeggedOrders | 2     |
@@ -45,7 +46,7 @@ Feature: When a market's trigger and extension_trigger are set to represent that
     And the parties submit the following liquidity provision:
       | id  | party   | market id | commitment amount | fee | lp type    |
       | lp1 | lpprov1 | ETH/DEC20 | 1873996252        | 0.1 | submission |
-      | lp2 | lpprov2 | ETH/DEC19 | 937000000         | 0.1 | submission |
+      | lp2 | lpprov2 | ETH/DEC19 | 1873996252        | 0.1 | submission |
     And the parties place the following pegged iceberg orders:
       | party   | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
       | lpprov1 | ETH/DEC20 | 2         | 1                    | buy  | BID              | 50     | 100    |
@@ -54,7 +55,7 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | lpprov2 | ETH/DEC19 | 2         | 1                    | sell | MID              | 50     | 100    |
 
   @LBA
-  Scenario: 0094-PRAC-008: market in price monitoring auction should not enter long block auction.
+  Scenario: 0094-PRAC-008: Long block auction exceeds the price monitoring auction duration, the auction gets extended.
     # place orders and generate trades - slippage 100
     When the parties place the following orders:
       | party  | market id | side | volume | price   | resulting trades | type       | tif     | reference |
@@ -106,12 +107,12 @@ Feature: When a market's trigger and extension_trigger are set to represent that
     Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
     And the market data for the market "ETH/DEC20" should be:
       | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest | auction end |
-      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 360     | 1000000   | 999999    | 1873996252   | 1873996252     | 1             | 55          |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 360     | 1000000   | 999999    | 1873996252   | 1873996252     | 1             | 61          |
 
     When the network moves ahead "2" blocks
     Then the market data for the market "ETH/DEC20" should be:
       | mark price | trading mode                    | target stake | supplied stake | open interest | auction end |
-      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 1873996252   | 1873996252     | 1             | 55          |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 1873996252   | 1873996252     | 1             | 61          |
 
     When the previous block duration was "90s"
     Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
@@ -131,23 +132,22 @@ Feature: When a market's trigger and extension_trigger are set to represent that
     When the network moves ahead "60" blocks
     # This is strange, it looks as though the trade went through at the end of the auction, but in doing so triggered a second auction?
     Then the market data for the market "ETH/DEC20" should be:
-      | mark price | trading mode                    | target stake | supplied stake | open interest | auction end | extension trigger           |
-      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2811000000   | 1873996252     | 3             | 55          | AUCTION_TRIGGER_UNSPECIFIED |
+      | mark price | trading mode                    | target stake | supplied stake | open interest | auction end | extension trigger          |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2810994378   | 1873996252     | 1             | 602         | AUCTION_TRIGGER_LONG_BLOCK |
 
     # move ahead another minute
     When the network moves ahead "60" blocks
     # This is strange, it looks as though the trade went through at the end of the auction, but in doing so triggered a second auction?
     Then the market data for the market "ETH/DEC20" should be:
-      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest | extension trigger           |
-      | 1000000    | TRADING_MODE_CONTINUOUS | 360     | 999999    | 999997    | 2811000000   | 1873996252     | 3             | AUCTION_TRIGGER_UNSPECIFIED |
-    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+      | mark price | trading mode                    | target stake | supplied stake | open interest | extension trigger          |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2810994378   | 1873996252     | 1             | AUCTION_TRIGGER_LONG_BLOCK |
 
     When the network moves ahead "7m50s" with block duration of "2s"
-    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
     And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
 
-    # still in auction, 10 seconds later, though:
-    When the network moves ahead "11" blocks
+    # still in auction, 150 seconds later, though:
+    When the network moves ahead "150" blocks
     Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
     And the following trades should be executed:
@@ -155,4 +155,102 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | party5 | 999998 | 1    | party6 |
       | party1 | 999998 | 1    | party2 |
       | party3 | 999999 | 1    | party4 |
+
+
+  @LBA2
+  Scenario: 0094-PRAC-008: Long block auction does not exceed the price monitoring auction duration, the auction does not get extended.
+    # place orders and generate trades - slippage 100
+    When the parties place the following orders:
+      | party  | market id | side | volume | price   | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | buy  | 1      | 999500  | 0                | TYPE_LIMIT | TIF_GTC | t1-b-1    |
+      | party1 | ETH/DEC20 | buy  | 1      | 1000000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC20 | sell | 2      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t2-s-1    |
+      | party3 | ETH/DEC19 | buy  | 1      | 999500  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t3-b-2    |
+      | party4 | ETH/DEC19 | sell | 2      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+    Then the market data for the market "ETH/DEC20" should be:
+      | trading mode                 | supplied stake | target stake |
+      | TRADING_MODE_OPENING_AUCTION | 1873996252     | 937000000    |
+    And the market data for the market "ETH/DEC19" should be:
+      | trading mode                 | supplied stake | target stake |
+      | TRADING_MODE_OPENING_AUCTION | 1873996252     | 937000000    |
+
+    When the network moves ahead "2" blocks
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    #And debug detailed orderbook volumes for market "ETH/DEC20"
+    And the order book should have the following volumes for market "ETH/DEC20":
+      | volume | price   | side |
+      | 2      | 999400  | buy  |
+      | 1      | 999500  | buy  |
+      | 1      | 1000000 | sell |
+      | 2      | 1000100 | sell |
+    #And debug detailed orderbook volumes for market "ETH/DEC19"
+    And the order book should have the following volumes for market "ETH/DEC19":
+      | volume | price   | side |
+      | 1      | 999500  | buy  |
+      | 2      | 999650  | buy  |
+      | 2      | 999850  | sell |
+      | 1      | 1000000 | sell |
+
+    And the following trades should be executed:
+      | buyer  | price   | size | seller |
+      | party1 | 1000000 | 1    | party2 |
+      | party3 | 1000000 | 1    | party4 |
+    And the mark price should be "1000000" for the market "ETH/DEC20"
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1000000    | TRADING_MODE_CONTINUOUS | 360     | 1000000   | 999999    | 937000000    | 1873996252     | 1             |
+
+    When the network moves ahead "10" blocks
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party5 | ETH/DEC19 | buy  | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t5-b-1    |
+      | party6 | ETH/DEC19 | sell | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t6-s-1    |
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest | auction end |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 360     | 1000000   | 999999    | 1873996252   | 1873996252     | 1             | 3600        |
+
+    When the network moves ahead "2" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode                    | target stake | supplied stake | open interest | auction end |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 1873996252   | 1873996252     | 1             | 3600        |
+
+    When the previous block duration was "40s"
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC20"
+
+    # We know what the volume on the books look like, but let's submit some orders that will trade regardless
+    # And we'll see no trades happen
+    When the parties place the following orders:
+      | party  | market id | side | volume | price   | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC19 | buy  | 1      | 999998  | 0                | TYPE_LIMIT | TIF_GTC | t1-b-3    |
+      | party2 | ETH/DEC19 | sell | 1      | 999998  | 0                | TYPE_LIMIT | TIF_GTC | t2-s-2    |
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC20"
+
+    # the monitoring auction is not extended
+    When the network moves ahead "1" blocks
+    Then the market data for the market "ETH/DEC19" should be:
+      | mark price | trading mode                    | target stake | supplied stake | open interest | auction end | extension trigger           |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2810994378   | 1873996252     | 1             | 3600        | AUCTION_TRIGGER_UNSPECIFIED |
+
+    When the network moves ahead "9m50s" with block duration of "2s"
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC20"
+
+    # still in auction, 1m10 seconds later, though:
+    When the network moves ahead "71" blocks
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    # we still have to leave the monitoring auction, so let's move ahead a bit
+    When the network moves ahead "2h" with block duration of "10m"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the following trades should be executed:
+      | buyer  | price   | size | seller |
+      | party5 | 999998  | 1    | party6 |
+      | party1 | 999998  | 1    | party2 |
 

--- a/core/integration/features/auctions/0094-PRAC-008.feature
+++ b/core/integration/features/auctions/0094-PRAC-008.feature
@@ -70,7 +70,7 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | TRADING_MODE_OPENING_AUCTION | 1873996252     | 937000000    |
     And the market data for the market "ETH/DEC19" should be:
       | trading mode                 | supplied stake | target stake |
-      | TRADING_MODE_OPENING_AUCTION | 937000000      | 937000000    |
+      | TRADING_MODE_OPENING_AUCTION | 1873996252     | 937000000    |
 
     When the network moves ahead "2" blocks
     Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
@@ -124,14 +124,9 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
       | party1 | ETH/DEC20 | buy  | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t1-b-3    |
       | party2 | ETH/DEC20 | sell | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t2-s-2    |
-      | party3 | ETH/DEC19 | buy  | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t3-b-3    |
-      | party4 | ETH/DEC19 | sell | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-2    |
     Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
     And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
-
-    When the network moves ahead "60" blocks
-    # This is strange, it looks as though the trade went through at the end of the auction, but in doing so triggered a second auction?
-    Then the market data for the market "ETH/DEC20" should be:
+    And the market data for the market "ETH/DEC20" should be:
       | mark price | trading mode                    | target stake | supplied stake | open interest | auction end | extension trigger          |
       | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2810994378   | 1873996252     | 1             | 602         | AUCTION_TRIGGER_LONG_BLOCK |
 
@@ -142,22 +137,21 @@ Feature: When a market's trigger and extension_trigger are set to represent that
       | mark price | trading mode                    | target stake | supplied stake | open interest | extension trigger          |
       | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2810994378   | 1873996252     | 1             | AUCTION_TRIGGER_LONG_BLOCK |
 
-    When the network moves ahead "7m50s" with block duration of "2s"
+    When the network moves ahead "8m50s" with block duration of "2s"
     Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
     And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
 
-    # still in auction, 150 seconds later, though:
+    # still in auction, but if we move ahead...
     When the network moves ahead "150" blocks
-    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
     And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
     And the following trades should be executed:
       | buyer  | price  | size | seller |
       | party5 | 999998 | 1    | party6 |
       | party1 | 999998 | 1    | party2 |
-      | party3 | 999999 | 1    | party4 |
 
 
-  @LBA2
+  @LBA
   Scenario: 0094-PRAC-008: Long block auction does not exceed the price monitoring auction duration, the auction does not get extended.
     # place orders and generate trades - slippage 100
     When the parties place the following orders:

--- a/core/integration/features/auctions/0094-PRAC-008.feature
+++ b/core/integration/features/auctions/0094-PRAC-008.feature
@@ -1,0 +1,158 @@
+Feature: When a market's trigger and extension_trigger are set to represent that the market went into auction due to the price monitoring mechanism and was later extended by the same mechanism and the auction is meant to finish at 11am, but now a long block auction is being triggered so that it ends at 10am then this market is unaffected in any way. (0094-PRAC-008)
+
+
+
+  Background:
+    Given the following assets are registered:
+      | id  | decimal places |
+      | ETH | 5              |
+    And the long block duration table is:
+      | threshold | duration |
+      | 3s        | 1m       |
+      | 40s       | 10m      |
+      | 2m        | 1h       |
+    And the price monitoring named "my-price-monitoring":
+      | horizon | probability | auction extension |
+      | 360     | 0.95        | 55                |
+    And the log normal risk model named "my-log-normal-risk-model":
+      | risk aversion | tau                    | mu | r     | sigma |
+      | 0.000001      | 0.00011407711613050422 | 0  | 0.016 | 2.0   |
+    And the simple risk model named "my-simple-risk-model":
+      | long                   | short                  | max move up | min move down | probability of trading |
+      | 0.08628781058136630000 | 0.09370922348428490000 | -1          | -1            | 0.2                    |
+    And the fees configuration named "my-fees-config":
+      | maker fee | infrastructure fee |
+      | 0.004     | 0.001              |
+    # create 2 markets
+    And the markets:
+      | id        | quote name | asset | risk model           | margin calculator         | auction duration | fees           | price monitoring    | data source config     | decimal places | linear slippage factor | quadratic slippage factor | sla params      |
+      | ETH/DEC19 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | default-none        | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
+      | ETH/DEC20 | ETH        | ETH   | my-simple-risk-model | default-margin-calculator | 1                | my-fees-config | my-price-monitoring | default-eth-for-future | 2              | 0.25                   | 0                         | default-futures |
+    And the following network parameters are set:
+      | name                           | value |
+      | limits.markets.maxPeggedOrders | 2     |
+    And the average block duration is "1"
+    And the parties deposit on asset's general account the following amount:
+      | party   | asset | amount        |
+      | party1  | ETH   | 1000000000000 |
+      | party2  | ETH   | 1000000000000 |
+      | party3  | ETH   | 1000000000000 |
+      | party4  | ETH   | 1000000000000 |
+      | party5  | ETH   | 1000000000000 |
+      | party6  | ETH   | 1000000000000 |
+      | lpprov1 | ETH   | 1000000000000 |
+      | lpprov2 | ETH   | 1000000000000 |
+    And the parties submit the following liquidity provision:
+      | id  | party   | market id | commitment amount | fee | lp type    |
+      | lp1 | lpprov1 | ETH/DEC20 | 1873996252        | 0.1 | submission |
+      | lp2 | lpprov2 | ETH/DEC19 | 937000000         | 0.1 | submission |
+    And the parties place the following pegged iceberg orders:
+      | party   | market id | peak size | minimum visible size | side | pegged reference | volume | offset |
+      | lpprov1 | ETH/DEC20 | 2         | 1                    | buy  | BID              | 50     | 100    |
+      | lpprov1 | ETH/DEC20 | 2         | 1                    | sell | ASK              | 50     | 100    |
+      | lpprov2 | ETH/DEC19 | 2         | 1                    | buy  | MID              | 50     | 100    |
+      | lpprov2 | ETH/DEC19 | 2         | 1                    | sell | MID              | 50     | 100    |
+
+  @LBA
+  Scenario: 0094-PRAC-008: market in price monitoring auction should not enter long block auction.
+    # place orders and generate trades - slippage 100
+    When the parties place the following orders:
+      | party  | market id | side | volume | price   | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | buy  | 1      | 999500  | 0                | TYPE_LIMIT | TIF_GTC | t1-b-1    |
+      | party1 | ETH/DEC20 | buy  | 1      | 1000000 | 0                | TYPE_LIMIT | TIF_GFA | t1-b-2    |
+      | party2 | ETH/DEC20 | sell | 2      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t2-s-1    |
+      | party3 | ETH/DEC19 | buy  | 1      | 999500  | 0                | TYPE_LIMIT | TIF_GTC | t3-b-1    |
+      | party3 | ETH/DEC19 | buy  | 1      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t3-b-2    |
+      | party4 | ETH/DEC19 | sell | 2      | 1000000 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-1    |
+    Then the market data for the market "ETH/DEC20" should be:
+      | trading mode                 | supplied stake | target stake |
+      | TRADING_MODE_OPENING_AUCTION | 1873996252     | 937000000    |
+    And the market data for the market "ETH/DEC19" should be:
+      | trading mode                 | supplied stake | target stake |
+      | TRADING_MODE_OPENING_AUCTION | 937000000      | 937000000    |
+
+    When the network moves ahead "2" blocks
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    #And debug detailed orderbook volumes for market "ETH/DEC20"
+    And the order book should have the following volumes for market "ETH/DEC20":
+      | volume | price   | side |
+      | 2      | 999400  | buy  |
+      | 1      | 999500  | buy  |
+      | 1      | 1000000 | sell |
+      | 2      | 1000100 | sell |
+    #And debug detailed orderbook volumes for market "ETH/DEC19"
+    And the order book should have the following volumes for market "ETH/DEC19":
+      | volume | price   | side |
+      | 1      | 999500  | buy  |
+      | 2      | 999650  | buy  |
+      | 2      | 999850  | sell |
+      | 1      | 1000000 | sell |
+
+    And the following trades should be executed:
+      | buyer  | price   | size | seller |
+      | party1 | 1000000 | 1    | party2 |
+      | party3 | 1000000 | 1    | party4 |
+    And the mark price should be "1000000" for the market "ETH/DEC19"
+    And the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest |
+      | 1000000    | TRADING_MODE_CONTINUOUS | 360     | 1000000   | 999999    | 937000000    | 1873996252     | 1             |
+
+    When the network moves ahead "10" blocks
+    Then the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party5 | ETH/DEC20 | buy  | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t5-b-1    |
+      | party6 | ETH/DEC20 | sell | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t6-s-1    |
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
+    And the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode                    | horizon | min bound | max bound | target stake | supplied stake | open interest | auction end |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 360     | 1000000   | 999999    | 1873996252   | 1873996252     | 1             | 55          |
+
+    When the network moves ahead "2" blocks
+    Then the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode                    | target stake | supplied stake | open interest | auction end |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 1873996252   | 1873996252     | 1             | 55          |
+
+    When the previous block duration was "90s"
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
+
+    # We know what the volume on the books look like, but let's submit some orders that will trade regardless
+    # And we'll see no trades happen
+    When the parties place the following orders:
+      | party  | market id | side | volume | price  | resulting trades | type       | tif     | reference |
+      | party1 | ETH/DEC20 | buy  | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t1-b-3    |
+      | party2 | ETH/DEC20 | sell | 1      | 999998 | 0                | TYPE_LIMIT | TIF_GTC | t2-s-2    |
+      | party3 | ETH/DEC19 | buy  | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t3-b-3    |
+      | party4 | ETH/DEC19 | sell | 1      | 999999 | 0                | TYPE_LIMIT | TIF_GTC | t4-s-2    |
+    Then the trading mode should be "TRADING_MODE_MONITORING_AUCTION" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
+
+    When the network moves ahead "60" blocks
+    # This is strange, it looks as though the trade went through at the end of the auction, but in doing so triggered a second auction?
+    Then the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode                    | target stake | supplied stake | open interest | auction end | extension trigger           |
+      | 1000000    | TRADING_MODE_MONITORING_AUCTION | 2811000000   | 1873996252     | 3             | 55          | AUCTION_TRIGGER_UNSPECIFIED |
+
+    # move ahead another minute
+    When the network moves ahead "60" blocks
+    # This is strange, it looks as though the trade went through at the end of the auction, but in doing so triggered a second auction?
+    Then the market data for the market "ETH/DEC20" should be:
+      | mark price | trading mode            | horizon | min bound | max bound | target stake | supplied stake | open interest | extension trigger           |
+      | 1000000    | TRADING_MODE_CONTINUOUS | 360     | 999999    | 999997    | 2811000000   | 1873996252     | 3             | AUCTION_TRIGGER_UNSPECIFIED |
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+
+    When the network moves ahead "7m50s" with block duration of "2s"
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_LONG_BLOCK_AUCTION" for the market "ETH/DEC19"
+
+    # still in auction, 10 seconds later, though:
+    When the network moves ahead "11" blocks
+    Then the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC20"
+    And the trading mode should be "TRADING_MODE_CONTINUOUS" for the market "ETH/DEC19"
+    And the following trades should be executed:
+      | buyer  | price  | size | seller |
+      | party5 | 999998 | 1    | party6 |
+      | party1 | 999998 | 1    | party2 |
+      | party3 | 999999 | 1    | party4 |
+

--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -1395,7 +1395,7 @@ func (app *App) startProtocolUpgrade(ctx context.Context) {
 					break Loop
 				}
 			case err := <-errsCh:
-				app.log.Fatal("failed to wait for data node to get ready for upgrade", logging.Error(err))
+				app.log.Panic("failed to wait for data node to get ready for upgrade", logging.Error(err))
 			}
 		}
 	}

--- a/core/processor/abci_test.go
+++ b/core/processor/abci_test.go
@@ -1039,7 +1039,7 @@ func getTestAppWithInit(t *testing.T, cfunc func(), stop func() error, PoW, Spam
 	return tstApp
 }
 
-// fake socket client
+// fake socket client.
 type brokerClient struct {
 	errCh chan error
 	evtCh chan events.Event

--- a/core/processor/abci_test.go
+++ b/core/processor/abci_test.go
@@ -19,10 +19,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"code.vegaprotocol.io/vega/core/blockchain/abci"
+	"code.vegaprotocol.io/vega/core/events"
 	"code.vegaprotocol.io/vega/core/genesis"
 	"code.vegaprotocol.io/vega/core/netparams"
 	"code.vegaprotocol.io/vega/core/processor"
@@ -701,6 +703,115 @@ type tstApp struct {
 	pChainID, sChainID uint64
 }
 
+func TestProtocolUpgradeFailedBrokerStreamError(t *testing.T) {
+	streamClient := newBrokerClient(0)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	stop := func() error {
+		wg.Done()
+		return nil
+	}
+	ctx, cfunc := context.WithCancel(context.Background())
+	app := getTestAppWithInit(t, cfunc, stop, false, false)
+	defer func() {
+		wg.Wait()
+		streamClient.finish()
+		app.ctrl.Finish()
+	}()
+
+	// vars
+	blockHeight := uint64(123)
+	blockHash := "0xDEADBEEF"
+	proposer := "0xCAFECAFE1"
+	updateTime := time.Now()
+	brokerErr := errors.Errorf("pretend something went wrong")
+
+	// let's make this look like a protocol upgrade
+	app.txCache.EXPECT().SetRawTxs(nil, blockHeight).Times(1)
+
+	// These are the calls made in the startProtocolUpgrade func:
+	app.puSvc.EXPECT().CoreReadyForUpgrade().Times(1).Return(true)
+	// broker streaming is enabled, so let's set up the channels and push some data
+	app.broker.EXPECT().StreamingEnabled().Times(1).Return(true)
+	app.broker.EXPECT().SocketClient().Times(1).Return(streamClient)
+	// we expect the protocol upgraded started event to be sent once at least.
+	app.broker.EXPECT().Send(gomock.Any()).Times(1)
+	// as part of the event data sent here, we call stats to get the height:
+	app.stats.EXPECT().Height().Times(1).Return(blockHeight - 1)
+	// now we set the upgrade service as ready:
+	app.puSvc.EXPECT().SetReadyForUpgrade().Times(0)
+
+	// start stream client routine, throw some events on the channels
+	go func() {
+		// this event should be read, but not have any effect on the logic.
+		streamClient.evtCh <- events.NewTime(ctx, updateTime)
+		require.True(t, blockHeight > 0) // just check we reach this part
+		streamClient.errCh <- brokerErr
+	}()
+
+	// see if we can recover here?
+	defer func() {
+		if r := recover(); r != nil {
+			expect := "failed to wait for data node to get ready for upgrade"
+			msg := fmt.Sprintf("Test likely passed, recovered: %v\n", r)
+			require.Contains(t, msg, expect, msg)
+		}
+	}()
+
+	// start upgrade
+	_ = app.OnBeginBlock(blockHeight, blockHash, updateTime, proposer, nil)
+}
+
+func TestOnBeginBlock(t *testing.T) {
+	// keeping the test for reference, as it can be used for reference with regular OnBeginBlock calls
+	// or error cases with for protocol upgrade stuff.
+	// set up stop call, so we can ensure the chain is stopped as part of protocol upgrade.
+	_, cfunc := context.WithCancel(context.Background())
+	app := getTestAppWithInit(t, cfunc, stopDummy, true, true)
+	defer app.ctrl.Finish()
+
+	// vars
+	blockHeight := uint64(123)
+	blockHash := "0xDEADBEEF"
+	proposer := "0xCAFECAFE1"
+	updateTime := time.Now()
+	prevTime := updateTime.Add(-1 * time.Second)
+
+	// let's make this look like a protocol upgrade
+	app.txCache.EXPECT().SetRawTxs(nil, blockHeight).Times(1)
+
+	// check for upgrade
+	app.puSvc.EXPECT().CoreReadyForUpgrade().Times(1).Return(false)
+
+	// now we're back to the OnBeginBlock call, set mocks for the remainder of that func:
+	app.broker.EXPECT().Send(gomock.Any()).Times(1)
+	// we're not passing any transactions ATM, so no setTxStats to worry about
+	// now PoW
+	app.pow.EXPECT().BeginBlock(blockHeight, blockHash, nil).Times(1)
+	// spam:
+	app.spam.EXPECT().BeginBlock(nil).Times(1)
+	// now do stats:
+	app.stats.EXPECT().SetHash(blockHash).Times(1)
+	app.stats.EXPECT().SetHeight(blockHeight).Times(1)
+	// now the calls to time service:
+	app.timeSvc.EXPECT().SetTimeNow(gomock.Any(), updateTime).Times(1)
+	app.timeSvc.EXPECT().GetTimeNow().Times(1).Return(updateTime)
+	app.timeSvc.EXPECT().GetTimeLastBatch().Times(1).Return(prevTime)
+	// begin upgrade:
+	app.puSvc.EXPECT().BeginBlock(gomock.Any(), blockHeight).Times(1)
+	// topology:
+	app.validator.EXPECT().BeginBlock(gomock.Any(), blockHeight, proposer).Times(1)
+	// balance checker:
+	app.balance.EXPECT().BeginBlock(gomock.Any()).Times(1)
+	// exec engine:
+	app.exec.EXPECT().BeginBlock(gomock.Any(), updateTime.Sub(prevTime)).Times(1)
+
+	// actually make the call now:
+	ctx := app.OnBeginBlock(blockHeight, blockHash, updateTime, proposer, nil)
+	// we should get a context back, this just checks the call returned.
+	require.NotNil(t, ctx)
+}
+
 func stopDummy() error {
 	return nil
 }
@@ -709,7 +820,10 @@ func getTestApp(t *testing.T, cfunc func(), stop func() error, PoW, Spam bool) *
 	t.Helper()
 	pChain := "1"
 	sChain := "2"
-	gHandler := &genesis.Handler{}
+	gHandler := genesis.New(
+		logging.NewTestLogger(),
+		genesis.NewDefaultConfig(),
+	)
 	pChainID, err := strconv.ParseUint(pChain, 10, 64)
 	if err != nil {
 		t.Fatalf("Could not get test app instance, chain ID parse error: %v", err)
@@ -904,4 +1018,55 @@ func getTestApp(t *testing.T, cfunc func(), stop func() error, PoW, Spam bool) *
 	tstApp.App = app
 	// return wrapper
 	return tstApp
+}
+
+func getTestAppWithInit(t *testing.T, cfunc func(), stop func() error, PoW, Spam bool) *tstApp {
+	t.Helper()
+	tstApp := getTestApp(t, cfunc, stop, PoW, Spam)
+	// now set up the OnInitChain stuff
+	req := &tmtypes.RequestInitChain{
+		ChainId:       "1",
+		InitialHeight: 0,
+		Time:          time.Now().Add(-1 * time.Hour), // some time in the past
+	}
+	// set up mock calls:
+	tstApp.broker.EXPECT().Send(gomock.Any()).Times(2) // once before, and once after gHandler is called
+	tstApp.ethCallEng.EXPECT().Start().Times(1)
+	tstApp.validator.EXPECT().GetValidatorPowerUpdates().Times(1).Return(nil)
+	resp, err := tstApp.OnInitChain(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return tstApp
+}
+
+// fake socket client
+type brokerClient struct {
+	errCh chan error
+	evtCh chan events.Event
+}
+
+func newBrokerClient(buf int) *brokerClient {
+	return &brokerClient{
+		errCh: make(chan error, buf),
+		evtCh: make(chan events.Event, buf),
+	}
+}
+
+func (b *brokerClient) finish() {
+	if b.errCh != nil {
+		close(b.errCh)
+		b.errCh = nil
+	}
+	if b.evtCh != nil {
+		close(b.evtCh)
+		b.evtCh = nil
+	}
+}
+
+func (b *brokerClient) SendBatch(events []events.Event) error {
+	return nil
+}
+
+func (b *brokerClient) Receive(ctx context.Context) (<-chan events.Event, <-chan error) {
+	return b.evtCh, b.errCh
 }


### PR DESCRIPTION
Also included some more unit testing to processor package, changed the `log.Fatal` call in the protocol upgrade flow to a `log.Panic` to be able to recover in a unit test, to check that code-path. 