### PR TITLE
fix: Delay the final termination of a transfer to the following epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [11650](https://github.com/vegaprotocol/vega/issues/11650) - Add include sub accounts flag to `listPositions`.
 - [11641](https://github.com/vegaprotocol/vega/issues/11641) - Panic with pegged orders.
 - [11646](https://github.com/vegaprotocol/vega/issues/11646) - Add tier numbers to API.
+- [11665](https://github.com/vegaprotocol/vega/issues/11665) - Delay the final termination of a transfer to the following epoch. 
 
 
 ## 0.78.1

--- a/core/banking/recurring_transfers.go
+++ b/core/banking/recurring_transfers.go
@@ -383,13 +383,6 @@ func (e *Engine) distributeRecurringTransfers(ctx context.Context, newEpoch uint
 		}
 
 		tresps = append(tresps, resps...)
-
-		// if we don't have anymore
-		if v.EndEpoch != nil && *v.EndEpoch == e.currentEpoch {
-			v.Status = types.TransferStatusDone
-			transfersDone = append(transfersDone, events.NewRecurringTransferFundsEvent(ctx, v, e.getGameID(v)))
-			doneIDs = append(doneIDs, v.ID)
-		}
 	}
 
 	// send events

--- a/core/banking/recurring_transfers_test.go
+++ b/core/banking/recurring_transfers_test.go
@@ -148,6 +148,8 @@ func TestMaturation(t *testing.T) {
 	e.OnEpoch(context.Background(), types.Epoch{Seq: 11, Action: vega.EpochAction_EPOCH_ACTION_END})
 	e.OnEpoch(context.Background(), types.Epoch{Seq: 12, Action: vega.EpochAction_EPOCH_ACTION_START})
 	e.OnEpoch(context.Background(), types.Epoch{Seq: 12, Action: vega.EpochAction_EPOCH_ACTION_END})
+	e.OnEpoch(context.Background(), types.Epoch{Seq: 13, Action: vega.EpochAction_EPOCH_ACTION_START})
+	e.OnEpoch(context.Background(), types.Epoch{Seq: 13, Action: vega.EpochAction_EPOCH_ACTION_END})
 
 	require.Equal(t, 10, len(seenEvts))
 	stoppedIDs := map[string]struct{}{}

--- a/core/integration/features/transfers/recurring_transfers.feature
+++ b/core/integration/features/transfers/recurring_transfers.feature
@@ -132,7 +132,7 @@ Scenario: As a user I can create a recurring transfer that decreases over time w
     Then "576380694832d9271682e86fffbbcebc09ca79c259baa5d4d0298e12ecdee303" should have general account balance of "21900" for asset "VEGA"
 
     # end of epoch 5 - the transfer is ended so can't be cancelled
-    When the network moves ahead "7" blocks
+    When the network moves ahead "8" blocks
     Then "a7c4b181ef9bf5e9029a016f854e4ad471208020fd86187d07f0b420004f06a4" should have general account balance of "962005" for asset "VEGA"
     Then "576380694832d9271682e86fffbbcebc09ca79c259baa5d4d0298e12ecdee303" should have general account balance of "25330" for asset "VEGA"
 
@@ -174,7 +174,7 @@ Scenario: As a user I can create a recurring transfer that decreases over time w
     Then "576380694832d9271682e86fffbbcebc09ca79c259baa5d4d0298e12ecdee303" should have general account balance of "21900" for asset "VEGA"
 
     # end of epoch 5 - the transfer is ended so can't be cancelled
-    When the network moves ahead "7" blocks
+    When the network moves ahead "8" blocks
     Then "a7c4b181ef9bf5e9029a016f854e4ad471208020fd86187d07f0b420004f06a4" should have general account balance of "956340" for asset "VEGA"
     Then "576380694832d9271682e86fffbbcebc09ca79c259baa5d4d0298e12ecdee303" should have general account balance of "25330" for asset "VEGA"
 


### PR DESCRIPTION
Closes #11665 