### PR TITLE
fix: unmarshal referral prog discount factors properly when loading f…

### DIFF
--- a/core/referral/engine.go
+++ b/core/referral/engine.go
@@ -427,9 +427,9 @@ func (e *Engine) loadFactorsByReferee(factors []*snapshotpb.FactorByReferee) {
 
 		factors := types.Factors{}
 		if fbr.DiscountFactors != nil {
-			factors.Infra, _ = num.UnmarshalBinaryDecimal([]byte(fbr.DiscountFactors.InfrastructureDiscountFactor))
-			factors.Liquidity, _ = num.UnmarshalBinaryDecimal([]byte(fbr.DiscountFactors.LiquidityDiscountFactor))
-			factors.Maker, _ = num.UnmarshalBinaryDecimal([]byte(fbr.DiscountFactors.MakerDiscountFactor))
+			factors.Infra, _ = num.DecimalFromString(fbr.DiscountFactors.InfrastructureDiscountFactor)
+			factors.Liquidity, _ = num.DecimalFromString(fbr.DiscountFactors.LiquidityDiscountFactor)
+			factors.Maker, _ = num.DecimalFromString(fbr.DiscountFactors.MakerDiscountFactor)
 		}
 		if len(fbr.DiscountFactor) > 0 {
 			defaultDF, _ := num.UnmarshalBinaryDecimal(fbr.DiscountFactor)


### PR DESCRIPTION
Every now and again I've seen the overight soak tests on the `a-d` job hang on loading a particular snapshot. Example:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/67157/pipeline/616

```
[2024-09-22T16:13:49.254Z] Restoring from height 2350...
[2024-09-22T16:13:49.254Z] Stopping: node has been stuck on block 2353 for too long.
[2024-09-22T16:13:49.254Z] Diagnosing snapshot restore failure at height 2350...
[2024-09-22T16:13:49.254Z] restore failed due to general panic
[2024-09-22T16:13:49.254Z] Restoring from height 2350 failed
```

which I put down to jenkins being jenkins, but it turns out it was a real issue.

When serialising the decimals types for the referral engine's discount factors, we did so using the normal string representation:
```
factors.MakerDiscountFactor = f.Maker.String()
```
but when we unserialised we were treating them as a binary string?
```
num.UnmarshalBinaryDecimal([]byte(fbr.DiscountFactors.MakerDiscountFactor))
```

which would unpack into a completely different and very large decimal, which would churn forever when trying to convert it into a `num.Uint()` when used to calculate fees after a trade.


