### PR TITLE
fix: send empty factors for party that does no quality

### DIFF
--- a/core/volumediscount/engine.go
+++ b/core/volumediscount/engine.go
@@ -210,9 +210,9 @@ func (e *Engine) computeFactorsByParty(ctx context.Context, epoch uint64) {
 		// if the party hasn't qualified, then still send the stats but with a zero factor
 		if !qualifiedForTier {
 			evt.Stats = append(evt.Stats, &eventspb.PartyVolumeDiscountStats{
-				PartyId:        party.String(),
-				DiscountFactor: "0",
-				RunningVolume:  notionalVolume.Round(0).String(),
+				PartyId:         party.String(),
+				DiscountFactors: types.EmptyFactors.IntoDiscountFactorsProto(),
+				RunningVolume:   notionalVolume.Round(0).String(),
 			})
 		}
 	}

--- a/core/volumediscount/helpers_for_test.go
+++ b/core/volumediscount/helpers_for_test.go
@@ -79,7 +79,7 @@ func expectStatsUpdatedWithUnqualifiedParties(t *testing.T, broker *mocks.MockBr
 		for _, s := range stats.Stats {
 			if s.PartyId == "p1" {
 				foundUnqualifiedParty = true
-				require.Equal(t, "0", s.DiscountFactor)
+				require.Equal(t, "", s.DiscountFactor)
 				require.Equal(t, "900", s.RunningVolume)
 			}
 		}


### PR DESCRIPTION
When a party wasn't eligible for a volume discount we were sending `nil` in the event instead of `types.EmptyFactors`. This was causing the data-node problems when it was trying to read the JSON blob for it and unmarshalling back into a `vega.DiscountFactors{}` where it didn't expect it to be `nil`.