### PR TITLE
fix: don't pass in self to cumulated-errors

### DIFF
--- a/core/processor/abci.go
+++ b/core/processor/abci.go
@@ -2298,7 +2298,7 @@ func (app *App) CheckBatchPropose(_ context.Context, tx abci.Tx, deterministicBa
 		switch term := change.Change.(type) {
 		case *types.ProposalTermsUpdateNetworkParameter:
 			if err := app.netp.IsUpdateAllowed(term.UpdateNetworkParameter.Changes.Key); err != nil {
-				errs.Add(errs)
+				errs.Add(err)
 			}
 		}
 	}


### PR DESCRIPTION
Small one to address the cause of that self-referential cumulative errors thing.