### PR TITLE
fix: calculate AMM tradable volume purely in position to avoid precis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [11568](https://github.com/vegaprotocol/vega/issues/11568) - order book shape on closing `AMM` no longer panics.
 - [11540](https://github.com/vegaprotocol/vega/issues/11540) - Fix spam check for spots to use not double count quantum.
 - [11542](https://github.com/vegaprotocol/vega/issues/11542) - Fix non determinism in lottery ranking.
+- [11616](https://github.com/vegaprotocol/vega/issues/11616) - `AMM` tradable volume now calculated purely in positions to prevent loss of precision.
 - [11544](https://github.com/vegaprotocol/vega/issues/11544) - Fix empty candles stream.
 - [11579](https://github.com/vegaprotocol/vega/issues/11579) - Spot calculate fee on amend, use order price if no amended price is provided.
 - [11585](https://github.com/vegaprotocol/vega/issues/11585) - Initialise rebate stats service in API.

--- a/core/execution/amm/engine_test.go
+++ b/core/execution/amm/engine_test.go
@@ -462,7 +462,7 @@ func TestBestPricesAndVolumeNearBound(t *testing.T) {
 	expectSubaccountCreation(t, tst, party, subAccount)
 	whenAMMIsSubmitted(t, tst, submit)
 
-	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(5).Return(
+	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(3).Return(
 		[]events.MarketPosition{&marketPosition{size: 0, averageEntry: num.NewUint(0)}},
 	)
 
@@ -473,7 +473,7 @@ func TestBestPricesAndVolumeNearBound(t *testing.T) {
 	assert.Equal(t, 1192, int(avolume))
 
 	// lets move its position so that the fair price is within one tick of the AMMs upper boundary
-	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(5).Return(
+	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(3).Return(
 		[]events.MarketPosition{&marketPosition{size: -222000, averageEntry: num.NewUint(0)}},
 	)
 
@@ -484,7 +484,7 @@ func TestBestPricesAndVolumeNearBound(t *testing.T) {
 	assert.Equal(t, 103, int(avolume))
 
 	// lets move its position so that the fair price is within one tick of the AMMs upper boundary
-	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(5).Return(
+	tst.pos.EXPECT().GetPositionsByParty(gomock.Any()).Times(3).Return(
 		[]events.MarketPosition{&marketPosition{size: 270400, averageEntry: num.NewUint(0)}},
 	)
 
@@ -492,7 +492,7 @@ func TestBestPricesAndVolumeNearBound(t *testing.T) {
 	assert.Equal(t, "180000", bid.String()) // make sure we are capped to the boundary and not 179904
 	assert.Equal(t, "180104", ask.String())
 	assert.Equal(t, 58, int(bvolume))
-	assert.Equal(t, 1463, int(avolume))
+	assert.Equal(t, 1460, int(avolume))
 }
 
 func testClosingReduceOnlyPool(t *testing.T) {

--- a/core/integration/features/amm/0090-VAMM-006-014.feature
+++ b/core/integration/features/amm/0090-VAMM-006-014.feature
@@ -478,10 +478,10 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party5 | ETH/MAR22 | buy  | 65     | 120   | 1                | TYPE_LIMIT | TIF_GTC |
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | ref price | mid price | static mid price | best offer price | best bid price |
-      | 95         | TRADING_MODE_CONTINUOUS | 100       | 120       | 120              | 121              | 120            |
+      | 95         | TRADING_MODE_CONTINUOUS | 100       | 120       | 120              | 121              | 119            |
     And the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
-      | party5 | 114   | 64   | vamm1-id | true   |
+      | party5 | 114   | 65   | vamm1-id | true   |
     # Check the resulting position, vAMM further increased their position
     When the network moves ahead "1" blocks
 	Then the parties should have the following profit and loss:
@@ -490,5 +490,5 @@ Feature: Ensure the vAMM positions follow the market correctly
       | party2   | -1     | -14            | 0            |        |
       | party3   | -350   | -6650          | 0            |        |
       | party4   | 420    | 7980           | 0            |        |
-      | party5   | 64     | 0              | 0            |        |
-      | vamm1-id | -134   | -1330          | 0            | true   |
+      | party5   | 65     | 0              | 0            |        |
+      | vamm1-id | -135   | -1330          | 0            | true   |

--- a/core/integration/features/amm/0090-VAMM-020.feature
+++ b/core/integration/features/amm/0090-VAMM-020.feature
@@ -151,18 +151,18 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | buyer  | price | size | seller   | is amm |
       | party5 | 89    | 10   | party4   |        |
       | party5 | 90    | 10   | party4   |        |
-      | party5 | 90    | 39   | vamm1-id | true   |
+      | party5 | 90    | 19   | vamm1-id | true   |
       | party5 | 91    | 10   | party4   |        |
-      | party5 | 90    | 39   | vamm1-id | true   |
-      | party5 | 94    | 211  | vamm1-id | true   |
+      | party5 | 90    | 19   | vamm1-id | true   |
+      | party5 | 94    | 231  | vamm1-id | true   |
 
     # check the state of the market, trigger MTM settlement and check balances before closing out the last 100 for the vAMM
     When the network moves ahead "1" blocks
 	  Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | 230            | 0            |        |
-      | party5   | 280    | 276            | 0            |        |
-      | vamm1-id | 100    | -100           | -406         | true   |
+      | party5   | 280    | 196            | 0            |        |
+      | vamm1-id | 100    | -100           | -326         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -171,14 +171,14 @@ Feature: Test vAMM cancellation by reduce-only from long.
     # vAMM receives some fees, but pays MTM loss, excess margin is released
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 80     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 506    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45731  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 87     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 426    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45811  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 81497   | 18225  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81576   | 18225  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -211,8 +211,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | -1290          | 0            |        |
-      | party5   | 380    | 1396           | 0            |        |
-      | vamm1-id | 0      | 0              | -106         | true   |
+      | party5   | 380    | 1316           | 0            |        |
+      | vamm1-id | 0      | 0              | -26          | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -224,10 +224,10 @@ Feature: Test vAMM cancellation by reduce-only from long.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE      |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 400    | USD   | true   | TRANSFER_TYPE_MTM_WIN                |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18625  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH            |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100162 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE            |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100241 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE            |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 1000162 |        |        |
+      | vamm1    | USD   |           | 1000241 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |
 
   @VAMM
@@ -284,18 +284,18 @@ Feature: Test vAMM cancellation by reduce-only from long.
       | buyer  | price | size | seller   | is amm |
       | party5 | 89    | 10   | party4   |        |
       | party5 | 90    | 10   | party4   |        |
-      | party5 | 90    | 39   | vamm1-id | true   |
+      | party5 | 90    | 19   | vamm1-id | true   |
       | party5 | 91    | 10   | party4   |        |
-      | party5 | 90    | 39   | vamm1-id | true   |
-      | party5 | 94    | 211  | vamm1-id | true   |
+      | party5 | 90    | 19   | vamm1-id | true   |
+      | party5 | 94    | 231  | vamm1-id | true   |
 
     # check the state of the market, trigger MTM settlement and check balances before closing out the last 100 for the vAMM
     When the network moves ahead "1" blocks
 	  Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | 230            | 0            |        |
-      | party5   | 280    | 276            | 0            |        |
-      | vamm1-id | 100    | -100           | -406         | true   |
+      | party5   | 280    | 196            | 0            |        |
+      | vamm1-id | 100    | -100           | -326         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -304,14 +304,14 @@ Feature: Test vAMM cancellation by reduce-only from long.
     # vAMM receives some fees, but pays MTM loss, excess margin is released
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 80     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 506    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45731  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 87     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 426    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45811  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 81497   | 18225  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81576   | 18225  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -343,8 +343,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | -1290          | 0            |        |
-      | party5   | 380    | 1396           | 0            |        |
-      | vamm1-id | 0      | 0              | -106         | true   |
+      | party5   | 380    | 1316           | 0            |        |
+      | vamm1-id | 0      | 0              | -26          | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -356,8 +356,8 @@ Feature: Test vAMM cancellation by reduce-only from long.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 400    | USD   | true   | TRANSFER_TYPE_MTM_WIN           |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18625  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100162 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE       |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100241 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE       |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 1000162 |        |        |
+      | vamm1    | USD   |           | 1000241 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |

--- a/core/integration/features/amm/11504-rounding.feature
+++ b/core/integration/features/amm/11504-rounding.feature
@@ -134,14 +134,14 @@ Feature: Ensure rounding errors do not cause empty curve panic.
       | party4 | ETH/MAR22 | buy  | 31     | 110   | 2                | TYPE_LIMIT | TIF_GTC |
     Then the following trades should be executed:
       | buyer  | price | size | seller   | is amm |
-      | party4 | 104   | 15   | vamm1-id | true   |
-      | party4 | 104   | 16   | vamm2-id | true   |
+      | party4 | 105   | 16   | vamm1-id | true   |
+      | party4 | 104   | 15   | vamm2-id | true   |
     When the network moves ahead "1" blocks
     Then the market data for the market "ETH/MAR22" should be:
       | mark price | trading mode            | mid price | static mid price |
       | 104        | TRADING_MODE_CONTINUOUS | 108       | 108              |
     And the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
-      | party4   | 36     | 20             | 0            |        |
-      | vamm1-id | -18    | -12            | 0            | true   |
-      | vamm2-id | -18    | -8             | 0            | true   |
+      | party4   | 36     | 4              | 0            |        |
+      | vamm1-id | -19    | 4              | 0            | true   |
+      | vamm2-id | -17    | -8             | 0            | true   |

--- a/core/integration/features/amm/reduce-only-single-sided.feature
+++ b/core/integration/features/amm/reduce-only-single-sided.feature
@@ -152,18 +152,18 @@ Feature: Cover more complex scenarios.
       | buyer  | price | size | seller   | is amm |
       | party5 | 89    | 10   | party4   |        |
       | party5 | 90    | 10   | party4   |        |
-      | party5 | 90    | 39   | vamm1-id | true   |
+      | party5 | 90    | 19   | vamm1-id | true   |
       | party5 | 91    | 10   | party4   |        |
-      | party5 | 90    | 39   | vamm1-id | true   |
-      | party5 | 94    | 211  | vamm1-id | true   |
+      | party5 | 90    | 19   | vamm1-id | true   |
+      | party5 | 94    | 231  | vamm1-id | true   |
 
     # check the state of the market, trigger MTM settlement and check balances before closing out the last 100 for the vAMM
     When the network moves ahead "2" blocks
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | 230            | 0            |        |
-      | party5   | 280    | 276            | 0            |        |
-      | vamm1-id | 100    | -100           | -406         | true   |
+      | party5   | 280    | 196            | 0            |        |
+      | vamm1-id | 100    | -100           | -326         | true   |
     # vAMM is still quoting bid price, though it is in reduce-only mode, and therefore doesn't place those orders.
     # The best bid should be 40 here?
     And the market data for the market "ETH/MAR22" should be:
@@ -172,14 +172,14 @@ Feature: Cover more complex scenarios.
     # vAMM receives some fees, but pays MTM loss, excess margin is released
     And the following transfers should happen:
       | from     | from account            | to       | to account              | market id | amount | asset | is amm | type                            |
-      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 80     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 506    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
-      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45731  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
+      |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 87     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     |          | ACCOUNT_TYPE_SETTLEMENT | ETH/MAR22 | 426    | USD   | true   | TRANSFER_TYPE_MTM_LOSS          |
+      | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL    | ETH/MAR22 | 45811  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
     # After receiving fees, and excess margin is correctly released, the balances of the vAMM sub-accounts match the position:
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
       | vamm1    | USD   |           | 900000  |        |        |
-      | vamm1-id | USD   | ETH/MAR22 | 81497   | 18225  | true   |
+      | vamm1-id | USD   | ETH/MAR22 | 81576   | 18225  | true   |
 
     # Now make sure the vAMM, though clearly having sufficient balance to increase its position, still doesn't place any buy orders (reduce only check 2)
     # Like before, place orders at mid, offer, and bid prices
@@ -236,8 +236,8 @@ Feature: Cover more complex scenarios.
 	Then the parties should have the following profit and loss:
       | party    | volume | unrealised pnl | realised pnl | is amm |
       | party4   | -380   | -1290          | 0            |        |
-      | party5   | 380    | 1396           | 0            |        |
-      | vamm1-id | 0      | 0              | -106         | true   |
+      | party5   | 380    | 1316           | 0            |        |
+      | vamm1-id | 0      | 0              | -26          | true   |
     And the AMM pool status should be:
       | party | market id | amount | status           | base | lower bound | upper bound | lower leverage | upper leverage |
       | vamm1 | ETH/MAR22 | 100000 | STATUS_CANCELLED | 100  | 85          | 150         | 4              | 4              |
@@ -249,10 +249,10 @@ Feature: Cover more complex scenarios.
        |          | ACCOUNT_TYPE_FEES_MAKER | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 40     | USD   | true   | TRANSFER_TYPE_MAKER_FEE_RECEIVE |
        |          | ACCOUNT_TYPE_SETTLEMENT | vamm1-id | ACCOUNT_TYPE_MARGIN  | ETH/MAR22 | 400    | USD   | true   | TRANSFER_TYPE_MTM_WIN           |
        | vamm1-id | ACCOUNT_TYPE_MARGIN     | vamm1-id | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 18625  | USD   | true   | TRANSFER_TYPE_MARGIN_HIGH       |
-       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100162 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE       |
+       | vamm1-id | ACCOUNT_TYPE_GENERAL    | vamm1    | ACCOUNT_TYPE_GENERAL | ETH/MAR22 | 100241 | USD   | true   | TRANSFER_TYPE_AMM_RELEASE       |
     And the parties should have the following account balances:
       | party    | asset | market id | general | margin | is amm |
-      | vamm1    | USD   |           | 1000162 |        |        |
+      | vamm1    | USD   |           | 1000241 |        |        |
       | vamm1-id | USD   | ETH/MAR22 | 0       | 0      | true   |
 
 


### PR DESCRIPTION
closes #11616 

`TradableVolumeInRange()` has been re-written to do everything in positions instead of hopping between positions and prices. This stops precision loss from every time we did a hop.