### PR TITLE
fix: restore snapshot for ackedEvts storr

### DIFF
--- a/core/datasource/external/ethverifier/acked_events.go
+++ b/core/datasource/external/ethverifier/acked_events.go
@@ -62,6 +62,18 @@ func (a *ackedEvents) AddAt(ts int64, hashes ...string) {
 	a.events.Add(&ackedEvtBucket{ts: ts, endTs: ts + oneHour, hashes: hashesM})
 }
 
+// RestoreExactAt - is to be used when loading a snapshot only
+// this prevent restoring in different buckets, which could happen
+// when events are received out of sync (e.g: timestamps 100 before 90) which could make gap between buckets.
+func (a *ackedEvents) RestoreExactAt(ts int64, hashes ...string) {
+	hashesM := map[string]struct{}{}
+	for _, v := range hashes {
+		hashesM[v] = struct{}{}
+	}
+
+	a.events.Add(&ackedEvtBucket{ts: ts, endTs: ts + oneHour, hashes: hashesM})
+}
+
 func (a *ackedEvents) Add(hash string) {
 	a.AddAt(a.timeService.GetTimeNow().Unix(), hash)
 }

--- a/core/datasource/external/ethverifier/l2_verifier_snapshot.go
+++ b/core/datasource/external/ethverifier/l2_verifier_snapshot.go
@@ -156,7 +156,7 @@ func (s *L2Verifiers) restoreState(ctx context.Context, l2EthOracles *snapshotpb
 			}
 
 			verifier.restorePatchBlock(ctx, patchBlock)
-			verifier.restoreSeen(v.Misc.Buckets)
+			verifier.restoreSeen(ctx, v.Misc.Buckets)
 		}
 		pending := []*ethcall.ContractCallEvent{}
 

--- a/core/evtforward/acked_events.go
+++ b/core/evtforward/acked_events.go
@@ -62,6 +62,18 @@ func (a *ackedEvents) AddAt(ts int64, hashes ...string) {
 	a.events.Add(&ackedEvtBucket{ts: ts, endTs: ts + oneHour, hashes: hashesM})
 }
 
+// RestoreExactAt - is to be used when loading a snapshot only
+// this prevent restoring in different buckets, which could happen
+// when events are received out of sync (e.g: timestamps 100 before 90) which could make gap between buckets.
+func (a *ackedEvents) RestoreExactAt(ts int64, hashes ...string) {
+	hashesM := map[string]struct{}{}
+	for _, v := range hashes {
+		hashesM[v] = struct{}{}
+	}
+
+	a.events.Add(&ackedEvtBucket{ts: ts, endTs: ts + oneHour, hashes: hashesM})
+}
+
 func (a *ackedEvents) Add(hash string) {
 	a.AddAt(a.timeService.GetTimeNow().Unix(), hash)
 }

--- a/core/evtforward/snapshot.go
+++ b/core/evtforward/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"code.vegaprotocol.io/vega/core/types"
+	vgcontext "code.vegaprotocol.io/vega/libs/context"
 	"code.vegaprotocol.io/vega/libs/proto"
 	snapshotpb "code.vegaprotocol.io/vega/protos/vega/snapshot/v1"
 
@@ -95,13 +96,24 @@ func (f *Forwarder) LoadState(ctx context.Context, p *types.Payload) ([]types.St
 	return nil, types.ErrUnknownSnapshotType
 }
 
-func (f *Forwarder) restore(_ context.Context, p *types.PayloadEventForwarder) {
+func (f *Forwarder) restore(ctx context.Context, p *types.PayloadEventForwarder) {
 	f.ackedEvts = &ackedEvents{
 		timeService: f.timeService,
 		events:      treeset.NewWith(ackedEvtBucketComparator),
 	}
 
+	// if we are executing a protocol upgrade,
+	// let's force bucketing things. This will reduce
+	// increase performance at startup, and everyone is starting
+	// from the same snapshot, so that will keep state consistent
+	if vgcontext.InProgressUpgrade(ctx) {
+		for _, v := range p.Buckets {
+			f.ackedEvts.AddAt(v.Ts, v.Hashes...)
+		}
+		return
+	}
+
 	for _, v := range p.Buckets {
-		f.ackedEvts.AddAt(v.Ts, v.Hashes...)
+		f.ackedEvts.RestoreExactAt(v.Ts, v.Hashes...)
 	}
 }


### PR DESCRIPTION
Restore the buckets exactly as they were saved in the snapshot to prevent them to be moved in different buckets