### PR TITLE
fix: empty-factor struct comparison does not work because decimal con…

### DIFF
--- a/core/fee/engine.go
+++ b/core/fee/engine.go
@@ -694,7 +694,7 @@ func (e *Engine) applyDiscountsAndRewards(taker string, maker string, tradeValue
 
 	// calculate rewards
 	factors := referral.RewardsFactorsMultiplierAppliedForParty(types.PartyID(taker))
-	if factors == types.EmptyFactors {
+	if factors.IsEmpty() {
 		return f, nil
 	}
 

--- a/core/types/referral_program.go
+++ b/core/types/referral_program.go
@@ -44,6 +44,10 @@ var EmptyFactors = Factors{
 	Maker:     num.DecimalZero(),
 }
 
+func (f Factors) IsEmpty() bool {
+	return f.Equal(EmptyFactors)
+}
+
 func (f Factors) String() string {
 	return fmt.Sprintf("infra(%s),liquidity(%s),maker(%s)", f.Infra.String(), f.Liquidity.String(), f.Maker.String())
 }


### PR DESCRIPTION
Fixes the snapshot issue seen on the overnight run the past few days.

On the normal node the factors are set to `Emptyfactors`, but on the restored node they restore to a _different_ struct where all values are zero. Despite the decimal values being the same, the shallow struct comparison does not work because the `Decimal` type contains pointers.

Switch to do an actual comparison of fields.