### PR TITLE
fix: keep AMM ephemeral position throughout entire auction uncrossing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [11459](https://github.com/vegaprotocol/vega/issues/11459) - Deprecate time weight position reward metric and replace it with time weighted notional.
 - [11528](https://github.com/vegaprotocol/vega/issues/11528) - Added support for eligible entities reward.
 - [11372](https://github.com/vegaprotocol/vega/issues/11372) - Support combined filters for the `AMM` API.
+- [11583](https://github.com/vegaprotocol/vega/issues/11583) - Keep `AMM` ephemeral position throughout entire auction uncrossing.
 - [11535](https://github.com/vegaprotocol/vega/issues/11535) - Added support for lottery rank distribution strategy.
 - [11536](https://github.com/vegaprotocol/vega/issues/11536) - Make the batch market instructions errors programmatically usable.
 - [11546](https://github.com/vegaprotocol/vega/issues/11546) - Add validation to market proposals metadata.

--- a/core/matching/orderbook.go
+++ b/core/matching/orderbook.go
@@ -597,6 +597,9 @@ func (b *OrderBook) uncrossBookSide(
 	if len(uncrossOrders) == 0 {
 		return nil, nil
 	}
+
+	defer b.buy.uncrossFinished()
+
 	// get price factor, if price is 10,000, but market price is 100, this is 10,000/100 -> 100
 	// so we can get the market price simply by doing price / (order.Price/ order.OriginalPrice)
 	// as the asset decimals may be < market decimals, the calculation must be done in decimals.
@@ -1001,6 +1004,9 @@ func (b *OrderBook) SubmitOrder(order *types.Order) (*types.OrderConfirmation, e
 
 	if !b.auction {
 		// uncross with opposite
+
+		defer b.buy.uncrossFinished()
+
 		idealPrice := b.theoreticalBestTradePrice(order)
 		trades, impactedOrders, lastTradedPrice, err = b.getOppositeSide(order.Side).uncross(order, true, idealPrice)
 		if !lastTradedPrice.IsZero() {

--- a/core/matching/side.go
+++ b/core/matching/side.go
@@ -669,7 +669,6 @@ func (s *OrderBookSide) uncrossOffbook(idx int, agg *types.Order, idealPrice *nu
 // uncross returns trades after order book side gets uncrossed with the agg order supplied,
 // checkWashTrades checks non-FOK orders for wash trades if set to true (FOK orders are always checked for wash trades).
 func (s *OrderBookSide) uncross(agg *types.Order, checkWashTrades bool, theoreticalBestTrade *num.Uint) ([]*types.Trade, []*types.Order, *num.Uint, error) {
-	defer s.uncrossFinished()
 	var (
 		trades            []*types.Trade
 		impactedOrders    []*types.Order


### PR DESCRIPTION
closes #11583 

During auction uncrossing when trades are matched with an AMM, the AMM's actual position is only updated _after_ we've left the matching engine and the trades are confirmed. This causes problems since as the uncrossing is happening and we are shooting orders from one side of the book at the other, the AMM's fair-price won't change as we go along and each incoming uncrossing order will just keep taking the same volume from the same region  of the same AMM.

Code exists that handles this where the AMM engine keeps track of an AMM's not-quite-confirmed position, and then clears it when uncrossing has finished so we can return to reading its position from the position's engine.

The bug here is that we were actually clearing the AMM's "ephemeral position" too soon, and _not_ at the end of uncrossing like we were supposed to.