### PR TITLE
feat: improve snapshot performance by using more targetted caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [11428](https://github.com/vegaprotocol/vega/issues/11428) - Add buy back and treasury fee and separate discount/reward factors. 
 - [11468](https://github.com/vegaprotocol/vega/issues/11468) - Added support for volume rebate program.
+- [11523](https://github.com/vegaprotocol/vega/issues/11523) - Change method of caching to improve `AMM` snapshot performance.
 - [11459](https://github.com/vegaprotocol/vega/issues/11459) - Deprecate time weight position reward metric and replace it with time weighted notional. 
 
 ### 🐛 Fixes


### PR DESCRIPTION
closes #11523

Early on in the development of AMM's there were fears that calculations of square-roots would be slow, so it was thought if we cache square-root results at all price levels in the neighbourhood of where trading is happening then we wouldn't have to keep calculating them.

In reality I don't think the square-root calcs are that intense and turning off the cache doesn't seem to really impact performance. In fact now the code is in place its clear that there are better things we can do. So I've removed the square-root cache and have instead:
- stored in the curve struct constant terms in the formulas, namely `sqrt(Pu)` and `L / sqrt(Pu)`
- stored the AMM's fair price given its current position, so we can avoid a whole lot of recalculation e.g all the calls throughout the code _not directly related to an inomcing trade_ that query best-bid/best-ask from the orderbook (SLA etc)

I've tested these changes locally by running a AMM heavy market-sim run replay file, and the performance is improved from taking ~9s to run down to ~7.5s to run.