### PR TITLE
fix: calculate rough bound on where to check for incoming trade volum…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [11542](https://github.com/vegaprotocol/vega/issues/11542) - Fix non determinism in lottery ranking.
 - [11616](https://github.com/vegaprotocol/vega/issues/11616) - `AMM` tradable volume now calculated purely in positions to prevent loss of precision.
 - [11544](https://github.com/vegaprotocol/vega/issues/11544) - Fix empty candles stream.
+- [11583](https://github.com/vegaprotocol/vega/issues/11583) - Rough bound on price interval when matching with `AMMs` is now looser and calculated in the `AMM` engine.
 - [11619](https://github.com/vegaprotocol/vega/issues/11619) - Fix `EstimatePositions` API for capped futures.
 - [11579](https://github.com/vegaprotocol/vega/issues/11579) - Spot calculate fee on amend, use order price if no amended price is provided.
 - [11585](https://github.com/vegaprotocol/vega/issues/11585) - Initialise rebate stats service in API.

--- a/core/matching/orderbook_amm_test.go
+++ b/core/matching/orderbook_amm_test.go
@@ -235,7 +235,7 @@ func testMatchOrdersBothSide(t *testing.T) {
 	assert.Len(t, trades, 8)
 
 	// uncross
-	expectOffbookOrders(t, tst, price, num.NewUint(oPrice-1), num.NewUint(120))
+	expectOffbookOrders(t, tst, price, nil, num.NewUint(120))
 	expectOffbookOrders(t, tst, price, num.NewUint(120), num.NewUint(110))
 	expectOffbookOrders(t, tst, price, num.NewUint(110), num.NewUint(90))
 	tst.obs.EXPECT().NotifyFinished().Times(1)

--- a/core/matching/side_test.go
+++ b/core/matching/side_test.go
@@ -178,7 +178,7 @@ func TestMemoryAllocationPriceLevelUncrossSide(t *testing.T) {
 		Remaining:     1,
 		TimeInForce:   types.OrderTimeInForceGTC,
 	}
-	side.uncross(aggressiveOrder, true, nil)
+	side.uncross(aggressiveOrder, true)
 	assert.Len(t, side.levels, 1)
 }
 
@@ -445,11 +445,11 @@ func TestFakeUncrossNormal(t *testing.T) {
 	}
 
 	checkWashTrades := false
-	fakeTrades, err := buySide.fakeUncross(&order, checkWashTrades, nil)
+	fakeTrades, err := buySide.fakeUncross(&order, checkWashTrades)
 	assert.Len(t, fakeTrades, 5)
 	assert.NoError(t, err)
 
-	trades, _, _, err := buySide.uncross(&order, checkWashTrades, nil)
+	trades, _, _, err := buySide.uncross(&order, checkWashTrades)
 	assert.Len(t, trades, 5)
 	assert.NoError(t, err)
 
@@ -474,11 +474,11 @@ func TestFakeUncrossSelfTradeFOKMarketOrder(t *testing.T) {
 	}
 
 	checkWashTrades := false
-	fakeTrades, err1 := buySide.fakeUncross(&order, checkWashTrades, nil)
+	fakeTrades, err1 := buySide.fakeUncross(&order, checkWashTrades)
 	assert.Len(t, fakeTrades, 0)
 	assert.Error(t, err1)
 
-	trades, _, _, err2 := buySide.uncross(&order, checkWashTrades, nil)
+	trades, _, _, err2 := buySide.uncross(&order, checkWashTrades)
 	assert.Len(t, trades, 0)
 	assert.Error(t, err2)
 
@@ -501,12 +501,12 @@ func TestFakeUncrossSelfTradeNonFOKLimitOrder_DontCheckWashTrades(t *testing.T) 
 	}
 
 	checkWashTrades := false
-	fakeTrades, err := buySide.fakeUncross(&order, checkWashTrades, nil)
+	fakeTrades, err := buySide.fakeUncross(&order, checkWashTrades)
 	assert.Len(t, fakeTrades, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, fakeTrades[0].SellOrder, order.ID)
 
-	trades, _, _, err := buySide.uncross(&order, checkWashTrades, nil)
+	trades, _, _, err := buySide.uncross(&order, checkWashTrades)
 	assert.Len(t, trades, 1)
 	assert.NoError(t, err)
 
@@ -529,12 +529,12 @@ func TestFakeUncrossSelfTradeNonFOKLimitOrder_CheckWashTrades(t *testing.T) {
 	}
 
 	checkWashTrades := true
-	fakeTrades, err1 := buySide.fakeUncross(&order, checkWashTrades, nil)
+	fakeTrades, err1 := buySide.fakeUncross(&order, checkWashTrades)
 	assert.Len(t, fakeTrades, 0)
 	assert.Error(t, err1)
 	assert.Equal(t, "party attempted to submit wash trade", err1.Error())
 
-	trades, _, _, err2 := buySide.uncross(&order, checkWashTrades, nil)
+	trades, _, _, err2 := buySide.uncross(&order, checkWashTrades)
 	assert.Len(t, trades, 0)
 	assert.Error(t, err2)
 	assert.Equal(t, "party attempted to submit wash trade", err2.Error())
@@ -556,11 +556,11 @@ func TestFakeUncrossNotEnoughVolume(t *testing.T) {
 	}
 
 	checkWashTrades := false
-	fakeTrades, err := buySide.fakeUncross(&order, checkWashTrades, nil)
+	fakeTrades, err := buySide.fakeUncross(&order, checkWashTrades)
 	assert.Len(t, fakeTrades, 0)
 	assert.NoError(t, err)
 
-	trades, _, _, err := buySide.uncross(&order, checkWashTrades, nil)
+	trades, _, _, err := buySide.uncross(&order, checkWashTrades)
 	assert.Len(t, trades, 0)
 	assert.NoError(t, err)
 }
@@ -594,13 +594,13 @@ func TestFakeUncrossAuction(t *testing.T) {
 
 	orders := []*types.Order{order1, order2}
 
-	fakeTrades, err := buySide.fakeUncrossAuction(orders, nil)
+	fakeTrades, err := buySide.fakeUncrossAuction(orders)
 	assert.Len(t, fakeTrades, 6)
 	assert.NoError(t, err)
 
 	trades := []*types.Trade{}
 	for _, order := range orders {
-		trds, _, _, err := buySide.uncross(order, false, nil)
+		trds, _, _, err := buySide.uncross(order, false)
 		assert.NoError(t, err)
 		trades = append(trades, trds...)
 	}


### PR DESCRIPTION
closes #11583 

When an order is sent to the AMM engine to match, the orderbook also gives a price range. One of those bounds is so that we only trade with AMM's up to the next price level on the book. The other is performance-y to help exclude AMM's from matching that aren't in range at all (e.g have been full traded out) which is usually the price of the previous price level.

In the case where we are considering the first price level on the orderbook,`p` , there might be a volume at a better price with the AMM's so the range we give the AMM engine is `[some reasonable lower bound, p]`. For auction uncrossing, we were giving the boundary of the crossed region as `some reasonable lower bound` but this was off by one. This is because it could be the best buy/ask of an AMM but the actual region we need to evaluate from is the AMM's fair-price, so we were missing volume and leaving the book crossed.

I've now made it less clever, where matching gives `nil` as `some reasonable lower bound` and the amm engine itself can work out what that is given more knowledge of the AMM's state.