### PR TITLE
fix: init pool cache in snapshot path, and write a snapshot test

### DIFF
--- a/core/execution/amm/pool.go
+++ b/core/execution/amm/pool.go
@@ -292,6 +292,7 @@ func NewPoolFromProto(
 		positionFactor: positionFactor,
 		oneTick:        num.Max(num.UintOne(), oneTick),
 		status:         state.Status,
+		cache:          NewPoolCache(),
 	}, nil
 }
 


### PR DESCRIPTION
Quick fix for the AMM caching change that went in on Friday.