### PR TITLE
fix: improve performance with the ackedEvent store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [1343](https://github.com/vegaprotocol/core-test-coverage/issues/1343) - Added coverage for `0093-TRTO-011`.
 - [1344](https://github.com/vegaprotocol/core-test-coverage/issues/1344) - Added coverage for `0093-TRTO-012`.
 - [1382](https://github.com/vegaprotocol/core-test-coverage/issues/1382) - Added coverage for `0093-TRTO-013`.
+- [11497](https://github.com/vegaprotocol/vega/issues/11497) - Improve performance with the `ackedEvents` store.
 
 ### 🐛 Fixes
 

--- a/core/datasource/external/ethverifier/acked_events.go
+++ b/core/datasource/external/ethverifier/acked_events.go
@@ -20,9 +20,12 @@ import (
 	"github.com/emirpasic/gods/utils"
 )
 
+const oneHour = 3600 // seconds
+
 type ackedEvtBucket struct {
 	ts     int64
-	hashes []string
+	endTs  int64
+	hashes map[string]struct{}
 }
 
 func ackedEvtBucketComparator(a, b interface{}) int {
@@ -39,30 +42,24 @@ type ackedEvents struct {
 func (a *ackedEvents) AddAt(ts int64, hashes ...string) {
 	_, value := a.events.Find(func(i int, value interface{}) bool {
 		bucket := value.(*ackedEvtBucket)
-		return bucket.ts == ts
+		return bucket.ts <= ts && bucket.endTs >= ts
 	})
 
 	if value != nil {
 		bucket := value.(*ackedEvtBucket)
 		for _, newHash := range hashes {
-			found := false
-			for _, v := range bucket.hashes {
-				// hash already exists
-				if v == newHash {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				bucket.hashes = append(bucket.hashes, newHash)
-			}
+			bucket.hashes[newHash] = struct{}{}
 		}
 
 		return
 	}
 
-	a.events.Add(&ackedEvtBucket{ts: ts, hashes: append([]string{}, hashes...)})
+	hashesM := map[string]struct{}{}
+	for _, v := range hashes {
+		hashesM[v] = struct{}{}
+	}
+
+	a.events.Add(&ackedEvtBucket{ts: ts, endTs: ts + oneHour, hashes: hashesM})
 }
 
 func (a *ackedEvents) Add(hash string) {
@@ -72,13 +69,8 @@ func (a *ackedEvents) Add(hash string) {
 func (a *ackedEvents) Contains(hash string) bool {
 	_, value := a.events.Find(func(index int, value interface{}) bool {
 		bucket := value.(*ackedEvtBucket)
-		for _, v := range bucket.hashes {
-			if hash == v {
-				return true
-			}
-		}
-
-		return false
+		_, ok := bucket.hashes[hash]
+		return ok
 	})
 
 	return value != nil

--- a/core/datasource/external/ethverifier/l2_verifier_snapshot.go
+++ b/core/datasource/external/ethverifier/l2_verifier_snapshot.go
@@ -17,6 +17,7 @@ package ethverifier
 
 import (
 	"context"
+	"slices"
 	"sort"
 
 	"code.vegaprotocol.io/vega/core/datasource/external/ethcall"
@@ -63,9 +64,11 @@ func (s *L2Verifiers) GetState(k string) ([]byte, []types.StateProvider, error) 
 		iter := v.ackedEvts.events.Iterator()
 		for iter.Next() {
 			v := (iter.Value().(*ackedEvtBucket))
+			hashes := maps.Keys(v.hashes)
+			slices.Sort(hashes)
 			slice = append(slice, &snapshotpb.EthVerifierBucket{
 				Ts:     v.ts,
-				Hashes: v.hashes,
+				Hashes: hashes,
 			})
 		}
 

--- a/core/datasource/external/ethverifier/verifier_snapshot.go
+++ b/core/datasource/external/ethverifier/verifier_snapshot.go
@@ -18,6 +18,7 @@ package ethverifier
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"code.vegaprotocol.io/vega/core/datasource/external/ethcall"
 	"code.vegaprotocol.io/vega/core/metrics"
@@ -26,6 +27,8 @@ import (
 	"code.vegaprotocol.io/vega/libs/proto"
 	"code.vegaprotocol.io/vega/logging"
 	snapshotpb "code.vegaprotocol.io/vega/protos/vega/snapshot/v1"
+
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -89,9 +92,11 @@ func (s *Verifier) serialiseMisc() ([]byte, error) {
 	iter := s.ackedEvts.events.Iterator()
 	for iter.Next() {
 		v := (iter.Value().(*ackedEvtBucket))
+		hashes := maps.Keys(v.hashes)
+		slices.Sort(hashes)
 		slice = append(slice, &snapshotpb.EthVerifierBucket{
 			Ts:     v.ts,
-			Hashes: v.hashes,
+			Hashes: hashes,
 		})
 	}
 

--- a/core/evtforward/acked_events.go
+++ b/core/evtforward/acked_events.go
@@ -20,9 +20,12 @@ import (
 	"github.com/emirpasic/gods/utils"
 )
 
+const oneHour = 3600 // seconds
+
 type ackedEvtBucket struct {
 	ts     int64
-	hashes []string
+	endTs  int64
+	hashes map[string]struct{}
 }
 
 func ackedEvtBucketComparator(a, b interface{}) int {
@@ -39,30 +42,24 @@ type ackedEvents struct {
 func (a *ackedEvents) AddAt(ts int64, hashes ...string) {
 	_, value := a.events.Find(func(i int, value interface{}) bool {
 		bucket := value.(*ackedEvtBucket)
-		return bucket.ts == ts
+		return bucket.ts <= ts && bucket.endTs >= ts
 	})
 
 	if value != nil {
 		bucket := value.(*ackedEvtBucket)
 		for _, newHash := range hashes {
-			found := false
-			for _, v := range bucket.hashes {
-				// hash already exists
-				if v == newHash {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				bucket.hashes = append(bucket.hashes, newHash)
-			}
+			bucket.hashes[newHash] = struct{}{}
 		}
 
 		return
 	}
 
-	a.events.Add(&ackedEvtBucket{ts: ts, hashes: append([]string{}, hashes...)})
+	hashesM := map[string]struct{}{}
+	for _, v := range hashes {
+		hashesM[v] = struct{}{}
+	}
+
+	a.events.Add(&ackedEvtBucket{ts: ts, endTs: ts + oneHour, hashes: hashesM})
 }
 
 func (a *ackedEvents) Add(hash string) {
@@ -72,13 +69,8 @@ func (a *ackedEvents) Add(hash string) {
 func (a *ackedEvents) Contains(hash string) bool {
 	_, value := a.events.Find(func(index int, value interface{}) bool {
 		bucket := value.(*ackedEvtBucket)
-		for _, v := range bucket.hashes {
-			if hash == v {
-				return true
-			}
-		}
-
-		return false
+		_, ok := bucket.hashes[hash]
+		return ok
 	})
 
 	return value != nil

--- a/core/evtforward/snapshot.go
+++ b/core/evtforward/snapshot.go
@@ -17,12 +17,14 @@ package evtforward
 
 import (
 	"context"
+	"slices"
 
 	"code.vegaprotocol.io/vega/core/types"
 	"code.vegaprotocol.io/vega/libs/proto"
 	snapshotpb "code.vegaprotocol.io/vega/protos/vega/snapshot/v1"
 
 	"github.com/emirpasic/gods/sets/treeset"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -50,9 +52,11 @@ func (f *Forwarder) serialise() ([]byte, error) {
 	iter := f.ackedEvts.events.Iterator()
 	for iter.Next() {
 		v := iter.Value().(*ackedEvtBucket)
+		hashes := maps.Keys(v.hashes)
+		slices.Sort(hashes)
 		slice = append(slice, &snapshotpb.EventForwarderBucket{
 			Ts:     v.ts,
-			Hashes: v.hashes,
+			Hashes: hashes,
 		})
 	}
 


### PR DESCRIPTION
Two things have been done here:
- first the buckets are for one hour instead of one per timestamps.
- hashes are stored in a map not a slice anymore to avoid long iterations

close #11497 