### PR TITLE
fix: when closing a market remove AMMs entirely from engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [11526](https://github.com/vegaprotocol/vega/issues/11526) - `EstimateAMMBounds` now respects the market's decimal places.
 - [11486](https://github.com/vegaprotocol/vega/issues/11486) - `AMMs` can now be submitted on markets with more decimal places than asset decimal places.
 - [11561](https://github.com/vegaprotocol/vega/issues/11561) - Failing amends on `AMMs` now restore original properly.
+- [11583](https://github.com/vegaprotocol/vega/issues/11583) - Remove `AMMs` entirely from engine when market closes.
 - [11568](https://github.com/vegaprotocol/vega/issues/11568) - order book shape on closing `AMM` no longer panics.
 - [11540](https://github.com/vegaprotocol/vega/issues/11540) - Fix spam check for spots to use not double count quantum.
 - [11542](https://github.com/vegaprotocol/vega/issues/11542) - Fix non determinism in lottery ranking.

--- a/core/execution/amm/engine.go
+++ b/core/execution/amm/engine.go
@@ -820,6 +820,10 @@ func (e *Engine) MarketClosing(ctx context.Context) error {
 		e.sendUpdate(ctx, p)
 		e.marketActivityTracker.RemoveAMMParty(e.assetID, e.marketID, p.AMMParty)
 	}
+
+	e.pools = nil
+	e.poolsCpy = nil
+	e.ammParties = nil
 	return nil
 }
 

--- a/core/execution/amm/engine_test.go
+++ b/core/execution/amm/engine_test.go
@@ -656,9 +656,9 @@ func testMarketClosure(t *testing.T) {
 	}
 
 	require.NoError(t, tst.engine.MarketClosing(ctx))
-	for _, p := range tst.engine.poolsCpy {
-		assert.Equal(t, types.AMMPoolStatusStopped, p.status)
-	}
+	require.Equal(t, 0, len(tst.engine.pools))
+	require.Equal(t, 0, len(tst.engine.poolsCpy))
+	require.Equal(t, 0, len(tst.engine.ammParties))
 }
 
 func expectSubaccountCreation(t *testing.T, tst *tstEngine, party, subAccount string) {


### PR DESCRIPTION
closes #11584