### PR TITLE
fix: typo in version

### DIFF
--- a/protos/sources/blockexplorer/api/v1/blockexplorer.proto
+++ b/protos/sources/blockexplorer/api/v1/blockexplorer.proto
@@ -11,7 +11,7 @@ option go_package = "code.vegaprotocol.io/vega/protos/blockexplorer/api/v1";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "Vega block explorer APIs";
-    version: "v0.78.0.preview.1";
+    version: "v0.78.0-preview.1";
   }
   schemes: [
     HTTP,

--- a/protos/sources/data-node/api/v2/trading_data.proto
+++ b/protos/sources/data-node/api/v2/trading_data.proto
@@ -17,7 +17,7 @@ option go_package = "code.vegaprotocol.io/vega/protos/data-node/api/v2";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "Vega data node APIs";
-    version: "v0.78.0.preview.1";
+    version: "v0.78.0-preview.1";
   }
   schemes: [
     HTTP,

--- a/protos/sources/vega/api/v1/core.proto
+++ b/protos/sources/vega/api/v1/core.proto
@@ -12,7 +12,7 @@ option go_package = "code.vegaprotocol.io/vega/protos/vega/api/v1";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "Vega core APIs";
-    version: "v0.78.0.preview.1";
+    version: "v0.78.0-preview.1";
   }
   schemes: [
     HTTP,

--- a/protos/sources/vega/api/v1/corestate.proto
+++ b/protos/sources/vega/api/v1/corestate.proto
@@ -13,7 +13,7 @@ option go_package = "code.vegaprotocol.io/vega/protos/vega/api/v1";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "Vega core state APIs";
-    version: "v0.78.0.preview.1";
+    version: "v0.78.0-preview.1";
   }
   schemes: [
     HTTP,

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	cliVersionHash = ""
-	cliVersion     = "v0.78.0.preview.1"
+	cliVersion     = "v0.78.0-preview.1"
 )
 
 func init() {


### PR DESCRIPTION
We have to update this version because We cannot do protocol upgrade:


```
vega  protocol_upgrade_proposal  --home "/home/vega/vega_home"  --passphrase-file "/home/vega/vega_home/all-wallet-passphrase.txt"  --vega-release-tag "v0.78.0.preview.1"  --height "12432200"  --output json


invalid protocol version for upgrade received: version (v0.78.0.preview.1), Invalid character(s) found in patch number \"0.preview.1\"", "stderr_lines": ["invalid protocol version for upgrade received: version (v0.78.0.preview.1), Invalid character(s) found in patch number \"0.preview.1\"
```