### PR TITLE
fix: count sub-key ELS for the parent key when voting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [11579](https://github.com/vegaprotocol/vega/issues/11579) - Spot calculate fee on amend, use order price if no amended price is provided.
 - [11585](https://github.com/vegaprotocol/vega/issues/11585) - Initialise rebate stats service in API.
 - [11592](https://github.com/vegaprotocol/vega/issues/11592) - Fix the order of calls at end of epoch between rebate engine and market tracker. 
+- [959](https://github.com/vegaprotocol/core-test-coverage/issues/959) - Include `ELS` for `AMM` sub keys to the parent key `ELS`.
 
 ## 0.77.5
 

--- a/core/execution/common/interfaces.go
+++ b/core/execution/common/interfaces.go
@@ -352,6 +352,7 @@ type CommonMarket interface {
 	GetMarketData() types.MarketData
 	StartOpeningAuction(context.Context) error
 	GetEquityShares() *EquityShares
+	GetEquitySharesForParty(partyID string) num.Decimal
 	IntoType() types.Market
 	OnEpochEvent(ctx context.Context, epoch types.Epoch)
 	OnEpochRestore(ctx context.Context, epoch types.Epoch)

--- a/core/execution/engine.go
+++ b/core/execution/engine.go
@@ -1457,7 +1457,7 @@ func (e *Engine) GetMarket(market string, settled bool) (types.Market, bool) {
 // party in the given market. If the market doesn't exist, it returns false.
 func (e *Engine) GetEquityLikeShareForMarketAndParty(market, party string) (num.Decimal, bool) {
 	if mkt, ok := e.allMarkets[market]; ok {
-		return mkt.GetEquityShares().SharesFromParty(party), true
+		return mkt.GetEquitySharesForParty(party), true
 	}
 	return num.DecimalZero(), false
 }

--- a/core/execution/future/market.go
+++ b/core/execution/future/market.go
@@ -586,6 +586,14 @@ func (m *Market) GetEquityShares() *common.EquityShares {
 	return m.equityShares
 }
 
+func (m *Market) GetEquitySharesForParty(partyID string) num.Decimal {
+	primary := m.equityShares.SharesFromParty(partyID)
+	if sub, err := m.amm.GetAMMParty(partyID); err == nil {
+		return primary.Add(m.equityShares.SharesFromParty(sub))
+	}
+	return primary
+}
+
 func (m *Market) ResetParentIDAndInsurancePoolFraction() {
 	m.mkt.ParentMarketID = ""
 	m.mkt.InsurancePoolFraction = num.DecimalZero()

--- a/core/execution/spot/market.go
+++ b/core/execution/spot/market.go
@@ -337,6 +337,15 @@ func (m *Market) GetEquityShares() *common.EquityShares {
 	return m.equityShares
 }
 
+func (m *Market) GetEquitySharesForParty(partyID string) num.Decimal {
+	primary := m.equityShares.SharesFromParty(partyID)
+	// AMM for spot has not been implemented yet
+	// if sub, err := m.amm.GetAMMParty(partyID); err == nil {
+	// return primary.Add(m.equityShares.SharesFromParty(sub))
+	// }
+	return primary
+}
+
 func (m *Market) SetNextMTM(tm time.Time) {
 	m.nextMTM = tm
 }


### PR DESCRIPTION
Fixes an issue where AMM ELS was not counted towards ELS (AMM can't vote on governance proposals): https://github.com/vegaprotocol/core-test-coverage/issues/959

Also closes #11269