### PR TITLE
fix long block auction market state/trading mode

### DIFF
--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -497,20 +497,22 @@ func (m *Market) EnterLongBlockAuction(ctx context.Context, duration int64) {
 		return
 	}
 
-	m.mkt.State = types.MarketStateSuspended
-	m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
 	if m.as.InAuction() {
-		effDuration := int(m.timeService.GetTimeNow().UnixNano()/1e9) + int(duration) - int(m.as.ExpiresAt().UnixNano()/1e9)
-		if effDuration <= 0 {
+		now := m.timeService.GetTimeNow()
+		aRemaining := int64(m.as.ExpiresAt().Sub(now) / time.Second)
+		if aRemaining >= duration {
 			return
 		}
-		m.as.ExtendAuctionLongBlock(types.AuctionDuration{Duration: int64(effDuration)})
-		evt := m.as.AuctionExtended(ctx, m.timeService.GetTimeNow())
-		if evt != nil {
+		m.as.ExtendAuctionLongBlock(types.AuctionDuration{
+			Duration: duration - aRemaining,
+		})
+		if evt := m.as.AuctionExtended(ctx, now); evt != nil {
 			m.broker.Send(evt)
 		}
 	} else {
 		m.as.StartLongBlockAuction(m.timeService.GetTimeNow(), duration)
+		m.mkt.TradingMode = types.MarketTradingModelLongBlockAuction
+		m.mkt.State = types.MarketStateSuspended
 		m.enterAuction(ctx)
 		m.broker.Send(events.NewMarketUpdatedEvent(ctx, *m.mkt))
 	}


### PR DESCRIPTION
fix: update market state correctly, subtract auction duration remaining from LBA duration