### PR TITLE
fix: prevent overflow when calculating tradable volume outside of sid…

### DIFF
--- a/core/execution/amm/pool.go
+++ b/core/execution/amm/pool.go
@@ -629,11 +629,17 @@ func (p *Pool) TradableVolumeInRange(side types.Side, price1 *num.Uint, price2 *
 
 	if side == types.SideSell {
 		// want all buy volume so everything below fair price, where the AMM is long
+		if pos > stP {
+			return 0
+		}
 		ndP = num.MaxV(pos, ndP)
 	}
 
 	if side == types.SideBuy {
 		// want all sell volume so everything above fair price, where the AMM is short
+		if pos < ndP {
+			return 0
+		}
 		stP = num.MinV(pos, stP)
 	}
 

--- a/core/execution/amm/pool_test.go
+++ b/core/execution/amm/pool_test.go
@@ -113,6 +113,22 @@ func testTradeableVolumeInRange(t *testing.T) {
 			expectedVolume: 1052,
 			position:       -350,
 		},
+		{
+			name:           "AMM is long and price range is fully in short section",
+			price1:         num.NewUint(1900),
+			price2:         num.NewUint(2200),
+			side:           types.SideSell,
+			expectedVolume: 0,
+			position:       700,
+		},
+		{
+			name:           "AMM is short and price range is fully in long section",
+			price1:         num.NewUint(1900),
+			price2:         num.NewUint(2100),
+			side:           types.SideBuy,
+			expectedVolume: 0,
+			position:       -700,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This error came up on a market-sim run:
```
panic: order too large to register, will overflow

goroutine 33115 [running]:
go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x2?, 0x2?, {0x0?, 0x0?, 0xc005959560?})
```

and is due to my re-write of `TradableVolumeInRange()` to be entirely position based. I missed the case where we query a range, the pool's current position exists outside of that range on the wrong side. For example, if we want the buy volume of an AMM between position `[30, 10]` but the AMM's current position is `50` then there is no buy volume, its already been traded.