### PR TITLE
fix: err shadowing prevented failed AMM amend to restore old AMM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [11521](https://github.com/vegaprotocol/vega/issues/11521) - Restore `AMM` position factor when loading from a snapshot.
 - [11526](https://github.com/vegaprotocol/vega/issues/11526) - `EstimateAMMBounds` now respects the market's decimal places.
 - [11486](https://github.com/vegaprotocol/vega/issues/11486) - `AMMs` can now be submitted on markets with more decimal places than asset decimal places.
+- [11561](https://github.com/vegaprotocol/vega/issues/11561) - Failing amends on `AMMs` now restore original properly.
 - [11540](https://github.com/vegaprotocol/vega/issues/11540) - Fix spam check for spots to use not double count quantum.
 - [11542](https://github.com/vegaprotocol/vega/issues/11542) - Fix non determinism in lottery ranking.
 - [11544](https://github.com/vegaprotocol/vega/issues/11544) - Fix empty candles stream.

--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -692,6 +692,14 @@ func (e *Engine) Create(
 		return nil, err
 	}
 
+	// sanity check, a *new* AMM should not already have a position. If it does it means that the party
+	// previously had an AMM but it was stopped/cancelled while still holding a position which should not happen.
+	// It should have either handed its position over to the liquidation engine, or be in reduce-only mode
+	// and only be removed when its position is 0.
+	if pool.getPosition() != 0 {
+		e.log.Panic("AMM has position before existing")
+	}
+
 	e.log.Debug("AMM created",
 		logging.String("owner", submit.Party),
 		logging.String("poolID", pool.ID),

--- a/core/execution/amm/engine_test.go
+++ b/core/execution/amm/engine_test.go
@@ -705,6 +705,8 @@ func whenAMMIsSubmitted(t *testing.T, tst *tstEngine, submission *types.SubmitAM
 	subAccount := DeriveAMMParty(party, tst.marketID, "AMMv1", 0)
 	expectBalanceChecks(t, tst, party, subAccount, submission.CommitmentAmount.Uint64())
 
+	ensurePosition(t, tst.pos, 0, nil)
+
 	ctx := context.Background()
 	pool, err := tst.engine.Create(ctx, submission, vgcrypto.RandomHash(), riskFactors, scalingFactors, slippage)
 	require.NoError(t, err)

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -5611,9 +5611,11 @@ func (m *Market) AmendAMM(ctx context.Context, amend *types.AmendAMM, determinis
 			logging.Error(err),
 		)
 		if amend.CommitmentAmount != nil {
-			_, err = m.amm.UpdateSubAccountBalance(ctx, pool.Owner(), pool.AMMParty, prevCommitment)
+			if _, err := m.amm.UpdateSubAccountBalance(ctx, pool.Owner(), pool.AMMParty, prevCommitment); err != nil {
+				m.log.Panic("unable to restore AMM balances after failed amend", logging.Error(err))
+			}
 		}
-		return err
+		return common.ErrAMMCannotRebase
 	}
 
 	m.amm.Confirm(ctx, pool)


### PR DESCRIPTION
closes #11561 

The call to `m.amm.UpdateSubAccountBalance()` after a failed rebase was setting `err` to `nil` which meant we didn't execute the code in a `defer` statement that would restore the original AMM.

This left a state where an AMM was essentially "removed" while it still had a position. This caused issues when the same party later submitted a new AMM.